### PR TITLE
ci: multi-arch image build (amd64+arm64)

### DIFF
--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -22,6 +22,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -51,6 +54,7 @@ jobs:
         with:
           context: .
           file: deploy/docker/Dockerfile
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             ghcr.io/knaisoma/data-olympus:${{ steps.image-tag.outputs.tag }}


### PR DESCRIPTION
The kn-dev node is arm64; the prior amd64-only image could not run there. Adds QEMU and builds linux/amd64,linux/arm64 so the GHCR image runs on both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)