### PR TITLE
Reliability: bound MCP session growth (idle reaper + observability)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,13 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   (`KB_ENFORCE_FAIL_MODE`), consultation freshness via `KB_CONSULT_TTL_SEC`.
 - Cross-agent enforcement providers: `kb enforce install --agent codex|gemini|opencode|copilot-cli|copilot-ide` and `--all`. Codex and Gemini get hard PreToolUse/BeforeTool gates (merging into existing hooks), OpenCode gets a `tool.execute.before` plugin, and Copilot CLI/IDE get a soft instructions-file + MCP provider. Antigravity is a documented-unsupported stub. The `kb-enforce-hook` dispatcher gained a `--dialect gemini` output mode.
 - Detection floor for un-hookable agents: `kb enforce report` (and `data-olympus report`) correlates governed git commits against the consult audit and lists changes with no consultation on record. An opt-in repo-scoped git provider (`kb enforce install --agent git`) installs a post-commit warning hook, or a pre-commit blocking hook with `--block`. Reuses the existing audit endpoint; no server change.
+- Streamable-http session idle reaper bounds transport accumulation (issue #43).
+  A background loop terminates sessions with no request activity for longer than
+  `KB_SESSION_IDLE_TIMEOUT_SEC` (default 1800s / 30 min; `0` disables reaping and
+  keeps observability only), scanning every `KB_SESSION_REAP_INTERVAL_SEC`
+  (default 60s). `kb_health` and `/api/v1/health` gained a `live_sessions` field
+  reporting the current live transport count (`null` until the HTTP app is
+  serving); a value that only climbs signals leaked sessions.
 - Enforcement hardening and observability: gate_bypass and gate_degraded events are now recorded (via `data-olympus report --emit-events` / the git warn hook, and the pre-tool hook on a reachable-degraded gate), so `kb_compliance` surfaces them. The gate receives `action_diff` and the classifier uses word-boundary matching plus dependency-install command signals (Codex and Claude now gate the Bash tool). New `kb enforce install --mode off|soft|hard`, ledger persistence via `KB_LEDGER_PATH`, a friendly PATH hint for `kb enforce report`, and a CI guard requiring a changelog entry for functional changes.
 - Guided onboarding: MCP prompts `onboard`, `onboard_project`, and `onboard_component` walk an agent through bootstrapping a new workspace or component, backed by a single-sourced playbook (`render_playbook`). A read-only `kb_cleanup_plan` MCP tool plus `POST /api/v1/onboarding/cleanup-plan` classify local repo docs against KB content and propose thin-pointer replacements for duplicates. `GET /api/v1/onboarding/playbook` and `kb onboard playbook` expose the same script to agents without native MCP prompt support.
 - Composable search pipeline: `Index.search()` now runs expand-query / match /

--- a/docs/serving.md
+++ b/docs/serving.md
@@ -70,8 +70,22 @@ data-olympus closes this two ways:
   only. Termination uses the SDK's own `terminate()` path, so a client that
   reconnects simply gets a fresh session.
 
-Idle is measured from the last request seen for a session; long-lived clients
-that poll or make periodic calls are never reaped.
+Idle is measured from the last *request* seen for a session: the activity clock
+advances only when a request carrying that session's `mcp-session-id` header
+reaches the server. A client that keeps polling or making periodic calls is
+therefore never reaped, because each call re-stamps its activity.
+
+The consequence to be aware of is that "idle" is per-request, not
+per-connection. A quiet long-lived `GET` SSE stream that stays open but makes no
+periodic `POST` requests still stamps no activity, so after
+`KB_SESSION_IDLE_TIMEOUT_SEC` its session is reaped and the stream is torn down;
+the client must reconnect (it gets a fresh session on the next handshake). If
+your client relies on a long-lived stream without periodic requests, either
+raise `KB_SESSION_IDLE_TIMEOUT_SEC` above your longest expected quiet period,
+set it to `0` to disable reaping (observability only), or have the client send a
+periodic keep-alive request. Excluding sessions with an active open stream from
+reaping (so a live stream is never torn down) is a possible follow-up; the
+current behavior reaps purely on request-activity age.
 
 ## Taxonomy and writable paths
 

--- a/docs/serving.md
+++ b/docs/serving.md
@@ -42,6 +42,37 @@ reports `degraded: true` only when the index has not been rebuilt within
 For a local read-only demo with no remote, set `KB_REMOTE_URL=""`. The server
 stays healthy as long as the index builds successfully on startup.
 
+## Streamable-http session lifecycle and reaping
+
+Each session-less `POST /mcp` handshake makes the underlying MCP SDK create a
+transport, register it in an in-memory session table, and start a task that
+blocks waiting for further messages on that session. The SDK removes a session
+only on an explicit client `DELETE`, on the session task crashing, or on server
+shutdown. It also supports an idle timeout, but only when its session manager is
+constructed with one, and FastMCP does not wire one through: under its default
+construction the idle timeout is unset, so nothing reaps idle sessions.
+
+Consequence: a client that handshakes and drops the connection without sending
+`DELETE` (the common cause of repeated "Created new transport with session ID"
+log lines) leaves its transport resident. Over long uptime the session table
+grows without bound and leaks memory and tasks.
+
+data-olympus closes this two ways:
+
+- Observability: `health` reports `live_sessions`, the current live transport
+  count (or `null` before the HTTP app has started serving). The server also
+  logs the live count each reaper pass. A `live_sessions` value that only ever
+  climbs is the signal of a leak.
+- Bound: a background reaper terminates sessions idle beyond
+  `KB_SESSION_IDLE_TIMEOUT_SEC` (default 1800s / 30 min). It scans every
+  `KB_SESSION_REAP_INTERVAL_SEC` (default 60s). Set
+  `KB_SESSION_IDLE_TIMEOUT_SEC=0` to disable reaping and keep observability
+  only. Termination uses the SDK's own `terminate()` path, so a client that
+  reconnects simply gets a fresh session.
+
+Idle is measured from the last request seen for a session; long-lived clients
+that poll or make periodic calls are never reaped.
+
 ## Taxonomy and writable paths
 
 The server maps each document's path to a `(tier, category)` pair. The built-in

--- a/src/data_olympus/config.py
+++ b/src/data_olympus/config.py
@@ -39,6 +39,11 @@ class Config:
     auth_principals: list[dict[str, Any]] = field(default_factory=list)
     consult_ttl_sec: int = 300
     ledger_path: str = "/state/ledger.json"
+    # Streamable-http session reaping: terminate transports idle beyond this many
+    # seconds to bound _server_instances (see session_metrics). 0 disables the
+    # reaper (observability-only). The scan runs every session_reap_interval_sec.
+    session_idle_timeout_sec: int = 1800
+    session_reap_interval_sec: int = 60
 
 
 def _split_csv(raw: str) -> list[str]:
@@ -74,6 +79,8 @@ def load_config() -> Config:
     auth_principals = parse_principals_env(os.getenv("KB_AUTH_PRINCIPALS", ""))
     consult_ttl_sec = int(os.getenv("KB_CONSULT_TTL_SEC", "300"))
     ledger_path = os.getenv("KB_LEDGER_PATH", "/state/ledger.json")
+    session_idle_timeout_sec = int(os.getenv("KB_SESSION_IDLE_TIMEOUT_SEC", "1800"))
+    session_reap_interval_sec = int(os.getenv("KB_SESSION_REAP_INTERVAL_SEC", "60"))
     return Config(
         kb_main_path=Path(os.environ.get("KB_MAIN_PATH", "/kb-main")),
         kb_index_path=Path(os.environ.get("KB_INDEX_PATH", "/index/kb.db")),
@@ -103,4 +110,6 @@ def load_config() -> Config:
         auth_principals=auth_principals,
         consult_ttl_sec=consult_ttl_sec,
         ledger_path=ledger_path,
+        session_idle_timeout_sec=session_idle_timeout_sec,
+        session_reap_interval_sec=session_reap_interval_sec,
     )

--- a/src/data_olympus/health.py
+++ b/src/data_olympus/health.py
@@ -35,6 +35,7 @@ class HealthState:
     last_git_fetch_at: float | None = None
     last_successful_refresh_at: float | None = None
     remote_head_sha: str | None = None
+    live_sessions: int | None = None
 
 
 def snapshot(
@@ -54,6 +55,7 @@ def snapshot(
     last_git_fetch_at: float | None = None,
     last_successful_refresh_at: float | None = None,
     remote_head_sha: str | None = None,
+    live_sessions: int | None = None,
 ) -> HealthState:
     """Compose a HealthState from the index and the last-pull/push timestamps.
 
@@ -90,4 +92,5 @@ def snapshot(
         last_git_fetch_at=last_git_fetch_at,
         last_successful_refresh_at=last_successful_refresh_at,
         remote_head_sha=remote_head_sha,
+        live_sessions=live_sessions,
     )

--- a/src/data_olympus/models.py
+++ b/src/data_olympus/models.py
@@ -29,6 +29,10 @@ class HealthResponse(BaseModel):
     last_git_fetch_at: float | None = None
     last_successful_refresh_at: float | None = None
     remote_head_sha: str | None = None
+    # Live streamable-http transport sessions. None when the count cannot be
+    # observed (e.g. before the HTTP app's lifespan starts, or in-memory tests).
+    # Surfaced so session accumulation is diagnosable in production (issue #43).
+    live_sessions: int | None = None
 
 
 class CategoryCount(BaseModel):

--- a/src/data_olympus/rest_api.py
+++ b/src/data_olympus/rest_api.py
@@ -68,6 +68,7 @@ def _build_health(state: ServerState) -> HealthResponse:
         last_git_fetch_at=state.last_git_fetch_at,
         last_successful_refresh_at=state.last_successful_refresh_at,
         remote_head_sha=state.remote_head_sha,
+        live_sessions=state.live_session_count(),
     )
 
 

--- a/src/data_olympus/server.py
+++ b/src/data_olympus/server.py
@@ -12,6 +12,7 @@ from fastmcp import FastMCP
 from fastmcp.server.middleware import Middleware
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
     from pathlib import Path
 
     import mcp.types as mt
@@ -139,9 +140,24 @@ class ServerState:
         self.audit_log: AuditLog | None = audit_log
         self.classifier: IntentClassifier = classifier or IntentClassifier()
         self.ledger: ConsultationLedger = ledger or ConsultationLedger()
+        # Set at serve time (main) to observe the live streamable-http session
+        # count. None until then / in tests, so health reports live_sessions=None
+        # rather than a misleading 0. See session_metrics.
+        self.session_count_provider: Callable[[], int | None] | None = None
 
     def record_pull(self, ts: float) -> None:
         self.last_git_pull_at = ts
+
+    def live_session_count(self) -> int | None:
+        """Best-effort live streamable-http session count for health. None when
+        no provider is wired (in-memory tests, pre-serve) or on any error."""
+        provider = self.session_count_provider
+        if provider is None:
+            return None
+        try:
+            return provider()
+        except Exception:  # pragma: no cover - defensive; must not break health
+            return None
 
 
 def build_app(
@@ -173,6 +189,8 @@ def build_app(
     auth_principals: list[dict[str, Any]] | None = None,
     audit_hmac_key: str = "",
     ledger_path: str | None = None,
+    session_idle_timeout_sec: int = 1800,
+    session_reap_interval_sec: int = 60,
 ) -> FastMCP:
     """Construct a FastMCP app with the read tools registered.
 
@@ -205,6 +223,8 @@ def build_app(
         auth_token=auth_token,
         auth_principals=auth_principals or [],
         audit_hmac_key=audit_hmac_key,
+        session_idle_timeout_sec=session_idle_timeout_sec,
+        session_reap_interval_sec=session_reap_interval_sec,
     )
     if audit_log_path is not None:
         config_kwargs["audit_log_path"] = audit_log_path
@@ -274,6 +294,7 @@ def build_app(
             last_git_fetch_at=state.last_git_fetch_at,
             last_successful_refresh_at=state.last_successful_refresh_at,
             remote_head_sha=state.remote_head_sha,
+            live_sessions=state.live_session_count(),
         )
         return resp.model_dump()
 
@@ -617,6 +638,8 @@ def build_app_from_config(config: Config, *, bootstrap_now: bool = True) -> Fast
         auth_principals=list(config.auth_principals),
         audit_hmac_key=config.audit_hmac_key,
         ledger_path=config.ledger_path,
+        session_idle_timeout_sec=config.session_idle_timeout_sec,
+        session_reap_interval_sec=config.session_reap_interval_sec,
     )
 
 
@@ -647,12 +670,36 @@ def main() -> None:
     state = app._dolympus_state  # type: ignore[attr-defined]  # set in build_app
     log.info("starting streamable HTTP MCP on port %s", config.http_port)
 
+    # Build the streamable-http ASGI app explicitly (rather than app.run_async)
+    # so we own the app object: we install the session-activity middleware, wire
+    # the live-session count into health, and run the idle-session reaper. See
+    # session_metrics for why FastMCP's default wiring never reaps sessions.
+    from starlette.middleware import Middleware as StarletteMiddleware
+
+    from data_olympus.session_metrics import (
+        SessionActivityMiddleware,
+        SessionActivityTracker,
+        count_live_sessions,
+    )
+
+    tracker = SessionActivityTracker()
+    http_app = app.http_app(
+        transport="streamable-http",
+        middleware=[StarletteMiddleware(SessionActivityMiddleware, tracker=tracker)],
+    )
+    # Health surfaces the live session count; the manager is only reachable once
+    # the lifespan has started, so this returns None before then (never raises).
+    state.session_count_provider = lambda: count_live_sessions(http_app)
+
     async def runner() -> None:
+        import uvicorn
+
         from data_olympus.refresh import (
             git_pull_loop,
             pending_gc_loop,
             push_retry_loop,
         )
+        from data_olympus.session_metrics import session_reaper_loop
         tasks = [
             asyncio.create_task(
                 git_pull_loop(state, config.sync_interval_sec),
@@ -677,10 +724,23 @@ def main() -> None:
                 ),
                 name="pending_gc_loop",
             ))
