### PR TITLE
feat(onboarding): guided onboarding, discovery capture & cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Cross-agent enforcement providers: `kb enforce install --agent codex|gemini|opencode|copilot-cli|copilot-ide` and `--all`. Codex and Gemini get hard PreToolUse/BeforeTool gates (merging into existing hooks), OpenCode gets a `tool.execute.before` plugin, and Copilot CLI/IDE get a soft instructions-file + MCP provider. Antigravity is a documented-unsupported stub. The `kb-enforce-hook` dispatcher gained a `--dialect gemini` output mode.
 - Detection floor for un-hookable agents: `kb enforce report` (and `data-olympus report`) correlates governed git commits against the consult audit and lists changes with no consultation on record. An opt-in repo-scoped git provider (`kb enforce install --agent git`) installs a post-commit warning hook, or a pre-commit blocking hook with `--block`. Reuses the existing audit endpoint; no server change.
 - Enforcement hardening and observability: gate_bypass and gate_degraded events are now recorded (via `data-olympus report --emit-events` / the git warn hook, and the pre-tool hook on a reachable-degraded gate), so `kb_compliance` surfaces them. The gate receives `action_diff` and the classifier uses word-boundary matching plus dependency-install command signals (Codex and Claude now gate the Bash tool). New `kb enforce install --mode off|soft|hard`, ledger persistence via `KB_LEDGER_PATH`, a friendly PATH hint for `kb enforce report`, and a CI guard requiring a changelog entry for functional changes.
+- Guided onboarding: MCP prompts `onboard`, `onboard_project`, and `onboard_component` walk an agent through bootstrapping a new workspace or component, backed by a single-sourced playbook (`render_playbook`). A read-only `kb_cleanup_plan` MCP tool plus `POST /api/v1/onboarding/cleanup-plan` classify local repo docs against KB content and propose thin-pointer replacements for duplicates. `GET /api/v1/onboarding/playbook` and `kb onboard playbook` expose the same script to agents without native MCP prompt support.
 
 ### Fixed
 
@@ -134,6 +135,18 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   write a file outside the worktree before `git add` aborted. The edit, resolve,
   and onboarding-bootstrap paths now use the same guard. Regression tests cover
   the helper directly and each write path.
+- Cleanup-plan input validation is now centralized in `kb_cleanup_plan_fn` itself,
+  so both `POST /api/v1/onboarding/cleanup-plan` and the MCP `kb_cleanup_plan`
+  tool are protected identically (previously only the REST route validated,
+  and the MCP tool called the function directly, unvalidated). The shared
+  function now rejects a non-list `local_files`, a non-object entry, a
+  non-string `path`, and a non-string `content` (including an explicit
+  `content: null`, which used to slip through `.get()` and crash later). It
+  also enforces a per-file `max_content_bytes` cap, an aggregate `max_files`
+  cap, and requires `jaccard_threshold` to be a finite number in `[0.0, 1.0]`
+  (rejecting `nan`, `inf`, and out-of-range values). REST and MCP callers pass
+  the existing `KB_MAX_BOOTSTRAP_FILES` / `KB_MAX_POSTIMAGE_BYTES` caps through
+  to the shared function.
 
 ### Changed
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,16 @@
+# data-olympus roadmap
+
+Guided onboarding (import, interview, bootstrap, cleanup) shipped as the first
+slice of a broader effort to keep team knowledge current, homogeneous, and
+retrievable by coding agents. The pieces below are tracked as GitHub issues; this
+file is the index.
+
+| Piece | Summary | Status | Tracking |
+|-------|---------|--------|----------|
+| A | Guided onboarding + discovery capture + dedup/cleanup | Shipped | this repo |
+| B | Curation / pattern promotion (`kb_curate`): surface repeated patterns and propose hoisting component to project to universal, human-gated | Planned | #31 |
+| C | Consultation telemetry + per-user stats + reporting, privacy-gated (config opt-in, stored off the public KB) | Planned | #32 |
+| D | Cross-agent skill distribution: import team-shareable skills from the MCP on first agent run | Planned | #33 |
+| E | Skill suggestion: detect repeated instructions and propose a reusable skill or workflow | Planned | #34 |
+
+Suggested build order after A: C, then B, then D and E.

--- a/bin/kb
+++ b/bin/kb
@@ -587,16 +587,32 @@ cmd_onboard_playbook() {
   local q="kind=$(url_encode "$kind")"
   [[ -n "$workspace" ]] && q="$q&workspace=$(url_encode "$workspace")"
   [[ -n "$component" ]] && q="$q&component=$(url_encode "$component")"
-  local tmpfile
+  local tmpfile REST_STATUS
   tmpfile=$(mktemp)
-  if ! curl --silent --max-time 10 --output "$tmpfile" \
-        "$KB_ENDPOINT/api/v1/onboarding/playbook?$q" 2>/dev/null; then
+  if ! REST_STATUS=$(curl --silent --max-time 10 --output "$tmpfile" \
+        --write-out "%{http_code}" \
+        "$KB_ENDPOINT/api/v1/onboarding/playbook?$q" 2>/dev/null); then
     rm -f "$tmpfile"
     echo "kb: data-olympus-mcp unreachable at $KB_ENDPOINT" >&2
     exit 1
   fi
   REST_BODY=$(cat "$tmpfile"); rm -f "$tmpfile"
-  python3 -c 'import sys,json; print(json.load(sys.stdin)["text"])' <<<"$REST_BODY"
+  if [[ "$REST_STATUS" == 2* ]]; then
+    python3 -c 'import sys,json; print(json.load(sys.stdin)["text"])' <<<"$REST_BODY"
+    return 0
+  fi
+  local err
+  err=$(python3 -c 'import sys,json
+try:
+    print(json.load(sys.stdin).get("error", ""))
+except Exception:
+    print("")' <<<"$REST_BODY" 2>/dev/null) || err=""
+  if [[ -n "$err" ]]; then
+    echo "kb: $err" >&2
+  else
+    echo "kb: server returned HTTP $REST_STATUS" >&2
+  fi
+  exit 1
 }
 
 # Subcommand: kb audit [--since EPOCH] [--agent A] [--status S] [--limit N] [-o json|plain]

--- a/bin/kb
+++ b/bin/kb
@@ -18,6 +18,7 @@
 #   kb onboard project <workspace>
 #   kb onboard component <workspace> <component>
 #   kb onboard rename <from> <to>
+#   kb onboard playbook [--kind dispatch|project|component] [--workspace W] [--component C]
 #   kb enforce install|uninstall|status|doctor [--agent NAME | --all] [--settings PATH]
 #   kb enforce report [--workspace W] [--range A..B | --since S] [--json] [--fail-on-unverified]
 #
@@ -569,6 +570,35 @@ Not automated in this slice. The rename_candidate detection in
 EOF
 }
 
+# Subcommand: kb onboard playbook [--kind dispatch|project|component]
+#                                  [--workspace W] [--component C]
+# Cross-agent fallback: prints the same guided-onboarding script the MCP
+# prompts surface, for agents that cannot use native MCP prompts.
+cmd_onboard_playbook() {
+  local kind="dispatch" workspace="" component=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --kind) need_value "$1" "${2:-}"; kind="$2"; shift 2 ;;
+      --workspace) need_value "$1" "${2:-}"; workspace="$2"; shift 2 ;;
+      --component) need_value "$1" "${2:-}"; component="$2"; shift 2 ;;
+      *) shift ;;
+    esac
+  done
+  local q="kind=$(url_encode "$kind")"
+  [[ -n "$workspace" ]] && q="$q&workspace=$(url_encode "$workspace")"
+  [[ -n "$component" ]] && q="$q&component=$(url_encode "$component")"
+  local tmpfile
+  tmpfile=$(mktemp)
+  if ! curl --silent --max-time 10 --output "$tmpfile" \
+        "$KB_ENDPOINT/api/v1/onboarding/playbook?$q" 2>/dev/null; then
+    rm -f "$tmpfile"
+    echo "kb: data-olympus-mcp unreachable at $KB_ENDPOINT" >&2
+    exit 1
+  fi
+  REST_BODY=$(cat "$tmpfile"); rm -f "$tmpfile"
+  python3 -c 'import sys,json; print(json.load(sys.stdin)["text"])' <<<"$REST_BODY"
+}
+
 # Subcommand: kb audit [--since EPOCH] [--agent A] [--status S] [--limit N] [-o json|plain]
 cmd_audit() {
   local fmt="json" since="" agent="" status_f="" limit="100" verify=""
@@ -666,13 +696,14 @@ case "$SUBCMD" in
     ;;
   onboarding-check) cmd_onboarding_check "$@"; exit $? ;;
   onboard)
