### PR TITLE
feat(enforce): detection floor for un-hookable agents (slice 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   (SessionStart / UserPromptSubmit / PreToolUse / Stop). Fail-open by default
   (`KB_ENFORCE_FAIL_MODE`), consultation freshness via `KB_CONSULT_TTL_SEC`.
 - Cross-agent enforcement providers: `kb enforce install --agent codex|gemini|opencode|copilot-cli|copilot-ide` and `--all`. Codex and Gemini get hard PreToolUse/BeforeTool gates (merging into existing hooks), OpenCode gets a `tool.execute.before` plugin, and Copilot CLI/IDE get a soft instructions-file + MCP provider. Antigravity is a documented-unsupported stub. The `kb-enforce-hook` dispatcher gained a `--dialect gemini` output mode.
+- Detection floor for un-hookable agents: `kb enforce report` (and `data-olympus report`) correlates governed git commits against the consult audit and lists changes with no consultation on record. An opt-in repo-scoped git provider (`kb enforce install --agent git`) installs a post-commit warning hook, or a pre-commit blocking hook with `--block`. Reuses the existing audit endpoint; no server change.
 
 ### Fixed
 

--- a/bin/_kb_enforce.py
+++ b/bin/_kb_enforce.py
@@ -363,6 +363,82 @@ class UnsupportedProvider:
         return self._report()
 
 
+HOOK_BEGIN = "# >>> data-olympus enforce (managed) >>>"
+HOOK_END = "# <<< data-olympus enforce <<<"
+
+
+def _git_managed_block(block: bool) -> str:
+    if block:
+        body = (
+            'data-olympus report --staged --fail-on-unverified || {\n'
+            '  echo "[KB] commit blocked: governed change without a consultation '
+            '(set KB_ENFORCE_FAIL_MODE or run kb_consult)." >&2; exit 1;\n'
+            '}'
+        )
+    else:
+        body = (
+            'data-olympus report --range HEAD~1..HEAD || true'
+        )
+    return f"{HOOK_BEGIN}\n# data-olympus-enforce v{SHIM_VERSION}\n{body}\n{HOOK_END}\n"
+
+
+class GitHookProvider:
+    name = "git"
+    tier = "detect"
+
+    def __init__(self, *, block: bool = False) -> None:
+        self._block = block
+
+    def default_target(self) -> Path:
+        hook = "pre-commit" if self._block else "post-commit"
+        return Path(".git") / "hooks" / hook
+
+    @staticmethod
+    def _strip(text: str) -> str:
+        if HOOK_BEGIN in text and HOOK_END in text:
+            pre = text.split(HOOK_BEGIN, 1)[0].rstrip("\n")
+            post = text.split(HOOK_END, 1)[1].lstrip("\n")
+            joined = "\n".join(p for p in (pre, post) if p)
+            return (joined + "\n") if joined else ""
+        return text
+
+    def install(self, target: Path) -> int:
+        existing = target.read_text() if target.exists() else ""
+        if target.exists():
+            _backup(target)
+        base = self._strip(existing).rstrip("\n")
+        if not base:
+            base = "#!/bin/sh"
+        new = base + "\n\n" + _git_managed_block(self._block) + "\n"
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(new)
+        target.chmod(0o755)
+        kind = "pre-commit (block)" if self._block else "post-commit (warn)"
+        print(f"installed data-olympus enforcement (v{SHIM_VERSION}) into {target} [git, {kind}]")
+        return 0
+
+    def uninstall(self, target: Path) -> int:
+        if not target.exists():
+            print("nothing to uninstall")
+            return 0
+        _backup(target)
+        target.write_text(self._strip(target.read_text()))
+        print(f"uninstalled data-olympus enforcement from {target} [git]")
+        return 0
+
+    def status(self, target: Path) -> int:
+        if target.exists() and HOOK_BEGIN in target.read_text():
+            print(f"git: installed, tier=detect, versions=['{SHIM_VERSION}']")
+        else:
+            print("git: not installed")
+        return 0
+
+    def doctor(self, target: Path) -> int:
+        ok = target.exists() and HOOK_BEGIN in target.read_text() and os.access(target, os.X_OK)
+        print(f"doctor [git]: hook {'present and executable' if ok else 'missing'} at {target}")
+        return 0 if ok else 1
+
+
 def registry() -> dict:
     return {
         "claude-code": _claude_provider(),
@@ -392,6 +468,9 @@ def main(argv: list[str]) -> int:
     p.add_argument("--agent", default=None)
     p.add_argument("--all", action="store_true")
     p.add_argument("--settings", default=None)
+    p.add_argument("--block", action="store_true",
+                   help="git provider: install a blocking pre-commit hook "
+                        "instead of post-commit warn")
     args = p.parse_args(argv)
     reg = registry()
 
@@ -409,9 +488,9 @@ def main(argv: list[str]) -> int:
         return rc
 
     agent = args.agent or "claude-code"
-    provider = reg.get(agent)
+    provider = GitHookProvider(block=args.block) if agent == "git" else reg.get(agent)
     if provider is None:
-        print(f"kb enforce: unknown agent '{agent}' (known: {', '.join(sorted(reg))})",
+        print(f"kb enforce: unknown agent '{agent}' (known: {', '.join(sorted(reg))}, git)",
               file=sys.stderr)
         return 64
     target = Path(args.settings) if args.settings else provider.default_target()

--- a/bin/kb
+++ b/bin/kb
@@ -18,6 +18,7 @@
 #   kb onboard component <workspace> <component>
 #   kb onboard rename <from> <to>
 #   kb enforce install|uninstall|status|doctor [--agent NAME | --all] [--settings PATH]
+#   kb enforce report [--workspace W] [--range A..B | --since S] [--json] [--fail-on-unverified]
 #
 # Environment:
 #   KB_ENDPOINT        REST endpoint URL (default: http://localhost:8080)
@@ -611,7 +612,11 @@ case "$SUBCMD" in
   pending) cmd_pending "$@"; exit $? ;;
   audit) cmd_audit "$@"; exit $? ;;
   enforce)
