### PR TITLE
Search: status-aware ranking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Retrieval now indexes `applies_when` trigger metadata and `description` with
   column-weighted ranking, improving coding-intent to governing-rule matching
   (index schema v5). `kb_get` returns both fields.
+- Status-aware search ranking (enabled by default): `kb_search` reranks hits by a
+  status prior on top of BM25, so an in-force doc (`active`, `accepted`,
+  `approved`) outranks a `superseded`/`deprecated`/`rejected` one that matches the
+  same query, and drafts do not beat live guidance. Status matching is
+  case-insensitive; unknown or empty statuses stay neutral and are never dropped.
+  This changes result ordering for queries that hit both a live and a retired doc.
+  A deployment overrides the built-in status->weight map via `KB_STATUS_WEIGHTS`
+  (a JSON object of `{status: weight}`, negative boosts, positive penalizes).
 - Enforcement core: data-olympus can now act as a gated, mandatory consultation
   proxy for code/architectural decisions, not only an advisory KB. New MCP tools
   `kb_consult`, `kb_gate_check`, `kb_compliance` and REST endpoints

--- a/docs/serving.md
+++ b/docs/serving.md
@@ -86,6 +86,39 @@ set it to `0` to disable reaping (observability only), or have the client send a
 periodic keep-alive request. Excluding sessions with an active open stream from
 reaping (so a live stream is never torn down) is a possible follow-up; the
 current behavior reaps purely on request-activity age.
+## Search ranking
+
+`kb_search` orders hits by BM25 relevance and then applies a **status-aware
+rerank on top of that score, enabled by default**. The rerank exists so a
+retired document does not outrank the live one that replaced it: for a query that
+matches both, the in-force doc is promoted and the retired one demoted.
+
+The built-in status-to-weight map is:
+
+- In-force (boosted): `active`, `accepted`, `approved`.
+- Retired (penalized): `superseded`, `deprecated`, `rejected`.
+- Not yet in force (penalized): `draft`, `proposed`.
+
+A negative weight boosts (moves a hit earlier), a positive weight penalizes
+(moves it later). Status matching is case-insensitive, so `Active` in frontmatter
+ranks like `active`. Any status not in the map (including an empty status) is
+neutral and is never dropped from results.
+
+Because this reorders results, a query that previously surfaced a `superseded`
+doc first may now surface the `active` one first. This is the intended behavior
+change.
+
+Override the map at deploy time, with no code change:
+
+- `KB_STATUS_WEIGHTS`: a JSON object of `{status: weight}` that **replaces** the
+  built-in map (it is not merged). Keys are statuses (matched
+  case-insensitively), values are numeric deltas: negative boosts an in-force
+  status, positive penalizes a retired one. A malformed value fails startup
+  loudly rather than silently shipping default ranking. Unset (the default) uses
+  the built-in map above.
+
+  Example: `KB_STATUS_WEIGHTS='{"active": -1.0, "approved": -1.0, "superseded":
+  2.0, "draft": 1.0}'`.
 
 ## Taxonomy and writable paths
 

--- a/src/data_olympus/config.py
+++ b/src/data_olympus/config.py
@@ -44,10 +44,37 @@ class Config:
     # reaper (observability-only). The scan runs every session_reap_interval_sec.
     session_idle_timeout_sec: int = 1800
     session_reap_interval_sec: int = 60
+    # Optional override for the status-aware reranker's status->weight map
+    # (issue #37). None means "use the Index built-in default map". A negative
+    # weight boosts an in-force status, a positive one penalizes a retired one.
+    status_weights: dict[str, float] | None = None
 
 
 def _split_csv(raw: str) -> list[str]:
     return [s.strip() for s in raw.split(",") if s.strip()]
