### PR TITLE
feat(lint): skip repo-meta dirs and root-level meta files

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -210,6 +210,11 @@ The serving transport MUST be streamable HTTP (not stdio). The MCP endpoint is `
 - Consumers MUST tolerate broken links (links to non-existent files).
 - A frontmatter block that contains a YAML syntax error is a parse failure; the document is non-conformant and MUST be reported as an error by `kb lint`.
 
+**`kb lint` skips the following paths automatically:**
+
+- **Vendor/VCS/meta directories:** `.git`, `__pycache__`, `.venv`, `.pytest_cache`, `.mypy_cache`, `.ruff_cache`, `node_modules`, `.github`, `.worktrees`, `archive`, `_archive`, `to-delete`, `test-fixtures`, `cli-fixtures`. Any `.md` file whose path passes through one of these directory names is not validated.
+- **Root-level repo-meta files:** `README.md`, `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `SECURITY.md`, `CHANGELOG.md`, `NOTICE.md`, `LICENSE.md`, `AGENTS.md`, `CLAUDE.md`, `GEMINI.md` — **only when they sit directly at the bundle root**. The same filename in a subdirectory (e.g. `projects/acme-app/README.md`) is a legitimate concept document and is still validated.
+
 **`kb lint` severity levels:**
 
 - `error`: missing required field, invalid enum value, or YAML parse failure. Blocks CI.

--- a/src/data_olympus/format/lint.py
+++ b/src/data_olympus/format/lint.py
@@ -7,18 +7,47 @@ from pathlib import Path
 from .document import Document
 from .validate import Finding, validate_document
 