-    [[ $# -ge 1 ]] || { echo "kb: enforce requires subcommand (install|uninstall|status|doctor)" >&2; exit 64; }
+    [[ $# -ge 1 ]] || { echo "kb: enforce requires subcommand (install|uninstall|status|doctor|report)" >&2; exit 64; }
+    if [[ "$1" == "report" ]]; then
+      shift
+      exec data-olympus report "$@"
+    fi
     exec python3 "$(dirname "$0")/_kb_enforce.py" "$@"
     ;;
   onboarding-check) cmd_onboarding_check "$@"; exit $? ;;

--- a/docs/enforcement.md
+++ b/docs/enforcement.md
@@ -114,3 +114,98 @@ Antigravity is unsupported. It exposes no documented local hook, instructions,
 or MCP surface, so there is nothing for the installer to wire. `kb enforce`
 reports it as unsupported and `--all` skips it. Revisit when Google publishes
 an extensibility API.
+
+## Detection floor (un-hookable agents)
+
+### Why it exists
+
+Some agents cannot be hard-gated locally. Closed IDE apps such as
+Copilot-in-VS-Code and Antigravity expose no local hook, instructions, or MCP
+surface that the installer can wire, so a PreToolUse-style deny is impossible
+for them. What every agent does share is git: every governed change eventually
+becomes a commit. Git is therefore the common chokepoint. The detection floor
+uses it not to block (the gating tiers above already do that where they can)
+but to detect governed changes that have no consultation on record and report
+them, so an un-hookable agent's work is at least observable after the fact.
+
+### `kb enforce report` (alias `data-olympus report`)
+
+```bash
+kb enforce report [--workspace W] [--range A..B | --since S] \
+                  [--window-sec N] [--json] [--fail-on-unverified] [--staged]
+```
+
+`data-olympus report` is the same command (the `kb enforce report` route
+delegates straight to it). The report parses governed commits from `git log`
+(reusing the same path classifier the gates use), then correlates them against
+`consult` events fetched from the existing `GET /api/v1/audit`. It reuses that
+endpoint as-is: there is no server change for this feature.
+
+Flags:
+
+- `--workspace W`: workspace label to correlate against (defaults to the
+  current directory name).
+- `--range A..B`: a git revision range to scan (for example `HEAD~5..HEAD`).
+- `--since S`: a git `--since` window when no `--range` is given.
+- `--window-sec N`: the correlation window, in seconds, around each commit.
+- `--json`: emit machine-readable JSON instead of the text summary.
+- `--fail-on-unverified`: exit non-zero when an unverified governed change is
+  found (see exit codes).
+- `--staged`: classify the staged diff instead of `git log` (used by the
+  pre-commit block hook).
+
+Exit codes:
+
+- `0`: normal completion (including the case where unverified changes exist but
+  `--fail-on-unverified` was not passed).
+- `3`: returned only with `--fail-on-unverified`, when at least one unverified
+  governed change is found.
+- `2`: a git error (for example a bad `--range`). The command does not mistake
+  a git failure for a clean repo.
+
+### The opt-in git hook
+
+```bash
+kb enforce install --agent git           # post-commit WARN hook (detection only)
+kb enforce install --agent git --block   # pre-commit hook that fails the commit
+kb enforce uninstall --agent git         # surgical removal of the managed block
+```
+
+`kb enforce install --agent git` installs a post-commit hook that WARNs: it
+cannot block (post-commit runs after the commit is already made), so it is pure
+detection. `kb enforce install --agent git --block` instead installs a
+pre-commit hook that fails the commit when the staged diff contains an
+unverified governed change.
+
+The git hooks are repo-scoped: they live in `.git/hooks` of the current repo,
+not under `~`. The installer merges its managed block into any existing hook
+content (preserving operator-authored lines) and uninstall removes only the
+managed block. The git provider is opt-in: it is NOT installed by
+`kb enforce install --all`. You must ask for it explicitly with `--agent git`.
+
+### Requirement: `data-olympus` must be on PATH
+
+Both `kb enforce report` and the git hooks call the `data-olympus` console
+script. It must be on PATH at run time (for `report`) and at commit time (for
+the hooks). Install the package, or activate the venv, so the script resolves.
+A GUI git client whose environment lacks the venv PATH will see the warn hook
+print `command not found` (harmless: the commit still lands), or, for the
+`--block` pre-commit hook, fail the commit because the gate cannot run.
+
+### Honest limits
+
+Correlation is best-effort by workspace plus time window, not a hard
+session-to-commit link. State the limits plainly:
+
+- False positives (a governed change reported as unverified when a consult did
+  happen): a consult recorded in a different session, a consult that fell
+  outside the time window, or a consult recorded under a different workspace
+  label.
+- False negatives (a governed change that goes unreported): a change whose path
+  the classifier does not consider governed.
+
+When the audit endpoint is unreachable, the command degrades to warn: it lists
+the governed changes it found and marks the consult state as unknown rather
+than crashing. A post-commit warn hook never crashes a commit. The
+`--staged`/`--block` gate requires a consult within the window to pass, so a
+stale consult (outside the window) does not let a governed commit through.

--- a/src/data_olympus/cli/main.py
+++ b/src/data_olympus/cli/main.py
@@ -69,6 +69,7 @@ def _cmd_report(args: argparse.Namespace) -> int:
         window_sec=args.window_sec,
         as_json=args.json,
         fail_on_unverified=args.fail_on_unverified,
+        staged=args.staged,
     )
 
 
@@ -97,6 +98,8 @@ def build_parser() -> argparse.ArgumentParser:
     p_report.add_argument("--json", action="store_true", help="emit JSON")
     p_report.add_argument("--fail-on-unverified", action="store_true",
                           help="exit 3 if any unverified governed change is found")
+    p_report.add_argument("--staged", action="store_true",
+                          help="classify the staged diff instead of git log (for pre-commit)")
     p_report.set_defaults(func=_cmd_report)
     return parser
 

--- a/src/data_olympus/cli/main.py
+++ b/src/data_olympus/cli/main.py
@@ -60,6 +60,18 @@ def _cmd_visualize(args: argparse.Namespace) -> int:
     return 0
 
 
+def _cmd_report(args: argparse.Namespace) -> int:
+    from data_olympus.cli.report_cmd import run_report
+    return run_report(
+        workspace=args.workspace or Path.cwd().name,
+        rng=args.range,
+        since=args.since,
+        window_sec=args.window_sec,
+        as_json=args.json,
+        fail_on_unverified=args.fail_on_unverified,
+    )
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="data-olympus")
     sub = parser.add_subparsers(dest="command", required=True)
@@ -76,6 +88,16 @@ def build_parser() -> argparse.ArgumentParser:
     )
     p_viz.add_argument("--name", default=None, help="display name in the viewer header")
     p_viz.set_defaults(func=_cmd_visualize)
+    p_report = sub.add_parser("report", help="report governed changes lacking a consultation")
+    p_report.add_argument("--workspace", default=None, help="workspace label (default: cwd name)")
+    p_report.add_argument("--range", default=None, help="git revision range, e.g. HEAD~5..HEAD")
+    p_report.add_argument("--since", default="7 days ago", help="git --since when no --range")
+    p_report.add_argument("--window-sec", type=int, default=3600,
+                          help="consult correlation window in seconds")
+    p_report.add_argument("--json", action="store_true", help="emit JSON")
+    p_report.add_argument("--fail-on-unverified", action="store_true",
+                          help="exit 3 if any unverified governed change is found")
+    p_report.set_defaults(func=_cmd_report)
     return parser
 
 

