### PR TITLE
fix(enforce): thread per-agent identity into the consult audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- The enforcement hook now reports the correct per-agent identity to the consult audit. Previously every agent (Claude, Codex, Gemini) was recorded as `claude-code`, so the `kb_compliance` per-agent view was wrong for Codex and Gemini. The `kb-enforce-hook` dispatcher gained an `--agent` flag and each provider threads its own identity.
 - `data-olympus lint` no longer false-greens when its file discovery matches nothing. The summary now reports how many concept files were actually linted (e.g. `0 errors across 0 files (9 linted)`), and the command exits non-zero when a bundle has no concept files to lint, so a broken or over-broad skip walk surfaces as a red CI gate instead of a silent pass. Reserved files (`index.md`, `log.md`, `template.md`) are exempt from the concept schema and so are excluded from the linted count, preventing a bundle that kept only its generated indexes from passing the guard. File discovery is now exposed as `discover_bundle_files` for direct testing.
 
 ## [0.1.0] - 2026-06-24

--- a/bin/_kb_enforce.py
+++ b/bin/_kb_enforce.py
@@ -73,9 +73,11 @@ class HookFileProvider:
         return self._default_target
 
     def _command(self, mode: str) -> str:
-        if self._dialect == "claude":
-            return f"{HOOK_BIN} {mode}"
-        return f"{HOOK_BIN} {mode} --dialect {self._dialect}"
+        # Always thread --agent so the consult audit records the correct
+        # per-agent identity. --dialect is still suppressed for claude (default)
+        # to keep its slice-1 command form.
+        dialect = "" if self._dialect == "claude" else f" --dialect {self._dialect}"
+        return f"{HOOK_BIN} {mode}{dialect} --agent {self.name}"
 
     def _managed_block(self, mode: str, matcher: str | None) -> dict:
         entry = {"type": "command", "command": self._command(mode), MARKER: SHIM_VERSION}

--- a/bin/kb-enforce-hook
+++ b/bin/kb-enforce-hook
@@ -25,9 +25,14 @@ HERE="$(cd "$(dirname "$0")" && pwd)"
 # to its JSON-on-stdout contract.
 shift || true
 DIALECT="claude"
+# AGENT is reported as agent_identity to the consult audit so the per-agent
+# compliance view is correct. The same dispatcher serves claude/codex/gemini, so
+# a hardcoded identity would mis-attribute every non-claude consultation.
+AGENT="unknown"
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --dialect) DIALECT="${2:-claude}"; shift; shift || true ;;
+    --agent) AGENT="${2:-unknown}"; shift; shift || true ;;
     *) shift ;;
   esac
 done
@@ -151,7 +156,7 @@ case "$MODE" in
     WS="$(resolve_workspace "$CWD")"
     BODY="$(python3 -c 'import json,sys
 print(json.dumps({"workspace":sys.argv[1],"intent":sys.argv[2],
-"source_session":sys.argv[3],"agent_identity":"claude-code"}))' "$WS" "$PROMPT" "$SESSION")"
+"source_session":sys.argv[3],"agent_identity":sys.argv[4]}))' "$WS" "$PROMPT" "$SESSION" "$AGENT")"
     # Prompt-rule injection is best-effort and never blocks: any failure
     # (connection error OR non-2xx) just means no injected rules this turn.
     if ! post_json "$KB_ENDPOINT/api/v1/consult" "$BODY" || ! is_2xx "$RESP_CODE"; then