-        try:
-            await app.run_async(
-                transport="streamable-http", host="0.0.0.0", port=config.http_port
+        if config.session_idle_timeout_sec > 0:
+            tasks.append(asyncio.create_task(
+                session_reaper_loop(
+                    app=http_app,
+                    tracker=tracker,
+                    idle_after_sec=config.session_idle_timeout_sec,
+                    interval_sec=config.session_reap_interval_sec,
+                ),
+                name="session_reaper_loop",
+            ))
+        server = uvicorn.Server(
+            uvicorn.Config(
+                http_app, host="0.0.0.0", port=config.http_port, log_level="info"
             )
+        )
+        try:
+            await server.serve()
         finally:
             for task in tasks:
                 task.cancel()

--- a/src/data_olympus/session_metrics.py
+++ b/src/data_olympus/session_metrics.py
@@ -149,8 +149,11 @@ class SessionActivityTracker:
     session manager is built with an idle timeout, which FastMCP does not do. We
     therefore keep our own map, updated from the ASGI middleware on every request
     that carries an ``mcp-session-id`` header (both the handshake response and
-    subsequent client requests carry it). ``touch`` is also called at session
-    creation so a brand-new session is not reaped before its first follow-up.
+    subsequent client requests carry it). There is no explicit ``touch`` at
+    session creation; instead :meth:`idle_session_ids` stamps any live session id
+    it has never seen before on that first pass (treating it as active-now), so a
+    brand-new session created between middleware touches gets a full idle window
+    before it can be reaped.
     """
 
     def __init__(self, *, clock: Callable[[], float] = time.monotonic) -> None:
@@ -256,12 +259,19 @@ async def session_reaper_loop(
     log_count: bool = True,
 ) -> None:
     """Background asyncio task: periodically reap idle sessions and log the live