-    [[ $# -ge 1 ]] || { echo "kb: onboard requires subcommand (status|project|component|rename)" >&2; exit 64; }
+    [[ $# -ge 1 ]] || { echo "kb: onboard requires subcommand (status|project|component|rename|playbook)" >&2; exit 64; }
     SUB2="$1"; shift
     case "$SUB2" in
       status) cmd_onboard_status "$@"; exit $? ;;
       project) cmd_onboard_project "$@"; exit $? ;;
       component) cmd_onboard_component "$@"; exit $? ;;
       rename) cmd_onboard_rename "$@"; exit $? ;;
+      playbook) cmd_onboard_playbook "$@"; exit $? ;;
       *) echo "kb: unknown onboard subcommand: $SUB2" >&2; exit 64 ;;
     esac
     ;;

--- a/src/data_olympus/dedup.py
+++ b/src/data_olympus/dedup.py
@@ -1,0 +1,57 @@
+"""Deterministic repo<->KB overlap detection. No LLM: exact-hash for duplicates,
+heading-set + k-shingle Jaccard for partial overlap. Ambiguous partials are left
+for the calling agent to judge (escalation path)."""
+from __future__ import annotations
+
+import hashlib
+import re
+
+_FRONTMATTER_RE = re.compile(r"\A---\n.*?\n---\n", re.DOTALL)
+_HEADING_RE = re.compile(r"^#{1,6}\s+(.*\S)\s*$", re.MULTILINE)
+_WS_RE = re.compile(r"\s+")
+
+
+def strip_frontmatter(text: str) -> str:
+    return _FRONTMATTER_RE.sub("", text, count=1)
+
+
+def normalize_markdown(text: str) -> str:
+    body = strip_frontmatter(text)
+    return _WS_RE.sub(" ", body).strip().lower()
+
+
+def content_hash(text: str) -> str:
+    return hashlib.sha256(normalize_markdown(text).encode("utf-8")).hexdigest()
+
+
+def extract_headings(text: str) -> set[str]:
+    return {m.strip().lower() for m in _HEADING_RE.findall(text)}
+
+
+def shingles(text: str, k: int = 5) -> set[str]:
+    words = normalize_markdown(text).split()
+    if not words:
+        return set()
+    if len(words) < k:
+        return {" ".join(words)}
+    return {" ".join(words[i:i + k]) for i in range(len(words) - k + 1)}
+
+
+def jaccard(a: set[str], b: set[str]) -> float:
+    if not a and not b:
+        return 1.0
+    if not a or not b:
+        return 0.0
+    return len(a & b) / len(a | b)
+
+
+def classify_overlap(
+    local_text: str, kb_text: str, *, jaccard_threshold: float = 0.6,
+) -> tuple[str, list[str]]:
+    """Return (classification, overlap_headings)."""
+    if content_hash(local_text) == content_hash(kb_text):
+        return ("imported_duplicate", [])
+    if jaccard(shingles(local_text), shingles(kb_text)) >= jaccard_threshold:
+        shared = sorted(extract_headings(local_text) & extract_headings(kb_text))
+        return ("partial_overlap", shared)
+    return ("unique", [])

--- a/src/data_olympus/models.py
+++ b/src/data_olympus/models.py
@@ -276,3 +276,19 @@ class BootstrapResponse(BaseModel):
     rejected_paths: list[str] = []
     push_state: str | None = None
     operator_prompt: str | None = None
+
+
+class CleanupItem(BaseModel):
+    local_path: str
+    classification: str  # imported_duplicate | partial_overlap | unique
+    kb_id: str | None = None
+    kb_path: str | None = None
+    overlap_headings: list[str] = []
+    thin_pointer_text: str | None = None
+
+
+class CleanupPlanResponse(BaseModel):
+    workspace: str
+    component: str | None = None
+    items: list[CleanupItem] = []
+    summary: dict[str, int] = {}

--- a/src/data_olympus/onboarding_playbook.py
+++ b/src/data_olympus/onboarding_playbook.py
@@ -1,0 +1,84 @@
+"""The guided onboarding script, authored once. Consumed by the MCP prompts
+(prompts.py), the REST/CLI playbook endpoint, and any fallback skill, so all
+surfaces render identical instructions."""
+from __future__ import annotations
+
+_INTERVIEW = """\
+Interview the human for discovery knowledge the repo does not already state.
+Ask only what imported files do not answer. Map answers to canonical files:
+  - identity, purpose, repo URL -> README.md (+ git_remote_url front-matter)
+  - architecture and rationale  -> README.md "Architecture"
+  - conventions and patterns     -> AGENTS.md
+  - integrations and deps        -> README.md "Integrations"
+  - gotchas / operational notes  -> AGENTS.md "Gotchas & operational notes"
+  - ownership and contacts       -> README.md "Ownership"
+"""
+
+_CLEANUP = """\
+After bootstrap, call kb_cleanup_plan with the local doc files. Present the plan
+per file (default to the recommended action). For imported_duplicate items, apply
+the supplied thin-pointer text to the project repo with your own edit tool and
+leave the changes staged for the human to commit. Show partial_overlap items for
+manual review; leave unique files untouched. The server never edits the project
+repo.
+"""
+
+_DISPATCH = """\
+# Onboarding: dispatch
+
+1. Detect the current workspace (and component, if inside a nested repo).
+2. Call kb_onboarding_status for it. If the state is 'onboarded', stop and say so.
+3. Ask the human: is this repo part of a known project already in the KB?
+   Show candidates with `kb_list` over projects.
+   - If yes, run the component onboarding for that project.
+   - If no, run the full project onboarding.
+"""
+
+_PROJECT = """\
+# Onboarding project: {workspace}
+
+1. Confirm kb_onboarding_status(workspace={workspace!r}) is 'absent' or 'partial'.
+2. Inventory local docs (README.md, AGENTS.md, CLAUDE.md, .rules/, docs/).
+{interview}
+3. Assemble imported files + interview answers and call kb_bootstrap_project
+   (workspace={workspace!r}, workspace_remote_url={workspace_remote_url!r}). One
+   atomic commit on high confidence, else one pending bundle.
+{cleanup}
+"""
+
+_COMPONENT = """\
+# Onboarding component: {component} (project {workspace})
+
+1. Read the parent project's AGENTS.md first (kb_get projects-{workspace}-AGENTS)
+   to inherit its conventions and lessons; only ask for component-specific deltas.
+2. Confirm kb_onboarding_status(workspace={workspace!r}, component={component!r})
+   is 'absent' or 'partial'.
+{interview}
+3. Call kb_bootstrap_project(workspace={workspace!r}, component={component!r},
+   component_remote_url={component_remote_url!r}).
+{cleanup}
+"""
+
+
+def render_playbook(
+    kind: str,
+    *,
+    workspace: str | None = None,
+    component: str | None = None,
+    workspace_remote_url: str | None = None,
+    component_remote_url: str | None = None,
+) -> str:
+    if kind == "dispatch":
+        return _DISPATCH
+    if kind == "project":
+        return _PROJECT.format(
+            workspace=workspace, workspace_remote_url=workspace_remote_url,
+            interview=_INTERVIEW, cleanup=_CLEANUP,
+        )
+    if kind == "component":
+        return _COMPONENT.format(
+            workspace=workspace, component=component,
+            component_remote_url=component_remote_url,
+            interview=_INTERVIEW, cleanup=_CLEANUP,
+        )
+    raise ValueError(f"unknown playbook kind: {kind!r}")

--- a/src/data_olympus/prompts.py
+++ b/src/data_olympus/prompts.py
@@ -1,0 +1,35 @@
+"""MCP prompts for guided onboarding. Thin wrappers over the single-sourced
+playbook (onboarding_playbook.py); no business logic here."""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from data_olympus.onboarding_playbook import render_playbook
+
+if TYPE_CHECKING:
+    from fastmcp import FastMCP
+
+
+def register_prompts(app: FastMCP) -> None:
+    @app.prompt
+    def onboard() -> str:
+        """Guided entry point: detect the workspace, then route to project or
+        component onboarding."""
+        return render_playbook("dispatch")
+
+    @app.prompt
+    def onboard_project(workspace: str, workspace_remote_url: str | None = None) -> str:
+        """Guided full-project (T3) onboarding: import, interview, bootstrap, clean up."""
+        return render_playbook(
+            "project", workspace=workspace, workspace_remote_url=workspace_remote_url,
+        )
+
+    @app.prompt
+    def onboard_component(
+        workspace: str, component: str, component_remote_url: str | None = None,
+    ) -> str:
+        """Guided component (T4) onboarding under a known project."""
+        return render_playbook(
+            "component", workspace=workspace, component=component,
+            component_remote_url=component_remote_url,
+        )