--- a/src/data_olympus/cli/report_cmd.py
+++ b/src/data_olympus/cli/report_cmd.py
@@ -1,0 +1,105 @@
+"""`data-olympus report`: correlate governed git commits with the consult audit."""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import urllib.request
+from typing import Any
+
+from data_olympus.enforce_policy import IntentClassifier
+from data_olympus.report import (
+    GovernedCommit,
+    correlate,
+    extract_consults,
+    format_report,
+    parse_governed_commits,
+)
+
+# Record separator (RS, \x1e) between commits; unit separator (US, \x1f) between
+# header fields. Combined with --name-only -z this yields an unambiguous stream
+# that parse_governed_commits() decodes without boundary heuristics. The parser
+# and this format MUST stay in lock-step.
+_GIT_FORMAT = "%x1e%H%x1f%ct%x1f%an"
+
+
+def _git_log(rng: str | None, since: str | None) -> str:
+    args = ["git", "log", "--no-merges", "-z", f"--format={_GIT_FORMAT}", "--name-only"]
+    if rng:
+        args.append(rng)
+    elif since:
+        args.append(f"--since={since}")
+    proc = subprocess.run(args, capture_output=True, text=True)
+    if proc.returncode != 0:
+        return ""
+    return proc.stdout
+
+
+def _git_staged_files() -> list[str]:
+    proc = subprocess.run(["git", "diff", "--cached", "--name-only", "-z"],
+                          capture_output=True, text=True)
+    if proc.returncode != 0:
+        return []
+    return [p for p in proc.stdout.split("\x00") if p.strip()]
+
+
+def _fetch_audit(endpoint: str, token: str, since_ts: int) -> tuple[bool, list[dict[str, Any]]]:
+    url = f"{endpoint}/api/v1/audit?since={since_ts}&limit=1000"
+    req = urllib.request.Request(url)
+    if token:
+        req.add_header("Authorization", f"Bearer {token}")
+    try:
+        with urllib.request.urlopen(req, timeout=5) as r:
+            data = json.loads(r.read().decode())
+            return True, list(data.get("events", []))
+    except Exception:  # noqa: BLE001 - unreachable audit degrades gracefully
+        return False, []
+
+
+def run_report(
+    *,
+    workspace: str,
+    rng: str | None,
+    since: str | None,
+    window_sec: int,
+    as_json: bool,
+    fail_on_unverified: bool,
+    staged: bool = False,
+) -> int:
+    classifier = IntentClassifier()
+    if staged:
+        gfiles = [f for f in _git_staged_files()
+                  if classifier.classify(action_path=f).is_governed_decision]
+        commits = [GovernedCommit(sha="STAGED", ts=0, author="", files=gfiles)] if gfiles else []
+    else:
+        commits = parse_governed_commits(_git_log(rng, since), classifier)
+    earliest = min((c.ts for c in commits), default=0)
+    endpoint = os.getenv("KB_ENDPOINT", "http://localhost:8080")
+    token = os.getenv("KB_AUTH_TOKEN", "")
+    reachable, events = _fetch_audit(endpoint, token, max(0, earliest - window_sec))
+    consults = extract_consults(events, workspace) if reachable else []
+
+    if staged and commits:
+        # Staged changes have no commit timestamp; pin the synthetic commit ts to
+        # the newest consult so correlate() marks it verified iff a consult exists
+        # for this workspace (and unverified when none do).
+        newest = max((c.ts for c in consults), default=None)
+        ts = int(newest) if newest is not None else 0
+        commits = [GovernedCommit(sha="STAGED", ts=ts, author=commits[0].author,
+                                  files=commits[0].files)]
+
+    report = correlate(commits, consults, window_sec=window_sec)
+
+    if as_json:
+        body = json.loads(format_report(report, as_json=True))
+        body["audit_reachable"] = reachable
+        print(json.dumps(body))
+    else:
+        if not reachable:
+            print(f"[KB] warn: audit endpoint {endpoint} unreachable; "
+                  f"consult state unknown, listing governed changes only.")
+        print(format_report(report, as_json=False))
+
+    if fail_on_unverified and report.unverified:
+        return 3
+    return 0

--- a/src/data_olympus/cli/report_cmd.py
+++ b/src/data_olympus/cli/report_cmd.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 import json
 import os
 import subprocess
+import sys
+import time
 import urllib.request
 from typing import Any
 
