### PR TITLE
Search: synonym & acronym query expansion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,15 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   (default 60s). `kb_health` and `/api/v1/health` gained a `live_sessions` field
   reporting the current live transport count (`null` until the HTTP app is
   serving); a value that only climbs signals leaked sessions.
+- Synonym / acronym query expansion (default-on). Before the FTS MATCH is built,
+  the search pipeline rewrites the query term list through a curated, bidirectional
+  synonym map, so a short-form query (`k8s`, `rls`) also reaches documents that only
+  use the long form (`kubernetes`, `row level security`) and vice versa. Adjacent
+  query tokens are scanned as n-grams so multi-word canonical keys match from a
+  long-form query. Expansion is bounded (32 terms) and de-duplicated, originals are
+  ranked first, and it is configurable via `KB_SYNONYMS` (extra/override groups) and
+  `KB_SYNONYMS_MODE` (`merge` default / `replace` / `off`). This is curated
+  lexical expansion, not semantic (embedding) retrieval.
 - Enforcement hardening and observability: gate_bypass and gate_degraded events are now recorded (via `data-olympus report --emit-events` / the git warn hook, and the pre-tool hook on a reachable-degraded gate), so `kb_compliance` surfaces them. The gate receives `action_diff` and the classifier uses word-boundary matching plus dependency-install command signals (Codex and Claude now gate the Bash tool). New `kb enforce install --mode off|soft|hard`, ledger persistence via `KB_LEDGER_PATH`, a friendly PATH hint for `kb enforce report`, and a CI guard requiring a changelog entry for functional changes.
 - Guided onboarding: MCP prompts `onboard`, `onboard_project`, and `onboard_component` walk an agent through bootstrapping a new workspace or component, backed by a single-sourced playbook (`render_playbook`). A read-only `kb_cleanup_plan` MCP tool plus `POST /api/v1/onboarding/cleanup-plan` classify local repo docs against KB content and propose thin-pointer replacements for duplicates. `GET /api/v1/onboarding/playbook` and `kb onboard playbook` expose the same script to agents without native MCP prompt support.
 - Composable search pipeline: `Index.search()` now runs expand-query / match /

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -76,7 +76,7 @@ This is data-olympus's clearest accuracy differentiator, and it is genuinely dem
 
 ### Where data-olympus loses
 
-On **semantic** (paraphrase) queries, data-olympus achieves recall=0.036, ndcg=0.021. Paraphrases lack the keyword overlap the FTS index relies on, so every keyword method does poorly here (BM25 0.009, grep-read 0.022, whole-dump 0.022); none is practically useful. This is the category where dense retrieval has the largest advantage, and **vector-RAG (not included in this run, `[bench]` deps absent) is expected to win decisively**. It is data-olympus's genuine weakness: full-text search cannot follow synonyms.
+On **semantic** (paraphrase) queries, data-olympus achieves recall=0.036, ndcg=0.021. Paraphrases lack the keyword overlap the FTS index relies on, so every keyword method does poorly here (BM25 0.009, grep-read 0.022, whole-dump 0.022); none is practically useful. This is the category where dense retrieval has the largest advantage, and **vector-RAG (not included in this run, `[bench]` deps absent) is expected to win decisively**. It remains data-olympus's genuine weakness: a curated synonym/acronym expansion layer bridges known lexical variants (`k8s` -> `kubernetes`, `rls` -> `row level security`), but full-text search still cannot follow arbitrary paraphrases the way dense retrieval does.
 
 On **exact** queries, data-olympus (recall=0.858) trails BM25 (recall=1.000). BM25 ranks chunks by TF-IDF over full bodies, while data-olympus ranks by SQLite FTS5 bm25 over its indexed surface; the gap is the cost of the lighter index.
 
