### PR TITLE
ci: build and publish image to GHCR on release

### DIFF
--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -1,0 +1,59 @@
+name: Release Docker Image
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "image tag to publish, e.g. v0.1.0"
+        required: false
+        default: "edge"
+
+jobs:
+  build-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute image tag
+        id: image-tag
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REF_TYPE: ${{ github.ref_type }}
+          REF_NAME: ${{ github.ref_name }}
+          INPUT_TAG: ${{ inputs.tag }}
+        run: |
+          if [ "$EVENT_NAME" = "push" ] && [ "$REF_TYPE" = "tag" ]; then
+            echo "tag=$REF_NAME" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=$INPUT_TAG" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: deploy/docker/Dockerfile
+          push: true
+          tags: |
+            ghcr.io/knaisoma/data-olympus:${{ steps.image-tag.outputs.tag }}
+            ghcr.io/knaisoma/data-olympus:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/release-image.yml` that builds the data-olympus Docker image and pushes it to `ghcr.io/knaisoma/data-olympus` on every `v*` tag push and on `workflow_dispatch`.
- Enables versioned image builds from CI, since neither the laptop nor kn-dev has a Docker builder available for release artefacts.
- Image tag is derived from the git tag on tag-push events, or from the `tag` input (default `edge`) on manual dispatch.

## Details

- `context: .` with `file: deploy/docker/Dockerfile` matches the Dockerfile's repo-root-relative `COPY` paths (`pyproject.toml`, `uv.lock`, `src/`, `deploy/docker/entrypoint.sh`).
- Pushes two tags on every run: the computed versioned tag and `:latest`.
- GHA layer caching (`type=gha`) cuts rebuild time on repeated runs.
- All GitHub context values used in the `run:` step are passed via `env:` variables to prevent shell injection.
- Permissions are minimal: `contents: read`, `packages: write`.

## Test plan

- [ ] Merge and push a `v*` tag; confirm the image appears at `ghcr.io/knaisoma/data-olympus:<tag>` and `:latest`.
- [ ] Trigger `workflow_dispatch` with a custom tag (e.g. `edge`); confirm the image publishes correctly.
- [ ] Confirm existing `test` CI job is unaffected (this workflow has no overlap with `ci.yaml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)