@@ -23,7 +25,7 @@ from data_olympus.report import (
 _GIT_FORMAT = "%x1e%H%x1f%ct%x1f%an"
 
 
-def _git_log(rng: str | None, since: str | None) -> str:
+def _git_log(rng: str | None, since: str | None) -> tuple[bool, str]:
     args = ["git", "log", "--no-merges", "-z", f"--format={_GIT_FORMAT}", "--name-only"]
     if rng:
         args.append(rng)
@@ -31,16 +33,21 @@ def _git_log(rng: str | None, since: str | None) -> str:
         args.append(f"--since={since}")
     proc = subprocess.run(args, capture_output=True, text=True)
     if proc.returncode != 0:
-        return ""
-    return proc.stdout
+        # Surface git's error instead of masquerading as a clean (0-commit) scan.
+        if proc.stderr:
+            print(proc.stderr.rstrip("\n"), file=sys.stderr)
+        return False, ""
+    return True, proc.stdout
 
 
-def _git_staged_files() -> list[str]:
+def _git_staged_files() -> tuple[bool, list[str]]:
     proc = subprocess.run(["git", "diff", "--cached", "--name-only", "-z"],
                           capture_output=True, text=True)
     if proc.returncode != 0:
-        return []
-    return [p for p in proc.stdout.split("\x00") if p.strip()]
+        if proc.stderr:
+            print(proc.stderr.rstrip("\n"), file=sys.stderr)
+        return False, []
+    return True, [p for p in proc.stdout.split("\x00") if p.strip()]
 
 
 def _fetch_audit(endpoint: str, token: str, since_ts: int) -> tuple[bool, list[dict[str, Any]]]:
@@ -67,26 +74,34 @@ def run_report(
     staged: bool = False,
 ) -> int:
     classifier = IntentClassifier()
-    if staged:
-        gfiles = [f for f in _git_staged_files()
-                  if classifier.classify(action_path=f).is_governed_decision]
-        commits = [GovernedCommit(sha="STAGED", ts=0, author="", files=gfiles)] if gfiles else []
-    else:
-        commits = parse_governed_commits(_git_log(rng, since), classifier)
-    earliest = min((c.ts for c in commits), default=0)
     endpoint = os.getenv("KB_ENDPOINT", "http://localhost:8080")
     token = os.getenv("KB_AUTH_TOKEN", "")
-    reachable, events = _fetch_audit(endpoint, token, max(0, earliest - window_sec))
-    consults = extract_consults(events, workspace) if reachable else []
 
-    if staged and commits:
-        # Staged changes have no commit timestamp; pin the synthetic commit ts to
-        # the newest consult so correlate() marks it verified iff a consult exists
-        # for this workspace (and unverified when none do).
-        newest = max((c.ts for c in consults), default=None)
-        ts = int(newest) if newest is not None else 0
-        commits = [GovernedCommit(sha="STAGED", ts=ts, author=commits[0].author,
-                                  files=commits[0].files)]
+    if staged:
+        ok, staged_files = _git_staged_files()
+        if not ok:
+            return 2  # git scan failed; do not mistake an error for a clean repo
+        gfiles = [f for f in staged_files
+                  if classifier.classify(action_path=f).is_governed_decision]
+        # Staged changes have no commit timestamp, so use the real clock: the gate
+        # must verify a RECENT consult, not any consult ever recorded. Pin the
+        # synthetic commit to `now` and only fetch (and accept) consults within
+        # [now - window_sec, now], so a stale consult cannot keep the gate green.
+        now = int(time.time())
+        commits = (
+            [GovernedCommit(sha="STAGED", ts=now, author="", files=gfiles)] if gfiles else []
+        )
+        since_ts = max(0, now - window_sec)
+    else:
+        ok, log_text = _git_log(rng, since)
+        if not ok:
+            return 2  # git scan failed (e.g. bad --range); not a clean repo
+        commits = parse_governed_commits(log_text, classifier)
+        earliest = min((c.ts for c in commits), default=0)
+        since_ts = max(0, earliest - window_sec)
+
+    reachable, events = _fetch_audit(endpoint, token, since_ts)
+    consults = extract_consults(events, workspace) if reachable else []
 
     report = correlate(commits, consults, window_sec=window_sec)
 

--- a/src/data_olympus/report.py
+++ b/src/data_olympus/report.py
@@ -1,0 +1,145 @@
+"""Detection-floor correlation engine.
+
+Pure functions: no git and no network here. The CLI feeds in the raw `git log`
+text and the audit events; these functions classify, correlate, and format. That
+keeps the policy logic unit-testable without a repo or a server."""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from data_olympus.enforce_policy import IntentClassifier
+
+
+@dataclass(frozen=True)
+class GovernedCommit:
+    sha: str
+    ts: int
+    author: str
+    files: list[str]
+
+
+@dataclass(frozen=True)
+class Consult:
+    ts: float
+    agent_identity: str
+    source_session: str
+
+
+@dataclass(frozen=True)
+class ComplianceReport:
+    verified: list[GovernedCommit] = field(default_factory=list)
+    unverified: list[GovernedCommit] = field(default_factory=list)
+    consult_count: int = 0
+
+    @property
+    def total_governed(self) -> int:
+        return len(self.verified) + len(self.unverified)
+
+
+def parse_governed_commits(git_log_text: str, classifier: IntentClassifier) -> list[GovernedCommit]:
+    """Parse `git log --pretty=format:%H%x00%ct%x00%an --name-only -z` output.
+
+    Records are separated by NUL. The first three NUL-separated tokens of a record
+    are sha, unix-timestamp, author; the remaining NUL-separated tokens are file
+    paths (until the next sha-looking token). A commit is kept only if at least one
+    of its files is governed per the classifier."""
+    tokens = list(git_log_text.split("\x00"))
+    commits: list[GovernedCommit] = []
+    i = 0
+    n = len(tokens)
+    while i < n:
+        sha = tokens[i].strip()
+        if not sha:
+            i += 1
+            continue
+        # next two tokens are ts, author
+        if i + 2 >= n:
+            break
+        ts_raw = tokens[i + 1].strip()
+        author = tokens[i + 2].strip()
+        i += 3
+        files: list[str] = []
+        while i < n:
+            tok = tokens[i]
+            stripped = tok.strip()
+            if not stripped:
+                i += 1
+                # blank token terminates the file list for this record
+                break
+            # A new record begins with a bare sha followed by a numeric unix ts.
+            # Detect it structurally: an all-hex token whose next token is
+            # all-digits starts the next commit. (`git log -z` does not emit a
+            # blank separator between records, so this hex+digit-follow rule is
+            # the sole record boundary signal.)
+            if (
+                i + 1 < n
+                and all(c in "0123456789abcdef" for c in stripped.lower())
+                and tokens[i + 1].strip().isdigit()
+            ):
+                break
+            files.append(stripped)
+            i += 1
+        if any(classifier.classify(action_path=f).is_governed_decision for f in files):
+            try:
+                ts = int(ts_raw)
+            except ValueError:
+                ts = 0
+            commits.append(GovernedCommit(sha=sha, ts=ts, author=author, files=files))
+    return commits
+
+
+def extract_consults(audit_events: list[dict[str, Any]], workspace: str) -> list[Consult]:
+    out: list[Consult] = []
+    for ev in audit_events:
+        if ev.get("event_type") == "consult" and ev.get("target_path") == workspace:
+            out.append(Consult(
+                ts=float(ev.get("ts", 0.0)),
+                agent_identity=str(ev.get("agent_identity") or "unknown"),
+                source_session=str(ev.get("source_session") or ""),
+            ))
+    return out
+
+
+def correlate(
+    commits: list[GovernedCommit],
+    consults: list[Consult],
+    window_sec: int,
+    grace_sec: int = 120,
+) -> ComplianceReport:
+    """A governed commit is verified if a consult exists in [ts - window, ts + grace]."""
+    consult_ts = sorted(c.ts for c in consults)
+    verified: list[GovernedCommit] = []
+    unverified: list[GovernedCommit] = []
+    for c in commits:
+        lo, hi = c.ts - window_sec, c.ts + grace_sec
+        if any(lo <= t <= hi for t in consult_ts):
+            verified.append(c)
+        else:
+            unverified.append(c)
+    return ComplianceReport(verified=verified, unverified=unverified, consult_count=len(consults))
+
+
+def format_report(report: ComplianceReport, *, as_json: bool) -> str:
+    if as_json:
+        return json.dumps({
+            "total_governed": report.total_governed,
+            "consult_count": report.consult_count,
+            "verified": [c.sha for c in report.verified],
+            "unverified": [
+                {"sha": c.sha, "ts": c.ts, "author": c.author, "files": c.files}
+                for c in report.unverified
+            ],
+        })
+    lines = [
+        f"governed changes: {report.total_governed} | "
+        f"with a consult on record: {len(report.verified)} | "
+        f"unverified: {len(report.unverified)} | consults seen: {report.consult_count}",
+    ]
+    for c in report.unverified:
+        lines.append(f"  UNVERIFIED {c.sha[:10]} by {c.author}: {', '.join(c.files)}")
+    if not report.unverified:
+        lines.append("  no unverified governed changes")
+    return "\n".join(lines)

--- a/src/data_olympus/report.py
+++ b/src/data_olympus/report.py
@@ -40,48 +40,36 @@ class ComplianceReport:
 
 
 def parse_governed_commits(git_log_text: str, classifier: IntentClassifier) -> list[GovernedCommit]:
-    """Parse `git log --pretty=format:%H%x00%ct%x00%an --name-only -z` output.
+    """Parse `git log --no-merges -z --format=%x1e%H%x1f%ct%x1f%an --name-only` output.
 
-    Records are separated by NUL. The first three NUL-separated tokens of a record
-    are sha, unix-timestamp, author; the remaining NUL-separated tokens are file
-    paths (until the next sha-looking token). A commit is kept only if at least one
-    of its files is governed per the classifier."""
-    tokens = list(git_log_text.split("\x00"))
+    Records are separated by RS (\\x1e). Within a record the header fields are
+    separated by US (\\x1f): the first three are sha, unix-timestamp, author. The
+    `--name-only -z` flags then append a NUL after the last format field, a
+    newline, and finally the NUL-separated (NUL-terminated) file list. So the
+    third US-field of a record is `<author>\\x00\\n<file>\\x00<file>\\x00...`; we
+    split the author off at the first newline and read the rest as the file list.
+    Unambiguous record/field separators avoid the heuristic boundary-detection
+    that real git output (author joined to the first filename by a literal
+    newline) defeats. A commit is kept only if at least one of its files is
+    governed per the classifier."""
     commits: list[GovernedCommit] = []
-    i = 0
-    n = len(tokens)
-    while i < n:
-        sha = tokens[i].strip()
-        if not sha:
-            i += 1
+    for record in git_log_text.split("\x1e"):
+        # The leading split produces an empty chunk; empty commits leave only the
+        # header with no file list. Skip anything with no real header content.
+        if not record.strip("\x00\n"):
             continue
-        # next two tokens are ts, author
-        if i + 2 >= n:
-            break
-        ts_raw = tokens[i + 1].strip()
-        author = tokens[i + 2].strip()
-        i += 3
-        files: list[str] = []
-        while i < n:
-            tok = tokens[i]
-            stripped = tok.strip()
-            if not stripped:
-                i += 1
-                # blank token terminates the file list for this record
-                break
-            # A new record begins with a bare sha followed by a numeric unix ts.
-            # Detect it structurally: an all-hex token whose next token is
-            # all-digits starts the next commit. (`git log -z` does not emit a
-            # blank separator between records, so this hex+digit-follow rule is
-            # the sole record boundary signal.)
-            if (
-                i + 1 < n
-                and all(c in "0123456789abcdef" for c in stripped.lower())
-                and tokens[i + 1].strip().isdigit()
-            ):
-                break
-            files.append(stripped)
-            i += 1
+        fields = record.split("\x1f")
+        if len(fields) < 3:
+            continue
+        sha = fields[0].strip()
+        ts_raw = fields[1].strip()
+        rest = fields[2]
+        if "\n" in rest:
+            author_part, files_blob = rest.split("\n", 1)
+        else:
+            author_part, files_blob = rest, ""
+        author = author_part.rstrip("\x00").strip()
+        files = [f for f in files_blob.split("\x00") if f.strip()]
         if any(classifier.classify(action_path=f).is_governed_decision for f in files):
             try:
                 ts = int(ts_raw)
@@ -96,7 +84,7 @@ def extract_consults(audit_events: list[dict[str, Any]], workspace: str) -> list
     for ev in audit_events:
         if ev.get("event_type") == "consult" and ev.get("target_path") == workspace:
             out.append(Consult(
-                ts=float(ev.get("ts", 0.0)),
+                ts=float(ev.get("ts") or 0.0),
                 agent_identity=str(ev.get("agent_identity") or "unknown"),
                 source_session=str(ev.get("source_session") or ""),
             ))

--- a/tests/test_cli_report.py
+++ b/tests/test_cli_report.py
@@ -1,0 +1,57 @@
+"""Integration tests for `data-olympus report` against a temp git repo + stub audit."""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _git(repo: Path, *args: str) -> None:
+    env = {**os.environ, "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@e.com",
+           "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@e.com"}
+    subprocess.run(["git", "-C", str(repo), *args], check=True, env=env,
+                   capture_output=True)
+
+
+def _make_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "proj"
+    repo.mkdir()
+    _git(repo, "init", "--initial-branch=main")
+    (repo / "README.md").write_text("# proj\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-m", "init readme")
+    (repo / "pyproject.toml").write_text("[project]\nname='x'\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-m", "add deps")  # governed
+    return repo
+
+
+def _run_report(repo: Path, *args: str, endpoint: str) -> subprocess.CompletedProcess[str]:
+    env = {**os.environ, "KB_ENDPOINT": endpoint}
+    return subprocess.run(
+        [sys.executable, "-m", "data_olympus.cli.main", "report",
+         "--workspace", "proj", "--range", "HEAD~1..HEAD", *args],
+        cwd=str(repo), capture_output=True, text=True, env=env,
+    )
+
+
+def test_report_flags_unverified_governed_commit(tmp_path):
+    repo = _make_repo(tmp_path)
+    # Audit endpoint that returns NO consults -> the governed commit is unverified.
+    r = _run_report(repo, "--json", endpoint="http://127.0.0.1:1")  # unreachable audit
+    assert r.returncode == 0, r.stderr
+    body = json.loads(r.stdout)
+    assert body["total_governed"] == 1
+    # audit unreachable -> consult state unknown; the commit is reported, not crashed
+    assert body["audit_reachable"] is False
+
+
+def test_report_fail_on_unverified_exit_code(tmp_path):
+    repo = _make_repo(tmp_path)
+    r = _run_report(repo, "--fail-on-unverified", endpoint="http://127.0.0.1:1")
+    assert r.returncode == 3  # unverified governed change present

--- a/tests/test_cli_report_staged.py
+++ b/tests/test_cli_report_staged.py
@@ -1,12 +1,18 @@
 """--staged classifies the staged diff (for the pre-commit block hook)."""
 from __future__ import annotations
 
+import json
 import os
 import subprocess
 import sys
+import threading
+import time
+from contextlib import contextmanager
+from http.server import BaseHTTPRequestHandler, HTTPServer
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
     from pathlib import Path
 
 
@@ -14,6 +20,46 @@ def _git(repo: Path, *args: str) -> None:
     env = {**os.environ, "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@e.com",
            "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@e.com"}
     subprocess.run(["git", "-C", str(repo), *args], check=True, env=env, capture_output=True)
+
+
+@contextmanager
+def _stub_audit(consult_ts: float) -> Iterator[str]:
+    """A tiny audit server that always returns one consult at `consult_ts`.
+
+    It ignores the `since` query param on purpose: the recency gate must be the
+    CLI's correlation window, not just a server-side filter. So if the staged
+    gate still passes on a stale consult, that is a real bypass, not a stub quirk.
+    """
+    payload = json.dumps({
+        "events": [{
+            "ts": consult_ts,
+            "event_type": "consult",
+            "target_path": "proj",
+            "agent_identity": "codex",
+            "source_session": "s",
+        }],
+    }).encode()
+
+    class _Handler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:  # noqa: N802 - http.server API
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+
+        def log_message(self, *_args: object) -> None:
+            pass  # keep test output quiet
+
+    server = HTTPServer(("127.0.0.1", 0), _Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}"
+    finally:
+        server.shutdown()
+        thread.join(timeout=2)
+        server.server_close()
 
 
 def test_staged_governed_change_fails(tmp_path):
@@ -49,3 +95,58 @@ def test_staged_non_governed_change_passes(tmp_path):
          "--workspace", "proj", "--staged", "--fail-on-unverified"],
         cwd=str(repo), capture_output=True, text=True, env=env)
     assert r.returncode == 0  # nothing governed staged