@@ -237,7 +237,7 @@ This is the nearest-adjacent category: tools that treat engineering decisions (A
 
 These are the areas where data-olympus is currently weakest, separate from deliberate scope decisions:
 
-- **Search is full-text only.** There is no semantic or embedding-based retrieval. Queries that depend on synonyms or conceptual proximity will miss results.
+- **Search is full-text, with curated lexical expansion but no semantics.** A curated, bidirectional synonym/acronym map expands the query before matching (so `k8s`/`kubernetes` and `rls`/`row level security` find each other), configurable via `KB_SYNONYMS` / `KB_SYNONYMS_MODE`. There is still no semantic or embedding-based retrieval: queries that depend on conceptual proximity or paraphrases outside the curated map will miss results.
 - **No automatic producer or ingestion agent.** Every concept must be authored or proposed by an agent, then reviewed and committed. There is no crawler, connector, or auto-enrichment pipeline.
 - **Pre-release specification (v0.1).** The SPEC is not yet frozen. Field names, required fields, and serving contracts may change before a stable release.
 - **Single-writer deployment required for writes.** The write pipeline assumes one server instance owns the git working tree. Horizontal write scaling requires a redesign of the lock and worktree model.

--- a/docs/serving.md
+++ b/docs/serving.md
@@ -108,6 +108,36 @@ time, with no code change:
 - `KB_MEMORY_INBOX_PREFIX`: directory new memory proposals are written under
   (default `memory/inbox/`).
 
+## Synonym / acronym query expansion
+
+Before building the FTS MATCH, the server rewrites the query term list through a
+curated, bidirectional synonym map. A short-form query (`k8s`, `rls`) also reaches
+documents that only use the long form (`kubernetes`, `row level security`), and
+vice versa; adjacent query tokens are scanned as n-grams so multi-word keys match
+from a long-form query. Expansion is bounded (32 terms) and de-duplicated, and the
+terms the user actually typed are ranked first. This is curated lexical expansion,
+not semantic (embedding) retrieval.
+
+The default map ships a small set of high-value, unambiguous technical acronyms
+(`k8s`/`kubernetes`, `authn`/`authz`, `rls`, `adr`, `rbac`, `sso`, `pii`, `iac`,
+`kb`). Ambiguous or generic short tokens are intentionally left out of the
+defaults to avoid recall noise; add them per deployment via `KB_SYNONYMS`.
+
+Two environment variables tune it:
+
+- `KB_SYNONYMS`: extra or override groups in `key=variant,variant;key2=variant`
+  form. Groups are `;`-separated; within a group the `key` is the canonical form
+  and the comma-separated tail are its variants. Whitespace is trimmed and empty
+  entries are dropped. Multi-word keys and variants are allowed (e.g.
+  `row level security=rls`). Example:
+  `KB_SYNONYMS="feature flag=ff,flag;service level objective=slo"`.
+- `KB_SYNONYMS_MODE`: how `KB_SYNONYMS` combines with the built-in defaults.
+  - `merge` (default): layer `KB_SYNONYMS` on top of the curated defaults; a key
+    present in both is overridden by `KB_SYNONYMS`.
+  - `replace`: use only `KB_SYNONYMS`; the curated defaults are dropped.
+  - `off`: disable expansion entirely (the expander becomes a passthrough, so
+    only the terms the user typed are matched).
+
 ## Authentication and network security
 
 The server supports optional bearer-token authentication with a per-principal

--- a/src/data_olympus/query_expansion.py
+++ b/src/data_olympus/query_expansion.py
@@ -29,19 +29,20 @@ if TYPE_CHECKING:
 # Curated default groups: canonical form -> its acronyms / long forms / variants.
 # Keep groups small and unambiguous; a synonym that is a common English word in
 # other contexts (e.g. "role") is deliberately avoided to keep recall precise.
+#
+# Only high-value, unambiguous technical acronyms are default-on. Ambiguous or
+# generic short tokens were deliberately dropped from the defaults because they
+# add recall noise more than signal (they already match literally without
+# expansion): "ci"/"cd" (shell/CD collisions, and the "continuous integration/
+# delivery" groups had no other variant), "pr"/"mr" and the "pull request" group,
+# "config", "repo", "db", "docs". Deployments that want them can add them back
+# via ``KB_SYNONYMS`` (merge mode).
 DEFAULT_SYNONYMS: dict[str, list[str]] = {
     "kubernetes": ["k8s", "microk8s"],
     "authentication": ["auth", "authn"],
     "authorization": ["authz"],
     "row level security": ["rls"],
     "architecture decision record": ["adr"],
-    "continuous integration": ["ci"],
-    "continuous delivery": ["cd"],
-    "pull request": ["pr", "mr", "merge request"],
-    "configuration": ["config"],
-    "repository": ["repo"],
-    "database": ["db"],
-    "documentation": ["docs"],
     "knowledge base": ["kb"],
     "personally identifiable information": ["pii"],
     "single sign on": ["sso"],
@@ -97,6 +98,11 @@ def make_synonym_expander(
     ``Callable[[list[str]], list[str]]`` signature the ``Index`` expects.
     """
     lookup = dict(_prebuilt) if _prebuilt is not None else build_synonym_map(groups or {})
+    # Longest multi-word key (in tokens), so a long-form query like
+    # "row level security" can match the 3-token canonical key. 1 when every key
+    # is a single token (the common case), which reduces the scan to single-token
+    # lookups only.
+    max_key_len = max((len(k.split()) for k in lookup), default=1)
 
     def expander(terms: list[str]) -> list[str]:
         # Original terms first (order-stable, de-duplicated), then synonyms.
@@ -106,13 +112,34 @@ def make_synonym_expander(
             if t not in seen:
                 out.append(t)
                 seen.add(t)
-        for t in terms:
-            for syn in lookup.get(t.lower(), ()):
+
+        def add_synonyms(key: str) -> bool:
+            # Append synonyms of `key`; return False once the cap is reached so
+            # the caller stops scanning. Originals are never dropped by the cap.
+            for syn in lookup.get(key, ()):
                 if len(out) >= max_terms:
-                    return out
+                    return False
                 if syn not in seen:
                     out.append(syn)
                     seen.add(syn)
+            return True
+
+        # Single-token lookups (fast path, preserves prior behaviour).
+        for t in terms:
+            if not add_synonyms(t.lower()):
+                return out
+        # Adjacent-token n-gram lookups, so multi-word canonical keys (e.g.
+        # "row level security", "pull request") match from a long-form query.
+        # `query.split()` upstream only yields single tokens, so without this a
+        # multi-word key is never looked up. Windows of length 2..max_key_len are
+        # joined by a single space to match the lower-cased keys.
+        if max_key_len >= 2:
+            lowered = [t.lower() for t in terms]
+            n = len(lowered)
+            for size in range(2, max_key_len + 1):
+                for start in range(0, n - size + 1):
+                    if not add_synonyms(" ".join(lowered[start : start + size])):
+                        return out
         return out
 
     return expander

--- a/src/data_olympus/query_expansion.py
+++ b/src/data_olympus/query_expansion.py
@@ -1,0 +1,167 @@
+"""Synonym / acronym query expansion (issue #38).
+
+Plugs into the ``query_expander`` seam of the search pipeline (issue #36). The
+expander rewrites the query term list before the FTS5 MATCH is built. Because
+``_build_match_expr`` OR-joins the terms, appending curated synonyms of a term
+broadens recall without narrowing it: a ``k8s`` query also reaches documents
+that only say ``kubernetes`` (and vice versa).
+
+Design notes:
+- The curated map (``DEFAULT_SYNONYMS``) lists one canonical form per group with
+  its variants. ``build_synonym_map`` symmetrises it into a lookup where every
+  member points at every other member, so expansion is bidirectional.
+- Lookup is case-insensitive, but original query terms keep their casing (FTS5
+  matching is case-insensitive anyway). Synonyms are appended after the original
+  terms so BM25 still favours the terms the user actually typed.
+- Expansion is bounded (``max_terms``) and de-duplicated to avoid runaway MATCH
+  expressions. Original terms are never dropped by the cap.
+- Configuration follows the ``config.py`` env pattern: ``KB_SYNONYMS`` overrides
+  or merges the map, ``KB_SYNONYMS_MODE`` selects merge/replace/off.
+"""
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable, Mapping
+
+# Curated default groups: canonical form -> its acronyms / long forms / variants.
+# Keep groups small and unambiguous; a synonym that is a common English word in
+# other contexts (e.g. "role") is deliberately avoided to keep recall precise.
+DEFAULT_SYNONYMS: dict[str, list[str]] = {
+    "kubernetes": ["k8s", "microk8s"],
+    "authentication": ["auth", "authn"],
+    "authorization": ["authz"],
+    "row level security": ["rls"],
+    "architecture decision record": ["adr"],
+    "continuous integration": ["ci"],
+    "continuous delivery": ["cd"],
+    "pull request": ["pr", "mr", "merge request"],
+    "configuration": ["config"],
+    "repository": ["repo"],
+    "database": ["db"],
+    "documentation": ["docs"],
+    "knowledge base": ["kb"],
+    "personally identifiable information": ["pii"],
+    "single sign on": ["sso"],
+    "role based access control": ["rbac"],
+    "infrastructure as code": ["iac"],
+}
+
+# Upper bound on the expanded term list. Keeps the FTS MATCH expression (and thus
+# query latency) bounded regardless of how synonym-dense a query is.
+DEFAULT_MAX_TERMS = 32
+
+
+def build_synonym_map(groups: Mapping[str, Iterable[str]]) -> dict[str, list[str]]:
+    """Symmetrise curated groups into a bidirectional lookup.
+
+    Each group (canonical key + its variants) becomes a fully-connected set: every
+    member maps to all other members of the group. Keys are lower-cased; a
+    multi-word member is kept verbatim (lower-cased) so multi-word synonyms are
+    possible, though single-token members drive the common case. Duplicate
+    members across groups are merged (union of neighbours), order-stable.
+    """
+    lookup: dict[str, list[str]] = {}
+    for canonical, variants in groups.items():
+        members = [canonical.lower(), *[v.lower() for v in variants]]
+        # De-dup members while preserving order.
+        seen: set[str] = set()
+        ordered: list[str] = []
+        for m in members:
+            if m not in seen:
+                ordered.append(m)
+                seen.add(m)
+        for member in ordered:
+            others = [m for m in ordered if m != member]
+            bucket = lookup.setdefault(member, [])
+            for other in others:
+                if other not in bucket:
+                    bucket.append(other)
+    return lookup
+
+
+def make_synonym_expander(
+    groups: Mapping[str, Iterable[str]] | None = None,
+    *,
+    max_terms: int = DEFAULT_MAX_TERMS,
+    _prebuilt: Mapping[str, list[str]] | None = None,
+) -> Callable[[list[str]], list[str]]:
+    """Build a ``query_expander`` closure from curated groups.
+
+    ``groups`` is the canonical-form map (like ``DEFAULT_SYNONYMS``); it is
+    symmetrised internally. Pass ``_prebuilt`` to supply an already-symmetrised
+    lookup (from ``build_synonym_map`` / ``load_synonyms_from_env``) and skip the
+    rebuild. The returned callable matches the
+    ``Callable[[list[str]], list[str]]`` signature the ``Index`` expects.
+    """
+    lookup = dict(_prebuilt) if _prebuilt is not None else build_synonym_map(groups or {})
+
+    def expander(terms: list[str]) -> list[str]:
+        # Original terms first (order-stable, de-duplicated), then synonyms.
+        out: list[str] = []
+        seen: set[str] = set()
+        for t in terms:
+            if t not in seen:
+                out.append(t)
+                seen.add(t)
+        for t in terms:
+            for syn in lookup.get(t.lower(), ()):
+                if len(out) >= max_terms:
+                    return out
+                if syn not in seen:
+                    out.append(syn)
+                    seen.add(syn)
+        return out
+
+    return expander
+
+
+def _parse_synonyms_spec(raw: str) -> dict[str, list[str]]:
+    """Parse a ``KB_SYNONYMS`` spec: ``key=a,b;key2=c,d`` (groups ``;``-split).
+
+    Within a group the ``key`` is the canonical form and the comma-separated tail
+    are its variants. Whitespace is trimmed; empty entries are dropped. A group
+    without ``=`` or without variants is ignored.
+    """
+    groups: dict[str, list[str]] = {}
+    for chunk in raw.split(";"):
+        chunk = chunk.strip()
+        if not chunk or "=" not in chunk:
+            continue
+        key, _, tail = chunk.partition("=")
+        key = key.strip()
+        variants = [v.strip() for v in tail.split(",") if v.strip()]
+        if key and variants:
+            groups[key] = variants
+    return groups
+
+
+def load_synonyms_from_env() -> dict[str, list[str]]:
+    """Load the symmetrised synonym lookup from the environment.
+
+    Env knobs (all optional; sane defaults):
+    - ``KB_SYNONYMS_MODE``: ``merge`` (default) layers ``KB_SYNONYMS`` on top of
+      the curated defaults; ``replace`` uses only ``KB_SYNONYMS``; ``off``
+      disables expansion (returns an empty lookup, so ``make_synonym_expander``
+      is a passthrough).
+    - ``KB_SYNONYMS``: extra/override groups in ``key=a,b;key2=c`` form.
+
+    Returns the symmetrised lookup (as ``build_synonym_map`` produces).
+    """
+    mode = os.getenv("KB_SYNONYMS_MODE", "merge").strip().lower()
+    if mode == "off":
+        return {}
+    extra = _parse_synonyms_spec(os.getenv("KB_SYNONYMS", ""))
+    if mode == "replace":
+        groups: dict[str, list[str]] = dict(extra)
+    else:  # merge (default)
+        groups = {k: list(v) for k, v in DEFAULT_SYNONYMS.items()}
+        groups.update(extra)
+    return build_synonym_map(groups)
+
+
+def default_query_expander() -> Callable[[list[str]], list[str]]:
+    """The serving expander: env-configured, defaulting to the curated map."""
+    return make_synonym_expander(_prebuilt=load_synonyms_from_env())

--- a/src/data_olympus/server.py
+++ b/src/data_olympus/server.py
@@ -35,6 +35,7 @@ from data_olympus.principals import (
     PrincipalRegistry,
 )
 from data_olympus.push_queue import PushQueue
+from data_olympus.query_expansion import default_query_expander
 from data_olympus.rate_limit import SlidingWindowLimiter
 from data_olympus.tools_read import kb_health_fn, kb_outline_fn, kb_search_fn
 from data_olympus.worktrees import WorktreeRegistry
@@ -229,7 +230,10 @@ def build_app(
     if audit_log_path is not None:
         config_kwargs["audit_log_path"] = audit_log_path
     config = Config(**config_kwargs)  # type: ignore[arg-type]
-    idx = Index(kb_index_path)
+    # Synonym/acronym query expansion (issue #38): broadens recall via the
+    # expand-query seam (issue #36). Enabled by default with the curated map;
+    # KB_SYNONYMS / KB_SYNONYMS_MODE tune or disable it (mode=off -> passthrough).
+    idx = Index(kb_index_path, query_expander=default_query_expander())
     git = GitOps(kb_main_path)
     # retention_sec = the consult TTL: an entry older than that can never be
     # fresh, so it is safe to evict and keeps the ledger bounded (see

--- a/tests/test_query_expansion.py
+++ b/tests/test_query_expansion.py
@@ -1,0 +1,188 @@
+"""Tests for synonym/acronym query expansion (issue #38).
+
+The expander plugs into the ``query_expander`` seam established by the search
+pipeline (issue #36): it rewrites the term list before the FTS5 MATCH is built,
+and because terms are OR-matched, adding curated synonyms broadens recall
+(e.g. a ``k8s`` query also matches documents mentioning ``kubernetes``).
+
+These tests cover the pure expander unit (bounded, de-duplicated, order-stable)
+and an end-to-end index search proving the short form finds the long form.
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from data_olympus.index import Index
+from data_olympus.query_expansion import (
+    DEFAULT_SYNONYMS,
+    build_synonym_map,
+    load_synonyms_from_env,
+    make_synonym_expander,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    import pytest
+
+
+# --- pure expander unit ------------------------------------------------------
+
+
+def test_expander_adds_synonyms_bidirectionally() -> None:
+    expander = make_synonym_expander({"k8s": ["kubernetes"]})
+    # short -> long
+    assert set(expander(["k8s"])) == {"k8s", "kubernetes"}
+    # long -> short (map is symmetrised)
+    assert set(expander(["kubernetes"])) == {"kubernetes", "k8s"}
+
+
+def test_expander_preserves_original_terms_first() -> None:
+    expander = make_synonym_expander({"k8s": ["kubernetes"]})
+    out = expander(["deploy", "k8s"])
+    # original terms come first, in order; synonyms appended after.
+    assert out[:2] == ["deploy", "k8s"]
+    assert "kubernetes" in out
+
+
+def test_expander_is_case_insensitive_on_lookup() -> None:
+    expander = make_synonym_expander({"auth": ["authentication"]})
+    out = expander(["AUTH"])
+    # the original term keeps its casing; synonym is added.
+    assert "AUTH" in out
+    assert "authentication" in out
+
+
+def test_expander_deduplicates() -> None:
+    expander = make_synonym_expander({"k8s": ["kubernetes"]})
+    out = expander(["k8s", "kubernetes"])
+    assert out.count("k8s") == 1
+    assert out.count("kubernetes") == 1
+
+
+def test_expander_is_bounded() -> None:
+    # A term with many synonyms plus a large query must not explode past the cap.
+    big = {"x": [f"syn{i}" for i in range(100)]}
+    expander = make_synonym_expander(big, max_terms=8)
+    out = expander(["x", "a", "b", "c"])
+    assert len(out) <= 8
+    # originals are never dropped by the cap.
+    for t in ("x", "a", "b", "c"):
+        assert t in out
+
+
+def test_expander_passthrough_when_no_match() -> None:
+    expander = make_synonym_expander({"k8s": ["kubernetes"]})
+    assert expander(["hello", "world"]) == ["hello", "world"]
+
+
+def test_default_map_covers_expected_acronyms() -> None:
+    sym = build_synonym_map(DEFAULT_SYNONYMS)
+    assert "kubernetes" in sym["k8s"]
+    assert "k8s" in sym["kubernetes"]
+    assert "authentication" in sym["auth"]
+    assert "auth" in sym["authentication"]
+    assert "rls" in sym
+    assert "adr" in sym
+
+
+# --- end-to-end via the Index search seam ------------------------------------
+
+
+def test_search_short_form_finds_long_form(tmp_kb: Path, tmp_index_path: Path) -> None:
+    # The tmp_kb corpus does not mention "kubernetes"; add a doc that does.
+    (tmp_kb / "tooling" / "deploy.md").write_text(
+        "# Deploy\n\nWe run workloads on kubernetes clusters.\n"
+    )
+    expander = make_synonym_expander(build_synonym_map(DEFAULT_SYNONYMS))
+    idx = Index(tmp_index_path, query_expander=expander)
+    idx.build(tmp_kb, source_commit="abc")
+    hits = idx.search("k8s", limit=10)
+    assert hits, "k8s query should reach the kubernetes doc via synonym expansion"
+    assert any("kubernetes" in (h.snippet + h.title).lower() for h in hits)
+
+
+def test_search_long_form_finds_short_form(tmp_kb: Path, tmp_index_path: Path) -> None:
+    (tmp_kb / "tooling" / "k8s-notes.md").write_text(
+        "# k8s notes\n\nCluster runs on k8s and microk8s.\n"
+    )
+    expander = make_synonym_expander(build_synonym_map(DEFAULT_SYNONYMS))
+    idx = Index(tmp_index_path, query_expander=expander)
+    idx.build(tmp_kb, source_commit="abc")
+    hits = idx.search("kubernetes", limit=10)
+    assert hits, "kubernetes query should reach the k8s doc via synonym expansion"
+    assert any("k8s" in (h.snippet + h.title).lower() for h in hits)
+
+
+def test_search_without_expander_misses_synonym(
+    tmp_kb: Path, tmp_index_path: Path
+) -> None:
+    (tmp_kb / "tooling" / "deploy.md").write_text(
+        "# Deploy\n\nWe run workloads on kubernetes clusters.\n"
+    )
+    idx = Index(tmp_index_path)  # no expander
+    idx.build(tmp_kb, source_commit="abc")
+    assert idx.search("k8s", limit=10) == []
+
+
+# --- env-based configuration -------------------------------------------------
+
+
+def test_load_synonyms_from_env_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("KB_SYNONYMS", raising=False)
+    monkeypatch.delenv("KB_SYNONYMS_MODE", raising=False)
+    sym = load_synonyms_from_env()
+    # Defaults to the curated map.
+    assert "kubernetes" in sym["k8s"]
+
+
+def test_load_synonyms_from_env_merge(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("KB_SYNONYMS", "foo=bar,baz")
+    monkeypatch.delenv("KB_SYNONYMS_MODE", raising=False)  # default merge
+    sym = load_synonyms_from_env()
+    # curated entries survive
+    assert "kubernetes" in sym["k8s"]
+    # new entry added, symmetrised
+    assert "bar" in sym["foo"]
+    assert "foo" in sym["bar"]
+
+
+def test_load_synonyms_from_env_replace(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("KB_SYNONYMS", "foo=bar")
+    monkeypatch.setenv("KB_SYNONYMS_MODE", "replace")
+    sym = load_synonyms_from_env()
+    assert "foo" in sym
+    assert "k8s" not in sym  # curated defaults dropped
+
+
+def test_load_synonyms_from_env_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("KB_SYNONYMS_MODE", "off")
+    sym = load_synonyms_from_env()
+    assert sym == {}
+
+
+# --- server wiring -----------------------------------------------------------
+
+
+def test_build_app_wires_expander_by_default(
+    tmp_kb: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import data_olympus.server as server
+
+    monkeypatch.delenv("KB_SYNONYMS", raising=False)
+    monkeypatch.delenv("KB_SYNONYMS_MODE", raising=False)
+    (tmp_kb / "tooling" / "deploy.md").write_text(
+        "# Deploy\n\nWe run workloads on kubernetes clusters.\n"
+    )
+    app = server.build_app(
+        kb_main_path=tmp_kb,
+        kb_index_path=tmp_path / "kb.db",
+        sync_interval_sec=60,
+        staleness_degraded_sec=600,
+        bootstrap_now=True,
+    )
+    state = app._dolympus_state  # type: ignore[attr-defined]
+    assert state.idx.query_expander is not None
+    # End-to-end: the short form reaches the long-form doc through the wiring.
+    hits = state.idx.search("k8s", limit=10)
+    assert any("kubernetes" in (h.snippet + h.title).lower() for h in hits)

--- a/tests/test_query_expansion.py
+++ b/tests/test_query_expansion.py
@@ -76,6 +76,41 @@ def test_expander_passthrough_when_no_match() -> None:
     assert expander(["hello", "world"]) == ["hello", "world"]
 
 
+def test_expander_matches_multiword_key_from_long_form() -> None:
+    # A multi-word canonical key must be reachable from a long-form query even
+    # though the upstream tokenizer only yields single tokens. The expander scans
+    # adjacent-token n-grams to find the key.
+    expander = make_synonym_expander({"row level security": ["rls"]})
+    out = expander(["row", "level", "security"])
+    assert out[:3] == ["row", "level", "security"]  # originals first, in order
+    assert "rls" in out  # long form -> acronym via n-gram lookup
+
+
+def test_expander_matches_multiword_key_embedded_in_query() -> None:
+    # The multi-word key sits inside a longer natural-language query.
+    expander = make_synonym_expander({"row level security": ["rls"]})
+    out = expander(["enable", "row", "level", "security", "policy"])
+    assert "rls" in out
+    # single-token synonyms still work alongside the n-gram scan.
+    expander2 = make_synonym_expander(
+        {"row level security": ["rls"], "kubernetes": ["k8s"]}
+    )
+    out2 = expander2(["kubernetes", "row", "level", "security"])
+    assert "k8s" in out2
+    assert "rls" in out2
+
+
+def test_expander_multiword_respects_bound() -> None:
+    # n-gram expansion still honours the cap and keeps originals.
+    expander = make_synonym_expander(
+        {"row level security": [f"syn{i}" for i in range(50)]}, max_terms=6
+    )
+    out = expander(["row", "level", "security", "extra"])
+    assert len(out) <= 6
+    for t in ("row", "level", "security", "extra"):
+        assert t in out
+
+
 def test_default_map_covers_expected_acronyms() -> None:
     sym = build_synonym_map(DEFAULT_SYNONYMS)
     assert "kubernetes" in sym["k8s"]
@@ -112,6 +147,23 @@ def test_search_long_form_finds_short_form(tmp_kb: Path, tmp_index_path: Path) -
     hits = idx.search("kubernetes", limit=10)
     assert hits, "kubernetes query should reach the k8s doc via synonym expansion"
     assert any("k8s" in (h.snippet + h.title).lower() for h in hits)
+
+
+def test_search_multiword_long_form_finds_acronym(
+    tmp_kb: Path, tmp_index_path: Path
+) -> None:
+    # A long-form multi-word query ("row level security") must reach a doc that
+    # only uses the acronym ("rls"). This is the multi-word direction that a pure
+    # single-token lookup misses.
+    (tmp_kb / "tooling" / "rls-notes.md").write_text(
+        "# RLS notes\n\nTenant isolation is enforced with rls policies.\n"
+    )
+    expander = make_synonym_expander(build_synonym_map(DEFAULT_SYNONYMS))
+    idx = Index(tmp_index_path, query_expander=expander)
+    idx.build(tmp_kb, source_commit="abc")
+    hits = idx.search("row level security", limit=10)
+    assert hits, "long-form query should reach the rls doc via n-gram expansion"
+    assert any("rls" in (h.snippet + h.title).lower() for h in hits)
 
 
 def test_search_without_expander_misses_synonym(


### PR DESCRIPTION
Synonym & acronym query expansion. Stacked on the foundation branch (`claude/cranky-matsumoto-2e60a7`).

Adds a `query_expander` (curated bidirectional map: k8s/kubernetes,
auth/authentication, rls, adr, ...), enabled by default. Originals kept first so
BM25 still favours typed terms; bounded at 32 terms. Configurable via
`KB_SYNONYMS_MODE` (merge/replace/off) and `KB_SYNONYMS`. Expanded terms still
pass through `_build_match_expr` quoting, so no FTS-operator injection.

Closes #38
