### PR TITLE
fix(lint): fail loud on empty discovery instead of false-greening the dogfood gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- `data-olympus lint` no longer false-greens when its file discovery matches nothing. The summary now reports how many concept files were actually linted (e.g. `0 errors across 0 files (9 linted)`), and the command exits non-zero when a bundle has no concept files to lint, so a broken or over-broad skip walk surfaces as a red CI gate instead of a silent pass. Reserved files (`index.md`, `log.md`, `template.md`) are exempt from the concept schema and so are excluded from the linted count, preventing a bundle that kept only its generated indexes from passing the guard. File discovery is now exposed as `discover_bundle_files` for direct testing.
+
 ## [0.1.0] - 2026-06-24
 
 ### Added

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -74,14 +74,18 @@ and is described in `SPEC.md`, but you can adapt it to your context.
 uv run data-olympus lint <your-bundle-dir>
 ```
 
-Expected output when the bundle is conformant:
+Expected output when the bundle is conformant (the trailing count is how many
+concept files were linted; `N` is the number of concept docs in your bundle):
 
 ```
-0 errors across 0 files
+0 errors across 0 files (N linted)
 ```
 
 The linter checks required frontmatter fields, controlled-vocabulary values,
 and reserved-file constraints. Fix any reported errors before proceeding.
+`lint` exits non-zero when it finds no concept files to lint (for example, an
+empty or mis-pathed bundle), so a clean pass always means real files were
+checked.
 
 ## 4. Generate navigation and graph
 

--- a/src/data_olympus/cli/main.py
+++ b/src/data_olympus/cli/main.py
@@ -7,7 +7,7 @@ import sys
 from pathlib import Path
 
 from data_olympus.cli.indexgen import regenerate_indexes
-from data_olympus.format import lint_bundle
+from data_olympus.format import discover_bundle_files, lint_files
 from data_olympus.viewer.generator import generate_visualization
 
 
@@ -21,7 +21,12 @@ def _require_dir(path: str) -> bool:
 def _cmd_lint(args: argparse.Namespace) -> int:
     if not _require_dir(args.path):
         return 1
-    results = lint_bundle(Path(args.path))
+    root = Path(args.path)
+    linted = discover_bundle_files(root)
+    if not linted:
+        print(f"error: no concept files to lint under {root}", file=sys.stderr)
+        return 1
+    results = lint_files(linted)
     error_files = 0
     total_errors = 0
     for path in sorted(results):
@@ -33,7 +38,7 @@ def _cmd_lint(args: argparse.Namespace) -> int:
         total_errors += len(errors)
         for f in errors + warnings:
             print(f"{path}: {f.severity}: {f.field}: {f.message}")
-    print(f"{total_errors} errors across {error_files} files")
+    print(f"{total_errors} errors across {error_files} files ({len(linted)} linted)")
     return 1 if total_errors else 0
 
 

--- a/src/data_olympus/format/__init__.py
+++ b/src/data_olympus/format/__init__.py
@@ -2,7 +2,7 @@
 
 from .document import Document
 from .frontmatter import parse_frontmatter
-from .lint import lint_bundle
+from .lint import discover_bundle_files, lint_bundle, lint_files
 from .validate import Finding, validate_document
 
 __all__ = [
@@ -11,4 +11,6 @@ __all__ = [
     "parse_frontmatter",
     "validate_document",
     "lint_bundle",
+    "discover_bundle_files",
+    "lint_files",
 ]

--- a/src/data_olympus/format/lint.py
+++ b/src/data_olympus/format/lint.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from .document import Document
-from .validate import Finding, validate_document
+from .validate import RESERVED, Finding, validate_document
 
 # Directories whose contents are never KB concepts.  Kept in sync with
 # _EXCLUDED_DIR_NAMES in src/data_olympus/index.py — if you add entries
@@ -33,23 +33,56 @@ _ROOT_META_FILES = frozenset({
 })
 
 
-def lint_bundle(root: str | Path) -> dict[Path, list[Finding]]:
-    """Validate every '*.md' under root. Returns {path: findings} for any
-    file that produced at least one finding.
+def discover_bundle_files(root: str | Path) -> list[Path]:
+    """Return the sorted '*.md' files under root that are subject to concept
+    linting, i.e. everything `lint_bundle` would validate.
 
-    Skipped:
+    This is the single source of truth for which files a bundle lints. The CLI
+    uses the length of this list to report how many files were actually linted
+    and to fail when a bundle has no concepts to lint (otherwise a broken walk
+    would silently pass as "0 errors across 0 files").
+
+    Returns only files subject to the concept schema. Skipped:
     - Files inside vendor/VCS/archival/meta directories (_SKIP_DIRS).
     - Well-known repo-meta filenames that sit DIRECTLY at the bundle root
       (_ROOT_META_FILES).  The same filename in a subdirectory is NOT skipped.
+    - Reserved filenames (`index.md`, `log.md`, `template.md`), which
+      `validate_document` exempts from the concept schema and so can never
+      produce a finding.  Counting them as "linted" would let a bundle that has
+      lost all its concept docs but kept its generated indexes still pass the
+      zero-file guard.
     """
     root = Path(root)
-    results: dict[Path, list[Finding]] = {}
+    files: list[Path] = []
     for md in sorted(root.rglob("*.md")):
         if any(part in _SKIP_DIRS for part in md.parts):
             continue
         if md.parent == root and md.name in _ROOT_META_FILES:
             continue
+        if md.name in RESERVED:
+            continue
+        files.append(md)
+    return files
+
+
+def lint_files(files: list[Path]) -> dict[Path, list[Finding]]:
+    """Validate an already-discovered list of concept files. Returns {path:
+    findings} for any file that produced at least one finding.
+
+    Pair with `discover_bundle_files` to lint a bundle in a single traversal."""
+    results: dict[Path, list[Finding]] = {}
+    for md in files:
         findings = validate_document(Document.load(md))
         if findings:
             results[md] = findings
     return results
+
+
+def lint_bundle(root: str | Path) -> dict[Path, list[Finding]]:
+    """Validate every concept '*.md' under root. Returns {path: findings} for any
+    file that produced at least one finding.
+
+    File discovery (which files are validated vs skipped) is delegated to
+    `discover_bundle_files`.
+    """
+    return lint_files(discover_bundle_files(root))

--- a/tests/test_cli_lint.py
+++ b/tests/test_cli_lint.py
@@ -26,3 +26,50 @@ def test_lint_returns_one_and_reports_errors(tmp_path, capsys):
     assert code == 1
     assert "bad.md" in out
     assert "missing required field 'id'" in out
+
+
+def test_lint_reports_number_of_files_linted(tmp_path, capsys):
+    # The summary must state how many files were actually linted so that
+    # "0 errors across 0 files" can never be confused with "nothing linted".
+    _write(
+        tmp_path / "universal/foundation/STD-U-001.md",
+        "---\nid: STD-U-001\ntype: standard\nstatus: active\ntier: T1\n"
+        "title: t\ndescription: d\ntags: [x]\ntimestamp: 2026-01-01\n---\nok\n",
+    )
+    code = main(["lint", str(tmp_path)])
+    out = capsys.readouterr().out
+    assert code == 0
+    assert "1 linted" in out
+
+
+def test_lint_fails_when_no_files_to_lint(tmp_path, capsys):
+    # An empty bundle must NOT false-green: the gate exits non-zero so a broken
+    # walk surfaces as red instead of "0 errors across 0 files".
+    code = main(["lint", str(tmp_path)])
+    err = capsys.readouterr().err
+    assert code == 1
+    assert "no" in err.lower()
+
+
+def test_lint_fails_when_every_file_is_skipped(tmp_path, capsys):
+    # Files exist on disk but all are skipped (root meta + repo-meta dir). The
+    # CLI must still fail rather than report a misleading clean pass.
+    _write(tmp_path / "README.md", "# root meta, skipped\n")
+    _write(tmp_path / ".github/CODEOWNERS.md", "# repo meta, skipped\n")
+    code = main(["lint", str(tmp_path)])
+    err = capsys.readouterr().err
+    assert code == 1
+    assert "no" in err.lower()
+
+
+def test_lint_fails_when_only_reserved_files(tmp_path, capsys):
+    # A bundle with only reserved files (index.md/log.md) validates zero
+    # concepts; counting them as "linted" would let it false-green, so the gate
+    # must fail instead.
+    _write(tmp_path / "index.md", "# generated index\n")
+    _write(tmp_path / "decisions/index.md", "# generated index\n")
+    _write(tmp_path / "log.md", "# log\n")
+    code = main(["lint", str(tmp_path)])
+    err = capsys.readouterr().err
+    assert code == 1
+    assert "no" in err.lower()

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
-from data_olympus.format import lint_bundle
+from data_olympus.format import discover_bundle_files, lint_bundle
+from data_olympus.format.validate import RESERVED
 
 
 def test_lint_bundle_reports_only_nonconformant_files(tmp_path: Path):
@@ -132,3 +133,84 @@ def test_lint_bundle_archive_and_github_zero_findings_combined(tmp_path: Path):
     for path in results:
         for part in path.parts:
             assert part not in skipped_dirs, f"Unexpected finding under skipped dir: {path}"
+
+
+# ---------------------------------------------------------------------------
+# File discovery (the count that proves the gate actually linted something)
+# ---------------------------------------------------------------------------
+
+
+def _repo_example_bundle() -> Path:
+    """The shipped example-bundle that the CI dogfood step lints."""
+    return Path(__file__).resolve().parents[1] / "example-bundle"
+
+
+def test_discover_bundle_files_returns_every_concept_file(tmp_path: Path):
+    (tmp_path / "a.md").write_text(_GOOD_FM, encoding="utf-8")
+    nested = tmp_path / "universal" / "foundation"
+    nested.mkdir(parents=True)
+    (nested / "b.md").write_text(_GOOD_FM, encoding="utf-8")
+
+    files = discover_bundle_files(tmp_path)
+
+    assert set(files) == {tmp_path / "a.md", nested / "b.md"}
+
+
+def test_discover_bundle_files_applies_skip_logic(tmp_path: Path):
+    (tmp_path / "keep.md").write_text(_GOOD_FM, encoding="utf-8")
+    (tmp_path / "README.md").write_text(_GOOD_FM, encoding="utf-8")  # root meta -> skipped
+    archive = tmp_path / "archive"
+    archive.mkdir()
+    (archive / "old.md").write_text(_GOOD_FM, encoding="utf-8")  # skip dir
+
+    assert discover_bundle_files(tmp_path) == [tmp_path / "keep.md"]
+
+
+def test_discover_bundle_files_empty_when_nothing_to_lint(tmp_path: Path):
+    # Files exist on disk but every one is skipped: discovery must report zero
+    # so the CLI can fail instead of false-greening.
+    (tmp_path / "README.md").write_text(_GOOD_FM, encoding="utf-8")
+    gh = tmp_path / ".github"
+    gh.mkdir()
+    (gh / "CODEOWNERS.md").write_text(_GOOD_FM, encoding="utf-8")
+
+    assert discover_bundle_files(tmp_path) == []
+
+
+def test_discover_bundle_files_excludes_reserved_files(tmp_path: Path):
+    # Reserved files are exempt from the concept schema and can never produce a
+    # finding, so they must not be counted as lintable; a concept doc beside
+    # them must still be discovered.
+    (tmp_path / "index.md").write_text("# generated index\n", encoding="utf-8")
+    (tmp_path / "log.md").write_text("# log\n", encoding="utf-8")
+    (tmp_path / "STD-A.md").write_text(_GOOD_FM, encoding="utf-8")
+
+    assert discover_bundle_files(tmp_path) == [tmp_path / "STD-A.md"]
+
+
+def test_example_bundle_discovery_matches_concept_files():
+    """Regression for the false-green CI gate: linting the shipped example-bundle
+    must discover every concept file and nothing reserved. The bundle has no
+    skip-dirs and no root-meta files, so discovery == all '*.md' minus reserved
+    names. If the skip/path logic ever silently swallows the subtree, the count
+    drops to zero and this fails loudly instead of passing as '0 errors across
+    0 files'.
+    """
+    bundle = _repo_example_bundle()
+    files = discover_bundle_files(bundle)
+    expected = [p for p in sorted(bundle.rglob("*.md")) if p.name not in RESERVED]
+
+    assert files == expected
+    assert len(files) > 0, "example-bundle discovery matched zero concept files"
+    assert all(p.name not in RESERVED for p in files)
+
+
+def test_example_bundle_is_conformant():
+    """The shipped example-bundle must stay schema-conformant (zero error-severity
+    findings) so the dogfood gate is green for the right reason, not because the
+    walk found nothing.
+    """
+    bundle = _repo_example_bundle()
+    results = lint_bundle(bundle)
+    errors = [f for findings in results.values() for f in findings if f.severity == "error"]
+    assert errors == [], f"example-bundle is not conformant: {errors}"


### PR DESCRIPTION
## Problem

The CI dogfood gate `uv run data-olympus lint example-bundle` printed `0 errors across 0 files` and exited 0 even though the bundle has 18 markdown files. The reported symptom was a false-green: the gate could pass without linting anything.

## Root cause (the original hypothesis was wrong)

The walk was **not** broken. `lint example-bundle` discovers and validates all files, and injecting an invalid `type:` makes it report `1 errors across 1 files` and exit 1. The bundle is genuinely conformant.

The real defect was unverifiable assurance: `lint_bundle` returned only files *with* findings, and the CLI printed `error_files` (files *with errors*) as the denominator. So a conformant bundle's output (`0 errors across 0 files`) was textually identical to what a genuinely broken or empty discovery would print, and both exited 0. Nothing in the output, exit code, or tests distinguished "linted everything, all green" from "linted nothing", so a future discovery regression would have passed silently.

(For the record: `tests/test_lint.py` was not deleted on main; it exists and was expanded in #14.)

## Fix

- Expose `discover_bundle_files(root) -> list[Path]` as the single source of truth for the walk+skip. It also excludes reserved files (`index.md`, `log.md`, `template.md`), which the concept schema exempts and which can never produce a finding, so a bundle that kept only its generated indexes cannot satisfy the guard.
- Add `lint_files(files)` to validate an already-discovered list; `lint_bundle(root) = lint_files(discover_bundle_files(root))` (one traversal, no count/results TOCTOU).
- CLI now reports the concept-file count (`0 errors across 0 files (N linted)`) and **exits non-zero when no concept files are discovered**, so a broken or over-broad skip walk surfaces as a red CI gate.
- Regression tests: non-zero discovery for the real `example-bundle`, reserved-file exclusion, and the empty / reserved-only exit-1 guard.
- Updated `docs/adoption.md` and `CHANGELOG.md [Unreleased]`.

## Verification

- `ruff check .` clean
- `pytest` = 277 passed
- `data-olympus lint example-bundle` = `0 errors across 0 files (9 linted)` exit 0 (9 concept docs; the 9 reserved index/log files are excluded)
- empty / reserved-only bundle = `error: no concept files to lint under <dir>` exit 1
- TDD red-green verified for each new guard

## Review

Companion-reviewed by Codex. It caught a blocker (reserved files were initially counted as linted, leaving a residual false-green for index-only bundles), which is fixed here; final verdict APPROVE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