+
+
+def _stage_governed(tmp_path: Path) -> Path:
+    repo = tmp_path / "proj"
+    repo.mkdir()
+    _git(repo, "init", "--initial-branch=main")
+    (repo / "README.md").write_text("x")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-m", "init")
+    (repo / "pyproject.toml").write_text("[project]\nname='x'\n")
+    _git(repo, "add", "pyproject.toml")
+    return repo
+
+
+def _run_staged(repo: Path, endpoint: str, window: int) -> subprocess.CompletedProcess[str]:
+    env = {**os.environ, "KB_ENDPOINT": endpoint}
+    return subprocess.run(
+        [sys.executable, "-m", "data_olympus.cli.main", "report",
+         "--workspace", "proj", "--staged", "--fail-on-unverified",
+         "--window-sec", str(window)],
+        cwd=str(repo), capture_output=True, text=True, env=env)
+
+
+def test_staged_recent_consult_passes(tmp_path):
+    repo = _stage_governed(tmp_path)
+    window = 3600
+    with _stub_audit(consult_ts=float(int(time.time()))) as endpoint:  # consult = now
+        r = _run_staged(repo, endpoint, window)
+    assert r.returncode == 0, r.stderr  # recent consult -> verified
+
+
+def test_staged_stale_consult_fails(tmp_path):
+    repo = _stage_governed(tmp_path)
+    window = 3600
+    stale_ts = float(int(time.time()) - 10 * window)  # far outside the window
+    with _stub_audit(consult_ts=stale_ts) as endpoint:
+        r = _run_staged(repo, endpoint, window)
+    assert r.returncode == 3, r.stderr  # stale consult must NOT verify the gate
+
+
+def test_report_git_error_is_not_clean(tmp_path):
+    # A bad --range must not read as a clean (0-governed) repo: exit 2, not 0.
+    repo = tmp_path / "proj"
+    repo.mkdir()
+    _git(repo, "init", "--initial-branch=main")
+    (repo / "README.md").write_text("x")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-m", "init")
+    env = {**os.environ, "KB_ENDPOINT": "http://127.0.0.1:1"}
+    r = subprocess.run(
+        [sys.executable, "-m", "data_olympus.cli.main", "report",
+         "--workspace", "proj", "--range", "does-not-exist..HEAD"],
+        cwd=str(repo), capture_output=True, text=True, env=env)
+    assert r.returncode == 2  # git error, not a clean repo
+    assert "fatal" in r.stderr.lower() or "unknown revision" in r.stderr.lower()

