### PR TITLE
Serving hardening (503 fix + bounded ledger) and composable search pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,9 +32,28 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Detection floor for un-hookable agents: `kb enforce report` (and `data-olympus report`) correlates governed git commits against the consult audit and lists changes with no consultation on record. An opt-in repo-scoped git provider (`kb enforce install --agent git`) installs a post-commit warning hook, or a pre-commit blocking hook with `--block`. Reuses the existing audit endpoint; no server change.
 - Enforcement hardening and observability: gate_bypass and gate_degraded events are now recorded (via `data-olympus report --emit-events` / the git warn hook, and the pre-tool hook on a reachable-degraded gate), so `kb_compliance` surfaces them. The gate receives `action_diff` and the classifier uses word-boundary matching plus dependency-install command signals (Codex and Claude now gate the Bash tool). New `kb enforce install --mode off|soft|hard`, ledger persistence via `KB_LEDGER_PATH`, a friendly PATH hint for `kb enforce report`, and a CI guard requiring a changelog entry for functional changes.
 - Guided onboarding: MCP prompts `onboard`, `onboard_project`, and `onboard_component` walk an agent through bootstrapping a new workspace or component, backed by a single-sourced playbook (`render_playbook`). A read-only `kb_cleanup_plan` MCP tool plus `POST /api/v1/onboarding/cleanup-plan` classify local repo docs against KB content and propose thin-pointer replacements for duplicates. `GET /api/v1/onboarding/playbook` and `kb onboard playbook` expose the same script to agents without native MCP prompt support.
+- Composable search pipeline: `Index.search()` now runs expand-query / match /
+  re-rank stages with pluggable `query_expander` and `reranker` hooks, so ranking
+  and query-expansion features compose without rewriting the core query. When a
+  reranker is installed the query is matched against a wider BM25 candidate pool
+  (over-fetched) and the reranked result is truncated back to the requested limit.
 
 ### Fixed
 
+- Intermittent `503 Service Unavailable` from the single-replica MCP under load.
+  The readiness probe was too aggressive (`timeoutSeconds: 1`) while every
+  REST/enforcement handler ran synchronous work on the one asyncio event loop, so
+  a burst stalled the probe and the only pod was ejected from the Service (nginx
+  then served a 503 with an empty upstream, leaving no application-log trace).
+  Fixes: relax the readiness probe (5s timeout, 5 failures) and raise the CPU
+  limit to 2; offload blocking handler work to the anyio worker pool while serving
+  `/api/v1/health` inline (off that pool) from a short-TTL cache of
+  `Index.health()`; add locks to the audit log and consultation ledger for safe
+  concurrent access.
+- The consultation ledger grew without bound (every `(session, workspace)` pair,
+  the whole file rewritten on every consult). It now evicts entries past the
+  consult TTL, enforces a hard max-entries cap, and bounds an oversized persisted
+  ledger on load rather than holding it all in memory until the first prune.
 - `data-olympus-mcp --help` now prints usage and exits 0 instead of crashing with
   `NotADirectoryError: KB root not a directory: /kb-main`. Argument parsing runs
   before config loading, so the documented quickstart command works on first run.

--- a/deploy/k8s/statefulset.yaml
+++ b/deploy/k8s/statefulset.yaml
@@ -77,7 +77,14 @@ spec:
             initialDelaySeconds: 10
             periodSeconds: 10
             successThreshold: 1
-            failureThreshold: 3
+            # This is a single-replica StatefulSet, so ejecting the pod on a
+            # transient event-loop stall has no failover benefit: it just turns
+            # "briefly slow" into a hard 503 (nginx has zero endpoints). A
+            # tolerant probe (5s timeout x 5 failures ~= 50s of sustained stall
+            # before ejection) rides out load spikes. Default timeoutSeconds is
+            # 1s, which was the direct cause of the intermittent 503s.
+            timeoutSeconds: 5
+            failureThreshold: 5
           livenessProbe:
             tcpSocket:
               port: 8080
@@ -89,7 +96,11 @@ spec:
               cpu: 100m
               memory: 256Mi
             limits:
-              cpu: 1
+              # 2 cores so a background index rebuild (CPU-bound, runs in a
+              # worker thread) and the asyncio event loop can run on separate
+              # cores instead of contending for one, keeping the readiness probe
+              # responsive under load.
+              cpu: 2
               memory: 1Gi
       volumes:
         # Writable scratch for the read-only root filesystem: the entrypoint copies

--- a/src/data_olympus/audit_log.py
+++ b/src/data_olympus/audit_log.py
@@ -15,6 +15,7 @@ import hashlib
 import hmac
 import json
 import os
+import threading
 import uuid
 from typing import TYPE_CHECKING, Any
 
@@ -28,6 +29,12 @@ class AuditLog:
     def __init__(self, *, log_path: str, hmac_key: str = "") -> None:
         self._path = log_path
         self._hmac_key = hmac_key or ""
+        # append() is a read-modify-write on _last_hash plus a file write. Once
+        # handlers are offloaded to the anyio threadpool, appends can run
+        # concurrently; without this lock two threads read the same _last_hash
+        # and produce sibling events that break the hash chain. Reads (verify /
+        # iter_filtered) take the same lock so they never observe a torn append.
+        self._lock = threading.Lock()
         self._last_hash = self._load_last_hash()
 
     # --- hashing helpers ---------------------------------------------------
@@ -70,14 +77,15 @@ class AuditLog:
         tests that never trigger a write) does not crash startup.
         """
         os.makedirs(os.path.dirname(self._path) or ".", exist_ok=True)
-        chained = dict(event)
-        chained["event_id"] = uuid.uuid4().hex
-        chained["prev_hash"] = self._last_hash
-        chained["hash"] = self._digest(self._canonical(chained))
-        line = json.dumps(chained, ensure_ascii=False)
-        with open(self._path, "a", encoding="utf-8") as f:
-            f.write(line + "\n")
-        self._last_hash = chained["hash"]
+        with self._lock:
+            chained = dict(event)
+            chained["event_id"] = uuid.uuid4().hex
+            chained["prev_hash"] = self._last_hash
+            chained["hash"] = self._digest(self._canonical(chained))
+            line = json.dumps(chained, ensure_ascii=False)
+            with open(self._path, "a", encoding="utf-8") as f:
+                f.write(line + "\n")
+            self._last_hash = chained["hash"]
 
     def verify(self) -> tuple[bool, int]:
         """Recompute the hash chain over the log.