--- a/src/data_olympus/rest_api.py
+++ b/src/data_olympus/rest_api.py
@@ -593,32 +593,17 @@ def register_routes(
             return big
         if (bad := _missing_fields_response(body, ["workspace", "local_files"])) is not None:
             return bad
-        local_files = body["local_files"]
-        if not isinstance(local_files, list):
-            return JSONResponse(
-                {"error": "local_files must be a list"}, status_code=400,
-            )
-        for entry in local_files:
-            if not isinstance(entry, dict) or not isinstance(entry.get("path"), str):
-                return JSONResponse(
-                    {"error": "each local_files entry must be an object with a "
-                              "string 'path'"},
-                    status_code=400,
-                )
-        if len(local_files) > state.config.max_bootstrap_files:
-            return JSONResponse({"error": "too many files"}, status_code=400)
+        from data_olympus.tools_onboarding import CleanupInputError, kb_cleanup_plan_fn
         try:
-            jaccard_threshold = float(body.get("jaccard_threshold", 0.6))
-        except (TypeError, ValueError):
-            return JSONResponse(
-                {"error": "jaccard_threshold must be a number"}, status_code=400,
+            resp = kb_cleanup_plan_fn(
+                idx=state.idx,
+                workspace=body["workspace"],
+                component=body.get("component"),
+                local_files=body["local_files"],
+                jaccard_threshold=body.get("jaccard_threshold", 0.6),
+                max_files=state.config.max_bootstrap_files,
+                max_content_bytes=state.config.max_postimage_bytes,
             )
-        from data_olympus.tools_onboarding import kb_cleanup_plan_fn
-        resp = kb_cleanup_plan_fn(
-            idx=state.idx,
-            workspace=body["workspace"],
-            component=body.get("component"),
-            local_files=local_files,
-            jaccard_threshold=jaccard_threshold,
-        )
+        except CleanupInputError as e:
+            return JSONResponse({"error": str(e)}, status_code=400)
         return JSONResponse(resp.model_dump())

--- a/src/data_olympus/rest_api.py
+++ b/src/data_olympus/rest_api.py
@@ -568,3 +568,20 @@ def register_routes(
         )
         status = _propose_status(resp.status)
         return JSONResponse(resp.model_dump(), status_code=status)
+
+    @app.custom_route("/api/v1/onboarding/cleanup-plan", methods=["POST"])
+    async def onboarding_cleanup_plan(request: Request) -> JSONResponse:
+        body, big = await _read_json_capped(request, state.config.max_body_bytes)
+        if big is not None:
+            return big
+        if (bad := _missing_fields_response(body, ["workspace", "local_files"])) is not None:
+            return bad
+        from data_olympus.tools_onboarding import kb_cleanup_plan_fn
+        resp = kb_cleanup_plan_fn(
+            idx=state.idx,
+            workspace=body["workspace"],
+            component=body.get("component"),
+            local_files=body["local_files"],
+            jaccard_threshold=float(body.get("jaccard_threshold", 0.6)),
+        )
+        return JSONResponse(resp.model_dump())

--- a/src/data_olympus/rest_api.py
+++ b/src/data_olympus/rest_api.py
@@ -569,6 +569,23 @@ def register_routes(
         status = _propose_status(resp.status)
         return JSONResponse(resp.model_dump(), status_code=status)
 
+    @app.custom_route("/api/v1/onboarding/playbook", methods=["GET"])
+    async def onboarding_playbook(request: Request) -> JSONResponse:
+        from data_olympus.onboarding_playbook import render_playbook
+        qp = request.query_params
+        kind = qp.get("kind", "dispatch")
+        try:
+            text = render_playbook(
+                kind,
+                workspace=qp.get("workspace") or None,
+                component=qp.get("component") or None,
+                workspace_remote_url=qp.get("workspace_remote_url") or None,
+                component_remote_url=qp.get("component_remote_url") or None,
+            )
+        except ValueError as e:
+            return JSONResponse({"error": str(e)}, status_code=400)
+        return JSONResponse({"kind": kind, "text": text})
+
     @app.custom_route("/api/v1/onboarding/cleanup-plan", methods=["POST"])
     async def onboarding_cleanup_plan(request: Request) -> JSONResponse:
         body, big = await _read_json_capped(request, state.config.max_body_bytes)

--- a/src/data_olympus/rest_api.py
+++ b/src/data_olympus/rest_api.py
@@ -593,12 +593,32 @@ def register_routes(
             return big
         if (bad := _missing_fields_response(body, ["workspace", "local_files"])) is not None:
             return bad
+        local_files = body["local_files"]
+        if not isinstance(local_files, list):
+            return JSONResponse(
+                {"error": "local_files must be a list"}, status_code=400,
+            )
+        for entry in local_files:
+            if not isinstance(entry, dict) or not isinstance(entry.get("path"), str):
+                return JSONResponse(
+                    {"error": "each local_files entry must be an object with a "
+                              "string 'path'"},
+                    status_code=400,
+                )
+        if len(local_files) > state.config.max_bootstrap_files:
+            return JSONResponse({"error": "too many files"}, status_code=400)
+        try:
+            jaccard_threshold = float(body.get("jaccard_threshold", 0.6))
+        except (TypeError, ValueError):
+            return JSONResponse(
+                {"error": "jaccard_threshold must be a number"}, status_code=400,
+            )
         from data_olympus.tools_onboarding import kb_cleanup_plan_fn
         resp = kb_cleanup_plan_fn(
             idx=state.idx,
             workspace=body["workspace"],
             component=body.get("component"),
-            local_files=body["local_files"],
-            jaccard_threshold=float(body.get("jaccard_threshold", 0.6)),
+            local_files=local_files,
+            jaccard_threshold=jaccard_threshold,
         )
         return JSONResponse(resp.model_dump())

--- a/src/data_olympus/server.py
+++ b/src/data_olympus/server.py
@@ -480,11 +480,16 @@ def build_app(
         """Read-only. Classify local project-repo docs against KB content for this
         workspace/component and return thin-pointer replacements for duplicates.
         The agent applies confirmed edits locally; the server writes nothing."""
-        from data_olympus.tools_onboarding import kb_cleanup_plan_fn
-        resp = kb_cleanup_plan_fn(
-            idx=state.idx, workspace=workspace, component=component,
-            local_files=local_files, jaccard_threshold=jaccard_threshold,
-        )
+        from data_olympus.tools_onboarding import CleanupInputError, kb_cleanup_plan_fn
+        try:
+            resp = kb_cleanup_plan_fn(
+                idx=state.idx, workspace=workspace, component=component,
+                local_files=local_files, jaccard_threshold=jaccard_threshold,
+                max_files=state.config.max_bootstrap_files,
+                max_content_bytes=state.config.max_postimage_bytes,
+            )
+        except CleanupInputError as e:
+            return {"status": "rejected_invalid_input", "error": str(e)}
         return resp.model_dump()
 
     @app.tool()

--- a/src/data_olympus/server.py
+++ b/src/data_olympus/server.py
@@ -473,6 +473,21 @@ def build_app(
         return resp.model_dump()
 
     @app.tool()
+    def kb_cleanup_plan(
+        workspace: str, local_files: list[dict[str, str]],
+        component: str | None = None, jaccard_threshold: float = 0.6,
+    ) -> dict[str, object]:
+        """Read-only. Classify local project-repo docs against KB content for this
+        workspace/component and return thin-pointer replacements for duplicates.
+        The agent applies confirmed edits locally; the server writes nothing."""
+        from data_olympus.tools_onboarding import kb_cleanup_plan_fn
+        resp = kb_cleanup_plan_fn(
+            idx=state.idx, workspace=workspace, component=component,
+            local_files=local_files, jaccard_threshold=jaccard_threshold,
+        )
+        return resp.model_dump()
+
+    @app.tool()
     def kb_consult(
         workspace: str, intent: str, source_session: str,
         agent_identity: str,

--- a/src/data_olympus/server.py
+++ b/src/data_olympus/server.py
@@ -563,6 +563,9 @@ def build_app(
 
     from data_olympus.rest_api import register_routes
     register_routes(app, state, registry)
+
+    from data_olympus.prompts import register_prompts
+    register_prompts(app)
     # Attach state for lifespan to discover; not used by tests
     app._dolympus_state = state  # type: ignore[attr-defined]
     return app

--- a/src/data_olympus/thin_pointer.py
+++ b/src/data_olympus/thin_pointer.py
@@ -1,0 +1,20 @@
+"""Canonical thin-pointer text. data-olympus owns this so every deployment
+emits identical pointers; the marker's first-line placement lets a project-repo
+lint validate drift unambiguously."""
+from __future__ import annotations
+
+THIN_POINTER_MARKER = "<!-- KB-THIN-POINTER v1 -->"
+
+
+def render_thin_pointer(*, kb_path: str, kb_id: str, kind: str = "project") -> str:
+    """Render the replacement body for a project-repo doc whose content now
+    lives in the knowledge base. `kb_path` is the KB-relative git path;
+    `kb_id` is the retrievable document id; `kind` is 'project' or 'component'."""
+    return (
+        f"{THIN_POINTER_MARKER}\n"
+        f"The canonical documentation for this {kind} lives in the knowledge base\n"
+        f"managed by data-olympus. This file is intentionally minimal.\n\n"
+        f"Source of truth (git path in the knowledge base):\n\n"
+        f"  {kb_path}\n\n"
+        f"Agents: retrieve it with `kb get {kb_id}` or the data-olympus MCP `kb_get` tool.\n"
+    )

--- a/src/data_olympus/tools_onboarding.py
+++ b/src/data_olympus/tools_onboarding.py
@@ -6,6 +6,8 @@ from typing import TYPE_CHECKING
 
 from data_olympus.models import (
     BootstrapResponse,
+    CleanupItem,
+    CleanupPlanResponse,
     OnboardingStatusResponse,
     RenameCandidateModel,
 )
@@ -251,3 +253,62 @@ def _inject_remote_url(
                 continue
         out.append(f)
     return out
+
+
+_RANK = {"imported_duplicate": 2, "partial_overlap": 1, "unique": 0}
+
+
+def kb_cleanup_plan_fn(
+    *,
+    idx: Index,
+    workspace: str,
+    component: str | None,
+    local_files: list[dict[str, str]],
+    jaccard_threshold: float = 0.6,
+) -> CleanupPlanResponse:
+    """Read-only: classify each local repo file against the KB content already
+    committed for this workspace/component, and render thin-pointer replacements
+    for exact duplicates. Server proposes; the agent applies edits locally."""
+    from data_olympus.dedup import classify_overlap, jaccard, shingles
+    from data_olympus.thin_pointer import render_thin_pointer
+
+    prefix = f"projects/{workspace}/"
+    if component:
+        prefix = f"projects/{workspace}/components/{component}/"
+    kb_docs = []
+    for entry in idx.list_by_prefix(prefix):
+        doc = idx.get(entry["id"])
+        if doc is not None:
+            kb_docs.append(doc)
+
+    kind = "component" if component else "project"
+    items: list[CleanupItem] = []
+    summary = {"imported_duplicate": 0, "partial_overlap": 0, "unique": 0}
+
+    for lf in local_files:
+        local_text = lf.get("content", "")
+        best_cls, best_headings, best_doc, best_j = "unique", [], None, -1.0
+        local_shingles = shingles(local_text)
+        for doc in kb_docs:
+            cls, headings = classify_overlap(
+                local_text, doc.content_markdown, jaccard_threshold=jaccard_threshold,
+            )
+            j = jaccard(local_shingles, shingles(doc.content_markdown))
+            if _RANK[cls] > _RANK[best_cls] or (_RANK[cls] == _RANK[best_cls] and j > best_j):
+                best_cls, best_headings, best_doc, best_j = cls, headings, doc, j
+
+        item = CleanupItem(local_path=lf["path"], classification=best_cls)
+        if best_doc is not None and best_cls == "imported_duplicate":
+            item.kb_id, item.kb_path = best_doc.id, best_doc.path
+            item.thin_pointer_text = render_thin_pointer(
+                kb_path=best_doc.path, kb_id=best_doc.id, kind=kind,
+            )
+        elif best_doc is not None and best_cls == "partial_overlap":
+            item.kb_id, item.kb_path = best_doc.id, best_doc.path
+            item.overlap_headings = best_headings
+        summary[best_cls] += 1
+        items.append(item)
+
+    return CleanupPlanResponse(
+        workspace=workspace, component=component, items=items, summary=summary,
+    )

--- a/src/data_olympus/tools_onboarding.py
+++ b/src/data_olympus/tools_onboarding.py
@@ -288,19 +288,26 @@ def kb_cleanup_plan_fn(
     items: list[CleanupItem] = []
     summary = {"imported_duplicate": 0, "partial_overlap": 0, "unique": 0}
 
+    # Precompute each KB doc's shingles once, outside the per-local-file loop,
+    # rather than recomputing them for every local file (O(files * docs) shingle
+    # builds otherwise). classify_overlap() still recomputes internally for its
+    # own exact-hash + jaccard check; that duplication is harmless and kept
+    # simple/behavior-preserving here.
+    kb_docs_shingled = [(doc, shingles(doc.content_markdown)) for doc in kb_docs]
+
     for lf in local_files:
         local_text = lf.get("content", "")
         best_cls, best_headings, best_doc, best_j = "unique", [], None, -1.0
         local_shingles = shingles(local_text)
-        for doc in kb_docs:
+        for doc, doc_shingles in kb_docs_shingled:
             cls, headings = classify_overlap(
                 local_text, doc.content_markdown, jaccard_threshold=jaccard_threshold,
             )
-            j = jaccard(local_shingles, shingles(doc.content_markdown))
+            j = jaccard(local_shingles, doc_shingles)
             if _RANK[cls] > _RANK[best_cls] or (_RANK[cls] == _RANK[best_cls] and j > best_j):
                 best_cls, best_headings, best_doc, best_j = cls, headings, doc, j
 
-        item = CleanupItem(local_path=lf["path"], classification=best_cls)
+        item = CleanupItem(local_path=lf.get("path", ""), classification=best_cls)
         if best_doc is not None and best_cls == "imported_duplicate":
             item.kb_id, item.kb_path = best_doc.id, best_doc.path
             item.thin_pointer_text = render_thin_pointer(

--- a/src/data_olympus/tools_onboarding.py
+++ b/src/data_olympus/tools_onboarding.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import contextlib
+import math
 from typing import TYPE_CHECKING
 
 from data_olympus.models import (
@@ -258,6 +259,12 @@ def _inject_remote_url(
 _RANK = {"imported_duplicate": 2, "partial_overlap": 1, "unique": 0}
 
 
+class CleanupInputError(ValueError):
+    """Raised by kb_cleanup_plan_fn when local_files / jaccard_threshold input
+    fails validation. Both the REST route and the MCP tool catch this and
+    surface it as a 400 / rejected_invalid_input response respectively."""
+
+
 def kb_cleanup_plan_fn(
     *,
     idx: Index,
@@ -265,10 +272,51 @@ def kb_cleanup_plan_fn(
     component: str | None,
     local_files: list[dict[str, str]],
     jaccard_threshold: float = 0.6,
+    max_files: int = 0,
+    max_content_bytes: int = 0,
 ) -> CleanupPlanResponse:
     """Read-only: classify each local repo file against the KB content already
     committed for this workspace/component, and render thin-pointer replacements
-    for exact duplicates. Server proposes; the agent applies edits locally."""
+    for exact duplicates. Server proposes; the agent applies edits locally.
+
+    Validation happens here (not just in the REST route) so that the MCP tool
+    path, which calls this function directly, is protected too. Raises
+    CleanupInputError on invalid input; callers translate that into their own
+    surface's error shape (REST: 400 JSON; MCP: rejected_invalid_input dict).
+    """
+    if not isinstance(local_files, list):
+        raise CleanupInputError("local_files must be a list")
+    validated_contents: list[str] = []
+    for entry in local_files:
+        if not isinstance(entry, dict):
+            raise CleanupInputError("each local_files entry must be an object")
+        if not isinstance(entry.get("path"), str):
+            raise CleanupInputError(
+                "each local_files entry must be an object with a string 'path'",
+            )
+        content = entry.get("content", "")
+        if not isinstance(content, str):
+            raise CleanupInputError(
+                "each local_files entry's 'content' must be a string",
+            )
+        if max_content_bytes > 0 and len(content.encode("utf-8")) > max_content_bytes:
+            raise CleanupInputError(
+                f"local_files entry '{entry.get('path')}' content exceeds "
+                f"max_content_bytes={max_content_bytes}",
+            )
+        validated_contents.append(content)
+
+    if max_files > 0 and len(local_files) > max_files:
+        raise CleanupInputError(f"too many files (max_files={max_files})")
+
+    try:
+        t = float(jaccard_threshold)
+    except (TypeError, ValueError) as e:
+        raise CleanupInputError("jaccard_threshold must be a number") from e
+    if not math.isfinite(t) or not (0.0 <= t <= 1.0):
+        raise CleanupInputError("jaccard_threshold must be a finite number in [0.0, 1.0]")
+    jaccard_threshold = t
+
     from data_olympus.dedup import classify_overlap, jaccard, shingles
     from data_olympus.thin_pointer import render_thin_pointer
 
@@ -295,8 +343,7 @@ def kb_cleanup_plan_fn(
     # simple/behavior-preserving here.
     kb_docs_shingled = [(doc, shingles(doc.content_markdown)) for doc in kb_docs]
 
-    for lf in local_files:
-        local_text = lf.get("content", "")
+    for lf, local_text in zip(local_files, validated_contents, strict=True):
         best_cls, best_headings, best_doc, best_j = "unique", [], None, -1.0
         local_shingles = shingles(local_text)
         for doc, doc_shingles in kb_docs_shingled:

--- a/src/data_olympus/tools_onboarding.py
+++ b/src/data_olympus/tools_onboarding.py
@@ -275,8 +275,11 @@ def kb_cleanup_plan_fn(
     prefix = f"projects/{workspace}/"
     if component:
         prefix = f"projects/{workspace}/components/{component}/"
+        entries = idx.list_by_prefix(prefix)
+    else:
+        entries = idx.list_by_prefix(prefix, exclude_under="components/")
     kb_docs = []
-    for entry in idx.list_by_prefix(prefix):
+    for entry in entries:
         doc = idx.get(entry["id"])
         if doc is not None:
             kb_docs.append(doc)

--- a/tests/bats/onboarding.bats
+++ b/tests/bats/onboarding.bats
@@ -52,3 +52,10 @@ teardown() {
   [ "$status" -eq 0 ]
   [[ "$output" == *"Onboarding project: foo"* ]]
 }
+
+@test "kb onboard playbook with bad kind fails cleanly, no traceback" {
+  run "$KB" onboard playbook --kind bogus
+  [ "$status" -ne 0 ]
+  [[ "$output" != *"Traceback"* ]]
+  [[ "$output" == *"kb:"* ]]
+}

--- a/tests/bats/onboarding.bats
+++ b/tests/bats/onboarding.bats
@@ -46,3 +46,9 @@ teardown() {
   [[ "$output" == *'"state"'* ]]
   [[ "$output" == *'"onboarded"'* ]]
 }
+
+@test "kb onboard playbook prints project script" {
+  run "$KB" onboard playbook --kind project --workspace foo
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Onboarding project: foo"* ]]
+}

--- a/tests/cli-fixtures/mock-server.py
+++ b/tests/cli-fixtures/mock-server.py
@@ -19,6 +19,8 @@ Read routes:
     GET /api/v1/onboarding/status       -> synthetic status:
                                             state=onboarded for workspace=example-project,
                                             state=absent for any other workspace.
+    GET /api/v1/onboarding/playbook     -> {"kind":..., "text":...} via the real
+                                            render_playbook() (single-sourced).
 
 Write routes:
     POST /api/v1/propose/memory         -> committed if confidence>=0.85,
@@ -35,6 +37,14 @@ from pathlib import Path
 from urllib.parse import parse_qs, urlparse
 
 FIXTURE_DIR = Path(sys.argv[2])
+
+# Make the real render_playbook() importable so the mock server stays
+# single-sourced with the REST endpoint instead of hand-maintaining a canned
+# copy of the onboarding script text.
+_SRC_DIR = Path(__file__).resolve().parents[2] / "src"
+if str(_SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(_SRC_DIR))
+from data_olympus.onboarding_playbook import render_playbook  # noqa: E402
 
 
 class Handler(BaseHTTPRequestHandler):
@@ -121,6 +131,24 @@ class Handler(BaseHTTPRequestHandler):
                     "rename_candidates": [],
                 }
             self._send(200, json.dumps(body))
+        elif path == "/api/v1/onboarding/playbook":
+            kind = qs.get("kind", ["dispatch"])[0]
+            workspace = qs.get("workspace", [None])[0]
+            component = qs.get("component", [None])[0]
+            workspace_remote_url = qs.get("workspace_remote_url", [None])[0]
+            component_remote_url = qs.get("component_remote_url", [None])[0]
+            try:
+                text = render_playbook(
+                    kind,
+                    workspace=workspace,
+                    component=component,
+                    workspace_remote_url=workspace_remote_url,
+                    component_remote_url=component_remote_url,
+                )
+            except ValueError as e:
+                self._send(400, json.dumps({"error": str(e)}))
+                return
+            self._send(200, json.dumps({"kind": kind, "text": text}))
         elif path == "/api/v1/audit":
             self._send(
                 200,

--- a/tests/test_dedup.py
+++ b/tests/test_dedup.py
@@ -7,7 +7,6 @@ from data_olympus.dedup import (
     extract_headings,
     jaccard,
     normalize_markdown,
-    shingles,
 )
 
 

--- a/tests/test_dedup.py
+++ b/tests/test_dedup.py
@@ -1,0 +1,64 @@
+"""Tests for the deterministic dedup heuristics."""
+from __future__ import annotations
+
+from data_olympus.dedup import (
+    classify_overlap,
+    content_hash,
+    extract_headings,
+    jaccard,
+    normalize_markdown,
+    shingles,
+)
+
+
+def test_normalize_strips_frontmatter_and_collapses_whitespace() -> None:
+    text = "---\nid: x\n---\n# Title\n\nHello   World\n"
+    norm = normalize_markdown(text)
+    assert "id: x" not in norm
+    assert "hello world" in norm
+
+
+def test_content_hash_ignores_frontmatter_and_whitespace_differences() -> None:
+    a = "---\nid: a\n---\n# T\n\nsame body here\n"
+    b = "---\nid: b\n---\n# T\nsame   body   here"
+    assert content_hash(a) == content_hash(b)
+
+
+def test_extract_headings_lowercased() -> None:
+    assert extract_headings("# Alpha\n## Beta Gamma\ntext") == {"alpha", "beta gamma"}
+
+
+def test_jaccard_bounds() -> None:
+    assert jaccard(set(), set()) == 1.0
+    assert jaccard({"a"}, set()) == 0.0
+    assert jaccard({"a", "b"}, {"a", "b"}) == 1.0
+
+
+def test_classify_exact_duplicate() -> None:
+    local = "# Purpose\n\nThe billing service charges customers monthly.\n"
+    kb = "---\nid: p\n---\n# Purpose\nThe billing   service charges customers monthly."
+    cls, headings = classify_overlap(local, kb)
+    assert cls == "imported_duplicate"
+    assert headings == []
+
+
+def test_classify_partial_overlap_returns_shared_headings() -> None:
+    local = (
+        "# Architecture\n\n" + " ".join(f"word{i}" for i in range(40))
+        + "\n# Extra Local\n\nlocal only text\n"
+    )
+    kb = (
+        "# Architecture\n\n" + " ".join(f"word{i}" for i in range(40))
+        + "\n# Extra Kb\n\ndifferent tail entirely here now\n"
+    )
+    cls, headings = classify_overlap(local, kb, jaccard_threshold=0.5)
+    assert cls == "partial_overlap"
+    assert "architecture" in headings
+
+
+def test_classify_unique_when_no_overlap() -> None:
+    local = "# Deploy\n\nkubernetes rollout steps for the gateway\n"
+    kb = "# Purpose\n\nunrelated billing invariants and money math\n"
+    cls, headings = classify_overlap(local, kb)
+    assert cls == "unique"
+    assert headings == []

--- a/tests/test_onboarding_playbook.py
+++ b/tests/test_onboarding_playbook.py
@@ -1,0 +1,31 @@
+"""Tests for the single-sourced onboarding playbook."""
+from __future__ import annotations
+
+import pytest
+
+from data_olympus.onboarding_playbook import render_playbook
+
+
+def test_dispatch_asks_the_known_project_branch_question() -> None:
+    out = render_playbook("dispatch")
+    assert "kb_onboarding_status" in out
+    assert "known project" in out.lower()
+
+
+def test_project_playbook_names_the_workspace_and_core_steps() -> None:
+    out = render_playbook("project", workspace="foo")
+    assert "foo" in out
+    assert "kb_bootstrap_project" in out
+    assert "kb_cleanup_plan" in out
+    assert "interview" in out.lower()
+
+
+def test_component_playbook_reads_parent_agents_first() -> None:
+    out = render_playbook("component", workspace="foo", component="svc")
+    assert "svc" in out and "foo" in out
+    assert "AGENTS.md" in out  # inherit parent lessons
+
+
+def test_unknown_kind_raises() -> None:
+    with pytest.raises(ValueError):
+        render_playbook("bogus")

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -1,0 +1,37 @@
+"""The three onboarding MCP prompts register and render the playbook."""
+from __future__ import annotations
+
+import asyncio
+
+from fastmcp import FastMCP
+
+from data_olympus.prompts import register_prompts
+
+
+def _names(app: FastMCP) -> set[str]:
+    prompts = asyncio.run(app.list_prompts())
+    return {p.name for p in prompts}
+
+
+def test_all_three_prompts_register() -> None:
+    app = FastMCP("test")
+    register_prompts(app)
+    assert {"onboard", "onboard_project", "onboard_component"} <= _names(app)
+
+
+def test_project_prompt_renders_with_workspace_argument() -> None:
+    # NOTE: adapted from the brief's `app.get_prompt(name, arguments)` call.
+    # In fastmcp 3.4.2, FastMCP.get_prompt(name) takes only a name and
+    # returns a Prompt (or None); rendering with arguments is a second step
+    # via Prompt.render(arguments) -> PromptResult. Confirmed via a throwaway
+    # probe against this repo's installed fastmcp. The two assertions the
+    # brief intends (names registered; "foo" appears in the rendered text)
+    # are unchanged.
+    app = FastMCP("test")
+    register_prompts(app)
+    prompt = asyncio.run(app.get_prompt("onboard_project"))
+    result = asyncio.run(prompt.render({"workspace": "foo"}))
+    text = " ".join(
+        m.content.text for m in result.messages if hasattr(m.content, "text")
+    )
+    assert "foo" in text

--- a/tests/test_rest_onboarding.py
+++ b/tests/test_rest_onboarding.py
@@ -71,6 +71,56 @@ async def test_rest_cleanup_plan_returns_200_and_classifies(http_app) -> None:
 
 
 @pytest.mark.asyncio
+async def test_rest_cleanup_plan_local_files_not_a_list_returns_400(http_app) -> None:
+    body = {
+        "workspace": "foo",
+        "local_files": "not-a-list",
+    }
+    transport = httpx.ASGITransport(app=http_app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post("/api/v1/onboarding/cleanup-plan", json=body)
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_rest_cleanup_plan_entry_missing_path_returns_400(http_app) -> None:
+    body = {
+        "workspace": "foo",
+        "local_files": [{"content": "no path key here"}],
+    }
+    transport = httpx.ASGITransport(app=http_app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post("/api/v1/onboarding/cleanup-plan", json=body)
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_rest_cleanup_plan_bad_jaccard_threshold_returns_400(http_app) -> None:
+    body = {
+        "workspace": "foo",
+        "local_files": [{"path": "README.md", "content": "hello"}],
+        "jaccard_threshold": "not-a-number",
+    }
+    transport = httpx.ASGITransport(app=http_app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post("/api/v1/onboarding/cleanup-plan", json=body)
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_rest_cleanup_plan_too_many_files_returns_400(http_app) -> None:
+    # Config default (KB_MAX_BOOTSTRAP_FILES) is 50; comfortably exceed it.
+    body = {
+        "workspace": "foo",
+        "local_files": [{"path": f"f{i}.md", "content": "x"} for i in range(10000)],
+    }
+    transport = httpx.ASGITransport(app=http_app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post("/api/v1/onboarding/cleanup-plan", json=body)
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
 async def test_rest_playbook_returns_text(http_app) -> None:
     transport = httpx.ASGITransport(app=http_app)
     async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:

--- a/tests/test_rest_onboarding.py
+++ b/tests/test_rest_onboarding.py
@@ -68,3 +68,22 @@ async def test_rest_cleanup_plan_returns_200_and_classifies(http_app) -> None:
     data = resp.json()
     assert "items" in data and "summary" in data
     assert len(data["items"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_rest_playbook_returns_text(http_app) -> None:
+    transport = httpx.ASGITransport(app=http_app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/api/v1/onboarding/playbook?kind=project&workspace=foo")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["kind"] == "project"
+    assert "foo" in data["text"]
+
+
+@pytest.mark.asyncio
+async def test_rest_playbook_invalid_kind_returns_400(http_app) -> None:
+    transport = httpx.ASGITransport(app=http_app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/api/v1/onboarding/playbook?kind=bogus")
+    assert resp.status_code == 400

--- a/tests/test_rest_onboarding.py
+++ b/tests/test_rest_onboarding.py
@@ -52,3 +52,19 @@ async def test_rest_onboarding_status_returns_onboarded_for_example_project(http
     body = resp.json()
     # Fixture has projects/example-project/README.md but no AGENTS.md, so partial.
     assert body["state"] in ("onboarded", "partial")
+
+
+@pytest.mark.asyncio
+async def test_rest_cleanup_plan_returns_200_and_classifies(http_app) -> None:
+    body = {
+        "workspace": "foo",
+        "component": None,
+        "local_files": [{"path": "README.md", "content": "# X\n\nunique local text\n"}],
+    }
+    transport = httpx.ASGITransport(app=http_app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post("/api/v1/onboarding/cleanup-plan", json=body)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "items" in data and "summary" in data
+    assert len(data["items"]) == 1

--- a/tests/test_rest_onboarding.py
+++ b/tests/test_rest_onboarding.py
@@ -108,6 +108,36 @@ async def test_rest_cleanup_plan_bad_jaccard_threshold_returns_400(http_app) -> 
 
 
 @pytest.mark.asyncio
+async def test_rest_cleanup_plan_null_content_returns_400(http_app) -> None:
+    """{"content": null} must be rejected as a 400, not raise a 500 (entry.get
+    returns None for an explicit JSON null, not the "" default)."""
+    body = {
+        "workspace": "foo",
+        "local_files": [{"path": "README.md", "content": None}],
+    }
+    transport = httpx.ASGITransport(app=http_app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post("/api/v1/onboarding/cleanup-plan", json=body)
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("bad_threshold", ["nan", "2.0", "-1"])
+async def test_rest_cleanup_plan_out_of_range_jaccard_threshold_returns_400(
+    http_app, bad_threshold: str,
+) -> None:
+    body = {
+        "workspace": "foo",
+        "local_files": [{"path": "README.md", "content": "hello"}],
+        "jaccard_threshold": bad_threshold,
+    }
+    transport = httpx.ASGITransport(app=http_app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post("/api/v1/onboarding/cleanup-plan", json=body)
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
 async def test_rest_cleanup_plan_too_many_files_returns_400(http_app) -> None:
     # Config default (KB_MAX_BOOTSTRAP_FILES) is 50; comfortably exceed it.
     body = {

--- a/tests/test_server_smoke.py
+++ b/tests/test_server_smoke.py
@@ -94,3 +94,16 @@ async def test_kb_list_round_trip(tmp_kb: Path, tmp_path: Path) -> None:
         text = str(result)
         # Expect at least STD-U-001 in the listing
         assert "STD-U-001" in text
+
+
+@pytest.mark.asyncio
+async def test_kb_cleanup_plan_tool_is_registered(tmp_kb: Path, tmp_path: Path) -> None:
+    app = build_app(
+        kb_main_path=tmp_kb,
+        kb_index_path=tmp_path / "idx.db",
+        sync_interval_sec=60,
+        staleness_degraded_sec=600,
+        bootstrap_now=True,
+    )
+    tools = await app.list_tools()
+    assert any(t.name == "kb_cleanup_plan" for t in tools)

--- a/tests/test_server_smoke.py
+++ b/tests/test_server_smoke.py
@@ -107,3 +107,32 @@ async def test_kb_cleanup_plan_tool_is_registered(tmp_kb: Path, tmp_path: Path) 
     )
     tools = await app.list_tools()
     assert any(t.name == "kb_cleanup_plan" for t in tools)
+
+
+@pytest.mark.asyncio
+async def test_kb_cleanup_plan_tool_rejects_invalid_input(tmp_kb: Path, tmp_path: Path) -> None:
+    """The MCP tool calls kb_cleanup_plan_fn directly (no REST layer in front
+    of it), so validation must live in the shared fn. An out-of-range
+    jaccard_threshold must surface as a rejected_invalid_input response, not an
+    unhandled exception. (A null/non-str 'content' entry is instead rejected
+    earlier, by FastMCP's own pydantic schema for the declared
+    list[dict[str, str]] parameter type, before kb_cleanup_plan_fn runs; that
+    path is covered at the fn level in test_tools_cleanup_plan.py.)"""
+    app = build_app(
+        kb_main_path=tmp_kb,
+        kb_index_path=tmp_path / "idx.db",
+        sync_interval_sec=60,
+        staleness_degraded_sec=600,
+        bootstrap_now=True,
+    )
+    async with Client(app) as client:
+        result = await client.call_tool(
+            "kb_cleanup_plan",
+            {
+                "workspace": "foo",
+                "local_files": [{"path": "README.md", "content": "x"}],
+                "jaccard_threshold": 2.0,
+            },
+        )
+        text = str(result)
+        assert "rejected_invalid_input" in text

--- a/tests/test_thin_pointer.py
+++ b/tests/test_thin_pointer.py
@@ -1,0 +1,21 @@
+"""Tests for the thin-pointer renderer."""
+from __future__ import annotations
+
+from data_olympus.thin_pointer import THIN_POINTER_MARKER, render_thin_pointer
+
+
+def test_marker_is_stable() -> None:
+    assert THIN_POINTER_MARKER == "<!-- KB-THIN-POINTER v1 -->"
+
+
+def test_render_starts_with_marker_and_carries_location_and_hint() -> None:
+    out = render_thin_pointer(
+        kb_path="projects/foo/README.md", kb_id="projects-foo-README", kind="project",
+    )
+    # First non-empty line is the marker so the lint is unambiguous.
+    first = next(line for line in out.splitlines() if line.strip())
+    assert first == THIN_POINTER_MARKER
+    # Human-readable location + agent retrieval hint both present.
+    assert "projects/foo/README.md" in out
+    assert "kb get projects-foo-README" in out
+    assert "project" in out

--- a/tests/test_tools_cleanup_plan.py
+++ b/tests/test_tools_cleanup_plan.py
@@ -54,3 +54,49 @@ def test_component_prefix_is_used() -> None:
         local_files=[{"path": "AGENTS.md", "content": "x"}],
     )
     idx.list_by_prefix.assert_called_once_with("projects/foo/components/svc/")
+
+
+def test_workspace_prefix_excludes_components() -> None:
+    idx = _idx_with_doc(
+        "projects-foo-README", "projects/foo/README.md", "# Purpose\n\naaa bbb ccc\n",
+    )
+    kb_cleanup_plan_fn(
+        idx=idx, workspace="foo", component=None,
+        local_files=[{"path": "README.md", "content": "x"}],
+    )
+    idx.list_by_prefix.assert_called_once_with(
+        "projects/foo/", exclude_under="components/",
+    )
+
+
+def test_best_match_wins_over_partial_overlap_by_rank() -> None:
+    """When multiple KB docs exist, the exact-duplicate doc (higher rank) must
+    win over a merely partially-overlapping doc, regardless of list order."""
+    local_body = "# Purpose\n\nThe gateway routes requests to services.\n"
+    partial_doc = SimpleNamespace(
+        id="projects-foo-partial", path="projects/foo/partial.md",
+        content_markdown="# Purpose\n\nThe gateway does something else entirely.\n",
+    )
+    exact_doc = SimpleNamespace(
+        id="projects-foo-exact", path="projects/foo/README.md",
+        content_markdown=local_body,
+    )
+    idx = MagicMock()
+    idx.list_by_prefix.return_value = [
+        {"id": "projects-foo-partial", "path": "projects/foo/partial.md",
+         "tier": "T3", "git_remote_url": None},
+        {"id": "projects-foo-exact", "path": "projects/foo/README.md",
+         "tier": "T3", "git_remote_url": None},
+    ]
+    idx.get.side_effect = lambda doc_id: {
+        "projects-foo-partial": partial_doc,
+        "projects-foo-exact": exact_doc,
+    }[doc_id]
+
+    resp = kb_cleanup_plan_fn(
+        idx=idx, workspace="foo", component=None,
+        local_files=[{"path": "README.md", "content": local_body}],
+    )
+    item = resp.items[0]
+    assert item.classification == "imported_duplicate"
+    assert item.kb_id == "projects-foo-exact"

--- a/tests/test_tools_cleanup_plan.py
+++ b/tests/test_tools_cleanup_plan.py
@@ -1,10 +1,13 @@
 """Tests for kb_cleanup_plan_fn (read-only dedup + thin-pointer plan)."""
 from __future__ import annotations
 
+import math
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
-from data_olympus.tools_onboarding import kb_cleanup_plan_fn
+import pytest
+
+from data_olympus.tools_onboarding import CleanupInputError, kb_cleanup_plan_fn
 
 
 def _idx_with_doc(doc_id: str, path: str, content: str) -> MagicMock:
@@ -69,20 +72,19 @@ def test_workspace_prefix_excludes_components() -> None:
     )
 
 
-def test_entry_missing_path_does_not_raise() -> None:
-    """kb_cleanup_plan_fn is also invoked directly by the MCP tool path, which
-    does not go through the REST route's input validation, so a local_files
-    entry missing 'path' must not raise -- it should classify normally with an
-    empty local_path."""
+def test_entry_missing_path_raises() -> None:
+    """Validation is now centralized in kb_cleanup_plan_fn itself so BOTH the
+    REST route and the MCP tool path are protected identically. entry.get("path")
+    is None when the key is missing, which is not a str, so this must raise
+    CleanupInputError rather than silently classifying with an empty local_path."""
     idx = _idx_with_doc(
         "projects-foo-README", "projects/foo/README.md", "# Purpose\n\naaa bbb ccc\n",
     )
-    resp = kb_cleanup_plan_fn(
-        idx=idx, workspace="foo", component=None,
-        local_files=[{"content": "# Deploy\n\nzzz yyy xxx\n"}],
-    )
-    assert len(resp.items) == 1
-    assert resp.items[0].local_path == ""
+    with pytest.raises(CleanupInputError):
+        kb_cleanup_plan_fn(
+            idx=idx, workspace="foo", component=None,
+            local_files=[{"content": "# Deploy\n\nzzz yyy xxx\n"}],
+        )
 
 
 def test_best_match_wins_over_partial_overlap_by_rank() -> None:
@@ -116,3 +118,100 @@ def test_best_match_wins_over_partial_overlap_by_rank() -> None:
     item = resp.items[0]
     assert item.classification == "imported_duplicate"
     assert item.kb_id == "projects-foo-exact"
+
+
+def test_local_files_not_a_list_raises() -> None:
+    idx = MagicMock()
+    with pytest.raises(CleanupInputError):
+        kb_cleanup_plan_fn(idx=idx, workspace="foo", component=None, local_files="nope")  # type: ignore[arg-type]
+
+
+def test_entry_not_a_dict_raises() -> None:
+    idx = MagicMock()
+    with pytest.raises(CleanupInputError):
+        kb_cleanup_plan_fn(idx=idx, workspace="foo", component=None, local_files=["nope"])  # type: ignore[list-item]
+
+
+def test_entry_path_not_str_raises() -> None:
+    idx = MagicMock()
+    with pytest.raises(CleanupInputError):
+        kb_cleanup_plan_fn(
+            idx=idx, workspace="foo", component=None,
+            local_files=[{"path": 123, "content": "x"}],
+        )
+
+
+def test_entry_content_none_raises() -> None:
+    """{"content": null} must be REJECTED, not silently treated as empty string.
+
+    entry.get("content", "") returns None (not the default) when the key is
+    present with an explicit JSON null, so the fn must check isinstance
+    explicitly rather than relying on the .get default alone.
+    """
+    idx = MagicMock()
+    with pytest.raises(CleanupInputError):
+        kb_cleanup_plan_fn(
+            idx=idx, workspace="foo", component=None,
+            local_files=[{"path": "README.md", "content": None}],
+        )
+
+
+def test_entry_content_non_str_raises() -> None:
+    idx = MagicMock()
+    with pytest.raises(CleanupInputError):
+        kb_cleanup_plan_fn(
+            idx=idx, workspace="foo", component=None,
+            local_files=[{"path": "README.md", "content": 42}],
+        )
+
+
+def test_max_content_bytes_exceeded_raises() -> None:
+    idx = _idx_with_doc("projects-foo-README", "projects/foo/README.md", "x")
+    with pytest.raises(CleanupInputError):
+        kb_cleanup_plan_fn(
+            idx=idx, workspace="foo", component=None,
+            local_files=[{"path": "README.md", "content": "a" * 100}],
+            max_content_bytes=10,
+        )
+
+
+def test_max_files_exceeded_raises() -> None:
+    idx = _idx_with_doc("projects-foo-README", "projects/foo/README.md", "x")
+    local_files = [{"path": f"f{i}.md", "content": "x"} for i in range(5)]
+    with pytest.raises(CleanupInputError):
+        kb_cleanup_plan_fn(
+            idx=idx, workspace="foo", component=None,
+            local_files=local_files, max_files=3,
+        )
+
+
+@pytest.mark.parametrize("bad_threshold", [math.nan, math.inf, -math.inf, -0.5, 2.0, "nan"])
+def test_bad_jaccard_threshold_raises(bad_threshold: object) -> None:
+    idx = _idx_with_doc("projects-foo-README", "projects/foo/README.md", "x")
+    with pytest.raises(CleanupInputError):
+        kb_cleanup_plan_fn(
+            idx=idx, workspace="foo", component=None,
+            local_files=[{"path": "README.md", "content": "x"}],
+            jaccard_threshold=bad_threshold,  # type: ignore[arg-type]
+        )
+
+
+def test_jaccard_threshold_not_coercible_raises() -> None:
+    idx = _idx_with_doc("projects-foo-README", "projects/foo/README.md", "x")
+    with pytest.raises(CleanupInputError):
+        kb_cleanup_plan_fn(
+            idx=idx, workspace="foo", component=None,
+            local_files=[{"path": "README.md", "content": "x"}],
+            jaccard_threshold="not-a-number",  # type: ignore[arg-type]
+        )
+
+
+@pytest.mark.parametrize("boundary", [0.0, 1.0])
+def test_jaccard_threshold_bounds_accepted(boundary: float) -> None:
+    idx = _idx_with_doc("projects-foo-README", "projects/foo/README.md", "x")
+    resp = kb_cleanup_plan_fn(
+        idx=idx, workspace="foo", component=None,
+        local_files=[{"path": "README.md", "content": "x"}],
+        jaccard_threshold=boundary,
+    )
+    assert resp.workspace == "foo"

--- a/tests/test_tools_cleanup_plan.py
+++ b/tests/test_tools_cleanup_plan.py
@@ -69,6 +69,22 @@ def test_workspace_prefix_excludes_components() -> None:
     )
 
 
+def test_entry_missing_path_does_not_raise() -> None:
+    """kb_cleanup_plan_fn is also invoked directly by the MCP tool path, which
+    does not go through the REST route's input validation, so a local_files
+    entry missing 'path' must not raise -- it should classify normally with an
+    empty local_path."""
+    idx = _idx_with_doc(
+        "projects-foo-README", "projects/foo/README.md", "# Purpose\n\naaa bbb ccc\n",
+    )
+    resp = kb_cleanup_plan_fn(
+        idx=idx, workspace="foo", component=None,
+        local_files=[{"content": "# Deploy\n\nzzz yyy xxx\n"}],
+    )
+    assert len(resp.items) == 1
+    assert resp.items[0].local_path == ""
+
+
 def test_best_match_wins_over_partial_overlap_by_rank() -> None:
     """When multiple KB docs exist, the exact-duplicate doc (higher rank) must
     win over a merely partially-overlapping doc, regardless of list order."""

--- a/tests/test_tools_cleanup_plan.py
+++ b/tests/test_tools_cleanup_plan.py
@@ -1,0 +1,56 @@
+"""Tests for kb_cleanup_plan_fn (read-only dedup + thin-pointer plan)."""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from data_olympus.tools_onboarding import kb_cleanup_plan_fn
+
+
+def _idx_with_doc(doc_id: str, path: str, content: str) -> MagicMock:
+    idx = MagicMock()
+    idx.list_by_prefix.return_value = [
+        {"id": doc_id, "path": path, "tier": "T3", "git_remote_url": None},
+    ]
+    idx.get.return_value = SimpleNamespace(id=doc_id, path=path, content_markdown=content)
+    return idx
+
+
+def test_duplicate_file_gets_thin_pointer_text() -> None:
+    body = "# Purpose\n\nThe gateway routes requests to services.\n"
+    idx = _idx_with_doc("projects-foo-README", "projects/foo/README.md", body)
+    resp = kb_cleanup_plan_fn(
+        idx=idx, workspace="foo", component=None,
+        local_files=[{"path": "README.md", "content": body}],
+    )
+    assert resp.summary["imported_duplicate"] == 1
+    item = resp.items[0]
+    assert item.classification == "imported_duplicate"
+    assert item.kb_path == "projects/foo/README.md"
+    assert item.thin_pointer_text is not None
+    assert "kb get projects-foo-README" in item.thin_pointer_text
+
+
+def test_unique_file_has_no_pointer() -> None:
+    idx = _idx_with_doc(
+        "projects-foo-README", "projects/foo/README.md", "# Purpose\n\naaa bbb ccc\n",
+    )
+    resp = kb_cleanup_plan_fn(
+        idx=idx, workspace="foo", component=None,
+        local_files=[{"path": "docs/unrelated.md", "content": "# Deploy\n\nzzz yyy xxx\n"}],
+    )
+    assert resp.items[0].classification == "unique"
+    assert resp.items[0].thin_pointer_text is None
+    assert resp.summary["unique"] == 1
+
+
+def test_component_prefix_is_used() -> None:
+    idx = _idx_with_doc(
+        "projects-foo-components-svc-AGENTS",
+        "projects/foo/components/svc/AGENTS.md", "# Conventions\n\nuse ruff\n",
+    )
+    kb_cleanup_plan_fn(
+        idx=idx, workspace="foo", component="svc",
+        local_files=[{"path": "AGENTS.md", "content": "x"}],
+    )
+    idx.list_by_prefix.assert_called_once_with("projects/foo/components/svc/")


### PR DESCRIPTION
## Guided onboarding, discovery capture & cleanup

Adds a guided project-onboarding experience on top of the existing onboarding primitives (`kb_onboarding_status`, `kb_bootstrap_project`). MCP prompts drive an import + interview + bootstrap + cleanup flow, backed by a new read-only `kb_cleanup_plan` tool that detects repo/KB duplication and returns thin-pointer replacements.

### What's added
- `thin_pointer.py`: thin-pointer renderer (data-olympus owns the template, so every deployment emits identical pointers).
- `dedup.py`: deterministic repo/KB overlap heuristics (exact hash; heading-set + k-shingle Jaccard for partial overlap).
- `kb_cleanup_plan_fn` + `CleanupItem`/`CleanupPlanResponse`: read-only classification of local docs vs committed KB content, with thin-pointer text for exact duplicates.
- MCP tool `kb_cleanup_plan` + REST mirror `POST /api/v1/onboarding/cleanup-plan`.
- `onboarding_playbook.py`: single-sourced guided script (dispatch / project / component).
- Three MCP prompts (`onboard`, `onboard_project`, `onboard_component`) as thin wrappers over the playbook.
- Playbook `GET /api/v1/onboarding/playbook` endpoint + `kb onboard playbook` CLI + mock-server extension (cross-agent fallback for agents that do not render MCP prompts).
- `ROADMAP.md` indexing the deferred pieces B-E.

### Design invariants (test-backed)
- **Server proposes, agent applies:** the cleanup tool and route are read-only; the server never edits a project repo.
- **Single-sourced playbook:** MCP prompts, the REST/CLI endpoint, and the bats mock-server all render from `render_playbook`; no divergent copies.
- **Additive only:** existing write/bootstrap primitives are unchanged.

### Testing
- Full pytest suite green (1 unrelated pre-existing skip: `sentence_transformers`).
- bats onboarding 3/3 (includes the new `kb onboard playbook` test).
- ruff clean.

### Review
Whole-branch review flagged input-validation/compute-bound gaps on the public, unauthenticated `cleanup-plan` REST route; hardened (400-not-500 on malformed `local_files`/`jaccard_threshold`, file-count cap via `max_bootstrap_files`, defensive fn + shingle precompute) and re-reviewed clean.

### Roadmap follow-ups (tracked)
- #31 Curation / pattern promotion (`kb_curate`)
- #32 Consultation telemetry + per-user stats (privacy-gated)
- #33 Cross-agent skill distribution
- #34 Skill suggestion from repeated instructions

### Minor deferred (non-blocking)
- `kb onboard playbook` CLI prints a raw traceback on a non-2xx response instead of a clean `kb: ...` message (fallback surface).
- dedup heuristic tuning (heading-level awareness, punctuation in shingles) deferred per design; affects only the advisory partial-overlap signal, not the exact-duplicate path.