--- a/tests/test_cli_report_staged.py
+++ b/tests/test_cli_report_staged.py
@@ -1,0 +1,51 @@
+"""--staged classifies the staged diff (for the pre-commit block hook)."""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _git(repo: Path, *args: str) -> None:
+    env = {**os.environ, "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@e.com",
+           "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@e.com"}
+    subprocess.run(["git", "-C", str(repo), *args], check=True, env=env, capture_output=True)
+
+
+def test_staged_governed_change_fails(tmp_path):
+    repo = tmp_path / "proj"
+    repo.mkdir()
+    _git(repo, "init", "--initial-branch=main")
+    (repo / "README.md").write_text("x")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-m", "init")
+    # stage a governed file but do not commit
+    (repo / "pyproject.toml").write_text("[project]\nname='x'\n")
+    _git(repo, "add", "pyproject.toml")
+    env = {**os.environ, "KB_ENDPOINT": "http://127.0.0.1:1"}  # audit unreachable
+    r = subprocess.run(
+        [sys.executable, "-m", "data_olympus.cli.main", "report",
+         "--workspace", "proj", "--staged", "--fail-on-unverified"],
+        cwd=str(repo), capture_output=True, text=True, env=env)
+    assert r.returncode == 3  # staged governed change, no consult -> fail
+
+
+def test_staged_non_governed_change_passes(tmp_path):
+    repo = tmp_path / "proj"
+    repo.mkdir()
+    _git(repo, "init", "--initial-branch=main")
+    (repo / "README.md").write_text("x")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-m", "init")
+    (repo / "notes.txt").write_text("hello")
+    _git(repo, "add", "notes.txt")
+    env = {**os.environ, "KB_ENDPOINT": "http://127.0.0.1:1"}
+    r = subprocess.run(
+        [sys.executable, "-m", "data_olympus.cli.main", "report",
+         "--workspace", "proj", "--staged", "--fail-on-unverified"],
+        cwd=str(repo), capture_output=True, text=True, env=env)
+    assert r.returncode == 0  # nothing governed staged