+# Directories whose contents are never KB concepts.  Kept in sync with
+# _EXCLUDED_DIR_NAMES in src/data_olympus/index.py — if you add entries
+# there, add them here too (and vice-versa).
 _SKIP_DIRS = frozenset({
-    ".git", "__pycache__", ".venv", ".pytest_cache", ".ruff_cache", "node_modules"
+    # VCS / tooling
+    ".git", "__pycache__", ".venv", ".pytest_cache", ".mypy_cache",
+    ".ruff_cache", "node_modules",
+    # Repo-meta / CI
+    ".github", ".worktrees",
+    # Archival and scratch
+    "archive", "_archive", "to-delete",
+    # Test data (fixture trees contain intentional duplicates)
+    "test-fixtures", "cli-fixtures",
+})
+
+# Well-known repo-meta files that may live at the bundle root without being KB
+# concepts.  Only files DIRECTLY under the bundle root are skipped; the same
+# filename nested inside any subdirectory is a legitimate concept document and
+# MUST still be validated (e.g. projects/acme-app/README.md is a project doc).
+_ROOT_META_FILES = frozenset({
+    "README.md", "CONTRIBUTING.md", "CODE_OF_CONDUCT.md", "SECURITY.md",
+    "CHANGELOG.md", "NOTICE.md", "LICENSE.md", "AGENTS.md", "CLAUDE.md",
+    "GEMINI.md",
 })
 
 
 def lint_bundle(root: str | Path) -> dict[Path, list[Finding]]:
     """Validate every '*.md' under root. Returns {path: findings} for any
-    file that produced at least one finding. Skips VCS/vendor directories."""
+    file that produced at least one finding.
+
+    Skipped:
+    - Files inside vendor/VCS/archival/meta directories (_SKIP_DIRS).
+    - Well-known repo-meta filenames that sit DIRECTLY at the bundle root
+      (_ROOT_META_FILES).  The same filename in a subdirectory is NOT skipped.
+    """
     root = Path(root)
     results: dict[Path, list[Finding]] = {}
     for md in sorted(root.rglob("*.md")):
         if any(part in _SKIP_DIRS for part in md.parts):
+            continue
+        if md.parent == root and md.name in _ROOT_META_FILES:
             continue
         findings = validate_document(Document.load(md))
         if findings:

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -36,3 +36,99 @@ def test_lint_bundle_skips_dot_and_vendor_dirs(tmp_path: Path):
     (hidden / "COMMIT_EDITMSG.md").write_text("---\n- bad\n---\n", encoding="utf-8")
     results = lint_bundle(tmp_path)
     assert all(".git" not in p.parts for p in results)
+
+
+# ---------------------------------------------------------------------------
+# Repo-meta directory and root-level file skipping
+# ---------------------------------------------------------------------------
+
+_BAD_MD = "# no frontmatter at all\n"
+_GOOD_FM = (
+    "---\nid: A-1\ntype: standard\nstatus: active\ntier: T1\n"
+    "title: t\ndescription: d\ntags: [x]\ntimestamp: 2026-01-01\n---\nok\n"
+)
+
+
+def test_lint_bundle_skips_archive_dir(tmp_path: Path):
+    """Files under 'archive/' are not concept docs and must produce zero findings."""
+    archive = tmp_path / "archive"
+    archive.mkdir()
+    (archive / "old.md").write_text(_BAD_MD, encoding="utf-8")
+    results = lint_bundle(tmp_path)
+    assert (archive / "old.md") not in results
+
+
+def test_lint_bundle_skips_dot_github_dir(tmp_path: Path):
+    """Files under '.github/' are repo-meta and must produce zero findings."""
+    gh = tmp_path / ".github"
+    gh.mkdir()
+    (gh / "CODEOWNERS.md").write_text(_BAD_MD, encoding="utf-8")
+    results = lint_bundle(tmp_path)
+    assert (gh / "CODEOWNERS.md") not in results
+
+
+def test_lint_bundle_skips_root_meta_files(tmp_path: Path):
+    """Well-known root-level repo-meta files must be skipped entirely."""
+    root_meta_names = [
+        "README.md",
+        "CONTRIBUTING.md",
+        "CODE_OF_CONDUCT.md",
+        "SECURITY.md",
+        "CHANGELOG.md",
+        "NOTICE.md",
+        "LICENSE.md",
+        "AGENTS.md",
+        "CLAUDE.md",
+        "GEMINI.md",
+    ]
+    for name in root_meta_names:
+        (tmp_path / name).write_text(_BAD_MD, encoding="utf-8")
+
+    results = lint_bundle(tmp_path)
+
+    for name in root_meta_names:
+        assert (tmp_path / name) not in results, f"Expected {name} to be skipped at root"
+
+
+def test_lint_bundle_root_readme_skipped_but_nested_readme_still_flagged(tmp_path: Path):
+    """Root README.md is skipped; a nested projects/p/README.md without frontmatter is flagged."""
+    # Root-level README: no frontmatter -> should be SKIPPED
+    (tmp_path / "README.md").write_text(_BAD_MD, encoding="utf-8")
+
+    # Nested README in a project dir: no frontmatter -> must still be FLAGGED
+    nested = tmp_path / "projects" / "p"
+    nested.mkdir(parents=True)
+    (nested / "README.md").write_text(_BAD_MD, encoding="utf-8")
+
+    results = lint_bundle(tmp_path)
+
+    assert (tmp_path / "README.md") not in results, "Root README.md must be skipped"
+    assert (nested / "README.md") in results, "Nested projects/p/README.md must still be flagged"
+
+
+def test_lint_bundle_normal_nonconformant_concept_still_flagged(tmp_path: Path):
+    """A non-conformant concept doc outside any skip path is still reported as an error."""
+    concept_dir = tmp_path / "universal" / "foundation"
+    concept_dir.mkdir(parents=True)
+    (concept_dir / "STD-MISSING.md").write_text("# no frontmatter\n", encoding="utf-8")
+
+    results = lint_bundle(tmp_path)
+
+    assert (concept_dir / "STD-MISSING.md") in results
+    errors = [f for f in results[concept_dir / "STD-MISSING.md"] if f.severity == "error"]
+    assert errors, "Expected at least one error finding for missing required fields"
+
+
+def test_lint_bundle_archive_and_github_zero_findings_combined(tmp_path: Path):
+    """archive/, _archive/, and .github/ together contribute zero findings."""
+    for dir_name in ("archive", "_archive", ".github"):
+        d = tmp_path / dir_name
+        d.mkdir()
+        (d / "x.md").write_text(_BAD_MD, encoding="utf-8")
+
+    results = lint_bundle(tmp_path)
+
+    skipped_dirs = {"archive", "_archive", ".github"}
+    for path in results:
+        for part in path.parts:
+            assert part not in skipped_dirs, f"Unexpected finding under skipped dir: {path}"


### PR DESCRIPTION
## Summary

- Expands `_SKIP_DIRS` in `lint.py` to align with the indexer's `_EXCLUDED_DIR_NAMES`: adds `.github`, `.worktrees`, `archive`, `_archive`, `to-delete`, `.mypy_cache`, `test-fixtures`, `cli-fixtures` alongside the existing VCS/vendor entries.
- Adds `_ROOT_META_FILES` constant (`README.md`, `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `SECURITY.md`, `CHANGELOG.md`, `NOTICE.md`, `LICENSE.md`, `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`). `lint_bundle()` skips these **only when they sit directly at the bundle root** (`md.parent == root`). The same filename in any subdirectory (e.g. `projects/acme-app/README.md`) is still validated.
- Documents both skip categories in `SPEC.md` section 9.
- Adds 6 new tests (267 total, up from 261).

## Test plan

- [x] `uv run pytest tests/test_lint.py -v` — all 9 lint tests pass (3 existing + 6 new)
- [x] `uv run pytest` — 267 passed, 0 failed
- [x] `uv run ruff check .` — all checks passed
- [x] `uv run data-olympus lint example-bundle` — 0 errors across 0 files

🤖 Generated with [Claude Code](https://claude.com/claude-code)