+
+
+def _load_status_weights(raw: str) -> dict[str, float] | None:
+    """Parse KB_STATUS_WEIGHTS: a JSON object of ``{status: weight}``.
+
+    Empty/unset returns None (the Index applies its built-in default map). A
+    malformed value raises ValueError rather than silently falling back, so a
+    misconfigured deployment fails loudly instead of shipping default ranking.
+    """
+    raw = raw.strip()
+    if not raw:
+        return None
+    import json
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as e:
+        raise ValueError(f"KB_STATUS_WEIGHTS must be a JSON object; {e}") from e
+    if not isinstance(data, dict):
+        raise ValueError(
+            "KB_STATUS_WEIGHTS must be a JSON object of {status: weight}; "
+            f"got {type(data).__name__}"
+        )
+    return {str(k): float(v) for k, v in data.items()}
 
 
 def load_config() -> Config:
@@ -81,6 +108,7 @@ def load_config() -> Config:
     ledger_path = os.getenv("KB_LEDGER_PATH", "/state/ledger.json")
     session_idle_timeout_sec = int(os.getenv("KB_SESSION_IDLE_TIMEOUT_SEC", "1800"))
     session_reap_interval_sec = int(os.getenv("KB_SESSION_REAP_INTERVAL_SEC", "60"))
+    status_weights = _load_status_weights(os.getenv("KB_STATUS_WEIGHTS", ""))
     return Config(
         kb_main_path=Path(os.environ.get("KB_MAIN_PATH", "/kb-main")),
         kb_index_path=Path(os.environ.get("KB_INDEX_PATH", "/index/kb.db")),
@@ -112,4 +140,5 @@ def load_config() -> Config:
         ledger_path=ledger_path,
         session_idle_timeout_sec=session_idle_timeout_sec,
         session_reap_interval_sec=session_reap_interval_sec,
+        status_weights=status_weights,
     )

--- a/src/data_olympus/index.py
+++ b/src/data_olympus/index.py
@@ -75,10 +75,17 @@ _RERANK_MAX_POOL = 200
 # In-force statuses boost; retired/not-yet-in-force statuses penalize; anything
 # not in this map (incl. the empty string) is neutral and is never dropped. A
 # deployment overrides the whole map via KB_STATUS_WEIGHTS (see config.py).