@@ -93,27 +101,30 @@ class AuditLog:
         """
         if not os.path.exists(self._path):
             return (True, -1)
+        # Snapshot the file under the lock (short hold), then verify in memory so
+        # a concurrent append cannot make us read a torn final line as tampering.
+        with self._lock, open(self._path, encoding="utf-8") as f:
+            raw_lines = f.readlines()
         prev = GENESIS
         seen_hashed = False
-        with open(self._path, encoding="utf-8") as f:
-            for i, raw in enumerate(f):
-                raw = raw.strip()
-                if not raw:
-                    continue
-                try:
-                    ev = json.loads(raw)
-                except json.JSONDecodeError:
-                    return (False, i)
-                if not (isinstance(ev, dict) and ev.get("hash")):
-                    if seen_hashed:
-                        return (False, i)  # unhashed line after the chain started
-                    continue  # legacy prefix, tolerated
-                if ev.get("prev_hash") != prev:
-                    return (False, i)
-                if self._digest(self._canonical(ev)) != ev["hash"]:
-                    return (False, i)
-                prev = ev["hash"]
-                seen_hashed = True
+        for i, raw in enumerate(raw_lines):
+            raw = raw.strip()
+            if not raw:
+                continue
+            try:
+                ev = json.loads(raw)
+            except json.JSONDecodeError:
+                return (False, i)
+            if not (isinstance(ev, dict) and ev.get("hash")):
+                if seen_hashed:
+                    return (False, i)  # unhashed line after the chain started
+                continue  # legacy prefix, tolerated
+            if ev.get("prev_hash") != prev:
+                return (False, i)
+            if self._digest(self._canonical(ev)) != ev["hash"]:
+                return (False, i)
+            prev = ev["hash"]
+            seen_hashed = True
         return (True, -1)
 
     def iter_filtered(
@@ -126,7 +137,10 @@ class AuditLog:
         """Yield events matching the filters, most-recent first."""
         if not os.path.exists(self._path):
             return
-        with open(self._path, encoding="utf-8") as f:
+        # Read under the lock so we never see a torn append, then yield from the
+        # in-memory snapshot (holding the lock across yields would block appends
+        # for as long as the caller iterates).
+        with self._lock, open(self._path, encoding="utf-8") as f:
             lines = f.readlines()
         for line in reversed(lines):
             line = line.strip()

--- a/src/data_olympus/enforce_policy.py
+++ b/src/data_olympus/enforce_policy.py
@@ -146,6 +146,11 @@ class ConsultationLedger:
         self._lock = threading.Lock()
         if path:
             self._load()
+            # A ledger persisted by the previous unbounded implementation can be
+            # arbitrarily large; cap it on load so an oversized /state/ledger.json
+            # is not held in memory until the first record() prunes it. TTL
+            # eviction still runs on the first record() (it needs a caller "now").
+            self._enforce_cap()
 
     def _load(self) -> None:
         if not self._path or not os.path.exists(self._path):
@@ -197,8 +202,13 @@ class ConsultationLedger:
         self._entries = {
             key: e for key, e in self._entries.items() if e.consulted_at >= cutoff
         }
+        self._enforce_cap()
+
+    def _enforce_cap(self) -> None:
+        """Bound _entries to the newest ``max_entries`` by consulted_at. Clock-free
+        so it can run on load (before any caller "now" is available). Caller holds
+        the lock, except the single-threaded construction-time call."""
         if len(self._entries) > self._max_entries:
-            # Keep the most recently consulted entries; drop the oldest.
             newest = sorted(
                 self._entries.items(), key=lambda kv: kv[1].consulted_at, reverse=True
             )[: self._max_entries]

--- a/src/data_olympus/enforce_policy.py
+++ b/src/data_olympus/enforce_policy.py
@@ -10,6 +10,7 @@ import logging
 import os
 import re
 import tempfile
+import threading
 from dataclasses import dataclass, field
 
 # Keyword signals that a user prompt is a governed code/architectural decision.
@@ -117,9 +118,32 @@ class ConsultationLedger:
     every ``record`` so consultations survive a server restart. A corrupt or
     unreadable file degrades to empty with a logged warning and never crashes."""
 
-    def __init__(self, path: str | None = None) -> None:
+    def __init__(
+        self,
+        path: str | None = None,
+        *,
+        retention_sec: float = 3600.0,
+        max_entries: int = 50_000,
+    ) -> None:
         self._path = path
         self._entries: dict[tuple[str, str], LedgerEntry] = {}
+        # An entry is a TTL freshness cache: once it is older than the consult
+        # TTL it can never be fresh again, so we evict it on the next record().
+        # ``retention_sec`` should be >= the ttl_sec passed to is_fresh (the
+        # server threads config.consult_ttl_sec in) so a still-fresh entry is
+        # never dropped. ``max_entries`` is a hard belt-and-suspenders cap that
+        # bounds memory/disk even under a flood of unique sessions inside one
+        # retention window. Together they stop _entries growing without bound and
+        # keep the per-record file rewrite O(active window) instead of O(all
+        # sessions ever seen).
+        self._retention_sec = retention_sec
+        self._max_entries = max_entries
+        # record() mutates _entries and rewrites the whole file; once consult
+        # handlers are offloaded to the anyio threadpool these can run
+        # concurrently. Without this lock, _save()'s iteration over _entries can
+        # race a concurrent insert (RuntimeError / dropped entries). Public
+        # methods take the lock; _save()/_evict() do not (called only while held).
+        self._lock = threading.Lock()
         if path:
             self._load()
 
@@ -163,21 +187,42 @@ class ConsultationLedger:
                 os.unlink(tmp)
             raise
 
+    def _evict(self, now: float) -> None:
+        """Drop entries that can no longer be fresh, then enforce the hard cap.
+
+        Caller must hold ``self._lock``. Reassigns ``self._entries`` to a pruned
+        dict; O(n) but n is exactly what this bounds.
+        """
+        cutoff = now - self._retention_sec
+        self._entries = {
+            key: e for key, e in self._entries.items() if e.consulted_at >= cutoff
+        }
+        if len(self._entries) > self._max_entries:
+            # Keep the most recently consulted entries; drop the oldest.
+            newest = sorted(
+                self._entries.items(), key=lambda kv: kv[1].consulted_at, reverse=True
+            )[: self._max_entries]
+            self._entries = dict(newest)
+
     def record(
         self, *, session_id: str, workspace: str, rule_ids: list[str], now: float
     ) -> None:
-        self._entries[(session_id, workspace)] = LedgerEntry(
-            consulted_at=now, rule_ids=list(rule_ids)
-        )
-        self._save()
+        with self._lock:
+            self._entries[(session_id, workspace)] = LedgerEntry(
+                consulted_at=now, rule_ids=list(rule_ids)
+            )
+            self._evict(now)
+            self._save()
 
     def is_fresh(
         self, *, session_id: str, workspace: str, now: float, ttl_sec: float
     ) -> bool:
-        entry = self._entries.get((session_id, workspace))
+        with self._lock:
+            entry = self._entries.get((session_id, workspace))
         if entry is None:
             return False
         return (now - entry.consulted_at) <= ttl_sec
 
     def get(self, *, session_id: str, workspace: str) -> LedgerEntry | None:
-        return self._entries.get((session_id, workspace))
+        with self._lock:
+            return self._entries.get((session_id, workspace))

--- a/src/data_olympus/index.py
+++ b/src/data_olympus/index.py
@@ -5,6 +5,7 @@ import datetime
 import os
 import sqlite3
 import subprocess
+import threading
 import time
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
@@ -13,6 +14,7 @@ from data_olympus.markdown_parse import parse_file
 
 if TYPE_CHECKING:
     import builtins
+    from collections.abc import Callable
     from pathlib import Path
 
 _SCHEMA = """
@@ -250,8 +252,39 @@ def _derive_id_from_path(rel: Path) -> str:
 class Index:
     """SQLite FTS5 index. Single-writer; safe for concurrent reads."""
 
-    def __init__(self, db_path: Path) -> None:
+    def __init__(
+        self,
+        db_path: Path,
+        *,
+        clock: Callable[[], float] = time.monotonic,
+        health_ttl_sec: float = 5.0,
+        query_expander: Callable[[list[str]], list[str]] | None = None,
+        reranker: Callable[[str, list[SearchHit]], list[SearchHit]] | None = None,
+    ) -> None:
         self._db_path = db_path
+        # Search pipeline seams (issue #36). search() runs three stages:
+        #   expand-query -> match -> re-rank
+        # ``query_expander`` rewrites the term list before the FTS MATCH is built
+        # (synonym / co-occurrence expansion plug in here); ``reranker`` reorders
+        # or rescores the BM25-ordered hits (status/tier priors, hybrid blending
+        # plug in here). Both default to identity so the base behaviour is
+        # unchanged. Features set them without touching the other stages.
+        self.query_expander = query_expander
+        self.reranker = reranker
+        # health() is on the readiness-probe path and the degraded-precheck of
+        # every read route, so its SQLite read is cached for a short TTL to keep
+        # that path memory-only in steady state (the underlying values only
+        # change on build(), which invalidates the cache). ``clock`` is injected
+        # so the TTL is deterministically testable; monotonic avoids wall-clock
+        # jumps. The cache is guarded by a lock because reads may run in the
+        # anyio threadpool concurrently.
+        self._clock = clock
+        self._health_ttl = health_ttl_sec
+        self._health_lock = threading.Lock()
+        self._health_cache: tuple[float, dict[str, object]] | None = None
+        # Test/observability counter: how many times the DB was actually read
+        # (cache misses). Not part of the public contract.
+        self._health_uncached_calls = 0
 
     def _connect(self) -> sqlite3.Connection:
         self._db_path.parent.mkdir(parents=True, exist_ok=True)
@@ -374,6 +407,10 @@ class Index:
         # Atomic swap: the previous index file (if any) is replaced. Open fds on the
         # old inode keep reading from it until they close.
         os.replace(tmp_path, self._db_path)
+        # Invalidate the health cache so the next health() reflects the rebuild
+        # immediately rather than serving the pre-swap commit for up to the TTL.
+        with self._health_lock:
+            self._health_cache = None
         return IndexBuildResult(docs_indexed=count, source_commit=source_commit, built_at=now)
 
     def search(
@@ -403,17 +440,15 @@ class Index:
         fts column incl. the UNINDEXED id at index 0); default boosts
         title/applies_when, deprioritizes body.
         """
+        # Stage 1 (expand-query): term extraction + optional expansion hook.
         terms = query.split()
         if not terms:
             return []
-        quoted = " OR ".join('"' + t.replace('"', '""') + '"' for t in terms)
-        if columns:
-            unknown = [c for c in columns if c not in _FTS_MATCH_COLUMNS]
-            if unknown:
-                raise ValueError(f"unknown fts column(s): {unknown}")
-            match_query = "{" + " ".join(columns) + "} : (" + quoted + ")"
-        else:
-            match_query = quoted
+        if self.query_expander is not None:
+            terms = list(self.query_expander(terms))
+            if not terms:
+                return []
+        match_query = self._build_match_expr(terms, columns)
         weights = column_weights if column_weights is not None else _DEFAULT_BM25_WEIGHTS
         bm25_expr = "bm25(fts, " + ", ".join(repr(float(w)) for w in weights) + ")"
         conn = self._connect()