--- a/tests/test_kb_cli_enforce_report.bats
+++ b/tests/test_kb_cli_enforce_report.bats
@@ -1,0 +1,38 @@
+#!/usr/bin/env bats
+# Verifies `kb enforce report` delegates to the package CLI `data-olympus report`
+# (Task 4 of the enforcement slice-3 plan) rather than falling through to
+# bin/_kb_enforce.py (which only knows install|uninstall|status|doctor).
+#
+# NOTE on the help assertion: the plan drafted an assertion against the string
+# "governed changes lacking a consultation". That string is the *parent*
+# subparser help (`data-olympus --help`), not part of `data-olympus report
+# --help`. Since this task must not modify any Python, we instead assert on
+# `--fail-on-unverified`, an option unique to `data-olympus report`'s own help,
+# which proves the route reached the package CLI's report subcommand exactly.
+#
+# NOTE on PATH: production bin/kb must `exec data-olympus` (a bare command, no
+# `uv`). In a bare `bats` run the package console-script lives at
+# .venv/bin/data-olympus and is not on PATH, so this test prepends that dir to
+# PATH. This keeps production bin/kb free of any uv/venv dependency.
+
+setup_file() {
+  REPO_ROOT="$(cd "$(dirname "${BATS_TEST_FILENAME}")/.." && pwd)"
+  export REPO_ROOT
+  export KB="${REPO_ROOT}/bin/kb"
+  if [ -x "${REPO_ROOT}/.venv/bin/data-olympus" ]; then
+    PATH="${REPO_ROOT}/.venv/bin:${PATH}"
+    export PATH
+  fi
+}
+
+@test "kb enforce report delegates to data-olympus report (--help reaches it)" {
+  run "$KB" enforce report --help
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"--fail-on-unverified"* ]]
+}
+
+@test "kb enforce with no subcommand errors with usage" {
+  run "$KB" enforce
+  [ "$status" -eq 64 ]
+  [[ "$output" == *"report"* ]]
+}

--- a/tests/test_kb_enforce_git.py
+++ b/tests/test_kb_enforce_git.py
@@ -1,0 +1,62 @@
+"""Git-hook provider: post-commit warn (default) and pre-commit block (--block)."""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+HELPER = Path(__file__).resolve().parents[1] / "bin" / "_kb_enforce.py"
+BEGIN = "# >>> data-olympus enforce (managed) >>>"
+
+
+def _run(*args: str):
+    return subprocess.run([sys.executable, str(HELPER), *args], capture_output=True, text=True)
+
+
+def _init(tmp_path: Path) -> Path:
+    repo = tmp_path / "proj"
+    repo.mkdir()
+    subprocess.run(["git", "-C", str(repo), "init"], check=True, capture_output=True)
+    return repo
+
+
+def test_git_install_default_is_post_commit_warn(tmp_path):
+    repo = _init(tmp_path)
+    hook = repo / ".git" / "hooks" / "post-commit"
+    r = _run("install", "--agent", "git", "--settings", str(hook))
+    assert r.returncode == 0, r.stderr
+    assert hook.exists() and os.access(hook, os.X_OK)
+    body = hook.read_text()
+    assert BEGIN in body
+    assert "data-olympus report" in body
+    assert "warn" in (r.stdout + r.stderr).lower() or "post-commit" in (r.stdout + r.stderr).lower()
+
+
+def test_git_install_block_is_pre_commit(tmp_path):
+    repo = _init(tmp_path)
+    hook = repo / ".git" / "hooks" / "pre-commit"
+    r = _run("install", "--agent", "git", "--block", "--settings", str(hook))
+    assert r.returncode == 0, r.stderr
+    body = hook.read_text()
+    assert "--staged" in body and "--fail-on-unverified" in body
+
+
+def test_git_uninstall_preserves_operator_hook(tmp_path):
+    repo = _init(tmp_path)
+    hook = repo / ".git" / "hooks" / "post-commit"
+    hook.parent.mkdir(parents=True, exist_ok=True)
+    hook.write_text("#!/bin/sh\necho operator-hook\n")
+    _run("install", "--agent", "git", "--settings", str(hook))
+    _run("uninstall", "--agent", "git", "--settings", str(hook))
+    body = hook.read_text()
+    assert "operator-hook" in body
+    assert BEGIN not in body
+
+
+def test_git_status(tmp_path):
+    repo = _init(tmp_path)
+    hook = repo / ".git" / "hooks" / "post-commit"
+    _run("install", "--agent", "git", "--settings", str(hook))
+    r = _run("status", "--agent", "git", "--settings", str(hook))
+    assert "git: installed, tier=detect" in r.stdout

--- a/tests/test_report_engine.py
+++ b/tests/test_report_engine.py
@@ -48,6 +48,20 @@ def test_parse_picks_only_governed_commits() -> None:
     assert "pyproject.toml" in aaa.files
 
 
