### PR TITLE
fix(kb): send base_commit on propose edit and harden write path

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,5 +13,9 @@ jobs:
       - run: uv pip install -e '.[dev]'
       - run: uv run ruff check .
       - run: uv run pytest -v
+      - name: Install bats + jq (CLI contract tests)
+        run: sudo apt-get update && sudo apt-get install -y bats jq
+      - name: bin/kb CLI tests (bats)
+        run: bats -r tests
       - name: Lint example bundle (dogfood conformance check)
         run: uv run data-olympus lint example-bundle

--- a/bin/kb
+++ b/bin/kb
@@ -110,9 +110,13 @@ do_curl_post() {
   if [[ -n "$KB_AUTH_TOKEN" ]]; then
     auth_k_arg=(-K <(printf 'header = "Authorization: Bearer %s"\n' "$KB_AUTH_TOKEN"))
   fi
+  # NOTE: expand auth_k_arg with the ${arr[@]+"${arr[@]}"} idiom, not a bare
+  # "${arr[@]}". Under `set -u`, expanding an EMPTY array as "${arr[@]}" aborts
+  # with "unbound variable" on bash < 4.4 (incl. macOS's system bash 3.2). The
+  # idiom expands to nothing when the array is empty and is safe on all bashes.
   if REST_STATUS=$(curl --silent --max-time 10 \
       -H "Content-Type: application/json" \
-      "${auth_k_arg[@]}" \
+      ${auth_k_arg[@]+"${auth_k_arg[@]}"} \
       --data "$body" \
       --output "$tmpfile" --write-out "%{http_code}" \
       -X POST "$url" 2>/dev/null); then
@@ -122,6 +126,23 @@ do_curl_post() {
   fi
   rm -f "$tmpfile"
   return 1
+}
+
+# Helper: fetch the KB's current commit from /api/v1/health, to use as the
+# base_commit of an edit proposal. Echoes the sha on success, empty on failure.
+# Writes never fall back to another endpoint, so this targets the primary
+# $KB_ENDPOINT only (consistent with the rest of the write path). Defined here,
+# before the write-subcommand dispatch, because the GET-side do_curl helper is
+# defined later in the file and is not yet available when cmd_propose_edit runs.
+kb_fetch_base_commit() {
+  local tmpfile sha=""
+  tmpfile=$(mktemp)
+  if curl --silent --max-time 10 --output "$tmpfile" \
+       "$KB_ENDPOINT/api/v1/health" 2>/dev/null; then
+    sha=$(jq -r '.kb_commit // ""' < "$tmpfile" 2>/dev/null) || sha=""
+  fi
+  rm -f "$tmpfile"
+  printf '%s' "$sha"
 }
 
 # Helper: interactive resolve flow per spec §2.5. Prompts the operator for
@@ -180,6 +201,15 @@ interactive_resolve() {
 # propose edit since the response schema is identical.
 handle_propose_response() {
   local non_interactive="$1"
+  # Guard: the response must be a JSON OBJECT. A plain-text 5xx ("Internal
+  # Server Error"), an empty body, or any non-object JSON would otherwise be
+  # piped to jq below and abort the script with an opaque "jq: parse error".
+  # Surface a clean, actionable diagnostic with the HTTP status and raw body
+  # instead. (Valid object bodies, including 4xx rejected_* responses, pass.)
+  if ! echo "$REST_BODY" | jq -e 'type == "object"' >/dev/null 2>&1; then
+    echo "kb: server error ${REST_STATUS:-?}: ${REST_BODY:-<empty response>}" >&2
+    exit 1
+  fi
   local status pid proposal
   status=$(echo "$REST_BODY" | jq -r '.status // ""')
   case "$status" in
@@ -260,15 +290,29 @@ cmd_propose_edit() {
   [[ -r "$postfile" ]] || { echo "kb: cannot read postimage file: $postfile" >&2; exit 64; }
   local postimage
   postimage=$(cat "$postfile")
+  # The server REQUIRES base_commit on /api/v1/propose/edit. We send the KB's
+  # current commit (from /api/v1/health). NOTE: this is the server's HEAD at
+  # submit time, not necessarily the commit the postimage was diffed against;
+  # the server stores it but does not yet enforce a stale-edit (CAS) check on
+  # resolve, so this satisfies the contract without guaranteeing conflict
+  # detection. base_blob_sha / target_file_hash are optional server-side (treated
+  # as None when absent), so they are intentionally omitted.
+  local base_commit
+  base_commit=$(kb_fetch_base_commit)
+  if [[ -z "$base_commit" ]]; then
+    echo "kb: could not determine base_commit (GET $KB_ENDPOINT/api/v1/health failed or returned no kb_commit)" >&2
+    exit 1
+  fi
   local body
   body=$(jq -n \
     --arg target "$target" \
     --arg post "$postimage" \
+    --arg base "$base_commit" \
     --arg reason "$reason" \
     --arg session "${USER:-cli}" \
     --arg agent "operator-cli" \
     --arg conf "$confidence" \
-    '{target_path: $target, postimage: $post, reason: $reason, source_session: $session, agent_identity: $agent, confidence: ($conf | tonumber)}')
+    '{target_path: $target, postimage: $post, base_commit: $base, reason: $reason, source_session: $session, agent_identity: $agent, confidence: ($conf | tonumber)}')
   if ! do_curl_post "$KB_ENDPOINT/api/v1/propose/edit" "$body"; then
     echo "kb: data-olympus-mcp unreachable at $KB_ENDPOINT" >&2; exit 1
   fi

--- a/src/data_olympus/rest_api.py
+++ b/src/data_olympus/rest_api.py
@@ -69,6 +69,47 @@ def _check_auth(request: Request, auth_token: str) -> JSONResponse | None:
     return None
 
 
+def _missing_fields_response(body: object, required: list[str]) -> JSONResponse | None:
+    """Return a 400 JSONResponse naming the missing/null required field(s), or
+    None when all are present and non-null.
+
+    Without this guard a missing field raised KeyError inside the handler,
+    surfacing as a plain-text HTTP 500 "Internal Server Error". The kb CLI fed
+    that non-JSON body to jq and aborted with a parse error, so a client that
+    forgot a field got an opaque crash instead of an actionable 400. An explicit
+    JSON null is treated the same as absent, since the handlers would otherwise
+    pass None straight into the write functions.
+    """
+    if not isinstance(body, dict):
+        return JSONResponse(
+            {"error": "bad_request", "message": "request body must be a JSON object"},
+            status_code=400,
+        )
+    missing = [f for f in required if body.get(f) is None]
+    if missing:
+        return JSONResponse(
+            {"error": "missing_field",
+             "message": f"missing or null required field(s): {', '.join(missing)}"},
+            status_code=400,
+        )
+    return None
+
+
+def _parse_confidence(body: dict) -> tuple[float, JSONResponse | None]:
+    """Coerce body['confidence'] to float, returning a 400 JSONResponse instead
+    of letting a non-numeric value raise ValueError/TypeError -> HTTP 500 (the
+    same opaque-crash class as a missing field). Presence/non-null is enforced
+    separately by _missing_fields_response, so the key is assumed present here.
+    """
+    try:
+        return float(body["confidence"]), None
+    except (TypeError, ValueError):
+        return 0.0, JSONResponse(
+            {"error": "bad_request", "message": "confidence must be a number"},
+            status_code=400,
+        )
+
+
 def register_routes(app: FastMCP, state: ServerState, auth_token: str = "") -> None:
     """Mount REST routes under /api/v1/ on the FastMCP app.
 
@@ -138,6 +179,13 @@ def register_routes(app: FastMCP, state: ServerState, auth_token: str = "") -> N
         if (denied := _check_auth(request, auth_token)) is not None:
             return denied
         body = await request.json()
+        if (bad := _missing_fields_response(
+            body, ["text", "source_session", "agent_identity", "confidence"],
+        )) is not None:
+            return bad
+        confidence, bad = _parse_confidence(body)
+        if bad is not None:
+            return bad
         assert state.worktrees is not None
         assert state.push_queue is not None
         assert state.pending is not None
@@ -148,7 +196,7 @@ def register_routes(app: FastMCP, state: ServerState, auth_token: str = "") -> N
             text=body["text"], tags=body.get("tags", []),
             source_session=body["source_session"],
             agent_identity=body["agent_identity"],
-            confidence=float(body["confidence"]),
+            confidence=confidence,
             confidence_threshold=state.config.confidence_threshold,
             worktrees=state.worktrees, push_queue=state.push_queue,
             pending=state.pending, rate_limiter=state.rate_limiter,
@@ -166,6 +214,15 @@ def register_routes(app: FastMCP, state: ServerState, auth_token: str = "") -> N
         if (denied := _check_auth(request, auth_token)) is not None:
             return denied
         body = await request.json()
+        if (bad := _missing_fields_response(
+            body,
+            ["target_path", "postimage", "base_commit",
+             "source_session", "agent_identity", "confidence"],
+        )) is not None:
+            return bad
+        confidence, bad = _parse_confidence(body)
+        if bad is not None:
+            return bad
         assert state.worktrees is not None
         assert state.push_queue is not None
         assert state.pending is not None
@@ -180,7 +237,7 @@ def register_routes(app: FastMCP, state: ServerState, auth_token: str = "") -> N
             reason=body.get("reason", ""),
             source_session=body["source_session"],
             agent_identity=body["agent_identity"],
-            confidence=float(body["confidence"]),
+            confidence=confidence,
             confidence_threshold=state.config.confidence_threshold,
             worktrees=state.worktrees, push_queue=state.push_queue,
             pending=state.pending, rate_limiter=state.rate_limiter,

--- a/tests/bats/onboarding.bats
+++ b/tests/bats/onboarding.bats
@@ -5,7 +5,10 @@
 #   state="absent"    for any other workspace
 
 setup_file() {
-  REPO_ROOT="$(cd "$(dirname "${BATS_TEST_FILENAME}")/../../.." && pwd)"
+  # This file lives at tests/bats/, two levels below the repo root, so the root
+  # is dir/../.. (the original `../../..` resolved outside the repo; see the
+  # note in tests/test_kb_cli_write.bats).
+  REPO_ROOT="$(cd "$(dirname "${BATS_TEST_FILENAME}")/../.." && pwd)"
   export REPO_ROOT
   export FIXTURE_DIR="${BATS_TEST_FILENAME%/*}/../cli-fixtures"
   export KB="${REPO_ROOT}/bin/kb"

--- a/tests/cli-fixtures/mock-server.py
+++ b/tests/cli-fixtures/mock-server.py
@@ -153,7 +153,39 @@ class Handler(BaseHTTPRequestHandler):
             body = json.loads(raw) if raw else {}
         except json.JSONDecodeError:
             body = {}
-        if path in ("/api/v1/propose/memory", "/api/v1/propose/edit"):
+        if path == "/api/v1/propose/edit" and body.get("target_path") == "trigger/server-error.md":
+            # Plain-text 5xx, mimicking the real server's unhandled-KeyError 500.
+            # Exercises the CLI's graceful non-JSON error handling (must not feed
+            # this body to jq and abort with a parse error).
+            self._send(500, "Internal Server Error")
+        elif path == "/api/v1/propose/edit" and not body.get("base_commit"):
+            # Contract: propose/edit REQUIRES base_commit. The real server 500s
+            # without it; here we return a clean 400 so the bats suite asserts
+            # the CLI actually sends base_commit (regression guard for the bug
+            # where cmd_propose_edit omitted it).
+            self._send(
+                400,
+                json.dumps(
+                    {
+                        "status": "rejected_missing_base_commit",
+                        "reason": "base_commit is required",
+                    }
+                ),
+            )
+        elif path == "/api/v1/propose/edit" and body.get("base_commit") != "abc1234":
+            # Value check: health-ok.json exposes kb_commit="abc1234", so a
+            # correct CLI must fetch /health and send THAT exact value (not a
+            # hardcoded "HEAD" or stale string). Guards presence != value.
+            self._send(
+                400,
+                json.dumps(
+                    {
+                        "status": "rejected_wrong_base_commit",
+                        "reason": "base_commit must equal the KB head (abc1234)",
+                    }
+                ),
+            )
+        elif path in ("/api/v1/propose/memory", "/api/v1/propose/edit"):
             confidence = float(body.get("confidence", 0.0))
             if confidence >= 0.85:
                 self._send(

--- a/tests/test_kb_cli.bats
+++ b/tests/test_kb_cli.bats
@@ -2,7 +2,9 @@
 # bats tests for bin/kb. Spins up a mock REST server on a free port per test.
 
 setup_file() {
-  REPO_ROOT="$(cd "$(dirname "${BATS_TEST_FILENAME}")/../../.." && pwd)"
+  # tests/ sits ONE level below the repo root in this repo (see note in
+  # test_kb_cli_write.bats); the original `../../..` resolved to $HOME here.
+  REPO_ROOT="$(cd "$(dirname "${BATS_TEST_FILENAME}")/.." && pwd)"
   export REPO_ROOT
   export FIXTURE_DIR="${BATS_TEST_FILENAME%/*}/cli-fixtures"
   export KB="${REPO_ROOT}/bin/kb"

--- a/tests/test_kb_cli_write.bats
+++ b/tests/test_kb_cli_write.bats
@@ -4,7 +4,11 @@
 # routes (propose/resolve) and the new GET routes (pending/audit).
 
 setup_file() {
-  REPO_ROOT="$(cd "$(dirname "${BATS_TEST_FILENAME}")/../../.." && pwd)"
+  # tests/ sits ONE level below the repo root in this repo, so the root is the
+  # parent of the bats file's directory. (The original `../../..` was carried
+  # over from the company-knowledge layout where these lived under
+  # tools/data-olympus-mcp/tests/, and resolved to $HOME here.)
+  REPO_ROOT="$(cd "$(dirname "${BATS_TEST_FILENAME}")/.." && pwd)"
   export REPO_ROOT
   export FIXTURE_DIR="${BATS_TEST_FILENAME%/*}/cli-fixtures"
   export KB="${REPO_ROOT}/bin/kb"
@@ -59,6 +63,35 @@ teardown() {
 @test "kb propose edit missing postimage-file errors" {
   run "$KB" propose edit "universal/foundation/STD-U-001.md" --non-interactive
   [ "$status" -eq 64 ]
+}
+
+@test "kb propose edit sends base_commit (strict mock rejects absent OR wrong value)" {
+  # The mock 400s with rejected_missing_base_commit when base_commit is absent,
+  # and rejected_wrong_base_commit when it != the health commit "abc1234". A
+  # 'Committed' result therefore proves the CLI fetched /api/v1/health and sent
+  # that exact commit as base_commit (guards both presence AND value).
+  tmpfile=$(mktemp -t kb-bats-edit.XXXXXX)
+  echo "edited content" > "$tmpfile"
+  run "$KB" propose edit "universal/foundation/STD-U-001.md" \
+    --postimage-file "$tmpfile" --confidence 0.95 --non-interactive
+  rm -f "$tmpfile"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Committed"* ]]
+  [[ "$output" != *"rejected_missing_base_commit"* ]]
+}
+
+@test "kb propose edit surfaces a non-JSON server error cleanly (no jq crash)" {
+  # Sentinel target makes the mock return a plain-text HTTP 500. The CLI must
+  # print a clean 'server error' diagnostic and exit non-zero, NOT abort by
+  # piping the non-JSON body into jq (the original 'jq: parse error' failure).
+  tmpfile=$(mktemp -t kb-bats-edit.XXXXXX)
+  echo "edited content" > "$tmpfile"
+  run "$KB" propose edit "trigger/server-error.md" \
+    --postimage-file "$tmpfile" --confidence 0.95 --non-interactive
+  rm -f "$tmpfile"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"server error"* ]]
+  [[ "$output" != *"parse error"* ]]
 }
 
 @test "kb resolve approve" {

--- a/tests/test_rest_write.py
+++ b/tests/test_rest_write.py
@@ -76,6 +76,81 @@ async def test_rest_propose_edit_rejects_traversal(http_app) -> None:
 
 
 @pytest.mark.asyncio
+async def test_rest_propose_edit_missing_base_commit_returns_400(http_app) -> None:
+    """A missing required field must yield a clean 400, never a 500/KeyError.
+
+    Regression: the handler accessed body["base_commit"] directly, so a body
+    without it raised KeyError -> HTTP 500 with a plain-text "Internal Server
+    Error" that the kb CLI then fed to jq, aborting with a parse error.
+    """
+    transport = httpx.ASGITransport(app=http_app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post(
+            "/api/v1/propose/edit",
+            json={
+                "target_path": "universal/foundation/STD-U-001.md",
+                "postimage": "x",
+                # base_commit intentionally omitted
+                "reason": "test", "source_session": "s",
+                "agent_identity": "claude", "confidence": 0.9,
+            },
+        )
+    assert resp.status_code == 400
+    body = resp.json()
+    assert "base_commit" in f"{body.get('error', '')} {body.get('message', '')}"
+
+
+@pytest.mark.asyncio
+async def test_rest_propose_edit_null_base_commit_returns_400(http_app) -> None:
+    """An explicit JSON null for a required field is treated as missing -> 400,
+    not passed through as None (which would crash deeper in the write path)."""
+    transport = httpx.ASGITransport(app=http_app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post(
+            "/api/v1/propose/edit",
+            json={"target_path": "universal/foundation/STD-U-001.md",
+                  "postimage": "x", "base_commit": None,
+                  "reason": "t", "source_session": "s",
+                  "agent_identity": "claude", "confidence": 0.9},
+        )
+    assert resp.status_code == 400
+    body = resp.json()
+    assert "base_commit" in f"{body.get('error', '')} {body.get('message', '')}"
+
+
+@pytest.mark.asyncio
+async def test_rest_propose_edit_non_numeric_confidence_returns_400(http_app) -> None:
+    """A non-numeric confidence yields a clean 400, not a 500 from float()."""
+    transport = httpx.ASGITransport(app=http_app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post(
+            "/api/v1/propose/edit",
+            json={"target_path": "universal/foundation/STD-U-001.md",
+                  "postimage": "x", "base_commit": "HEAD",
+                  "reason": "t", "source_session": "s",
+                  "agent_identity": "claude", "confidence": "high"},
+        )
+    assert resp.status_code == 400
+    body = resp.json()
+    assert "confidence" in f"{body.get('error', '')} {body.get('message', '')}"
+
+
+@pytest.mark.asyncio
+async def test_rest_propose_memory_missing_text_returns_400(http_app) -> None:
+    """propose/memory must also 400 (not 500) on a missing required field."""
+    transport = httpx.ASGITransport(app=http_app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post(
+            "/api/v1/propose/memory",
+            json={"tags": [], "source_session": "s",
+                  "agent_identity": "claude", "confidence": 0.9},
+        )
+    assert resp.status_code == 400
+    body = resp.json()
+    assert "text" in f"{body.get('error', '')} {body.get('message', '')}"
+
+
+@pytest.mark.asyncio
 async def test_rest_list_pending_returns_entries(http_app) -> None:
     transport = httpx.ASGITransport(app=http_app)
     async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:


### PR DESCRIPTION
## Problem

`kb propose edit` was completely broken against the live server. It POSTed to
`/api/v1/propose/edit` without `base_commit`, which the server requires
(`body["base_commit"]`). The resulting `KeyError` surfaced as a plain-text
HTTP 500 `Internal Server Error`, which the CLI then piped into `jq`, aborting
with `jq: parse error: Invalid numeric literal at line 1, column 9` (exit 5).
Nothing committed.

While fixing it, two adjacent pre-existing defects in the same write path were
found and fixed (without them the fix can't even be exercised):

1. `do_curl_post` expanded an **empty** array as `"${auth_k_arg[@]}"`, which
   aborts under `set -u` with `unbound variable` on bash < 4.4 (macOS system
   bash 3.2). This broke **every** write command on macOS.
2. The bats `setup_file` `REPO_ROOT` used `../../..` (carried over from the
   old `tools/data-olympus-mcp/tests/` layout in company-knowledge), which
   resolved to `$HOME` here — so the bats suite never exercised the repo's own
   `bin/kb` and could not run in CI.

## Changes

- **`bin/kb`**
  - `cmd_propose_edit` fetches the KB commit from `GET /api/v1/health`
    (`.kb_commit`) and sends it as `base_commit`. `base_blob_sha` /
    `target_file_hash` stay omitted (optional server-side).
  - `handle_propose_response` rejects non-object responses (validated with
    `jq -e 'type == "object"'`) with a clean `kb: server error <code>: <body>`
    instead of crashing in `jq`.
  - `do_curl_post` empty-array `set -u` fix (`${arr[@]+"${arr[@]}"}`).
- **`src/data_olympus/rest_api.py`** — `propose/memory` and `propose/edit`
  return a clean **400** (not 500) on missing/null required fields and on a
  non-numeric `confidence`, via `_missing_fields_response` + `_parse_confidence`.
  `_check_auth` untouched.
- **Tests** — fixed bats `REPO_ROOT` in all three bats files; wired bats into
  CI (`bats -r tests`); added CLI regression tests (sends correct `base_commit`
  value; graceful non-JSON server error) and server tests (missing/null field,
  non-numeric confidence → 400).

## Verification

- `ruff check .` clean; `pytest` 361 passed / 1 skipped (the one
  `test_lint.py::test_example_bundle_discovery_matches_concept_files` failure
  reproduces only inside a git worktree — `discover_bundle_files` returns 0
  there — and passes on a normal checkout / in CI; unrelated to this diff).
- `bats -r tests` 29/29.
- Live against kn-dev: `kb propose edit` and `kb propose memory` now go
  `pending -> rejected` (rc=0), no 500 / no jq crash.
- Companion review (Codex): no blockers; its 2 concerns + 2 nits are addressed
  in this PR (base_commit comment no longer overclaims conflict detection;
  null-field + non-numeric-confidence 400s; `jq` object guard; value-level
  `base_commit` assertion in the bats mock).

## Notes / out of scope

- The deployed `v0.1.1` server needs **no** redeploy for the fix to take
  effect — the CLI now sends the field the server already requires. The 400
  hardening only ships with the next image.
- `discover_bundle_files()` returning 0 under a git worktree is a real
  dev-ergonomics bug (false `test_lint` failure for worktree-based dev) and is
  worth a separate issue.