@@ -448,8 +483,9 @@ class Index:
                 ORDER BY score
                 LIMIT ?
             """
+            # Stage 2 (match): rows come back BM25-ordered from SQLite.
             rows = conn.execute(sql, params).fetchall()
-            return [
+            hits = [
                 SearchHit(
                     id=r["id"],
                     path=r["path"],
@@ -463,6 +499,27 @@ class Index:
             ]
         finally:
             conn.close()
+        # Stage 3 (re-rank): optional hook reorders/rescores (default identity).
+        if self.reranker is not None:
+            hits = list(self.reranker(query, hits))
+        return hits
+
+    def _build_match_expr(self, terms: list[str], columns: list[str] | None) -> str:
+        """Match stage: build the FTS5 MATCH expression from query terms.
+
+        Each term is quoted individually (doubling embedded quotes so user input
+        cannot break out of its phrase or inject FTS operators) and OR-joined, so
+        a natural-language query matches on any term, ranked by bm25. ``columns``
+        restricts the match to the given fts columns (ablation); an unknown column
+        is a ValueError rather than a silent no-op.
+        """
+        quoted = " OR ".join('"' + t.replace('"', '""') + '"' for t in terms)
+        if columns:
+            unknown = [c for c in columns if c not in _FTS_MATCH_COLUMNS]
+            if unknown:
+                raise ValueError(f"unknown fts column(s): {unknown}")
+            return "{" + " ".join(columns) + "} : (" + quoted + ")"
+        return quoted
 
     def get(self, id: str) -> IndexedDoc | None:
         """Retrieve a single document by id. Returns None if not found."""
@@ -544,7 +601,29 @@ class Index:
         return [{"name": k, "categories": v} for k, v in tiers.items()]
 
     def health(self) -> dict[str, object]:
-        """Return commit, built_at, total_docs, db_size_bytes."""
+        """Return commit, built_at, total_docs, db_size_bytes.
+
+        Cached for ``health_ttl_sec`` (see __init__): within the window the
+        cached snapshot is returned without touching SQLite, so the readiness
+        probe and per-route degraded-precheck stay off the DB under load. The
+        cache is invalidated by build(); the underlying values change nowhere
+        else.
+        """
+        now = self._clock()
+        with self._health_lock:
+            cached = self._health_cache
+            if cached is not None and (now - cached[0]) < self._health_ttl:
+                return dict(cached[1])
+        # Cache miss: read the DB outside the lock (the connection is per-call,
+        # so a concurrent miss is harmless — both compute the same snapshot).
+        snapshot = self._health_uncached()
+        with self._health_lock:
+            self._health_cache = (now, dict(snapshot))
+        return snapshot
+
+    def _health_uncached(self) -> dict[str, object]:
+        """The raw health read, bypassing the cache. See health()."""
+        self._health_uncached_calls += 1
         if not self._db_path.exists():
             return {
                 "source_commit": "",

--- a/src/data_olympus/index.py
+++ b/src/data_olympus/index.py
@@ -61,6 +61,14 @@ _FTS_MATCH_COLUMNS: tuple[str, ...] = ("title", "tags", "applies_when", "descrip
 # Title and applies_when are weighted highest; body lowest. Tune in D2.
 _DEFAULT_BM25_WEIGHTS: tuple[float, ...] = (0.0, 10.0, 5.0, 10.0, 4.0, 1.0)
 
+# When a reranker is installed, fetch a wider BM25 candidate pool than the caller
+# asked for so the reranker can promote a relevant doc sitting just outside the
+# top-N window, then truncate back to the requested limit. Bounded so a small
+# limit still gets a useful pool and a large one cannot drag in the whole corpus.
+_RERANK_OVERFETCH_FACTOR = 5
+_RERANK_MIN_POOL = 50
+_RERANK_MAX_POOL = 200
+
 # Generic, deployment-neutral default taxonomy. A deployment with a different
 # directory layout supplies its own table at runtime via KB_TAXONOMY_PATH (a
 # JSON file holding a list of [prefix, tier, category] triples). The two
@@ -467,7 +475,18 @@ class Index:
             if doc_type:
                 where.append("docs.type = ?")
                 params.append(doc_type)
-            params.append(limit)
+            # Over-fetch a wider candidate pool when a reranker will reorder the
+            # hits (see stage 3); never fewer than `limit`.
+            candidate_limit = limit
+            if self.reranker is not None:
+                candidate_limit = max(
+                    limit,
+                    min(
+                        max(limit * _RERANK_OVERFETCH_FACTOR, _RERANK_MIN_POOL),
+                        _RERANK_MAX_POOL,
+                    ),
+                )
+            params.append(candidate_limit)
             sql = f"""
                 SELECT
                     fts.id AS id,
@@ -499,9 +518,10 @@ class Index:
             ]
         finally:
             conn.close()
-        # Stage 3 (re-rank): optional hook reorders/rescores (default identity).
+        # Stage 3 (re-rank): optional hook reorders/rescores (default identity),
+        # then truncate the (possibly wider / prepended) pool back to `limit`.
         if self.reranker is not None:
-            hits = list(self.reranker(query, hits))
+            hits = list(self.reranker(query, hits))[:limit]
         return hits
 
     def _build_match_expr(self, terms: list[str], columns: list[str] | None) -> str:

--- a/src/data_olympus/rest_api.py
+++ b/src/data_olympus/rest_api.py
@@ -2,9 +2,11 @@
 so MCP + REST share one Starlette/uvicorn process."""
 from __future__ import annotations
 
+import functools
 import json
 from typing import TYPE_CHECKING, Any
 
+import anyio
 from starlette.responses import JSONResponse
 
 from data_olympus.principals import (
@@ -30,6 +32,21 @@ if TYPE_CHECKING:
     from data_olympus.models import HealthResponse
     from data_olympus.principals import Principal
     from data_olympus.server import ServerState
+
+
+async def _offload(fn: Any, /, *args: Any, **kwargs: Any) -> Any:
+    """Run a blocking callable in the anyio worker-thread pool.
+
+    Every REST handler's core is synchronous (SQLite reads, audit/ledger file
+    I/O, git worktree ops). Running it inline would block the single asyncio
+    event loop, and the k8s readiness probe (``GET /api/v1/health``, 1s timeout)
+    is served on that same loop: a stalled loop under load drops the probe, the
+    only pod is ejected from the Service, and nginx returns 503. Offloading keeps
+    the loop free to answer the probe. SQLite is safe here because ``Index`` opens
+    a connection per call; the stateful writers (AuditLog, ConsultationLedger)
+    are lock-guarded for concurrent thread access.
+    """
+    return await anyio.to_thread.run_sync(functools.partial(fn, *args, **kwargs))
 
 
 def _build_health(state: ServerState) -> HealthResponse:
@@ -216,7 +233,7 @@ def register_routes(
 
     @app.custom_route("/api/v1/health", methods=["GET"])
     async def health(_request: Request) -> JSONResponse:
-        resp = _build_health(state)
+        resp = await _offload(_build_health, state)
         # Degraded health responses MUST return 503 so the
         # CLI's --no-stale contract (exit 2 on HTTP 200 or 503 degraded) is meaningful.
         status = 503 if resp.degraded else 200
@@ -224,15 +241,15 @@ def register_routes(
 
     @app.custom_route("/api/v1/outline", methods=["GET"])
     async def outline(_request: Request) -> JSONResponse:
-        h = _build_health(state)
+        h = await _offload(_build_health, state)
         if h.degraded:
             return _degraded_response(h)
-        resp = kb_outline_fn(idx=state.idx)
+        resp = await _offload(kb_outline_fn, idx=state.idx)
         return JSONResponse(resp.model_dump())
 
     @app.custom_route("/api/v1/search", methods=["GET"])
     async def search(request: Request) -> JSONResponse:
-        h = _build_health(state)
+        h = await _offload(_build_health, state)
         if h.degraded:
             return _degraded_response(h)
         q = request.query_params.get("q", "")
@@ -244,31 +261,33 @@ def register_routes(
             return JSONResponse({"error": "bad_limit"}, status_code=400)
         tier = request.query_params.get("tier") or None
         category = request.query_params.get("category") or None
-        resp = kb_search_fn(idx=state.idx, query=q, limit=limit, tier=tier, category=category)
+        resp = await _offload(
+            kb_search_fn, idx=state.idx, query=q, limit=limit, tier=tier, category=category
+        )
         return JSONResponse(resp.model_dump())
 
     @app.custom_route("/api/v1/get/{id}", methods=["GET"])
     async def get(request: Request) -> JSONResponse:
-        h = _build_health(state)
+        h = await _offload(_build_health, state)
         if h.degraded:
             return _degraded_response(h)
         id_ = request.path_params["id"]
         try:
-            resp = kb_get_fn(idx=state.idx, id=id_)
+            resp = await _offload(kb_get_fn, idx=state.idx, id=id_)
         except KbNotFoundError as e:
             return JSONResponse({"error": "not_found", "message": str(e)}, status_code=404)
         return JSONResponse(resp.model_dump())
 
     @app.custom_route("/api/v1/list", methods=["GET"])
     async def list_(request: Request) -> JSONResponse:
-        h = _build_health(state)
+        h = await _offload(_build_health, state)
         if h.degraded:
             return _degraded_response(h)
         tier = request.query_params.get("tier")
         if not tier:
             return JSONResponse({"error": "missing_tier"}, status_code=400)
         category = request.query_params.get("category") or None
-        resp = kb_list_fn(idx=state.idx, tier=tier, category=category)
+        resp = await _offload(kb_list_fn, idx=state.idx, tier=tier, category=category)
         return JSONResponse(resp.model_dump())
 
     @app.custom_route("/api/v1/propose/memory", methods=["POST"])
@@ -294,7 +313,8 @@ def register_routes(
         assert state.rate_limiter is not None
         assert state.blocklist is not None
         from data_olympus.tools_write import kb_propose_memory_fn
-        resp = kb_propose_memory_fn(
+        resp = await _offload(
+            kb_propose_memory_fn,
             text=body["text"], tags=body.get("tags", []),
             source_session=body["source_session"],
             agent_identity=body["agent_identity"],
@@ -336,7 +356,8 @@ def register_routes(
         assert state.rate_limiter is not None
         assert state.blocklist is not None
         from data_olympus.tools_write import kb_propose_edit_fn
-        resp = kb_propose_edit_fn(
+        resp = await _offload(
+            kb_propose_edit_fn,
             target_path=body["target_path"], postimage=body["postimage"],
             base_commit=body["base_commit"],
             base_blob_sha=body.get("base_blob_sha"),
@@ -372,7 +393,8 @@ def register_routes(
         assert state.push_queue is not None
         assert state.pending is not None
         from data_olympus.tools_write import kb_resolve_pending_fn
-        resp = kb_resolve_pending_fn(
+        resp = await _offload(
+            kb_resolve_pending_fn,
             pending_id=pid, decision=body["decision"],
             edited_text=body.get("edited_text"),
             worktrees=state.worktrees, push_queue=state.push_queue,
@@ -393,7 +415,7 @@ def register_routes(
         if state.pending is None:
             return JSONResponse({"pending": []})
         from data_olympus.tools_write import kb_list_pending_fn
-        resp = kb_list_pending_fn(pending=state.pending)
+        resp = await _offload(kb_list_pending_fn, pending=state.pending)
         return JSONResponse(resp.model_dump())
 
     @app.custom_route("/api/v1/audit", methods=["GET"])
@@ -409,8 +431,8 @@ def register_routes(
         agent = qp.get("agent")
         status_filter = qp.get("status")
         limit = int(qp.get("limit", "100"))
-        resp = kb_audit_fn(audit_log=state.audit_log, since=since,
-                          agent=agent, status=status_filter, limit=limit)
+        resp = await _offload(kb_audit_fn, audit_log=state.audit_log, since=since,
+                              agent=agent, status=status_filter, limit=limit)
         return JSONResponse(resp.model_dump())
 
     @app.custom_route("/api/v1/audit/verify", methods=["GET"])
@@ -420,7 +442,7 @@ def register_routes(
             return denied
         if state.audit_log is None:
             return JSONResponse({"ok": True, "first_broken_index": -1})
-        ok, idx = state.audit_log.verify()
+        ok, idx = await _offload(state.audit_log.verify)
         return JSONResponse({"ok": ok, "first_broken_index": idx})
 
     @app.custom_route("/api/v1/consult", methods=["POST"])
@@ -436,7 +458,8 @@ def register_routes(
             body, ["workspace", "source_session"],
         )) is not None:
             return bad
-        resp = kb_consult_fn(
+        resp = await _offload(
+            kb_consult_fn,
             idx=state.idx, classifier=state.classifier, ledger=state.ledger,
             workspace=body["workspace"], intent=body.get("intent", ""),
             source_session=body["source_session"],
@@ -459,7 +482,8 @@ def register_routes(
             body, ["workspace", "session_id"],
         )) is not None:
             return bad
-        resp = kb_gate_check_fn(
+        resp = await _offload(
+            kb_gate_check_fn,
             classifier=state.classifier, ledger=state.ledger,
             workspace=body["workspace"], session_id=body["session_id"],
             tool_name=body.get("tool_name", ""),
@@ -483,7 +507,8 @@ def register_routes(
         qp = request.query_params
         since = float(qp["since"]) if qp.get("since") else None
         agent = qp.get("agent")
-        resp = kb_compliance_fn(audit_log=state.audit_log, since=since, agent=agent)
+        resp = await _offload(
+            kb_compliance_fn, audit_log=state.audit_log, since=since, agent=agent)
         return JSONResponse(resp.model_dump())
 
     @app.custom_route("/api/v1/audit/event", methods=["POST"])
@@ -500,7 +525,8 @@ def register_routes(
             return bad
         from data_olympus.tools_enforce import kb_record_event_fn
         try:
-            resp = kb_record_event_fn(
+            resp = await _offload(
+                kb_record_event_fn,
                 audit_log=state.audit_log, event_type=body["event_type"],
                 workspace=body["workspace"],
                 agent_identity=body.get("agent_identity", "unknown"),
@@ -514,7 +540,8 @@ def register_routes(
     async def onboarding_status(request: Request) -> JSONResponse:
         from data_olympus.tools_onboarding import kb_onboarding_status_fn
         qp = request.query_params
-        resp = kb_onboarding_status_fn(
+        resp = await _offload(
+            kb_onboarding_status_fn,
             idx=state.idx,
             workspace=qp.get("workspace", ""),
             component=qp.get("component") or None,
@@ -547,7 +574,8 @@ def register_routes(
         assert state.rate_limiter is not None
         assert state.blocklist is not None
         from data_olympus.tools_onboarding import kb_bootstrap_project_fn
-        resp = kb_bootstrap_project_fn(
+        resp = await _offload(
+            kb_bootstrap_project_fn,
             idx=state.idx,
             workspace=body["workspace"],
             component=body.get("component"),

--- a/src/data_olympus/rest_api.py
+++ b/src/data_olympus/rest_api.py
@@ -233,7 +233,12 @@ def register_routes(
 
     @app.custom_route("/api/v1/health", methods=["GET"])
     async def health(_request: Request) -> JSONResponse:
-        resp = await _offload(_build_health, state)
+        # Served INLINE, not via _offload(): the readiness probe must never queue
+        # behind the shared anyio worker pool it exists to outlive. _build_health
+        # reads the cached Index.health() snapshot (memory in steady state; the
+        # rare cache-miss SQLite read is sub-millisecond on the loop), so keeping
+        # it off the limiter is the right trade for probe responsiveness.
+        resp = _build_health(state)
         # Degraded health responses MUST return 503 so the
         # CLI's --no-stale contract (exit 2 on HTTP 200 or 503 degraded) is meaningful.
         status = 503 if resp.degraded else 200

--- a/src/data_olympus/server.py
+++ b/src/data_olympus/server.py
@@ -211,7 +211,12 @@ def build_app(
     config = Config(**config_kwargs)  # type: ignore[arg-type]
     idx = Index(kb_index_path)
     git = GitOps(kb_main_path)
-    ledger = ConsultationLedger(path=ledger_path)
+    # retention_sec = the consult TTL: an entry older than that can never be
+    # fresh, so it is safe to evict and keeps the ledger bounded (see
+    # ConsultationLedger). is_fresh is always called with this same ttl.
+    ledger = ConsultationLedger(
+        path=ledger_path, retention_sec=float(config.consult_ttl_sec)
+    )
     state = ServerState(idx=idx, git=git, config=config, ledger=ledger)
 
     if config.kb_remote_url:

--- a/tests/test_foundation_review_fixes.py
+++ b/tests/test_foundation_review_fixes.py
@@ -1,0 +1,105 @@
+"""Tests for the review fixes on the foundation PR (#50).
+
+1. `/api/v1/health` must be served inline, NOT through the shared anyio worker
+   pool, so a saturated pool cannot delay the readiness probe it needs to survive.
+2. `ConsultationLedger` must bound an oversized persisted ledger on load (the
+   hard max-entries cap), not only on the first new record().
+3. `Index.search()` must over-fetch a candidate pool when a reranker is set and
+   truncate the reranked result back to `limit` (fixes the status reranker being
+   unable to promote a doc outside the BM25 window, and the id/tag reranker
+   returning limit+1 rows).
+"""
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import httpx
+import pytest
+
+from data_olympus.enforce_policy import ConsultationLedger
+from data_olympus.index import Index, SearchHit
+from data_olympus.server import build_app
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+# --- 1. health served inline (off the shared worker pool) --------------------
+
+
+@pytest.mark.asyncio
+async def test_health_does_not_use_the_worker_pool(tmp_kb, tmp_path, monkeypatch) -> None:
+    app = build_app(
+        kb_main_path=tmp_kb, kb_index_path=tmp_path / "idx.db",
+        sync_interval_sec=60, staleness_degraded_sec=600, bootstrap_now=True,
+    )
+    http_app = app.http_app()
+
+    # If /api/v1/health went through _offload (anyio.to_thread.run_sync), breaking
+    # run_sync would break the probe. Inline serving is unaffected.
+    import data_olympus.rest_api as rest_api
+
+    async def boom(*_a, **_k):
+        raise RuntimeError("worker pool is saturated / unavailable")
+
+    monkeypatch.setattr(rest_api.anyio.to_thread, "run_sync", boom)
+
+    transport = httpx.ASGITransport(app=http_app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://t") as client:
+        resp = await client.get("/api/v1/health")
+    assert resp.status_code in (200, 503)  # served, not crashed
+    assert "kb_commit" in resp.json()
+
+
+# --- 2. ledger bounded on load ----------------------------------------------
+
+
+def test_persisted_ledger_is_capped_on_load(tmp_path: Path) -> None:
+    path = tmp_path / "ledger.json"
+    rows = [
+        {"session_id": f"s{i}", "workspace": "w", "consulted_at": float(i), "rule_ids": []}
+        for i in range(50)
+    ]
+    path.write_text(json.dumps(rows))
+
+    led = ConsultationLedger(path=str(path), retention_sec=1e12, max_entries=10)
+    # Oversized file must not load 50 entries into memory; capped to newest 10.
+    assert len(led._entries) == 10
+    # Newest by consulted_at survive (s40..s49).
+    assert led.get(session_id="s49", workspace="w") is not None
+    assert led.get(session_id="s0", workspace="w") is None
+
+
+# --- 3. search over-fetch + truncate around a reranker -----------------------
+
+
+def test_reranker_receives_wider_pool_than_limit(tmp_kb, tmp_index_path) -> None:
+    seen = {}
+
+    def spy(_query: str, hits: list[SearchHit]) -> list[SearchHit]:
+        seen["n"] = len(hits)
+        return hits
+
+    idx = Index(tmp_index_path, reranker=spy)
+    idx.build(tmp_kb, source_commit="abc")
+    idx.search("STD", limit=2)  # tmp_kb has >2 STD docs
+    assert seen["n"] > 2, "reranker should see a candidate pool wider than limit"
+
+
+def test_reranked_results_truncated_to_limit(tmp_kb, tmp_index_path) -> None:
+    def prepend_extra(_query: str, hits: list[SearchHit]) -> list[SearchHit]:
+        extra = SearchHit(id="SYNTH", path="p", title="t", snippet="", score=-999.0)
+        return [extra, *hits]
+
+    idx = Index(tmp_index_path, reranker=prepend_extra)
+    idx.build(tmp_kb, source_commit="abc")
+    hits = idx.search("STD", limit=2)
+    assert len(hits) == 2, "prepended synthetic hit must not push result past limit"
+    assert hits[0].id == "SYNTH"
+
+
+def test_no_reranker_keeps_exact_limit(tmp_kb, tmp_index_path) -> None:
+    idx = Index(tmp_index_path)
+    idx.build(tmp_kb, source_commit="abc")
+    assert len(idx.search("STD", limit=2)) == 2  # unchanged default path

--- a/tests/test_perf_hardening.py
+++ b/tests/test_perf_hardening.py
@@ -1,0 +1,146 @@
+"""Tests for the 503-hardening work: health-snapshot TTL cache and thread-safety
+of the audit log and consultation ledger.
+
+Context: the single-replica server ran every REST/enforce handler's synchronous
+core inline on the one asyncio event loop. Under load the loop stalled past the
+1s readiness probe timeout, the only pod was ejected from the Service, and nginx
+returned 503. The fixes: cache Index.health() so the readiness path is memory-only
+in steady state, and add locks so the stateful writers stay correct once their
+work is offloaded to a threadpool (anyio.to_thread) and can run concurrently.
+"""
+from __future__ import annotations
+
+import threading
+from typing import TYPE_CHECKING
+
+from data_olympus.audit_log import AuditLog
+from data_olympus.enforce_policy import ConsultationLedger
+from data_olympus.index import Index
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+# --- Index.health() TTL cache ------------------------------------------------
+
+
+def test_health_cached_within_ttl_and_refreshed_after(tmp_kb: Path, tmp_path: Path) -> None:
+    clock = [1000.0]
+    idx = Index(tmp_path / "idx.db", clock=lambda: clock[0], health_ttl_sec=5.0)
+    idx.build(tmp_kb, source_commit="abc")
+
+    h1 = idx.health()
+    assert idx._health_uncached_calls == 1  # first read hits the DB
+
+    clock[0] += 4.0  # still inside the TTL window
+    h2 = idx.health()
+    assert idx._health_uncached_calls == 1  # served from cache, no DB read
+    assert h2 == h1
+
+    clock[0] += 2.0  # 6s since the cached read -> past the 5s TTL
+    idx.health()
+    assert idx._health_uncached_calls == 2  # re-read from DB
+
+
+def test_build_invalidates_health_cache(tmp_kb: Path, tmp_path: Path) -> None:
+    clock = [0.0]
+    # Large TTL so only build() (not expiry) can refresh the cache.
+    idx = Index(tmp_path / "idx.db", clock=lambda: clock[0], health_ttl_sec=1000.0)
+    idx.build(tmp_kb, source_commit="one")
+    assert idx.health()["source_commit"] == "one"
+
+    idx.build(tmp_kb, source_commit="two")
+    # Cache must reflect the rebuild immediately, despite the TTL not elapsing.
+    assert idx.health()["source_commit"] == "two"
+
+
+# --- AuditLog thread-safety --------------------------------------------------
+
+
+def test_concurrent_appends_preserve_hash_chain(tmp_path: Path) -> None:
+    log = AuditLog(log_path=str(tmp_path / "audit.log"))
+    workers, per_worker = 8, 20
+
+    def worker(n: int) -> None:
+        for i in range(per_worker):
+            log.append({"status": "ok", "tag": f"{n}-{i}"})
+
+    threads = [threading.Thread(target=worker, args=(n,)) for n in range(workers)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    ok, broken_idx = log.verify()
+    assert ok, f"hash chain broken at line {broken_idx}"
+    assert sum(1 for _ in log.iter_filtered()) == workers * per_worker
+
+
+# --- ConsultationLedger thread-safety ----------------------------------------
+
+
+def test_concurrent_ledger_records_persist_all_entries(tmp_path: Path) -> None:
+    led = ConsultationLedger(path=str(tmp_path / "ledger.json"))
+    workers, per_worker = 8, 20
+
+    def worker(n: int) -> None:
+        for i in range(per_worker):
+            led.record(session_id=f"s{n}-{i}", workspace="w", rule_ids=[], now=float(i))
+
+    threads = [threading.Thread(target=worker, args=(n,)) for n in range(workers)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    # Reload from disk: a torn write or dict-mutation-during-iteration would drop
+    # entries or corrupt the JSON.
+    reloaded = ConsultationLedger(path=str(tmp_path / "ledger.json"))
+    for n in range(workers):
+        for i in range(per_worker):
+            assert reloaded.get(session_id=f"s{n}-{i}", workspace="w") is not None
+
+
+# --- ConsultationLedger bounded growth ---------------------------------------
+# The ledger is a TTL freshness cache: an entry older than the consult TTL can
+# never be "fresh" again, so keeping it is pure dead weight. Before this fix,
+# _entries grew unbounded (every (session, workspace) pair ever seen) and
+# record() rewrote the whole file each call -> O(n) that climbs forever.
+
+
+def test_ledger_evicts_entries_past_retention() -> None:
+    led = ConsultationLedger(retention_sec=100.0)
+    led.record(session_id="old", workspace="w", rule_ids=[], now=0.0)
+    # Recording at now=200 makes 'old' 200s stale (> 100s retention): evicted.
+    led.record(session_id="new", workspace="w", rule_ids=[], now=200.0)
+    assert led.get(session_id="old", workspace="w") is None
+    assert led.get(session_id="new", workspace="w") is not None
+
+
+def test_ledger_keeps_still_fresh_entries() -> None:
+    led = ConsultationLedger(retention_sec=100.0)
+    led.record(session_id="a", workspace="w", rule_ids=[], now=0.0)
+    # 'a' is only 50s old at the next record (< 100s retention): kept.
+    led.record(session_id="b", workspace="w", rule_ids=[], now=50.0)
+    assert led.get(session_id="a", workspace="w") is not None
+    assert led.get(session_id="b", workspace="w") is not None
+
+
+def test_ledger_enforces_max_entries_cap() -> None:
+    # Retention effectively disabled so only the hard cap can evict.
+    led = ConsultationLedger(retention_sec=1e12, max_entries=3)
+    for i in range(6):
+        led.record(session_id=f"s{i}", workspace="w", rule_ids=[], now=float(i))
+    remaining = [i for i in range(6) if led.get(session_id=f"s{i}", workspace="w") is not None]
+    assert remaining == [3, 4, 5]  # only the 3 most-recent survive
+
+
+def test_ledger_eviction_is_persisted(tmp_path: Path) -> None:
+    path = str(tmp_path / "ledger.json")
+    led = ConsultationLedger(path=path, retention_sec=100.0)
+    led.record(session_id="old", workspace="w", rule_ids=[], now=0.0)
+    led.record(session_id="new", workspace="w", rule_ids=[], now=200.0)
+    # The on-disk file must also be pruned, not just the in-memory dict.
+    reloaded = ConsultationLedger(path=path, retention_sec=100.0)
+    assert reloaded.get(session_id="old", workspace="w") is None
+    assert reloaded.get(session_id="new", workspace="w") is not None

--- a/tests/test_search_pipeline.py
+++ b/tests/test_search_pipeline.py
@@ -1,0 +1,89 @@
+"""Tests for the composable search pipeline (issue #36).
+
+Establishes the staged seams that the search-enhancement features plug into:
+- expand-query: an optional ``query_expander`` hook rewrites the term list.
+- match: ``_build_match_expr`` turns terms (+ optional column restriction) into
+  the FTS5 MATCH expression.
+- re-rank: an optional ``reranker`` hook reorders/rescores the hit list.
+
+The existing tests in test_index.py assert that the default pipeline (no hooks)
+preserves current search behaviour; these assert the seams exist and are wired.
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from data_olympus.index import Index
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+# --- match stage: _build_match_expr ------------------------------------------
+
+
+def test_build_match_expr_or_joins_quoted_terms(tmp_index_path: Path) -> None:
+    idx = Index(tmp_index_path)
+    assert idx._build_match_expr(["alpha", "beta"], None) == '"alpha" OR "beta"'
+
+
+def test_build_match_expr_restricts_to_columns(tmp_index_path: Path) -> None:
+    idx = Index(tmp_index_path)
+    assert idx._build_match_expr(["alpha"], ["title", "body"]) == '{title body} : ("alpha")'
+
+
+def test_build_match_expr_rejects_unknown_column(tmp_index_path: Path) -> None:
+    idx = Index(tmp_index_path)
+    try:
+        idx._build_match_expr(["alpha"], ["title", "bogus"])
+    except ValueError as e:
+        assert "bogus" in str(e)
+    else:
+        raise AssertionError("expected ValueError for unknown column")
+
+
+def test_build_match_expr_quotes_embedded_quotes(tmp_index_path: Path) -> None:
+    # A term containing a double quote must not break out of its phrase.
+    assert idx_quote(tmp_index_path, 'a"b') == '"a""b"'
+
+
+def idx_quote(path: Path, term: str) -> str:
+    return Index(path)._build_match_expr([term], None)
+
+
+# --- expand-query stage: query_expander hook ---------------------------------
+
+
+def test_query_expander_hook_rewrites_terms(tmp_kb: Path, tmp_index_path: Path) -> None:
+    # A term that does not occur in the corpus, expanded to one that does.
+    def expander(terms: list[str]) -> list[str]:
+        return ["worktree" if t == "zzznope" else t for t in terms]
+
+    idx = Index(tmp_index_path, query_expander=expander)
+    idx.build(tmp_kb, source_commit="abc")
+    hits = idx.search("zzznope", limit=10)
+    assert hits, "expander should have rewritten the query to a matching term"
+    assert any("worktree" in h.snippet.lower() or "worktree" in h.title.lower() for h in hits)
+
+
+def test_no_expander_leaves_query_unchanged(tmp_kb: Path, tmp_index_path: Path) -> None:
+    idx = Index(tmp_index_path)
+    idx.build(tmp_kb, source_commit="abc")
+    assert idx.search("zzznope", limit=10) == []  # unknown term, no expansion -> no hits
+
+
+# --- re-rank stage: reranker hook --------------------------------------------
+
+
+def test_reranker_hook_reorders_results(tmp_kb: Path, tmp_index_path: Path) -> None:
+    base = Index(tmp_index_path)
+    base.build(tmp_kb, source_commit="abc")
+    default_order = [h.id for h in base.search("STD", limit=10)]
+    assert len(default_order) >= 2, "need >=2 hits to prove reordering"
+
+    def reverser(query: str, hits: list) -> list:  # noqa: ARG001
+        return list(reversed(hits))
+
+    ranked = Index(tmp_index_path, reranker=reverser)
+    reordered = [h.id for h in ranked.search("STD", limit=10)]
+    assert reordered == list(reversed(default_order))


### PR DESCRIPTION
Foundation branch for the search + reliability work (wave 1). Base for the
stacked feature PRs (#37, #38, #39, #43).

## What's here
**Serving reliability — eliminate the intermittent 503s.** Root cause: the
single-replica pod flapped NotReady under load because the readiness probe
(`timeoutSeconds: 1`) timed out while synchronous work ran on the one asyncio
event loop; TCP-only liveness meant no restart and no log trace (nginx served the
503 with an empty upstream). Fixes: relax the readiness probe (5s timeout, 5
failures) + raise CPU to 2; offload synchronous REST/enforce handler work to the
anyio threadpool; cache `Index.health()` (short TTL, invalidated on rebuild);
lock `AuditLog` and `ConsultationLedger` for concurrent thread access.

**Bounded consultation ledger.** TTL eviction + hard max-entries cap so the
ledger stops growing without bound and the per-record rewrite stays O(active
window).

**Composable search pipeline (Closes #36).** `Index.search()` refactored into
expand-query / match / re-rank stages with pluggable `query_expander` and
`reranker` hooks. Behaviour unchanged.

## Review notes
- This branch was cut before #35 merged, so it is 1 commit behind `main`. It
  needs a rebase onto `main` before merge (small conflict surface: rest_api.py,
  server.py).
- `index.py` bundles the health-snapshot cache with the pipeline refactor
  because they touch the same file; can be split on request.

Closes #36