-    session count for production observability. Cancellable via asyncio."""
+    session count for production observability. Cancellable via asyncio.
+
+    To keep log volume low on a busy-but-steady server (the loop runs every
+    ``interval_sec``, ~1440 passes/day at the 60s default), the live count is
+    logged only when it *changes* from the previous pass, plus whenever a pass
+    reaps at least one session. A steady-state server therefore emits at most
+    the one startup line, not a line per interval."""
     log.info(
         "session_reaper_loop started (idle_after=%ss interval=%ss)",
         idle_after_sec,
         interval_sec,
     )
+    prev_live: int | None = None
     while True:
         try:
             reaped = await reap_idle_sessions(
@@ -269,8 +279,12 @@ async def session_reaper_loop(
             )
             if log_count:
                 live = count_live_sessions(app)
+                if live is not None and (live != prev_live or reaped):
+                    log.info(
+                        "live streamable-http sessions: %d (reaped %d)", live, reaped
+                    )
                 if live is not None:
-                    log.info("live streamable-http sessions: %d (reaped %d)", live, reaped)
+                    prev_live = live
         except asyncio.CancelledError:
             log.info("session_reaper_loop cancelled")
             raise

--- a/src/data_olympus/session_metrics.py
+++ b/src/data_olympus/session_metrics.py
@@ -1,0 +1,289 @@
+"""Observability and a bound for FastMCP streamable-http transport sessions.
+
+Why this module exists
+----------------------
+Each session-less ``POST /mcp`` handshake makes the mcp SDK's
+``StreamableHTTPSessionManager`` create a ``StreamableHTTPServerTransport``,
+register it in ``_server_instances[session_id]``, and start a long-lived task
+whose ``app.run()`` blocks on the transport read stream (see the installed
+``mcp/server/streamable_http_manager.py`` ``_handle_stateful_request`` /
+``run_server``). That entry is removed on exactly three events: an explicit
+client ``DELETE`` (``streamable_http.py`` ``_handle_delete_request`` ->
+``terminate``), the session task crashing, or the manager shutting down
+(``run`` finally -> ``_server_instances.clear()``).
+
+The SDK *does* support idle reaping, but only when its manager is built with a
+positive ``session_idle_timeout`` (``streamable_http_manager.py`` lines ~293-311
+arm an ``anyio.CancelScope`` deadline). FastMCP 3.4.2 constructs that manager
+with no ``session_idle_timeout`` argument and exposes no setting or ``run_async``
+knob to inject one (``fastmcp/server/http.py`` ``create_streamable_http_app``
+lifespan). So under FastMCP's default wiring the timeout is ``None`` and there is
+no automatic reaping.
+
+Consequence: a client that handshakes and drops the connection without sending
+``DELETE`` (the exact symptom behind the repeated "Created new transport with
+session ID" logs) leaves its transport resident. Over long uptime
+``_server_instances`` grows without bound and leaks memory + tasks.
+
+This module adds, entirely inside our own code and using only the public
+transport surface (``mcp_session_id``, ``terminate``, ``is_terminated``) plus the
+``_server_instances`` mapping that FastMCP itself iterates on shutdown:
+
+- :func:`find_session_manager` / :func:`count_live_sessions` to *observe* the
+  live session count (surfaced via ``kb_health`` / ``/api/v1/health`` and logged
+  periodically).
+- :class:`SessionActivityTracker` to stamp last-activity per session id from an
+  ASGI middleware, since the SDK does not stamp activity when idle-timeout is
+  off.
+- :func:`reap_idle_sessions` and :func:`session_reaper_loop` to terminate
+  sessions idle beyond a configured bound, closing the leak.
+
+Everything degrades safely: if a future FastMCP/mcp version relocates or renames
+these internals, discovery returns ``None`` and the count is reported as
+``None`` rather than crashing the health probe.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from typing import TYPE_CHECKING, Any, Protocol
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from starlette.types import ASGIApp, Receive, Scope, Send
+
+log = logging.getLogger("data_olympus.session_metrics")
+
+# Header the mcp SDK uses to carry the streamable-http session id on both the
+# handshake response and subsequent requests. Mirrored here (rather than
+# imported) so a rename upstream degrades to "no activity stamp" instead of an
+# ImportError at module load.
+_MCP_SESSION_ID_HEADER = b"mcp-session-id"
+
+
+class _Transport(Protocol):
+    """The subset of mcp's StreamableHTTPServerTransport we rely on. Public
+    attributes only; see mcp/server/streamable_http.py."""
+
+    mcp_session_id: str | None
+
+    @property
+    def is_terminated(self) -> bool: ...
+
+    async def terminate(self) -> None: ...
+
+
+def find_session_manager(app: Any) -> Any | None:
+    """Locate the live ``StreamableHTTPSessionManager`` for a FastMCP app, or None.
+
+    FastMCP stores the manager on the ``StreamableHTTPASGIApp`` wrapper, set
+    fresh on each lifespan cycle, not on the FastMCP object. We walk the built
+    Starlette app's routes to find the wrapper's ``session_manager`` that carries
+    a ``_server_instances`` dict. Returns None (never raises) when the app has
+    not been built into an HTTP app yet or the internals moved.
+    """
+    if app is None:
+        return None
+    # Direct: some callers pass the manager (or its holder) straight in.
+    if _has_instances(app):
+        return app
+    holder = getattr(app, "session_manager", None)
+    if _has_instances(holder):
+        return holder
+
+    starlette_app = _resolve_starlette_app(app)
+    if starlette_app is None:
+        return None
+    routes = getattr(getattr(starlette_app, "router", None), "routes", None) or []
+    for route in routes:
+        endpoint = getattr(route, "endpoint", None) or getattr(route, "app", None)
+        mgr = getattr(endpoint, "session_manager", None)
+        if _has_instances(mgr):
+            return mgr
+    return None
+
+
+def _has_instances(obj: Any) -> bool:
+    return obj is not None and isinstance(
+        getattr(obj, "_server_instances", None), dict
+    )
+
+
+def _resolve_starlette_app(app: Any) -> Any | None:
+    """Best-effort resolve a Starlette app from a FastMCP instance or a Starlette
+    app. Prefers a cached HTTP app the server already built; never builds a new
+    one (that would create a second, unrelated session manager)."""
+    # Already a Starlette-like app with a router.
+    if getattr(getattr(app, "router", None), "routes", None) is not None:
+        return app
+    # FastMCP caches the built http app under private attrs across versions.
+    for attr in ("_http_app", "_cached_http_app", "_streamable_http_app"):
+        candidate = getattr(app, attr, None)
+        if getattr(getattr(candidate, "router", None), "routes", None) is not None:
+            return candidate
+    return None
+
+
+def count_live_sessions(app: Any) -> int | None:
+    """Return the number of live streamable-http sessions, or None if the session
+    manager cannot be located (e.g. app not yet serving). Never raises."""
+    try:
+        mgr = find_session_manager(app)
+        if mgr is None:
+            return None
+        instances = getattr(mgr, "_server_instances", None)
+        if not isinstance(instances, dict):
+            return None
+        return len(instances)
+    except Exception:  # pragma: no cover - defensive; observability must not crash callers
+        log.debug("count_live_sessions failed", exc_info=True)
+        return None
+
+
+class SessionActivityTracker:
+    """Last-activity timestamps per streamable-http session id.
+
+    The mcp SDK only stamps activity (via ``idle_scope.deadline``) when the
+    session manager is built with an idle timeout, which FastMCP does not do. We
+    therefore keep our own map, updated from the ASGI middleware on every request
+    that carries an ``mcp-session-id`` header (both the handshake response and
+    subsequent client requests carry it). ``touch`` is also called at session
+    creation so a brand-new session is not reaped before its first follow-up.
+    """
+
+    def __init__(self, *, clock: Callable[[], float] = time.monotonic) -> None:
+        self._clock = clock
+        self._last_seen: dict[str, float] = {}
+
+    def touch(self, session_id: str, *, now: float | None = None) -> None:
+        if not session_id:
+            return
+        self._last_seen[session_id] = self._clock() if now is None else now
+
+    def last_seen(self, session_id: str) -> float | None:
+        return self._last_seen.get(session_id)
+
+    def forget(self, session_id: str) -> None:
+        self._last_seen.pop(session_id, None)
+
+    def idle_session_ids(
+        self, *, live_ids: set[str], idle_after_sec: float, now: float | None = None
+    ) -> list[str]:
+        """Return live session ids whose last activity is older than
+        ``idle_after_sec``. A live session we have never seen is treated as
+        active-now and stamped, so it gets a full idle window before eviction
+        (avoids reaping a session created between middleware touches)."""
+        current = self._clock() if now is None else now
+        # Drop bookkeeping for sessions the manager no longer tracks.
+        for stale_id in [sid for sid in self._last_seen if sid not in live_ids]:
+            self._last_seen.pop(stale_id, None)
+        idle: list[str] = []
+        for sid in live_ids:
+            seen = self._last_seen.get(sid)
+            if seen is None:
+                self._last_seen[sid] = current
+                continue
+            if current - seen >= idle_after_sec:
+                idle.append(sid)
+        return idle
+
+
+class SessionActivityMiddleware:
+    """ASGI middleware that stamps :class:`SessionActivityTracker` on each request
+    carrying an ``mcp-session-id`` header. Pure pass-through otherwise; adds no
+    latency beyond a header scan."""
+
+    def __init__(self, app: ASGIApp, tracker: SessionActivityTracker) -> None:
+        self.app = app
+        self._tracker = tracker
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope.get("type") == "http":
+            for key, value in scope.get("headers", []):
+                if key.lower() == _MCP_SESSION_ID_HEADER and value:
+                    self._tracker.touch(value.decode("latin-1"))
+                    break
+        await self.app(scope, receive, send)
+
+
+async def reap_idle_sessions(
+    *,
+    app: Any,
+    tracker: SessionActivityTracker,
+    idle_after_sec: float,
+    now: float | None = None,
+) -> int:
+    """Terminate live sessions idle beyond ``idle_after_sec``. Returns the count
+    reaped. Uses only the public transport surface (``mcp_session_id``,
+    ``is_terminated``, ``terminate``); the SDK's own crash-cleanup ``finally``
+    then removes the entry from ``_server_instances``. Safe to call when no
+    session manager exists yet (returns 0)."""
+    mgr = find_session_manager(app)
+    if mgr is None:
+        return 0
+    instances = getattr(mgr, "_server_instances", None)
+    if not isinstance(instances, dict):
+        return 0
+    live: dict[str, _Transport] = dict(instances)
+    idle_ids = tracker.idle_session_ids(
+        live_ids=set(live.keys()), idle_after_sec=idle_after_sec, now=now
+    )
+    reaped = 0
+    for sid in idle_ids:
+        transport = live.get(sid)
+        if transport is None or transport.is_terminated:
+            tracker.forget(sid)
+            continue
+        try:
+            await transport.terminate()
+            reaped += 1
+            log.info("reaped idle streamable-http session %s", sid)
+        except Exception:  # pragma: no cover - defensive
+            log.warning("failed to terminate idle session %s", sid, exc_info=True)
+        finally:
+            tracker.forget(sid)
+    return reaped
+
+
+async def session_reaper_loop(
+    *,
+    app: Any,
+    tracker: SessionActivityTracker,
+    idle_after_sec: float,
+    interval_sec: float,
+    log_count: bool = True,
+) -> None:
+    """Background asyncio task: periodically reap idle sessions and log the live
+    session count for production observability. Cancellable via asyncio."""
+    log.info(
+        "session_reaper_loop started (idle_after=%ss interval=%ss)",
+        idle_after_sec,
+        interval_sec,
+    )
+    while True:
+        try:
+            reaped = await reap_idle_sessions(
+                app=app, tracker=tracker, idle_after_sec=idle_after_sec
+            )
+            if log_count:
+                live = count_live_sessions(app)
+                if live is not None:
+                    log.info("live streamable-http sessions: %d (reaped %d)", live, reaped)
+        except asyncio.CancelledError:
+            log.info("session_reaper_loop cancelled")
+            raise
+        except Exception:  # pragma: no cover - defensive
+            log.warning("session_reaper_loop iteration failed", exc_info=True)
+        await asyncio.sleep(interval_sec)
+
+
+__all__ = [
+    "SessionActivityMiddleware",
+    "SessionActivityTracker",
+    "count_live_sessions",
+    "find_session_manager",
+    "reap_idle_sessions",
+    "session_reaper_loop",
+]

--- a/src/data_olympus/tools_read.py
+++ b/src/data_olympus/tools_read.py
@@ -42,6 +42,7 @@ def kb_health_fn(
     last_git_fetch_at: float | None = None,
     last_successful_refresh_at: float | None = None,
     remote_head_sha: str | None = None,
+    live_sessions: int | None = None,
 ) -> HealthResponse:
     state = snapshot(
         idx=idx,
@@ -59,6 +60,7 @@ def kb_health_fn(
         last_git_fetch_at=last_git_fetch_at,
         last_successful_refresh_at=last_successful_refresh_at,
         remote_head_sha=remote_head_sha,
+        live_sessions=live_sessions,
     )
     return HealthResponse(
         kb_commit=state.kb_commit,
@@ -81,6 +83,7 @@ def kb_health_fn(
         last_git_fetch_at=state.last_git_fetch_at,
         last_successful_refresh_at=state.last_successful_refresh_at,
         remote_head_sha=state.remote_head_sha,
+        live_sessions=state.live_sessions,
     )
 
 

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -93,3 +93,58 @@ def test_health_response_includes_path_locks_held(tmp_kb, tmp_index_path):
         path_locks_held=2,
     )
     assert resp.path_locks_held == 2
+
+
+def test_health_response_surfaces_live_sessions(tmp_kb, tmp_index_path):
+    """live_sessions defaults to None (unobservable) and is threaded when set."""
+    from data_olympus.index import Index
+    from data_olympus.tools_read import kb_health_fn
+
+    idx = Index(tmp_index_path)
+    idx.build(tmp_kb, source_commit="x")
+    default = kb_health_fn(idx=idx, last_git_pull_at=None, staleness_degraded_sec=600)
+    assert default.live_sessions is None
+
+    with_count = kb_health_fn(
+        idx=idx, last_git_pull_at=None, staleness_degraded_sec=600, live_sessions=3
+    )
+    assert with_count.live_sessions == 3
+
+
+def test_server_state_live_session_count(tmp_kb, tmp_index_path):
+    """ServerState.live_session_count() returns None with no provider, the
+    provider's value when wired, and None (not a crash) when the provider raises."""
+    from data_olympus.git_ops import GitOps
+    from data_olympus.index import Index
+    from data_olympus.server import ServerState
+
+    idx = Index(tmp_index_path)
+    idx.build(tmp_kb, source_commit="x")
+    cfg = _config_stub()
+    state = ServerState(idx=idx, git=GitOps(tmp_kb), config=cfg)
+    assert state.live_session_count() is None
+
+    state.session_count_provider = lambda: 5
+    assert state.live_session_count() == 5
+
+    def boom() -> int:
+        raise RuntimeError("manager gone")
+
+    state.session_count_provider = boom
+    assert state.live_session_count() is None
+
+
+def _config_stub():
+    from pathlib import Path
+
+    from data_olympus.config import Config
+
+    return Config(
+        kb_main_path=Path("/kb"),
+        kb_index_path=Path("/kb.db"),
+        kb_remote_url="",
+        sync_interval_sec=60,
+        staleness_degraded_sec=600,
+        confidence_threshold=0.85,
+        http_port=8080,
+    )

--- a/tests/test_server_config_wiring.py
+++ b/tests/test_server_config_wiring.py
@@ -37,6 +37,8 @@ def test_non_default_config_is_threaded_into_app(
     monkeypatch.setenv("KB_PENDING_TIMEOUT_SEC", "7200")
     monkeypatch.setenv("KB_PENDING_QUEUE_CAP", "25")
     monkeypatch.setenv("KB_WORKTREE_IDLE_SEC", "999")
+    monkeypatch.setenv("KB_SESSION_IDLE_TIMEOUT_SEC", "900")
+    monkeypatch.setenv("KB_SESSION_REAP_INTERVAL_SEC", "45")
     monkeypatch.setenv("KB_GIT_KEY_PATH", "/tmp/test-key")
     # No KB_REMOTE_URL: write-pipeline objects are None when no remote is set.
     # We still get the config values threaded into state.config.
@@ -51,6 +53,8 @@ def test_non_default_config_is_threaded_into_app(
     assert cfg.pending_timeout_sec == 7200
     assert cfg.pending_queue_cap == 25
     assert cfg.worktree_idle_sec == 999
+    assert cfg.session_idle_timeout_sec == 900
+    assert cfg.session_reap_interval_sec == 45
     assert cfg.git_key_path == "/tmp/test-key"
 
     app = server.build_app_from_config(cfg, bootstrap_now=False)
@@ -64,6 +68,8 @@ def test_non_default_config_is_threaded_into_app(
     assert state.config.pending_timeout_sec == 7200
     assert state.config.pending_queue_cap == 25
     assert state.config.worktree_idle_sec == 999
+    assert state.config.session_idle_timeout_sec == 900
+    assert state.config.session_reap_interval_sec == 45
     assert state.config.git_key_path == "/tmp/test-key"
     assert state.config.write_block_tiers == ["T1", "T2"]
     assert state.config.write_block_paths == ["decisions/DEC-008-*.md"]

--- a/tests/test_session_metrics.py
+++ b/tests/test_session_metrics.py
@@ -14,6 +14,7 @@ import pytest
 
 from data_olympus.server import build_app
 from data_olympus.session_metrics import (
+    SessionActivityMiddleware,
     SessionActivityTracker,
     count_live_sessions,
     find_session_manager,
@@ -170,6 +171,122 @@ def test_tracker_forgets_vanished_sessions() -> None:
     tracker.touch("a")
     tracker.idle_session_ids(live_ids=set(), idle_after_sec=30)
     assert tracker.last_seen("a") is None
+
+
+# ---------------------------------------------------------------------------
+# SessionActivityMiddleware
+# ---------------------------------------------------------------------------
+
+
+class _RecordingApp:
+    """A downstream ASGI app that records whether it was called."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    async def __call__(self, scope, _receive, _send) -> None:
+        self.calls.append(scope)
+
+
+async def _noop_receive():  # pragma: no cover - never awaited in these tests
+    return {"type": "http.request"}
+
+
+async def _noop_send(_message) -> None:  # pragma: no cover - never awaited
+    return None
+
+
+def _http_scope(headers: list[tuple[bytes, bytes]]) -> dict:
+    return {"type": "http", "headers": headers}
+
+
+@pytest.mark.asyncio
+async def test_middleware_stamps_activity_when_header_present() -> None:
+    now = _clock()
+    tracker = SessionActivityTracker(clock=now)
+    downstream = _RecordingApp()
+    mw = SessionActivityMiddleware(downstream, tracker)
+
+    scope = _http_scope([(b"mcp-session-id", b"sess-1")])
+    await mw(scope, _noop_receive, _noop_send)
+
+    # Activity was stamped for the header's session id...
+    assert tracker.last_seen("sess-1") == 1000.0
+    # ...and the request was passed through unchanged.
+    assert downstream.calls == [scope]
+
+
+@pytest.mark.asyncio
+async def test_middleware_header_casing_and_latin1_decode() -> None:
+    """ASGI header names arrive lowercased by spec, but the middleware lowercases
+    defensively; the value is decoded latin-1 (the SDK emits ascii uuids, but a
+    non-ascii byte must not raise)."""
+    now = _clock()
+    tracker = SessionActivityTracker(clock=now)
+    mw = SessionActivityMiddleware(_RecordingApp(), tracker)
+
+    # Mixed-case header key is still matched.
+    await mw(_http_scope([(b"Mcp-Session-Id", b"sess-cased")]), _noop_receive, _noop_send)
+    assert tracker.last_seen("sess-cased") == 1000.0
+
+    # A 0xff byte decodes cleanly under latin-1 (would raise under utf-8).
+    await mw(_http_scope([(b"mcp-session-id", b"sess-\xff")]), _noop_receive, _noop_send)
+    assert tracker.last_seen("sess-\xff".encode("latin-1").decode("latin-1")) == 1000.0
+
+
+@pytest.mark.asyncio
+async def test_middleware_noop_and_passthrough_when_header_absent() -> None:
+    tracker = SessionActivityTracker()
+    downstream = _RecordingApp()
+    mw = SessionActivityMiddleware(downstream, tracker)
+
+    scope = _http_scope([(b"content-type", b"application/json")])
+    await mw(scope, _noop_receive, _noop_send)
+
+    # No session id stamped, nothing tracked, and the request still passed through.
+    assert tracker.last_seen("content-type") is None
+    assert downstream.calls == [scope]
+
+
+@pytest.mark.asyncio
+async def test_middleware_empty_header_value_is_ignored() -> None:
+    tracker = SessionActivityTracker()
+    downstream = _RecordingApp()
+    mw = SessionActivityMiddleware(downstream, tracker)
+
+    # An empty value must not stamp (and must not crash).
+    await mw(_http_scope([(b"mcp-session-id", b"")]), _noop_receive, _noop_send)
+    assert tracker.last_seen("") is None
+    assert len(downstream.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_middleware_non_http_scope_passes_through() -> None:
+    tracker = SessionActivityTracker()
+    downstream = _RecordingApp()
+    mw = SessionActivityMiddleware(downstream, tracker)
+
+    # A lifespan/websocket scope has no headers to scan; must not crash.
+    scope = {"type": "lifespan"}
+    await mw(scope, _noop_receive, _noop_send)
+    assert downstream.calls == [scope]
+
+
+@pytest.mark.asyncio
+async def test_middleware_early_break_stamps_once_on_first_match() -> None:
+    """The header scan breaks on the first matching id, so a (malformed) request
+    with two session-id headers stamps only the first and does not double-scan."""
+    now = _clock()
+    tracker = SessionActivityTracker(clock=now)
+    mw = SessionActivityMiddleware(_RecordingApp(), tracker)
+
+    scope = _http_scope(
+        [(b"mcp-session-id", b"first"), (b"mcp-session-id", b"second")]
+    )
+    await mw(scope, _noop_receive, _noop_send)
+
+    assert tracker.last_seen("first") == 1000.0
+    assert tracker.last_seen("second") is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_session_metrics.py
+++ b/tests/test_session_metrics.py
@@ -1,0 +1,232 @@
+"""Tests for streamable-http session observability + idle reaper.
+
+These exercise the leak fix without a live HTTP server: the mcp SDK's
+``StreamableHTTPSessionManager`` tracks transports in a plain
+``_server_instances`` dict, so a fake manager + fake transports faithfully model
+the accumulation the reaper must bound. One test also asserts discovery against
+the real FastMCP-built HTTP app.
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from data_olympus.server import build_app
+from data_olympus.session_metrics import (
+    SessionActivityTracker,
+    count_live_sessions,
+    find_session_manager,
+    reap_idle_sessions,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class FakeTransport:
+    """Mimics mcp's StreamableHTTPServerTransport public surface."""
+
+    def __init__(self, session_id: str) -> None:
+        self.mcp_session_id = session_id
+        self._terminated = False
+
+    @property
+    def is_terminated(self) -> bool:
+        return self._terminated
+
+    async def terminate(self) -> None:
+        self._terminated = True
+
+
+class FakeSessionManager:
+    """Mimics the SDK manager: transports live in a _server_instances dict."""
+
+    def __init__(self) -> None:
+        self._server_instances: dict[str, FakeTransport] = {}
+
+    def handshake(self, session_id: str) -> FakeTransport:
+        t = FakeTransport(session_id)
+        self._server_instances[session_id] = t
+        return t
+
+    def drop_terminated(self) -> None:
+        # Mirror the SDK: a terminated session's task finally-block removes it.
+        for sid, t in list(self._server_instances.items()):
+            if t.is_terminated:
+                del self._server_instances[sid]
+
+
+def _clock():
+    """A controllable monotonic clock."""
+    holder = {"t": 1000.0}
+
+    def now() -> float:
+        return holder["t"]
+
+    def advance(dt: float) -> None:
+        holder["t"] += dt
+
+    now.advance = advance  # type: ignore[attr-defined]
+    return now
+
+
+# ---------------------------------------------------------------------------
+# find_session_manager / count_live_sessions
+# ---------------------------------------------------------------------------
+
+
+def test_count_none_when_no_manager() -> None:
+    assert count_live_sessions(None) is None
+    assert count_live_sessions(object()) is None
+
+
+def test_find_manager_direct_and_via_holder() -> None:
+    mgr = FakeSessionManager()
+    assert find_session_manager(mgr) is mgr
+
+    class Holder:
+        def __init__(self, m: FakeSessionManager) -> None:
+            self.session_manager = m
+
+    assert find_session_manager(Holder(mgr)) is mgr
+
+
+def test_count_tracks_handshakes() -> None:
+    mgr = FakeSessionManager()
+    assert count_live_sessions(mgr) == 0
+    mgr.handshake("a")
+    mgr.handshake("b")
+    assert count_live_sessions(mgr) == 2
+
+
+def test_find_manager_before_lifespan_is_none(tmp_kb: Path, tmp_path: Path) -> None:
+    """FastMCP only populates the session manager inside the lifespan. Before
+    the app starts serving there is nothing to count, and discovery must return
+    None (not crash the health probe)."""
+    app = build_app(
+        kb_main_path=tmp_kb,
+        kb_index_path=tmp_path / "idx.db",
+        sync_interval_sec=60,
+        staleness_degraded_sec=600,
+        bootstrap_now=True,
+    )
+    http_app = app.http_app(transport="streamable-http")
+    assert find_session_manager(http_app) is None
+    assert count_live_sessions(http_app) is None
+
+
+@pytest.mark.asyncio
+async def test_find_manager_on_real_fastmcp_app(tmp_kb: Path, tmp_path: Path) -> None:
+    """Discovery must locate the manager on a real FastMCP-built streamable-http
+    app once its lifespan has started. Guards against FastMCP relocating the
+    wrapper across versions."""
+    app = build_app(
+        kb_main_path=tmp_kb,
+        kb_index_path=tmp_path / "idx.db",
+        sync_interval_sec=60,
+        staleness_degraded_sec=600,
+        bootstrap_now=True,
+    )
+    http_app = app.http_app(transport="streamable-http")
+    async with http_app.router.lifespan_context(http_app):
+        mgr = find_session_manager(http_app)
+        # The wrapper's manager is populated inside the lifespan.
+        assert mgr is not None
+        assert isinstance(getattr(mgr, "_server_instances", None), dict)
+        assert count_live_sessions(http_app) == 0
+
+
+# ---------------------------------------------------------------------------
+# SessionActivityTracker
+# ---------------------------------------------------------------------------
+
+
+def test_tracker_idle_detection() -> None:
+    now = _clock()
+    tracker = SessionActivityTracker(clock=now)
+    tracker.touch("a")
+    tracker.touch("b")
+    # Nothing idle yet.
+    assert tracker.idle_session_ids(live_ids={"a", "b"}, idle_after_sec=30) == []
+    now.advance(31)  # type: ignore[attr-defined]
+    tracker.touch("b")  # b stays active
+    idle = tracker.idle_session_ids(live_ids={"a", "b"}, idle_after_sec=30)
+    assert idle == ["a"]
+
+
+def test_tracker_unseen_live_session_gets_full_window() -> None:
+    now = _clock()
+    tracker = SessionActivityTracker(clock=now)
+    # "c" is live but never touched: first pass stamps it, does not reap it.
+    assert tracker.idle_session_ids(live_ids={"c"}, idle_after_sec=30) == []
+    now.advance(31)  # type: ignore[attr-defined]
+    assert tracker.idle_session_ids(live_ids={"c"}, idle_after_sec=30) == ["c"]
+
+
+def test_tracker_forgets_vanished_sessions() -> None:
+    now = _clock()
+    tracker = SessionActivityTracker(clock=now)
+    tracker.touch("a")
+    tracker.idle_session_ids(live_ids=set(), idle_after_sec=30)
+    assert tracker.last_seen("a") is None
+
+
+# ---------------------------------------------------------------------------
+# reap_idle_sessions
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_reaper_terminates_only_idle_sessions() -> None:
+    now = _clock()
+    mgr = FakeSessionManager()
+    tracker = SessionActivityTracker(clock=now)
+
+    ta = mgr.handshake("a")
+    tb = mgr.handshake("b")
+    tracker.touch("a")
+    tracker.touch("b")
+
+    now.advance(31)  # type: ignore[attr-defined]
+    tracker.touch("b")  # keep b active
+
+    reaped = await reap_idle_sessions(app=mgr, tracker=tracker, idle_after_sec=30)
+    assert reaped == 1
+    assert ta.is_terminated is True
+    assert tb.is_terminated is False
+
+
+@pytest.mark.asyncio
+async def test_reaper_bounds_growth_across_repeated_handshakes() -> None:
+    """Regression for #43: repeated handshakes that never DELETE would grow
+    _server_instances without bound. With activity stamping + reaper, the live
+    count stays bounded once sessions go idle."""
+    now = _clock()
+    mgr = FakeSessionManager()
+    tracker = SessionActivityTracker(clock=now)
+
+    # Simulate 50 handshakes over time; each stamps activity then goes silent.
+    for i in range(50):
+        mgr.handshake(f"s{i}")
+        tracker.touch(f"s{i}")
+        now.advance(1)  # type: ignore[attr-defined]
+
+    # Without a reaper the SDK dict would hold all 50 forever.
+    assert count_live_sessions(mgr) == 50
+
+    # Advance past the idle window and reap; the SDK finally-block equivalent
+    # removes terminated transports from the dict.
+    now.advance(60)  # type: ignore[attr-defined]
+    reaped = await reap_idle_sessions(app=mgr, tracker=tracker, idle_after_sec=30)
+    mgr.drop_terminated()
+
+    assert reaped == 50
+    assert count_live_sessions(mgr) == 0
+
+
+@pytest.mark.asyncio
+async def test_reaper_no_manager_is_noop() -> None:
+    tracker = SessionActivityTracker()
+    assert await reap_idle_sessions(app=None, tracker=tracker, idle_after_sec=30) == 0
+    assert await reap_idle_sessions(app=object(), tracker=tracker, idle_after_sec=30) == 0


### PR DESCRIPTION
MCP transport/session lifecycle — fix the session leak. Stacked on the
foundation branch (`claude/cranky-matsumoto-2e60a7`).

**Finding: sessions genuinely leak.** FastMCP 3.4.2 builds the SDK session
manager with no `session_idle_timeout` (defaults None), so a `POST /mcp`
handshake with no follow-up `DELETE` leaves the transport + its task resident
forever — unbounded growth over uptime. Cited to file:line in the installed
mcp/fastmcp packages.

Fix: `session_metrics.py` (live-session count + activity-tracking middleware +
idle reaper loop); `live_sessions` surfaced on `/api/v1/health`; knobs
`KB_SESSION_IDLE_TIMEOUT_SEC` (default 1800) / `KB_SESSION_REAP_INTERVAL_SEC`.
Includes a 50-handshake regression test asserting bounded growth.

Closes #43
