### PR TITLE
ci: restrict GITHUB_TOKEN to contents:read

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,6 +3,8 @@ on:
   push:
     branches: [main]
   pull_request:
+permissions:
+  contents: read
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What

Adds an explicit top-level `permissions` block to the CI workflow, restricting the `GITHUB_TOKEN` to `contents: read`.

## Why

Resolves the open code scanning alert `actions/missing-workflow-permissions` (medium severity, `.github/workflows/ci.yaml`). Without an explicit block, the workflow token defaults to broad permissions.

The `test` job only checks out the repo and runs tests/lint (`ruff`, `pytest`, `bats`, `data-olympus lint`); it never writes to the repo, posts comments, or touches releases/packages, so `contents: read` is the least-privilege fit. A top-level block applies to every job.

The alert will auto-close once this merges to `main` and the scan re-runs.