### PR TITLE
Search: exact-id and tag short-circuit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Search now short-circuits exact-id and exact-tag queries: a single-token query
+  that is a document id (e.g. `STD-U-002`, or a path-derived id) is surfaced as
+  the top hit via a direct lookup even when it is absent from the bm25 results,
+  and a single-token exact-tag query lifts docs carrying that tag ahead of the
+  rest. Implemented as a composable `reranker` (issue #39); the match stage and
+  `_build_match_expr` are untouched.
 - `kb_search` and `kb_get` now support and return `status` and `type`, making the
   documented "filter by status / tier / type" capability real (index schema v4).
 - Retrieval now indexes `applies_when` trigger metadata and `description` with

--- a/src/data_olympus/index.py
+++ b/src/data_olympus/index.py
@@ -651,6 +651,27 @@ class Index:
             description=row["description"] or "",
         )
 
+    def ids_with_exact_tag(self, tag: str) -> set[str]:
+        """Return the ids of docs carrying ``tag`` as an EXACT (whole) tag.
+
+        Tags are stored space-joined in ``docs.tags``. A LIKE query would match
+        substrings ('style' inside 'styleguide'), so candidates are pre-filtered
+        with LIKE for index use, then confirmed by splitting the stored value and
+        checking membership. An empty/blank tag yields the empty set.
+        """
+        tag = tag.strip()
+        if not tag:
+            return set()
+        conn = self._connect()
+        try:
+            rows = conn.execute(
+                "SELECT id, tags FROM docs WHERE tags LIKE ?",
+                (f"%{tag}%",),
+            ).fetchall()
+        finally:
+            conn.close()
+        return {r["id"] for r in rows if tag in (r["tags"] or "").split()}
+
     def list(self, *, tier: str, category: str | None = None) -> list[dict[str, str]]:
         """List docs in the given tier (and optional category), ordered by id ascending."""
         conn = self._connect()

--- a/src/data_olympus/index.py
+++ b/src/data_olympus/index.py
@@ -657,16 +657,20 @@ class Index:
         Tags are stored space-joined in ``docs.tags``. A LIKE query would match
         substrings ('style' inside 'styleguide'), so candidates are pre-filtered
         with LIKE for index use, then confirmed by splitting the stored value and
