### PR TITLE
ci: add Dependabot config (actions + pip)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "ci"
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "build"


### PR DESCRIPTION
Adds `.github/dependabot.yml` to enable weekly Dependabot version-update PRs for GitHub Actions and pip dependencies. This complements the already-enabled Dependabot security alerts and keeps the CI action versions current (addresses the Node-20 deprecation over time).

First PR through the new `main` ruleset (require PR + the `test` check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)