+#
+# Keys are matched case-insensitively against the document's status (both are
+# casefolded before lookup), so mixed-case frontmatter (e.g. ``Active``) is not
+# silently treated as neutral. Keep the keys here lowercase.
 _DEFAULT_STATUS_WEIGHTS: dict[str, float] = {
-    # In-force: the guidance that currently applies. Boost.
+    # In-force: the guidance that currently applies. Boost. ``approved`` is the
+    # in-force status the target KB uses for accepted decisions, alongside the
+    # spec's ``accepted``; both carry the same boost.
     "active": -1.0,
     "accepted": -1.0,
+    "approved": -1.0,
     # Retired or superseded: kept for history, must not outrank its replacement.
     "superseded": 2.0,
     "deprecated": 2.0,
@@ -236,14 +243,25 @@ def make_status_reranker(
     defaults to ``_DEFAULT_STATUS_WEIGHTS``; a caller-supplied map REPLACES it
     rather than merging, so an override is fully explicit.
 
+    Status matching is case-insensitive: both the configured keys and each hit's
+    status are casefolded before lookup, so mixed-case frontmatter (e.g.
+    ``Active``) is boosted like ``active`` rather than silently treated as
+    neutral.
+
     The re-sort is stable: hits with equal adjusted score keep their incoming
     (bm25) order.
     """
-    table = _DEFAULT_STATUS_WEIGHTS if weights is None else weights
+    source = _DEFAULT_STATUS_WEIGHTS if weights is None else weights
+    # Casefold the keys once so per-hit lookup is a plain dict.get on the
+    # casefolded status. A caller-supplied map with two keys that collide under
+    # casefold (e.g. "Draft" and "draft") keeps the last one, matching normal
+    # dict semantics; deployments should supply distinct statuses.
+    table = {status.casefold(): weight for status, weight in source.items()}
 
     def reranker(query: str, hits: list[SearchHit]) -> list[SearchHit]:  # noqa: ARG001
         adjusted = [
-            replace(h, score=h.score + table.get(h.status, 0.0)) for h in hits
+            replace(h, score=h.score + table.get(h.status.casefold(), 0.0))
+            for h in hits
         ]
         adjusted.sort(key=lambda h: h.score)
         return adjusted

--- a/src/data_olympus/index.py
+++ b/src/data_olympus/index.py
@@ -7,7 +7,7 @@ import sqlite3
 import subprocess
 import threading
 import time
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import TYPE_CHECKING, Any
 
 from data_olympus.markdown_parse import parse_file
@@ -68,6 +68,25 @@ _DEFAULT_BM25_WEIGHTS: tuple[float, ...] = (0.0, 10.0, 5.0, 10.0, 4.0, 1.0)
 _RERANK_OVERFETCH_FACTOR = 5
 _RERANK_MIN_POOL = 50
 _RERANK_MAX_POOL = 200
+
+# Status priors for the status-aware reranker (issue #37). search() orders by
+# bm25 ASCENDING (lower = better), so these deltas are ADDED to the raw score:
+# a NEGATIVE delta boosts (moves the hit earlier), a POSITIVE delta penalizes.
+# In-force statuses boost; retired/not-yet-in-force statuses penalize; anything
+# not in this map (incl. the empty string) is neutral and is never dropped. A
+# deployment overrides the whole map via KB_STATUS_WEIGHTS (see config.py).
+_DEFAULT_STATUS_WEIGHTS: dict[str, float] = {
+    # In-force: the guidance that currently applies. Boost.
+    "active": -1.0,
+    "accepted": -1.0,
+    # Retired or superseded: kept for history, must not outrank its replacement.
+    "superseded": 2.0,
+    "deprecated": 2.0,
+    "rejected": 2.0,
+    # Not yet in force: a draft should not beat an active doc.
+    "draft": 1.0,
+    "proposed": 1.0,
+}
 
 # Generic, deployment-neutral default taxonomy. A deployment with a different
 # directory layout supplies its own table at runtime via KB_TAXONOMY_PATH (a
@@ -198,6 +217,38 @@ class SearchHit:
     score: float
     status: str = ""
     doc_type: str = ""
+
+
+def make_status_reranker(
+    weights: dict[str, float] | None = None,
+) -> Callable[[str, list[SearchHit]], list[SearchHit]]:
+    """Build a reranker that nudges each hit's score by its ``status`` (issue #37).
+
+    Governance intent: a ``superseded``/``deprecated`` doc must not outrank the
+    ``active`` one that replaced it. The returned callable matches the ``reranker``
+    hook signature ``(query, hits) -> hits``.
+
+    ``score`` is a bm25 value ordered ASCENDING in search() (lower = better), so
+    the status delta is ADDED to the raw score: an in-force status carries a
+    NEGATIVE delta (boost, moves earlier) and a retired one a POSITIVE delta
+    (penalize, moves later). A status not present in ``weights`` (including the
+    empty string) is neutral (delta 0.0) and is never dropped. ``weights``
+    defaults to ``_DEFAULT_STATUS_WEIGHTS``; a caller-supplied map REPLACES it
+    rather than merging, so an override is fully explicit.
+
+    The re-sort is stable: hits with equal adjusted score keep their incoming
+    (bm25) order.
+    """
+    table = _DEFAULT_STATUS_WEIGHTS if weights is None else weights
+
+    def reranker(query: str, hits: list[SearchHit]) -> list[SearchHit]:  # noqa: ARG001
+        adjusted = [
+            replace(h, score=h.score + table.get(h.status, 0.0)) for h in hits
+        ]
+        adjusted.sort(key=lambda h: h.score)
+        return adjusted
+
+    return reranker
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/data_olympus/server.py
+++ b/src/data_olympus/server.py
@@ -25,7 +25,7 @@ from data_olympus.auth import PathBlocklist
 from data_olympus.config import Config, load_config
 from data_olympus.enforce_policy import ConsultationLedger, IntentClassifier
 from data_olympus.git_ops import GitOps
-from data_olympus.index import Index
+from data_olympus.index import Index, make_status_reranker
 from data_olympus.pending import PendingQueue
 from data_olympus.principals import (
     AUTH_REQUIRED_TOOLS,
@@ -192,6 +192,7 @@ def build_app(
     ledger_path: str | None = None,
     session_idle_timeout_sec: int = 1800,
     session_reap_interval_sec: int = 60,
+    status_weights: dict[str, float] | None = None,
 ) -> FastMCP:
     """Construct a FastMCP app with the read tools registered.
 
@@ -226,14 +227,22 @@ def build_app(
         audit_hmac_key=audit_hmac_key,
         session_idle_timeout_sec=session_idle_timeout_sec,
         session_reap_interval_sec=session_reap_interval_sec,
+        status_weights=status_weights,
     )
     if audit_log_path is not None:
         config_kwargs["audit_log_path"] = audit_log_path
     config = Config(**config_kwargs)  # type: ignore[arg-type]
-    # Synonym/acronym query expansion (issue #38): broadens recall via the
-    # expand-query seam (issue #36). Enabled by default with the curated map;
-    # KB_SYNONYMS / KB_SYNONYMS_MODE tune or disable it (mode=off -> passthrough).
-    idx = Index(kb_index_path, query_expander=default_query_expander())
+    # Synonym/acronym query expansion (issue #38) via the expand-query seam, plus
+    # status-aware reranking (issue #37) via the re-rank seam. Both on by default:
+    # expansion broadens recall (KB_SYNONYMS / KB_SYNONYMS_MODE tune or disable it),
+    # and the status reranker keeps a superseded/deprecated doc from outranking the
+    # active one that replaced it (status_weights=None uses the built-in map;
+    # KB_STATUS_WEIGHTS overrides it).
+    idx = Index(
+        kb_index_path,
+        query_expander=default_query_expander(),
+        reranker=make_status_reranker(config.status_weights),
+    )
     git = GitOps(kb_main_path)
     # retention_sec = the consult TTL: an entry older than that can never be
     # fresh, so it is safe to evict and keeps the ledger bounded (see
@@ -644,6 +653,7 @@ def build_app_from_config(config: Config, *, bootstrap_now: bool = True) -> Fast
         ledger_path=config.ledger_path,
         session_idle_timeout_sec=config.session_idle_timeout_sec,
         session_reap_interval_sec=config.session_reap_interval_sec,
+        status_weights=config.status_weights,
     )
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -50,6 +50,32 @@ def test_load_config_rejects_bad_threshold(monkeypatch: pytest.MonkeyPatch) -> N
         load_config()
 
 
+def test_status_weights_default_to_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Unset KB_STATUS_WEIGHTS leaves the override empty (Index applies its
+    built-in default map)."""
+    monkeypatch.delenv("KB_STATUS_WEIGHTS", raising=False)
+    cfg = load_config()
+    assert cfg.status_weights is None
+
+
+def test_status_weights_parsed_from_json(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("KB_STATUS_WEIGHTS", '{"active": -3.0, "deprecated": 4.0}')
+    cfg = load_config()
+    assert cfg.status_weights == {"active": -3.0, "deprecated": 4.0}
+
+
+def test_status_weights_rejects_bad_json(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("KB_STATUS_WEIGHTS", "not-json")
+    with pytest.raises(ValueError, match="KB_STATUS_WEIGHTS"):
+        load_config()
+
+
+def test_status_weights_rejects_non_object(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("KB_STATUS_WEIGHTS", '["active", -3.0]')
+    with pytest.raises(ValueError, match="KB_STATUS_WEIGHTS"):
+        load_config()
+
+
 def test_config_is_frozen() -> None:
     """Config instances are immutable."""
     cfg = Config(

--- a/tests/test_search_pipeline.py
+++ b/tests/test_search_pipeline.py
@@ -164,6 +164,39 @@ def test_default_status_weights_shape() -> None:
     assert _DEFAULT_STATUS_WEIGHTS["draft"] > 0
 
 
+def test_default_status_weights_include_approved_as_in_force() -> None:
+    # The target KB marks in-force decisions ``approved``; it must boost like
+    # ``accepted`` rather than fall through to neutral.
+    assert "approved" in _DEFAULT_STATUS_WEIGHTS
+    assert _DEFAULT_STATUS_WEIGHTS["approved"] == _DEFAULT_STATUS_WEIGHTS["accepted"]
+
+
+def test_status_reranker_boosts_approved() -> None:
+    reranker = make_status_reranker()
+    (adjusted,) = reranker("q", [_hit("x", 0.0, "approved")])
+    assert adjusted.score < 0.0, "approved is in-force and must LOWER the score"
+
+
+def test_status_reranker_status_match_is_case_insensitive() -> None:
+    # Mixed-case frontmatter (e.g. ``Active``, ``SUPERSEDED``) must match the
+    # lowercase weight keys, not be silently treated as neutral.
+    reranker = make_status_reranker()
+    (boosted,) = reranker("q", [_hit("a", 0.0, "Active")])
+    assert boosted.score == _DEFAULT_STATUS_WEIGHTS["active"]
+    (penalized,) = reranker("q", [_hit("s", 0.0, "SUPERSEDED")])
+    assert penalized.score == _DEFAULT_STATUS_WEIGHTS["superseded"]
+
+
+def test_status_reranker_case_insensitive_override_keys() -> None:
+    # A caller-supplied map with a mixed-case key still matches a mixed-case
+    # (or any-case) document status.
+    reranker = make_status_reranker({"Draft": -5.0})
+    (adjusted,) = reranker("q", [_hit("x", 0.0, "draft")])
+    assert adjusted.score == -5.0
+    (adjusted,) = reranker("q", [_hit("y", 0.0, "DRAFT")])
+    assert adjusted.score == -5.0
+
+
 def test_status_reranker_end_to_end_ranks_active_first(
     status_kb: Path, tmp_index_path: Path
 ) -> None:

--- a/tests/test_search_pipeline.py
+++ b/tests/test_search_pipeline.py
@@ -13,7 +13,12 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from data_olympus.index import Index
+from data_olympus.index import (
+    _DEFAULT_STATUS_WEIGHTS,
+    Index,
+    SearchHit,
+    make_status_reranker,
+)
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -87,3 +92,89 @@ def test_reranker_hook_reorders_results(tmp_kb: Path, tmp_index_path: Path) -> N
     ranked = Index(tmp_index_path, reranker=reverser)
     reordered = [h.id for h in ranked.search("STD", limit=10)]
     assert reordered == list(reversed(default_order))
+
+
+# --- status-aware reranker (issue #37) ---------------------------------------
+#
+# bm25 direction: search() does ``ORDER BY score`` ASCENDING where score is a
+# bm25 expression and LOWER is better. So the status reranker LOWERS the score of
+# an in-force status (boost) and RAISES it for a retired one (penalize). These
+# tests pin that direction rather than trusting the sign of the weights.
+
+
+def _hit(id_: str, score: float, status: str) -> SearchHit:
+    return SearchHit(id=id_, path=f"{id_}.md", title=id_, snippet="", score=score, status=status)
+
+
+def test_status_reranker_boosts_active_over_superseded_at_same_bm25() -> None:
+    reranker = make_status_reranker()
+    # Same raw bm25 score; only status differs. Active must sort first.
+    hits = [_hit("old", -1.0, "superseded"), _hit("new", -1.0, "active")]
+    ordered = [h.id for h in reranker("caching", hits)]
+    assert ordered == ["new", "old"]
+
+
+def test_status_reranker_can_overturn_bm25_order() -> None:
+    # The superseded doc wins on raw bm25 (more negative = better) but the
+    # active doc must still rank first once the status prior is applied.
+    reranker = make_status_reranker()
+    hits = [_hit("old", -2.0, "superseded"), _hit("new", -1.9, "active")]
+    ordered = [h.id for h in reranker("caching", hits)]
+    assert ordered == ["new", "old"]
+
+
+def test_status_reranker_lowers_score_for_boost_raises_for_penalty() -> None:
+    reranker = make_status_reranker()
+    (adjusted,) = reranker("q", [_hit("a", 0.0, "active")])
+    assert adjusted.score < 0.0, "in-force status must LOWER the (ascending) score"
+    (adjusted,) = reranker("q", [_hit("d", 0.0, "deprecated")])
+    assert adjusted.score > 0.0, "retired status must RAISE the (ascending) score"
+
+
+def test_status_reranker_neutral_for_unknown_or_empty_status() -> None:
+    reranker = make_status_reranker()
+    for status in ("", "mystery-status"):
+        (adjusted,) = reranker("q", [_hit("x", 3.0, status)])
+        assert adjusted.score == 3.0, f"status {status!r} must be neutral"
+
+
+def test_status_reranker_never_drops_a_hit() -> None:
+    reranker = make_status_reranker()
+    hits = [_hit("a", 0.0, "active"), _hit("b", 0.0, ""), _hit("c", 0.0, "deprecated")]
+    out = reranker("q", hits)
+    assert {h.id for h in out} == {"a", "b", "c"}
+
+
+def test_status_reranker_accepts_weight_override() -> None:
+    # A caller-supplied map overrides the default; here "draft" is boosted.
+    reranker = make_status_reranker({"draft": -5.0})
+    (adjusted,) = reranker("q", [_hit("x", 0.0, "draft")])
+    assert adjusted.score == -5.0
+    # A status absent from the override map is neutral, not defaulted.
+    (adjusted,) = reranker("q", [_hit("y", 0.0, "active")])
+    assert adjusted.score == 0.0
+
+
+def test_default_status_weights_shape() -> None:
+    # In-force statuses boost (negative), retired ones penalize (positive).
+    assert _DEFAULT_STATUS_WEIGHTS["active"] < 0
+    assert _DEFAULT_STATUS_WEIGHTS["accepted"] < 0
+    assert _DEFAULT_STATUS_WEIGHTS["superseded"] > 0
+    assert _DEFAULT_STATUS_WEIGHTS["deprecated"] > 0
+    assert _DEFAULT_STATUS_WEIGHTS["draft"] > 0
+
+
+def test_status_reranker_end_to_end_ranks_active_first(
+    status_kb: Path, tmp_index_path: Path
+) -> None:
+    # Acceptance: a query matching both an active and a superseded doc ranks the
+    # active one higher once the reranker is wired onto the Index.
+    baseline = Index(tmp_index_path)
+    baseline.build(status_kb, source_commit="abc")
+    plain = [h.id for h in baseline.search("caching", limit=10)]
+    assert "STD-OLD" in plain and "STD-NEW" in plain
+
+    ranked = Index(tmp_index_path, reranker=make_status_reranker())
+    ranked.build(status_kb, source_commit="abc")
+    order = [h.id for h in ranked.search("caching", limit=10)]
+    assert order.index("STD-NEW") < order.index("STD-OLD")


### PR DESCRIPTION
Status-aware search ranking. Stacked on the foundation branch (`claude/cranky-matsumoto-2e60a7`).

A governance KB must not rank a retired decision above the one that replaced it.
Adds a `reranker` (`make_status_reranker`) wired on by default: boosts in-force
statuses (active, accepted), penalises retired ones (superseded, deprecated,
draft), neutral for unknown/empty (never drops a hit). Correctly handles the bm25
direction (lower score = better) with explicit ordering tests. Configurable via
`KB_STATUS_WEIGHTS` (JSON; fails loud on malformed).

## Integration note
Composes with #39: both use the single `reranker` slot, to be combined as
`make_id_tag_reranker(idx, inner=make_status_reranker(...))` at merge.

Closes #37