-        checking membership. An empty/blank tag yields the empty set.
+        checking membership. ``%`` and ``_`` in the tag are escaped so they are
+        matched literally rather than as LIKE wildcards, keeping the candidate
+        pre-filter tight. An empty/blank tag yields the empty set.
         """
         tag = tag.strip()
         if not tag:
             return set()
+        # Escape LIKE metacharacters so the pre-filter matches ``tag`` literally.
+        escaped = tag.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
         conn = self._connect()
         try:
             rows = conn.execute(
-                "SELECT id, tags FROM docs WHERE tags LIKE ?",
-                (f"%{tag}%",),
+                "SELECT id, tags FROM docs WHERE tags LIKE ? ESCAPE '\\'",
+                (f"%{escaped}%",),
             ).fetchall()
         finally:
             conn.close()

--- a/src/data_olympus/search_shortcut.py
+++ b/src/data_olympus/search_shortcut.py
@@ -1,0 +1,146 @@
+"""Exact-id and exact-tag short-circuit reranker (issue #39).
+
+When a query is a single token that is an exact document id (``STD-U-002``,
+``DEC-001``, or a path-derived id like ``tooling-AGENTS``) or an exact tag, that
+document should rank FIRST instead of competing on full-text bm25 score, which
+ties or loses when the id/tag also appears verbatim in unrelated documents.
+
+This plugs into the ``reranker`` seam of :class:`data_olympus.index.Index`
+(signature ``Callable[[str, list[SearchHit]], list[SearchHit]]``). The reranker
+runs AFTER the bm25-ordered ``search()`` results are produced, so:
+
+- Exact id: a single-token query is looked up directly with ``Index.get`` (the
+  match stage never guarantees the id doc is in, or at the top of, the FTS hit
+  list). If the doc exists it is prepended (or moved to the front) so it is the
+  top hit even when it is absent from the FTS results.
+- Exact tag: docs in the current hit list that carry the token as an EXACT tag
+  are moved ahead of the rest, preserving their relative bm25 order.
+
+Detection is conservative: only a single-token query is considered, and the
+token must survive :func:`looks_like_id` / :func:`looks_like_tag` before any
+lookup. Ordinary multi-term full-text queries are passed through untouched, and
+``_build_match_expr`` is not modified.
+
+The reranker is composable: pass an ``inner`` reranker (e.g. a status/tier
+prior) and it runs FIRST; the id/tag short-circuit is then applied on top so the
+exact match wins regardless of the inner ordering.
+"""
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING, Protocol
+
+from data_olympus.index import SearchHit
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+# A conservative id shape: a single token of alphanumeric segments joined by
+# '-', '.', '_' or ':' with at least one separator. Matches KB ids
+# (STD-U-002, DEC-001, STD-BN-001, ADR-014) and path-derived ids
+# (tooling-AGENTS, projects-example-project-README). Does NOT match ordinary
+# single words ("caching", "worktree") or natural-language phrases. Detection
+# is only a cheap pre-filter: the authoritative check is Index.get() returning a
+# real document.
+_ID_TOKEN_RE = re.compile(r"^[A-Za-z0-9]+(?:[-._:][A-Za-z0-9]+)+$")
+
+# A tag is a looser single token (tags like "style", "policy", "backend-nestjs"
+# can be a bare word). We still require the query to be a single token, then
+# gate on an EXACT tag match in the corpus, so a bare word only short-circuits
+# when it is literally a tag on some document.
+_TAG_TOKEN_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9\-._:]*$")
+
+
+class _IdTagIndex(Protocol):
+    """The slice of Index this reranker depends on (keeps it testable)."""
+
+    def get(self, id: str) -> object | None: ...
+
+    def ids_with_exact_tag(self, tag: str) -> set[str]: ...
+
+
+def looks_like_id(query: str) -> str | None:
+    """Return the single id-shaped token, or None if the query is not id-shaped.
+
+    Conservative: the query must be exactly one token and match the id pattern
+    (at least one separator between alphanumeric segments).
+    """
+    token = query.strip()
+    if not token or " " in token or "\t" in token:
+        return None
+    return token if _ID_TOKEN_RE.match(token) else None
+
+
+def looks_like_tag(query: str) -> str | None:
+    """Return the single tag-shaped token, or None.
+
+    Conservative: exactly one token matching the tag pattern. Whether it is
+    actually a tag is decided by the exact-tag lookup, not by this shape check.
+    """
+    token = query.strip()
+    if not token or " " in token or "\t" in token:
+        return None
+    return token if _TAG_TOKEN_RE.match(token) else None
+
+
+def _hit_from_doc(doc: object) -> SearchHit:
+    """Build a synthetic top hit for a directly-fetched document.
+
+    score is set below any real bm25 score (bm25 is <= 0 and lower is better;
+    ``-inf`` guarantees the id doc sorts first if a caller re-sorts by score).
+    """
+    return SearchHit(
+        id=getattr(doc, "id", ""),
+        path=getattr(doc, "path", ""),
+        title=getattr(doc, "title", ""),
+        snippet=getattr(doc, "description", "") or "",
+        score=float("-inf"),
+        status=getattr(doc, "status", "") or "",
+        doc_type=getattr(doc, "doc_type", "") or "",
+    )
+
+
+def make_id_tag_reranker(
+    index: _IdTagIndex,
+    *,
+    inner: Callable[[str, list[SearchHit]], list[SearchHit]] | None = None,
+) -> Callable[[str, list[SearchHit]], list[SearchHit]]:
+    """Build a reranker that short-circuits exact-id and exact-tag queries.
+
+    ``inner`` runs first (compose an existing status/tier reranker here); the
+    id/tag short-circuit is then applied so the exact match wins regardless of
+    the inner ordering. Both stages default to identity behaviour, so an
+    ordinary multi-term query is returned unchanged (aside from ``inner``).
+    """
+
+    def reranker(query: str, hits: list[SearchHit]) -> list[SearchHit]:
+        if inner is not None:
+            hits = list(inner(query, hits))
+
+        # --- exact id: single id-shaped token that resolves to a real doc ---
+        id_token = looks_like_id(query)
+        if id_token is not None:
+            doc = index.get(id_token)
+            if doc is not None:
+                doc_id = getattr(doc, "id", id_token)
+                existing = next((h for h in hits if h.id == doc_id), None)
+                rest = [h for h in hits if h.id != doc_id]
+                top = existing if existing is not None else _hit_from_doc(doc)
+                return [top, *rest]
+
+        # --- exact tag: single token that is literally a tag on some docs ---
+        tag_token = looks_like_tag(query)
+        if tag_token is not None:
+            tagged_ids = index.ids_with_exact_tag(tag_token)
+            if tagged_ids:
+                tagged = [h for h in hits if h.id in tagged_ids]
+                untagged = [h for h in hits if h.id not in tagged_ids]
+                if tagged:
+                    # Preserve each group's relative (bm25 / inner) order;
+                    # only lift the tagged group ahead of the untagged group.
+                    return [*tagged, *untagged]
+
+        return hits
+
+    return reranker

--- a/src/data_olympus/server.py
+++ b/src/data_olympus/server.py
@@ -37,6 +37,7 @@ from data_olympus.principals import (
 from data_olympus.push_queue import PushQueue
 from data_olympus.query_expansion import default_query_expander
 from data_olympus.rate_limit import SlidingWindowLimiter
+from data_olympus.search_shortcut import make_id_tag_reranker
 from data_olympus.tools_read import kb_health_fn, kb_outline_fn, kb_search_fn
 from data_olympus.worktrees import WorktreeRegistry
 
@@ -232,16 +233,16 @@ def build_app(
     if audit_log_path is not None:
         config_kwargs["audit_log_path"] = audit_log_path
     config = Config(**config_kwargs)  # type: ignore[arg-type]
-    # Synonym/acronym query expansion (issue #38) via the expand-query seam, plus
-    # status-aware reranking (issue #37) via the re-rank seam. Both on by default:
-    # expansion broadens recall (KB_SYNONYMS / KB_SYNONYMS_MODE tune or disable it),
-    # and the status reranker keeps a superseded/deprecated doc from outranking the
-    # active one that replaced it (status_weights=None uses the built-in map;
-    # KB_STATUS_WEIGHTS overrides it).
-    idx = Index(
-        kb_index_path,
-        query_expander=default_query_expander(),
-        reranker=make_status_reranker(config.status_weights),
+    # Composed search wiring. Expand-query seam: synonym/acronym expansion (issue
+    # #38, KB_SYNONYMS / KB_SYNONYMS_MODE). Re-rank seam: the exact-id / exact-tag
+    # short-circuit (issue #39) runs outermost -- a single-token query that is a
+    # document id or an exact tag ranks that document first -- and delegates to the
+    # status-aware reranker (issue #37) as its ``inner``, so among the remaining
+    # hits an active doc still outranks the superseded one it replaced.
+    # status_weights=None uses the built-in map; KB_STATUS_WEIGHTS overrides it.
+    idx = Index(kb_index_path, query_expander=default_query_expander())
+    idx.reranker = make_id_tag_reranker(
+        idx, inner=make_status_reranker(config.status_weights)
     )
     git = GitOps(kb_main_path)
     # retention_sec = the consult TTL: an entry older than that can never be

--- a/tests/test_search_shortcut.py
+++ b/tests/test_search_shortcut.py
@@ -75,6 +75,44 @@ def test_ids_with_exact_tag_no_substring_match(tmp_kb: Path, tmp_index_path: Pat
     assert idx.ids_with_exact_tag("") == set()
 
 
+def test_ids_with_exact_tag_escapes_like_wildcards(
+    tmp_kb: Path, tmp_index_path: Path
+) -> None:
+    """Tags carrying LIKE metacharacters ('_', '%') resolve to exact matches.
+
+    The stored ``tags`` column is space-joined, so a tag may legitimately carry
+    '_' or '%'. Final correctness comes from the split-recheck, but the LIKE
+    pre-filter now escapes '_'/'%' (ESCAPE '\\') so it stays a literal-substring
+    filter instead of treating '_' as 'any single char' and '%' as 'any run of
+    chars' (which would pre-select 'beXend' for 'be_end', or every doc for '%').
+    This pins the observable contract: (a) a genuine exact tag with '_'/'%' still
+    matches, and (b) a near-miss differing only at the metacharacter position
+    does NOT appear in the result.
+    """
+    foundation = tmp_kb / "universal" / "foundation"
+    # Target doc: exact tag 'be_end'.
+    (foundation / "STD-U-100-underscore.md").write_text(
+        "---\nid: STD-U-100\ntier: T1\ncategory: foundation\ntags: [be_end]\n"
+        "title: Underscore Tag\n---\n# STD-U-100\n\nBody.\n"
+    )
+    # Near-miss doc: tag 'beXend' would match '%be_end%' only if '_' were a
+    # wildcard. Also carries a '100%' tag to exercise the '%' escape.
+    (foundation / "STD-U-101-nearmiss.md").write_text(
+        "---\nid: STD-U-101\ntier: T1\ncategory: foundation\ntags: [beXend, 100%]\n"
+        "title: Near Miss Tag\n---\n# STD-U-101\n\nBody.\n"
+    )
+    idx = Index(tmp_index_path)
+    idx.build(tmp_kb, source_commit="x")
+
+    # (a) genuine exact tags containing metacharacters still match.
+    assert idx.ids_with_exact_tag("be_end") == {"STD-U-100"}
+    assert idx.ids_with_exact_tag("100%") == {"STD-U-101"}
+    # (b) '_' is literal: 'beXend' is not the queried tag 'be_end'.
+    assert "STD-U-101" not in idx.ids_with_exact_tag("be_end")
+    # (c) a bare '%' must not act as a wildcard selecting every doc.
+    assert idx.ids_with_exact_tag("%") == set()
+
+
 # --- exact-id short-circuit --------------------------------------------------
 
 

--- a/tests/test_search_shortcut.py
+++ b/tests/test_search_shortcut.py
@@ -1,0 +1,222 @@
+"""Tests for the exact-id / exact-tag short-circuit reranker (issue #39).
+
+Covers:
+- detection helpers (looks_like_id / looks_like_tag) are conservative.
+- Index.ids_with_exact_tag matches whole tags, not substrings.
+- an exact-id query returns that doc as the top hit, even when it is absent
+  from the FTS hit list.
+- an exact-tag query favours docs carrying that tag.
+- ordinary multi-term queries are unaffected.
+- the reranker composes with an inner reranker.
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from data_olympus.index import Index, SearchHit
+from data_olympus.search_shortcut import (
+    looks_like_id,
+    looks_like_tag,
+    make_id_tag_reranker,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+# --- detection helpers -------------------------------------------------------
+
+
+def test_looks_like_id_accepts_kb_and_path_ids() -> None:
+    assert looks_like_id("STD-U-002") == "STD-U-002"
+    assert looks_like_id("DEC-001") == "DEC-001"
+    assert looks_like_id("ADR-014") == "ADR-014"
+    assert looks_like_id("tooling-AGENTS") == "tooling-AGENTS"
+    assert looks_like_id("projects-example-project-README") == (
+        "projects-example-project-README"
+    )
+    assert looks_like_id("  STD-U-002  ") == "STD-U-002"  # trims
+
+
+def test_looks_like_id_rejects_words_and_phrases() -> None:
+    assert looks_like_id("caching") is None  # no separator
+    assert looks_like_id("worktree") is None
+    assert looks_like_id("code review guide") is None  # multi-token
+    assert looks_like_id("STD-U-002 style") is None  # id + word is not a bare id
+    assert looks_like_id("") is None
+
+
+def test_looks_like_tag_accepts_single_token_only() -> None:
+    assert looks_like_tag("style") == "style"
+    assert looks_like_tag("backend-nestjs") == "backend-nestjs"
+    assert looks_like_tag("two words") is None
+    assert looks_like_tag("") is None
+
+
+# --- Index.ids_with_exact_tag ------------------------------------------------
+
+
+def test_ids_with_exact_tag_matches_whole_tag(tmp_kb: Path, tmp_index_path: Path) -> None:
+    idx = Index(tmp_index_path)
+    idx.build(tmp_kb, source_commit="x")
+    # STD-U-001 has tags [policy, test]; STD-U-002 has [style].
+    assert idx.ids_with_exact_tag("style") == {"STD-U-002"}
+    assert idx.ids_with_exact_tag("policy") == {"STD-U-001"}
+    # 'test' is a whole tag on STD-U-001; must not also match via substring of
+    # some other value.
+    assert idx.ids_with_exact_tag("test") == {"STD-U-001"}
+
+
+def test_ids_with_exact_tag_no_substring_match(tmp_kb: Path, tmp_index_path: Path) -> None:
+    idx = Index(tmp_index_path)
+    idx.build(tmp_kb, source_commit="x")
+    # 'styl' is a substring of the 'style' tag but not a whole tag.
+    assert idx.ids_with_exact_tag("styl") == set()
+    assert idx.ids_with_exact_tag("") == set()
+
+
+# --- exact-id short-circuit --------------------------------------------------
+
+
+def test_exact_id_query_returns_doc_first(tmp_kb: Path, tmp_index_path: Path) -> None:
+    idx = Index(tmp_index_path)
+    idx.reranker = make_id_tag_reranker(idx)
+    idx.build(tmp_kb, source_commit="x")
+    hits = idx.search("STD-U-002", limit=10)
+    assert hits, "expected at least the id doc"
+    assert hits[0].id == "STD-U-002"
+
+
+def test_exact_id_first_even_when_absent_from_fts(
+    tmp_index_path: Path, tmp_path: Path
+) -> None:
+    # Construct a KB where the id doc does NOT contain its own id in any indexed
+    # column, so a plain FTS search for the id returns other docs (or nothing),
+    # yet the reranker must still surface it via Index.get.
+    kb = tmp_path / "kb"
+    d = kb / "universal" / "foundation"
+    d.mkdir(parents=True)
+    # Target doc: id in front matter only; body/title never mention "STD-Z-999".
+    (d / "target.md").write_text(
+        "---\nid: STD-Z-999\ntier: T1\ntitle: Quiet Doc\n---\n# Quiet Doc\n\n"
+        "Nothing here repeats the identifier.\n"
+    )
+    # A decoy doc whose BODY mentions the id string, so FTS ranks it for the query.
+    (d / "decoy.md").write_text(
+        "---\nid: DECOY-1\ntier: T1\ntitle: Decoy\n---\n# Decoy\n\n"
+        "See STD-Z-999 STD-Z-999 STD-Z-999 for details.\n"
+    )
+    idx = Index(tmp_index_path)
+    idx.reranker = make_id_tag_reranker(idx)
+    idx.build(kb, source_commit="x")
+
+    # Precondition: on the same built index, a plain FTS search (no reranker)
+    # does NOT already put the id doc first, so the assertion below is proving
+    # the reranker's effect rather than incidental ordering.
+    plain_ids = [h.id for h in Index(tmp_index_path).search("STD-Z-999", limit=10)]
+    assert not plain_ids or plain_ids[0] != "STD-Z-999", (
+        "precondition: plain FTS should not already put the id doc first"
+    )
+
+    hits = idx.search("STD-Z-999", limit=10)
+    assert hits[0].id == "STD-Z-999", "reranker must surface the exact-id doc first"
+
+
+def test_unknown_id_shaped_query_unchanged(tmp_kb: Path, tmp_index_path: Path) -> None:
+    idx = Index(tmp_index_path)
+    idx.reranker = make_id_tag_reranker(idx)
+    idx.build(tmp_kb, source_commit="x")
+    base = Index(tmp_index_path)  # no reranker
+    # An id-shaped token that is not a real doc must not alter results.
+    q = "STD-U-001"  # this IS a doc, so use a non-existent one:
+    q = "STD-QQ-404"
+    assert idx.search(q, limit=10) == base.search(q, limit=10)
+
+
+# --- exact-tag short-circuit -------------------------------------------------
+
+
+def test_exact_tag_query_favours_tagged_docs(tmp_kb: Path, tmp_index_path: Path) -> None:
+    idx = Index(tmp_index_path)
+    idx.reranker = make_id_tag_reranker(idx)
+    idx.build(tmp_kb, source_commit="x")
+    hits = idx.search("style", limit=10)
+    # STD-U-002 carries the 'style' tag; if any hits come back it must lead.
+    assert hits, "expected hits for the 'style' query"
+    tagged = idx.ids_with_exact_tag("style")
+    assert hits[0].id in tagged
+
+
+def test_exact_tag_moves_tagged_ahead_of_untagged(tmp_index_path: Path, tmp_path: Path) -> None:
+    kb = tmp_path / "kb"
+    d = kb / "universal" / "foundation"
+    d.mkdir(parents=True)
+    # Both docs mention 'alpha' in the body so both are FTS hits; only doc B
+    # carries 'alpha' as a tag, so the reranker must lift B above A.
+    (d / "a.md").write_text(
+        "---\nid: DOC-A\ntier: T1\ntitle: A\n---\n# A\n\nalpha alpha alpha keyword.\n"
+    )
+    (d / "b.md").write_text(
+        "---\nid: DOC-B\ntier: T1\ntags: [alpha]\ntitle: B\n---\n# B\n\nalpha here.\n"
+    )
+    base = Index(tmp_index_path)
+    base.build(kb, source_commit="x")
+    base_ids = [h.id for h in base.search("alpha", limit=10)]
+    assert set(base_ids) == {"DOC-A", "DOC-B"}
+
+    idx = Index(tmp_index_path)
+    idx.reranker = make_id_tag_reranker(idx)
+    ranked = [h.id for h in idx.search("alpha", limit=10)]
+    assert ranked[0] == "DOC-B", "the tagged doc must lead"
+    assert set(ranked) == {"DOC-A", "DOC-B"}, "no hits dropped or duplicated"
+
+
+# --- ordinary queries unaffected ---------------------------------------------
+
+
+def test_ordinary_multiterm_query_unchanged(tmp_kb: Path, tmp_index_path: Path) -> None:
+    idx = Index(tmp_index_path)
+    idx.reranker = make_id_tag_reranker(idx)
+    idx.build(tmp_kb, source_commit="x")
+    base = Index(tmp_index_path)  # no reranker
+    q = "review structure"  # multi-term, not an id, not a single tag token
+    assert [h.id for h in idx.search(q, limit=10)] == [
+        h.id for h in base.search(q, limit=10)
+    ]
+
+
+def test_single_word_non_tag_unchanged(tmp_kb: Path, tmp_index_path: Path) -> None:
+    idx = Index(tmp_index_path)
+    idx.reranker = make_id_tag_reranker(idx)
+    idx.build(tmp_kb, source_commit="x")
+    base = Index(tmp_index_path)
+    # 'worktree' is a plain content word, not a tag and not an id.
+    assert [h.id for h in idx.search("worktree", limit=10)] == [
+        h.id for h in base.search("worktree", limit=10)
+    ]
+
+
+# --- composability -----------------------------------------------------------
+
+
+def test_composes_with_inner_reranker(tmp_kb: Path, tmp_index_path: Path) -> None:
+    calls: list[str] = []
+
+    def inner(query: str, hits: list[SearchHit]) -> list[SearchHit]:
+        calls.append(query)
+        return list(reversed(hits))
+
+    idx = Index(tmp_index_path)
+    idx.reranker = make_id_tag_reranker(idx, inner=inner)
+    idx.build(tmp_kb, source_commit="x")
+
+    # Exact-id query: inner runs (recorded), but the id short-circuit still wins.
+    hits = idx.search("STD-U-002", limit=10)
+    assert calls == ["STD-U-002"], "inner reranker must be invoked"
+    assert hits[0].id == "STD-U-002"
+
+    # Ordinary query: inner ordering is preserved end-to-end (reversed of base).
+    calls.clear()
+    base_ids = [h.id for h in Index(tmp_index_path).search("review structure", limit=10)]
+    composed_ids = [h.id for h in idx.search("review structure", limit=10)]
+    assert composed_ids == list(reversed(base_ids))


### PR DESCRIPTION
Exact-id and tag short-circuit. Stacked on the foundation branch (`claude/cranky-matsumoto-2e60a7`).

Detects id-shaped queries (single token, id pattern) gated on a real
`Index.get`, and exact tag matches, and puts the target document first — even
when SQL's `LIMIT` would exclude it (prepends via lookup). New
`search_shortcut.py` + `Index.ids_with_exact_tag`. Ordinary multi-term queries
are unaffected.

## Integration note
Built composably: `make_id_tag_reranker(index, inner=...)` — plug #37's status
reranker in as `inner` at merge so exact-match wins on top of status ranking.

Closes #39