--- a/tests/cli-fixtures/enforce-mock-server.py
+++ b/tests/cli-fixtures/enforce-mock-server.py
@@ -5,6 +5,7 @@
 /api/v1/compliance    -> {"counts": {}, "by_agent": {}}
 """
 import json
+import os
 import sys
 from http.server import BaseHTTPRequestHandler, HTTPServer
 
@@ -31,6 +32,12 @@ class Handler(BaseHTTPRequestHandler):
         length = int(self.headers.get("Content-Length", "0"))
         body = json.loads(self.rfile.read(length) or "{}")
         if self.path == "/api/v1/consult":
+            # When KB_MOCK_CAPTURE_FILE is set, record the raw consult request body
+            # so a test can assert the agent_identity the hook threaded through.
+            capture = os.getenv("KB_MOCK_CAPTURE_FILE")
+            if capture:
+                with open(capture, "w", encoding="utf-8") as fh:
+                    json.dump(body, fh)
             self._send({
                 "is_governed_decision": True,
                 "rules": [{"id": "STD-U-002", "path": "p", "title": "Style",

--- a/tests/test_kb_enforce_codex.py
+++ b/tests/test_kb_enforce_codex.py
@@ -26,6 +26,7 @@ def test_codex_install_writes_pretooluse_and_merges(tmp_path):
     blob = json.dumps(data)
     assert "protect-files.py" in blob  # operator hook preserved
     assert "kb-enforce-hook pre-tool" in blob
+    assert "--agent codex" in blob  # consult audit records codex, not claude-code
     assert "UserPromptSubmit" in data["hooks"]
     assert "trust" in (r.stdout + r.stderr).lower()  # trust note printed
 

--- a/tests/test_kb_enforce_gemini.py
+++ b/tests/test_kb_enforce_gemini.py
@@ -26,6 +26,7 @@ def test_gemini_install_preserves_mcp_and_uses_dialect(tmp_path):
     assert "BeforeTool" in data["hooks"]
     blob = json.dumps(data)
     assert "--dialect gemini" in blob                       # gemini command form
+    assert "--agent gemini" in blob                         # consult audit records gemini
     # BeforeTool gates the mutating tools
     bt = data["hooks"]["BeforeTool"][0]
     assert bt["matcher"] == "write_file|replace|run_shell_command"

--- a/tests/test_kb_enforce_hook.bats
+++ b/tests/test_kb_enforce_hook.bats
@@ -38,6 +38,44 @@ teardown() {
   [[ "$output" == *"STD-U-002"* ]]
 }
 
+@test "user-prompt --agent codex threads agent_identity=codex to the consult body" {
+  # Regression guard for the audit-attribution bug: the hardcoded "claude-code"
+  # in the consult body meant every agent was recorded as claude-code. We capture
+  # the raw consult request body via the mock's KB_MOCK_CAPTURE_FILE hook and
+  # assert the threaded --agent value reaches agent_identity.
+  CAP="${BATS_TEST_TMPDIR}/consult-body.json"
+  # Restart the mock with capture enabled (setup()'s instance has no capture file).
+  kill "$MOCK_PID" 2>/dev/null || true
+  wait "$MOCK_PID" 2>/dev/null || true
+  KB_MOCK_CAPTURE_FILE="$CAP" python3 "${FIXTURE_DIR}/enforce-mock-server.py" "$PORT" &
+  MOCK_PID=$!
+  for _ in $(seq 1 30); do
+    if curl --silent --max-time 0.2 "http://127.0.0.1:${PORT}/api/v1/compliance" >/dev/null 2>&1; then break; fi
+    sleep 0.1
+  done
+
+  run bash -c 'echo "{\"session_id\":\"s1\",\"cwd\":\"/tmp/proj\",\"prompt\":\"add a library\"}" | "'"$HOOK"'" user-prompt --agent codex'
+  [ "$status" -eq 0 ]
+  [ -f "$CAP" ]
+  run python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["agent_identity"])' "$CAP"
+  [ "$output" = "codex" ]
+}
+
+@test "user-prompt with a trailing --agent (no value) does not hang and exits 0" {
+  # set -u + a bad `shift 2` on a trailing flag would hang/error; the guarded
+  # `shift; shift || true` must tolerate a value-less trailing --agent. We bound
+  # the run with a portable background watchdog (macOS has no coreutils timeout).
+  bash -c 'echo "{\"session_id\":\"s1\",\"cwd\":\"/tmp/proj\",\"prompt\":\"add a library\"}" | "'"$HOOK"'" user-prompt --agent' &
+  hook_pid=$!
+  ( sleep 10; kill "$hook_pid" 2>/dev/null ) &
+  watchdog_pid=$!
+  wait "$hook_pid"
+  hook_status=$?
+  kill "$watchdog_pid" 2>/dev/null || true
+  wait "$watchdog_pid" 2>/dev/null || true
+  [ "$hook_status" -eq 0 ]
+}
+
 @test "pre-tool mode blocks (exit 2) when consult_required" {
   run bash -c 'echo "{\"session_id\":\"blockme\",\"cwd\":\"/tmp/proj\",\"tool_name\":\"Edit\",\"tool_input\":{\"file_path\":\"/tmp/proj/pyproject.toml\"}}" | "'"$HOOK"'" pre-tool'
   [ "$status" -eq 2 ]

--- a/tests/test_kb_enforce_registry.py
+++ b/tests/test_kb_enforce_registry.py
@@ -39,3 +39,13 @@ def test_claude_pretooluse_uses_dialect_claude(tmp_path) -> None:
     # Claude commands keep the slice-1 form: "<hook> <mode>" (dialect claude is default, omitted)
     assert "kb-enforce-hook session-start" in blob
     assert "kb-enforce-hook pre-tool" in blob
+
+
+def test_claude_commands_thread_agent_identity(tmp_path) -> None:
+    settings = tmp_path / "settings.json"
+    settings.write_text("{}")
+    _run("install", "--agent", "claude-code", "--settings", str(settings))
+    blob = settings.read_text()
+    # Every generated command carries --agent so the consult audit records the
+    # correct per-agent identity (not a hardcoded "claude-code" for all agents).
+    assert "--agent claude-code" in blob


### PR DESCRIPTION
## Summary

Follow-up to the slice-2 provider pack (#22). The `bin/kb-enforce-hook` dispatcher hardcoded `agent_identity:"claude-code"` in the `/api/v1/consult` body. Since that dispatcher now serves Claude, Codex, and Gemini, every Codex and Gemini consultation was recorded in the compliance audit under `claude-code`, so `kb_compliance`'s per-agent view was wrong for those agents.

Fix: add an `--agent <name>` flag to the dispatcher (hang-safe parsing, like `--dialect`), thread it from each provider's generated command (`--agent claude-code|codex|gemini`), and use it as `agent_identity` in the consult body. Audit-only change; gating is unaffected (the ledger keys on `(session, workspace)`).

## Test Plan
- [x] New bats test captures the actual consult request body (env-gated mock capture) and asserts `agent_identity == "codex"` for `--agent codex` — fails against the pre-fix code.
- [x] Provider tests assert each command carries its `--agent <name>`.
- [x] Trailing `--agent` (no value) does not hang (watchdog test).
- [x] `uv run --extra dev pytest` -> 413 passed, 1 skipped; bats 14/14; shellcheck clean; ruff clean; clean tree.

Known minor follow-up: a value-less `--agent` falls back to an "unknown" identity bucket (fail-soft, consistent with `--dialect`); only reachable via manual misuse since the installer always emits a value.