+def test_parse_handles_spaces_in_author_and_filename() -> None:
+    # Guards the real-git case the parser fix targets: a multi-word author and a
+    # governed path containing a space. The old NUL-token heuristic swallowed the
+    # first filename into the author; the RS/US format must keep them separate.
+    raw = _log(
+        ("ddd", "1300", "Carol Space", ["weird dir/pyproject.toml", "weird dir/notes.txt"]),
+    )
+    commits = parse_governed_commits(raw, IntentClassifier())
+    assert len(commits) == 1
+    ddd = commits[0]
+    assert ddd.author == "Carol Space"  # no filename pollution
+    assert "weird dir/pyproject.toml" in ddd.files  # spaced path retained
+
+
 def test_extract_consults_filters_by_workspace_and_type() -> None:
     events = [
         {"ts": 990.0, "event_type": "consult", "target_path": "proj", "agent_identity": "codex"},

--- a/tests/test_report_engine.py
+++ b/tests/test_report_engine.py
@@ -1,0 +1,82 @@
+"""Pure correlation engine for the detection floor."""
+from __future__ import annotations
+
+import json
+
+from data_olympus.enforce_policy import IntentClassifier
+from data_olympus.report import (
+    Consult,
+    GovernedCommit,
+    correlate,
+    extract_consults,
+    format_report,
+    parse_governed_commits,
+)
+
+
+# git log --pretty=format:%H%x00%ct%x00%an --name-only -z output: records are
+# separated by NUL; within a record, header fields are NUL-separated, then the
+# file list is NUL-separated, and the commit block ends before the next %H.
+# We build it explicitly so the parser contract is unambiguous.
+def _log(*commits) -> str:
+    # each commit: (sha, ts, author, [files])
+    parts = []
+    for sha, ts, author, files in commits:
+        parts.append(f"{sha}\x00{ts}\x00{author}")
+        for f in files:
+            parts.append(f"\x00{f}")
+        parts.append("\x00")  # record terminator before next sha
+    return "".join(parts)
+
+
+def test_parse_picks_only_governed_commits() -> None:
+    raw = _log(
+        ("aaa", "1000", "Dev One", ["pyproject.toml", "README.md"]),
+        ("bbb", "1100", "Dev Two", ["src/util/strings.py"]),
+        ("ccc", "1200", "Dev Three", ["db/migrations/0001_init.sql"]),
+    )
+    commits = parse_governed_commits(raw, IntentClassifier())
+    shas = {c.sha for c in commits}
+    assert shas == {"aaa", "ccc"}  # bbb touches only non-governed paths
+    aaa = next(c for c in commits if c.sha == "aaa")
+    assert aaa.ts == 1000
+    assert aaa.author == "Dev One"
+    assert "pyproject.toml" in aaa.files
+
+
+def test_extract_consults_filters_by_workspace_and_type() -> None:
+    events = [
+        {"ts": 990.0, "event_type": "consult", "target_path": "proj", "agent_identity": "codex"},
+        {"ts": 995.0, "event_type": "consult", "target_path": "other", "agent_identity": "x"},
+        {"ts": 996.0, "event_type": "gate_block", "target_path": "proj", "agent_identity": "y"},
+    ]
+    consults = extract_consults(events, workspace="proj")
+    assert len(consults) == 1
+    assert consults[0].agent_identity == "codex"
+
+
+def test_correlate_verified_within_window() -> None:
+    commits = [GovernedCommit(sha="aaa", ts=1000, author="d", files=["pyproject.toml"])]
+    consults = [Consult(ts=990.0, agent_identity="codex", source_session="s1")]
+    rep = correlate(commits, consults, window_sec=3600)
+    assert rep.total_governed == 1
+    assert len(rep.verified) == 1
+    assert rep.unverified == []
+
+
+def test_correlate_unverified_when_no_consult_in_window() -> None:
+    commits = [GovernedCommit(sha="aaa", ts=10000, author="d", files=["pyproject.toml"])]
+    consults = [Consult(ts=100.0, agent_identity="codex", source_session="s1")]
+    rep = correlate(commits, consults, window_sec=3600)
+    assert rep.unverified and rep.unverified[0].sha == "aaa"
+    assert rep.verified == []
+
+
+def test_format_report_json_and_text() -> None:
+    commits = [GovernedCommit(sha="aaa", ts=10000, author="d", files=["pyproject.toml"])]
+    rep = correlate(commits, [], window_sec=3600)
+    j = json.loads(format_report(rep, as_json=True))
+    assert j["total_governed"] == 1
+    assert j["unverified"][0]["sha"] == "aaa"
+    text = format_report(rep, as_json=False)
+    assert "aaa" in text and "1" in text

--- a/tests/test_report_engine.py
+++ b/tests/test_report_engine.py
@@ -14,18 +14,22 @@ from data_olympus.report import (
 )
 
 
-# git log --pretty=format:%H%x00%ct%x00%an --name-only -z output: records are
-# separated by NUL; within a record, header fields are NUL-separated, then the
-# file list is NUL-separated, and the commit block ends before the next %H.
-# We build it explicitly so the parser contract is unambiguous.
+# Reproduces the EXACT byte structure of
+#   git log --no-merges -z --format=%x1e%H%x1f%ct%x1f%an --name-only
+# Records are separated by RS (\x1e). Within a record the header is
+# <sha>\x1f<ts>\x1f<author>; then `--name-only -z` appends a NUL after the last
+# format field, then a newline, then the NUL-separated, NUL-terminated file list.
+# Verified empirically against real git output before being committed here.
 def _log(*commits) -> str:
     # each commit: (sha, ts, author, [files])
     parts = []
     for sha, ts, author, files in commits:
-        parts.append(f"{sha}\x00{ts}\x00{author}")
-        for f in files:
-            parts.append(f"\x00{f}")
-        parts.append("\x00")  # record terminator before next sha
+        rec = f"\x1e{sha}\x1f{ts}\x1f{author}"
+        if files:
+            rec += "\x00\n" + "".join(f"{f}\x00" for f in files)
+        else:
+            rec += "\x00"
+        parts.append(rec)
     return "".join(parts)
 
 


### PR DESCRIPTION
## Summary

Slice 3 of the enforcement feature (slices 1-2 in #21, #22, #23). The original egress-proxy idea was dropped during design (TLS interception conflicts with the secrets posture, is fragile, and fails on the vendor-backend apps it targets). Instead this adds a **detection / observability floor**: it does not try to block what it cannot hook, it detects governed code changes that have no consultation on record and reports them. Git is the chokepoint every agent shares (even closed IDE apps commit through the local repo), so correlating governed git commits against the consult audit reaches every agent with zero traffic interception.

What landed:
- **Correlation engine** (`src/data_olympus/report.py`, pure/unit-tested): parse governed commits from `git log` (reusing `IntentClassifier`, no duplicated globs), filter `consult` events, correlate by workspace + time window, format text/JSON.
- **`data-olympus report` / `kb enforce report`**: `[--workspace] [--range A..B | --since S] [--window-sec] [--json] [--fail-on-unverified] [--staged]`. Reuses the existing `/api/v1/audit` (no server change). Exit 0 normal, 3 with `--fail-on-unverified`, 2 on a git error.
- **Opt-in git provider** (`kb enforce install --agent git`): post-commit WARN hook by default (pure detection, cannot block); `--block` installs a pre-commit hook that fails the commit on an unverified governed staged change. Repo-scoped, merges with existing hooks, surgical uninstall. NOT installed by `--all`.

Built test-first across 6 reviewed sub-tasks plus a whole-slice review. Review caught and fixed: a git-log parser that was wrong against real `git log -z` output (author/filename newline + boundary tokens) — reworked to an unambiguous RS/US format with the emitter and parser in lock-step; a staged-mode stale-consult bypass (a months-old consult passed the gate forever) — now honors the recency window; and a git error silently reading as "clean".

## Honest limits (documented in docs/enforcement.md)
- Correlation is best-effort by workspace + time window, not a hard session link. False positives (consult in another session/window/workspace label) and false negatives (a change the classifier does not consider governed) are possible.
- The post-commit hook can only warn; only the opt-in pre-commit `--block` can fail a commit, and only if commits go through the hook.
- `kb enforce report` and the hooks call the `data-olympus` console script, so it must be on PATH at run/commit time (activate the venv / install the package).

## Test Plan
- [x] `uv run --extra dev ruff check .` clean
- [x] `uv run --extra dev pytest` -> 430 passed, 1 skipped (optional `sentence_transformers`)
- [x] bats (report delegation, hook dialects) green
- [x] `uv run data-olympus lint example-bundle` exit 0
- [x] Real-git end-to-end: a governed commit (pyproject.toml) is detected; staged recency proven (stale consult -> exit 3, recent -> exit 0); audit-unreachable degrades gracefully
- [x] Full `pytest` leaves a clean worktree

## Note
Rebased onto current main so it does not revert the #24/#25 cleanup. Per that convention, this PR contains no internal planning/design docs (they stay as working notes, not committed).