### PR TITLE
Scaling: read-only replica serving mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   and query-expansion features compose without rewriting the core query. When a
   reranker is installed the query is matched against a wider BM25 candidate pool
   (over-fetched) and the reranked result is truncated back to the requested limit.
+- Read-only replica serving mode (`KB_READ_ONLY`, issue #44) for horizontal read scaling. When set, the server registers only the read tools and read REST routes; the write/enforcement-write tools and routes (propose/resolve/bootstrap/consult/gate/record-event plus the observability GETs `/api/v1/pending`, `/api/v1/audit`, `/api/v1/audit/verify`, `/api/v1/compliance`) are not registered and return 404, and the write pipeline (worktrees/push queue/pending) is never initialised, so a replica is never a git writer. A new `deploy/k8s/read-replica/` overlay (Deployment, Service, ConfigMap, NetworkPolicy, kustomization) runs N interchangeable read pods with per-pod ephemeral clone + index scratch and references a separate read-only git deploy key Secret (`data-olympus-mcp-readonly`). The replica logs an unambiguous "starting in READ-ONLY mode; write pipeline disabled" line at startup.
 
 ### Fixed
 

--- a/deploy/k8s/read-replica/README.md
+++ b/deploy/k8s/read-replica/README.md
@@ -1,0 +1,76 @@
+# Read-only replica overlay (issue #44)
+
+Horizontally scalable read serving for data-olympus. This overlay runs N
+interchangeable, stateless read pods (a `Deployment`, not the writer
+`StatefulSet`). Each replica clones the KB from the git remote into a per-pod
+`emptyDir`, builds its own index, and refreshes both via the `git_pull_loop`.
+`KB_READ_ONLY=true` (from `configmap.yaml`) makes the server register only the
+read tools and read REST routes; the write pipeline (worktrees / push queue /
+pending) is never initialised, so a replica is never a git writer. The single
+`StatefulSet` remains the only writer/owner of the git remote.
+
+At startup a read replica logs an unambiguous line:
+
+```
+starting in READ-ONLY mode; write pipeline disabled
+```
+
+If this line is absent from a replica's logs, the pod is misconfigured (wrong
+image or the flag did not reach the container) and must not be trusted as a
+read-only pod.
+
+## Operator prerequisites (do these BEFORE `kubectl apply -k`)
+
+Two prerequisites are operator/CI actions and are NOT performed by the manifests:
+
+### 1. Build and publish a `KB_READ_ONLY`-capable image
+
+`deployment.yaml` intentionally pins a placeholder tag
+(`ghcr.io/knaisoma/data-olympus:read-only-preview`) that will fail to pull until
+you replace it. Do NOT point it at the writer's published `v0.1.1` tag: that
+image predates `KB_READ_ONLY`, ignores the flag, and would initialise the write
+pipeline, turning the replica into a second git writer.
+
+Build and publish an image from a revision that understands `KB_READ_ONLY`
+(this feature branch or later), then pin it in `deployment.yaml` by tag or,
+preferably, by immutable digest:
+
+```
+image: ghcr.io/knaisoma/data-olympus@sha256:<digest-of-your-build>
+```
+
+Verify a candidate image honours the flag before rolling it out: run it locally
+with `KB_READ_ONLY=true` and confirm the startup log shows the READ-ONLY line
+above and that `POST /api/v1/propose/memory` returns 404.
+
+### 2. Provision a separate read-only git deploy key
+
+The read Deployment references a Secret named `data-olympus-mcp-readonly` for
+its git key and remote URL. It does NOT reuse the writer's `data-olympus-mcp`
+Secret, whose deploy key has write (push) access. This keeps a write-capable key
+off read pods by default.
+
+Provision a dedicated read-only key using `secret.template.yaml` in this
+directory:
+
+1. Generate a key: `ssh-keygen -t ed25519 -f /tmp/ro-deploy-key -N "" -C "data-olympus-read"`
+2. Register `/tmp/ro-deploy-key.pub` on the KB repo as a **read-only** deploy
+   key (GitHub: add a deploy key WITHOUT "Allow write access"). If the host has
+   no per-key permission control, use a read-only machine account.
+3. `cp secret.template.yaml secret.yaml`, fill in the values, SOPS-encrypt to
+   `secret.sops.yaml`, and apply it (commit only the `.sops.yaml`, never the
+   plaintext).
+
+## Apply
+
+```
+kubectl apply -k deploy/k8s              # namespace + writer secret + writer
+# provision data-olympus-mcp-readonly (step 2 above)
+kubectl apply -k deploy/k8s/read-replica # N read replicas
+```
+
+Scale reads with:
+
+```
+kubectl -n data-olympus scale deployment/data-olympus-mcp-read --replicas=N
+```

--- a/deploy/k8s/read-replica/configmap.yaml
+++ b/deploy/k8s/read-replica/configmap.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: data-olympus-mcp-read
+  namespace: data-olympus
+data:
+  # Read-only replica (issue #44). KB_READ_ONLY switches the server to serve
+  # ONLY the read tools + read REST routes: no write/enforcement-write tools or
+  # routes are registered, and the write pipeline (worktrees / push queue /
+  # pending) is not initialised. The git_pull_loop still runs so each replica
+  # refreshes its own index snapshot from the same git remote as the writer.
+  KB_READ_ONLY: "true"
+  KB_MAIN_PATH: /kb-main
+  KB_INDEX_PATH: /index/kb.db
+  KB_HTTP_PORT: "8080"
+  KB_SYNC_INTERVAL_SEC: "60"
+  KB_STALENESS_DEGRADED_SEC: "600"
+  # Taxonomy overrides. Empty values use the built-in generic defaults; a
+  # deployment with a different directory layout supplies its own mapping (see
+  # the writer ConfigMap for the full field docs).
+  KB_TAXONOMY_PATH: ""
+  KB_INDEXED_PREFIXES: ""

--- a/deploy/k8s/read-replica/deployment.yaml
+++ b/deploy/k8s/read-replica/deployment.yaml
@@ -31,8 +31,15 @@ spec:
           type: RuntimeDefault
       containers:
         - name: data-olympus-mcp
-          # Same image as the writer; behaviour differs only by KB_READ_ONLY.
-          image: ghcr.io/knaisoma/data-olympus:v0.1.1  # replace with your registry/tag or digest
+          # SAFETY: this image MUST be built from a revision that understands the
+          # KB_READ_ONLY flag. Do NOT use the writer's published v0.1.1 tag: that
+          # image predates KB_READ_ONLY, ignores the flag, and would initialise
+          # the write pipeline -- turning this replica into a SECOND git writer.
+          # Build and publish an image from this feature branch first (see the
+          # README in this directory), then pin it here by tag or, preferably,
+          # by immutable digest. The placeholder tag below will fail to pull
+          # until the operator replaces it, which is intentional.
+          image: ghcr.io/knaisoma/data-olympus:read-only-preview  # REPLACE: build from a KB_READ_ONLY-capable revision; pin by digest
           imagePullPolicy: IfNotPresent
           # The entrypoint starts as root to copy/chown the deploy key and clone
           # /kb-main, then drops to uid 65534 via gosu. Same hardening as the
@@ -54,18 +61,22 @@ spec:
             - configMapRef:
                 name: data-olympus-mcp-read
           env:
-            # The deploy key only needs read (fetch/clone) access for a replica,
-            # but we reuse the same Secret as the writer for simplicity. Grant a
-            # read-only key here if your platform supports per-workload keys.
+            # SECURITY: a replica only needs read (fetch/clone) access, so it
+            # references its OWN Secret `data-olympus-mcp-readonly` -- NOT the
+            # writer's `data-olympus-mcp` Secret, whose deploy key has write
+            # (push) access to the git remote. The operator must provision a
+            # separate, read-only deploy key for this Secret (see the README in
+            # this directory). This keeps a write-capable key off read pods by
+            # default.
             - name: KB_GIT_REMOTE_URL
               valueFrom:
                 secretKeyRef:
-                  name: data-olympus-mcp
+                  name: data-olympus-mcp-readonly
                   key: KB_GIT_REMOTE_URL
             - name: KB_REMOTE_URL
               valueFrom:
                 secretKeyRef:
-                  name: data-olympus-mcp
+                  name: data-olympus-mcp-readonly
                   key: KB_GIT_REMOTE_URL
           volumeMounts:
             - name: kb-main
@@ -109,8 +120,10 @@ spec:
         - name: tmp
           emptyDir: {}
         - name: git-key
+          # Read-only deploy key (see the env block above and the README): this
+          # is the operator-provisioned read-only Secret, not the writer's.
           secret:
-            secretName: data-olympus-mcp
+            secretName: data-olympus-mcp-readonly
             defaultMode: 0400
             items:
               - key: git-key

--- a/deploy/k8s/read-replica/deployment.yaml
+++ b/deploy/k8s/read-replica/deployment.yaml
@@ -1,0 +1,117 @@
+# Read-only replica set (issue #44): horizontally scalable read serving.
+#
+# This is a Deployment (NOT the StatefulSet writer). Every replica is
+# interchangeable and stateless: it clones /kb-main from the git remote on
+# start, builds its own index under /index, and refreshes both via the
+# git_pull_loop. Because KB_READ_ONLY=true (from the read ConfigMap) the write
+# pipeline is never initialised and no write/enforcement-write tools or routes
+# are registered, so no replica is a git writer. The single StatefulSet remains
+# the only writer/owner of the git remote.
+#
+# Scratch is per-pod emptyDir (not PVCs): each replica owns an ephemeral clone +
+# index snapshot, so pods scale up/down freely and never contend for a volume.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: data-olympus-mcp-read
+  namespace: data-olympus
+spec:
+  # Scale this to N for more read throughput.
+  replicas: 3
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: data-olympus-mcp-read
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: data-olympus-mcp-read
+    spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: data-olympus-mcp
+          # Same image as the writer; behaviour differs only by KB_READ_ONLY.
+          image: ghcr.io/knaisoma/data-olympus:v0.1.1  # replace with your registry/tag or digest
+          imagePullPolicy: IfNotPresent
+          # The entrypoint starts as root to copy/chown the deploy key and clone
+          # /kb-main, then drops to uid 65534 via gosu. Same hardening as the
+          # writer: drop all caps except those the entrypoint needs, forbid
+          # privilege escalation, read-only root filesystem (writes go to the
+          # emptyDir mounts and /tmp below).
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+              add: ["CHOWN", "DAC_OVERRIDE", "FOWNER", "SETGID", "SETUID"]
+            seccompProfile:
+              type: RuntimeDefault
+          ports:
+            - name: http
+              containerPort: 8080
+          envFrom:
+            - configMapRef:
+                name: data-olympus-mcp-read
+          env:
+            # The deploy key only needs read (fetch/clone) access for a replica,
+            # but we reuse the same Secret as the writer for simplicity. Grant a
+            # read-only key here if your platform supports per-workload keys.
+            - name: KB_GIT_REMOTE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: data-olympus-mcp
+                  key: KB_GIT_REMOTE_URL
+            - name: KB_REMOTE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: data-olympus-mcp
+                  key: KB_GIT_REMOTE_URL
+          volumeMounts:
+            - name: kb-main
+              mountPath: /kb-main
+            - name: kb-index
+              mountPath: /index
+            - name: tmp
+              mountPath: /tmp
+            - name: git-key
+              mountPath: /etc/git-key-mount
+              subPath: git-key
+              readOnly: true
+          readinessProbe:
+            httpGet:
+              path: /api/v1/health
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 3
+          livenessProbe:
+            tcpSocket:
+              port: 8080
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 1
+              memory: 1Gi
+      volumes:
+        # Per-pod ephemeral clone + index snapshot + writable scratch. No PVCs:
+        # a read replica holds no durable state and re-clones on (re)start.
+        - name: kb-main
+          emptyDir: {}
+        - name: kb-index
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}
+        - name: git-key
+          secret:
+            secretName: data-olympus-mcp
+            defaultMode: 0400
+            items:
+              - key: git-key
+                path: git-key

--- a/deploy/k8s/read-replica/kustomization.yaml
+++ b/deploy/k8s/read-replica/kustomization.yaml
@@ -2,10 +2,17 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: data-olympus
 # Read-only replica overlay (issue #44). Apply AFTER the base deploy/k8s/ stack,
-# which owns the namespace, the git-remote Secret (data-olympus-mcp, referenced
-# by the read Deployment for its deploy key), and the single StatefulSet writer.
+# which owns the namespace and the single StatefulSet writer (with the writer's
+# write-capable Secret `data-olympus-mcp`).
 #
-#   kubectl apply -k deploy/k8s              # namespace + secret + writer
+# BEFORE applying this overlay the operator must ALSO provision a separate,
+# read-only git deploy key in a Secret named `data-olympus-mcp-readonly` in this
+# namespace (the read Deployment references it -- it does NOT reuse the writer's
+# write-capable Secret) AND build+publish an image from a KB_READ_ONLY-capable
+# revision and pin it in deployment.yaml. See README.md in this directory.
+#
+#   kubectl apply -k deploy/k8s              # namespace + writer secret + writer
+#   # provision data-olympus-mcp-readonly (read-only deploy key) -- see README.md
 #   kubectl apply -k deploy/k8s/read-replica # N read replicas
 #
 # Scale reads with: kubectl -n data-olympus scale deployment/data-olympus-mcp-read --replicas=N

--- a/deploy/k8s/read-replica/kustomization.yaml
+++ b/deploy/k8s/read-replica/kustomization.yaml
@@ -1,0 +1,16 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: data-olympus
+# Read-only replica overlay (issue #44). Apply AFTER the base deploy/k8s/ stack,
+# which owns the namespace, the git-remote Secret (data-olympus-mcp, referenced
+# by the read Deployment for its deploy key), and the single StatefulSet writer.
+#
+#   kubectl apply -k deploy/k8s              # namespace + secret + writer
+#   kubectl apply -k deploy/k8s/read-replica # N read replicas
+#
+# Scale reads with: kubectl -n data-olympus scale deployment/data-olympus-mcp-read --replicas=N
+resources:
+  - configmap.yaml
+  - service.yaml
+  - networkpolicy.yaml
+  - deployment.yaml

--- a/deploy/k8s/read-replica/networkpolicy.yaml
+++ b/deploy/k8s/read-replica/networkpolicy.yaml
@@ -1,0 +1,27 @@
+# Default-deny ingress for the read-replica pods, then allow only the ingress
+# controller and same-namespace clients (mirrors the writer's networkpolicy).
+# Egress is left open so each replica can reach the git remote and DNS to
+# refresh its snapshot; tighten it for your environment if required.
+#
+# Adjust the ingress-controller selector to match your cluster. If your CNI does
+# not enforce NetworkPolicy this manifest is a no-op; verify with your platform.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: data-olympus-mcp-read
+  namespace: data-olympus
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: data-olympus-mcp-read
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network-policy: ingress
+        - podSelector: {}
+      ports:
+        - protocol: TCP
+          port: 8080

--- a/deploy/k8s/read-replica/secret.template.yaml
+++ b/deploy/k8s/read-replica/secret.template.yaml
@@ -1,0 +1,33 @@
+# Template for the read-only replica Secret (data-olympus-mcp-readonly).
+#
+# SECURITY: the read replicas reference THIS Secret, not the writer's
+# `data-olympus-mcp` Secret. The writer's deploy key has WRITE (push) access to
+# the git remote; a read replica must never hold it. Provision a SEPARATE deploy
+# key here with READ-ONLY access (on GitHub: add a deploy key WITHOUT "Allow
+# write access"; on GitLab: a read-only deploy token/key). If the git host does
+# not support per-key permissions, use a machine account whose access to the KB
+# repo is read-only.
+#
+# Operator:
+# 1. Generate a dedicated read-only key:
+#      ssh-keygen -t ed25519 -f /tmp/ro-deploy-key -N "" -C "data-olympus-read"
+# 2. Register /tmp/ro-deploy-key.pub as a READ-ONLY deploy key on the KB repo.
+# 3. cp secret.template.yaml secret.yaml
+# 4. Fill in the literal values below (NEVER commit the unencrypted file).
+# 5. SOPS-encrypt: sops --encrypt --in-place secret.yaml (rename to secret.sops.yaml).
+# 6. Add the .sops.yaml to this overlay's kustomization.yaml resources list, or
+#    apply it directly (commit the .sops.yaml only, never the plaintext).
+#
+# This template stays in git as guidance. The .sops.yaml file is what gets applied.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: data-olympus-mcp-readonly
+  namespace: data-olympus
+type: Opaque
+stringData:
+  KB_GIT_REMOTE_URL: "git@github.com:YOUR-ORG/YOUR-KB.git"
+  # Paste the full content of your READ-ONLY ed25519 deploy key here (multi-line).
+  # This is the private key generated in step 1 (the file, NOT .pub).
+  # Make sure a trailing newline is present after the last line.
+  git-key: "REPLACE_WITH_READ_ONLY_ED25519_PRIVATE_KEY"

--- a/deploy/k8s/read-replica/service.yaml
+++ b/deploy/k8s/read-replica/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: data-olympus-mcp-read
+  namespace: data-olympus
+spec:
+  # ClusterIP load-balances read traffic across all replica pods. Point read
+  # clients at this Service; keep the writer's data-olympus-mcp Service for the
+  # single write-enabled endpoint.
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+  selector:
+    app.kubernetes.io/name: data-olympus-mcp-read

--- a/docs/serving.md
+++ b/docs/serving.md
@@ -25,11 +25,31 @@ race.
 
 ## Read-only mirrors may scale horizontally
 
-A read-only replica that serves only `kb_search`, `kb_get`, `kb_list`, and
-`kb_outline` need not maintain the write pipeline and may run as many instances
-as needed. For higher read throughput, place a caching reverse proxy in front
-of the single write instance, or run dedicated read-only replicas that
-periodically pull from the main instance's git remote.
+Set `KB_READ_ONLY=true` to run an instance as a read-only replica. In this mode
+the server registers only the read tools (`kb_search`, `kb_get`, `kb_list`,
+`kb_outline`, `kb_health`) and the read REST routes; the write and
+enforcement-write tools and routes (`propose`, `resolve`, `bootstrap`,
+`consult`, `gate`, `record-event`, and their observability mirrors) are not
+registered at all and return 404. The write pipeline (worktrees, push queue,
+pending) is never initialised, so no replica is a git writer.
+
+Crucially, the `git_pull_loop` still runs, so each replica keeps `KB_REMOTE_URL`
+set and refreshes its own index snapshot from the same git remote as the single
+writer. Run as many replicas as you need for read throughput; the single
+write-enabled instance remains the only owner of the git remote.
+
+`KB_READ_ONLY` is a truthy flag: `1`, `true`, `yes`, or `on` (case-insensitive)
+enable it; unset or anything else keeps the default read-write behaviour.
+
+See `deploy/k8s/read-replica/` for a ready-to-apply `Deployment` (not the
+StatefulSet writer) that runs N read replicas with per-pod ephemeral clone +
+index scratch. Apply the base stack first, then the overlay:
+
+```bash
+kubectl apply -k deploy/k8s              # namespace + secret + writer StatefulSet
+kubectl apply -k deploy/k8s/read-replica # N read replicas + read Service
+kubectl -n data-olympus scale deployment/data-olympus-mcp-read --replicas=5
+```
 
 ## Git pull loop
 

--- a/src/data_olympus/config.py
+++ b/src/data_olympus/config.py
@@ -48,6 +48,7 @@ class Config:
     # (issue #37). None means "use the Index built-in default map". A negative
     # weight boosts an in-force status, a positive one penalizes a retired one.
     status_weights: dict[str, float] | None = None
+    read_only: bool = False
 
 
 def _split_csv(raw: str) -> list[str]:
@@ -75,6 +76,10 @@ def _load_status_weights(raw: str) -> dict[str, float] | None:
             f"got {type(data).__name__}"
         )
     return {str(k): float(v) for k, v in data.items()}
+def _env_bool(raw: str) -> bool:
+    """Parse a truthy env string. True for 1/true/yes/on (case-insensitive);
+    everything else (including empty) is False."""
+    return raw.strip().lower() in ("1", "true", "yes", "on")
 
 
 def load_config() -> Config:
@@ -109,6 +114,7 @@ def load_config() -> Config:
     session_idle_timeout_sec = int(os.getenv("KB_SESSION_IDLE_TIMEOUT_SEC", "1800"))
     session_reap_interval_sec = int(os.getenv("KB_SESSION_REAP_INTERVAL_SEC", "60"))
     status_weights = _load_status_weights(os.getenv("KB_STATUS_WEIGHTS", ""))
+    read_only = _env_bool(os.getenv("KB_READ_ONLY", ""))
     return Config(
         kb_main_path=Path(os.environ.get("KB_MAIN_PATH", "/kb-main")),
         kb_index_path=Path(os.environ.get("KB_INDEX_PATH", "/index/kb.db")),
@@ -141,4 +147,5 @@ def load_config() -> Config:
         session_idle_timeout_sec=session_idle_timeout_sec,
         session_reap_interval_sec=session_reap_interval_sec,
         status_weights=status_weights,
+        read_only=read_only,
     )

--- a/src/data_olympus/rest_api.py
+++ b/src/data_olympus/rest_api.py
@@ -223,13 +223,22 @@ async def _read_json_capped(
 
 
 def register_routes(
-    app: FastMCP, state: ServerState, registry: PrincipalRegistry
+    app: FastMCP,
+    state: ServerState,
+    registry: PrincipalRegistry,
+    *,
+    read_only: bool = False,
 ) -> None:
     """Mount REST routes under /api/v1/ on the FastMCP app.
 
     Write and enforcement-plane routes are authorized against ``registry``
     (see ``_authorize``). When no auth is configured every caller is trusted and
     behavior matches the pre-auth product. Read routes are always open.
+
+    When ``read_only`` is True (a scaling replica, issue #44) the write and
+    enforcement-write routes (propose / resolve / bootstrap / consult / gate /
+    record-event and the observability mirrors) are not registered at all, so
+    they return 404. Only the pure-read routes are mounted.
     """
 
     @app.custom_route("/api/v1/health", methods=["GET"])
@@ -296,251 +305,254 @@ def register_routes(
         resp = await _offload(kb_list_fn, idx=state.idx, tier=tier, category=category)
         return JSONResponse(resp.model_dump())
 
-    @app.custom_route("/api/v1/propose/memory", methods=["POST"])
-    async def propose_memory(request: Request) -> JSONResponse:
-        principal, denied = _authorize(request, registry, CAP_PROPOSE)
-        if denied is not None:
-            return denied
-        if (off := _write_pipeline_ready(state)) is not None:
-            return off
-        body, big = await _read_json_capped(request, state.config.max_body_bytes)
-        if big is not None:
-            return big
-        if (bad := _missing_fields_response(
-            body, ["text", "source_session", "agent_identity", "confidence"],
-        )) is not None:
-            return bad
-        confidence, bad = _parse_confidence(body)
-        if bad is not None:
-            return bad
-        assert state.worktrees is not None
-        assert state.push_queue is not None
-        assert state.pending is not None
-        assert state.rate_limiter is not None
-        assert state.blocklist is not None
-        from data_olympus.tools_write import kb_propose_memory_fn
-        resp = await _offload(
-            kb_propose_memory_fn,
-            text=body["text"], tags=body.get("tags", []),
-            source_session=body["source_session"],
-            agent_identity=body["agent_identity"],
-            confidence=confidence,
-            confidence_threshold=state.config.confidence_threshold,
-            worktrees=state.worktrees, push_queue=state.push_queue,
-            pending=state.pending, rate_limiter=state.rate_limiter,
-            blocklist=state.blocklist,
-            remote_addr=request.client.host if request.client else "unknown",
-            audit_log=state.audit_log,
-            can_auto_commit=principal.can_auto_commit,
-            max_text_bytes=state.config.max_text_bytes,
-        )
-        status = _propose_status(resp.status)
-        return JSONResponse(resp.model_dump(), status_code=status)
-
-    @app.custom_route("/api/v1/propose/edit", methods=["POST"])
-    async def propose_edit(request: Request) -> JSONResponse:
-        principal, denied = _authorize(request, registry, CAP_PROPOSE)
-        if denied is not None:
-            return denied
-        if (off := _write_pipeline_ready(state)) is not None:
-            return off
-        body, big = await _read_json_capped(request, state.config.max_body_bytes)
-        if big is not None:
-            return big
-        if (bad := _missing_fields_response(
-            body,
-            ["target_path", "postimage", "base_commit",
-             "source_session", "agent_identity", "confidence"],
-        )) is not None:
-            return bad
-        confidence, bad = _parse_confidence(body)
-        if bad is not None:
-            return bad
-        assert state.worktrees is not None
-        assert state.push_queue is not None
-        assert state.pending is not None
-        assert state.rate_limiter is not None
-        assert state.blocklist is not None
-        from data_olympus.tools_write import kb_propose_edit_fn
-        resp = await _offload(
-            kb_propose_edit_fn,
-            target_path=body["target_path"], postimage=body["postimage"],
-            base_commit=body["base_commit"],
-            base_blob_sha=body.get("base_blob_sha"),
-            target_file_hash=body.get("target_file_hash"),
-            reason=body.get("reason", ""),
-            source_session=body["source_session"],
-            agent_identity=body["agent_identity"],
-            confidence=confidence,
-            confidence_threshold=state.config.confidence_threshold,
-            worktrees=state.worktrees, push_queue=state.push_queue,
-            pending=state.pending, rate_limiter=state.rate_limiter,
-            blocklist=state.blocklist,
-            remote_addr=request.client.host if request.client else "unknown",
-            audit_log=state.audit_log,
-            can_auto_commit=principal.can_auto_commit,
-            max_postimage_bytes=state.config.max_postimage_bytes,
-        )
-        status = _propose_status(resp.status)
-        return JSONResponse(resp.model_dump(), status_code=status)
-
-    @app.custom_route("/api/v1/resolve/{pending_id}", methods=["POST"])
-    async def resolve_pending(request: Request) -> JSONResponse:
-        _principal, denied = _authorize(request, registry, CAP_RESOLVE)
-        if denied is not None:
-            return denied
-        if (off := _write_pipeline_ready(state)) is not None:
-            return off
-        pid = request.path_params["pending_id"]
-        body = await request.json()
-        if (bad := _missing_fields_response(body, ["decision"])) is not None:
-            return bad
-        assert state.worktrees is not None
-        assert state.push_queue is not None
-        assert state.pending is not None
-        from data_olympus.tools_write import kb_resolve_pending_fn
-        resp = await _offload(
-            kb_resolve_pending_fn,
-            pending_id=pid, decision=body["decision"],
-            edited_text=body.get("edited_text"),
-            worktrees=state.worktrees, push_queue=state.push_queue,
-            pending=state.pending,
-            source_session=body.get("source_session", "operator"),
-            agent_identity=body.get("agent_identity", "operator"),
-            audit_log=state.audit_log,
-        )
-        return JSONResponse(resp.model_dump())
-
-    @app.custom_route("/api/v1/pending", methods=["GET"])
-    async def list_pending(request: Request) -> JSONResponse:
-        # Observability routes leak target paths / agent identities, so when auth
-        # is configured they require an authenticated principal (open otherwise).
-        _principal, denied = _authorize(request, registry)
-        if denied is not None:
-            return denied
-        if state.pending is None:
-            return JSONResponse({"pending": []})
-        from data_olympus.tools_write import kb_list_pending_fn
-        resp = await _offload(kb_list_pending_fn, pending=state.pending)
-        return JSONResponse(resp.model_dump())
-
-    @app.custom_route("/api/v1/audit", methods=["GET"])
-    async def audit(request: Request) -> JSONResponse:
-        _principal, denied = _authorize(request, registry)
-        if denied is not None:
-            return denied
-        if state.audit_log is None:
-            return JSONResponse({"events": [], "returned": 0, "limit_hit": False})
-        from data_olympus.tools_audit import kb_audit_fn
-        qp = request.query_params
-        since = float(qp["since"]) if qp.get("since") else None
-        agent = qp.get("agent")
-        status_filter = qp.get("status")
-        limit = int(qp.get("limit", "100"))
-        resp = await _offload(kb_audit_fn, audit_log=state.audit_log, since=since,
-                              agent=agent, status=status_filter, limit=limit)
-        return JSONResponse(resp.model_dump())
-
-    @app.custom_route("/api/v1/audit/verify", methods=["GET"])
-    async def audit_verify(request: Request) -> JSONResponse:
-        _principal, denied = _authorize(request, registry)
-        if denied is not None:
-            return denied
-        if state.audit_log is None:
-            return JSONResponse({"ok": True, "first_broken_index": -1})
-        ok, idx = await _offload(state.audit_log.verify)
-        return JSONResponse({"ok": ok, "first_broken_index": idx})
-
-    @app.custom_route("/api/v1/consult", methods=["POST"])
-    async def consult(request: Request) -> JSONResponse:
-        _principal, denied = _authorize(request, registry)
-        if denied is not None:
-            return denied
-        import time as _time
-
-        from data_olympus.tools_enforce import kb_consult_fn
-        body = await request.json()
-        if (bad := _missing_fields_response(
-            body, ["workspace", "source_session"],
-        )) is not None:
-            return bad
-        resp = await _offload(
-            kb_consult_fn,
-            idx=state.idx, classifier=state.classifier, ledger=state.ledger,
-            workspace=body["workspace"], intent=body.get("intent", ""),
-            source_session=body["source_session"],
-            agent_identity=body.get("agent_identity", "unknown"),
-            ttl_sec=state.config.consult_ttl_sec, now=_time.time(),
-            audit_log=state.audit_log,
-        )
-        return JSONResponse(resp.model_dump())
-
-    @app.custom_route("/api/v1/gate/check", methods=["POST"])
-    async def gate_check(request: Request) -> JSONResponse:
-        _principal, denied = _authorize(request, registry)
-        if denied is not None:
-            return denied
-        import time as _time
-
-        from data_olympus.tools_enforce import kb_gate_check_fn
-        body = await request.json()
-        if (bad := _missing_fields_response(
-            body, ["workspace", "session_id"],
-        )) is not None:
-            return bad
-        resp = await _offload(
-            kb_gate_check_fn,
-            classifier=state.classifier, ledger=state.ledger,
-            workspace=body["workspace"], session_id=body["session_id"],
-            tool_name=body.get("tool_name", ""),
-            action_path=body.get("action_path"),
-            action_diff=body.get("action_diff", ""),
-            now=_time.time(), ttl_sec=state.config.consult_ttl_sec,
-            audit_log=state.audit_log,
-        )
-        return JSONResponse(resp.model_dump())
-
-    @app.custom_route("/api/v1/compliance", methods=["GET"])
-    async def compliance(request: Request) -> JSONResponse:
-        # Enforcement aggregates are observability data; gate like /pending,
-        # /audit, /consult, /gate when auth is configured.
-        _principal, denied = _authorize(request, registry)
-        if denied is not None:
-            return denied
-        if state.audit_log is None:
-            return JSONResponse({"counts": {}, "by_agent": {}})
-        from data_olympus.tools_enforce import kb_compliance_fn
-        qp = request.query_params
-        since = float(qp["since"]) if qp.get("since") else None
-        agent = qp.get("agent")
-        resp = await _offload(
-            kb_compliance_fn, audit_log=state.audit_log, since=since, agent=agent)
-        return JSONResponse(resp.model_dump())
-
-    @app.custom_route("/api/v1/audit/event", methods=["POST"])
-    async def record_event(request: Request) -> JSONResponse:
-        _principal, denied = _authorize(request, registry, CAP_RECORD_EVENT)
-        if denied is not None:
-            return denied
-        if state.audit_log is None:
-            return JSONResponse({"recorded": False}, status_code=503)
-        import time as _time
-
-        body = await request.json()
-        if (bad := _missing_fields_response(body, ["event_type", "workspace"])) is not None:
-            return bad
-        from data_olympus.tools_enforce import kb_record_event_fn
-        try:
+    if not read_only:
+        # Write + enforcement-write REST surface. A read-only replica
+        # (issue #44) mounts none of these, so they return 404.
+        @app.custom_route("/api/v1/propose/memory", methods=["POST"])
+        async def propose_memory(request: Request) -> JSONResponse:
+            principal, denied = _authorize(request, registry, CAP_PROPOSE)
+            if denied is not None:
+                return denied
+            if (off := _write_pipeline_ready(state)) is not None:
+                return off
+            body, big = await _read_json_capped(request, state.config.max_body_bytes)
+            if big is not None:
+                return big
+            if (bad := _missing_fields_response(
+                body, ["text", "source_session", "agent_identity", "confidence"],
+            )) is not None:
+                return bad
+            confidence, bad = _parse_confidence(body)
+            if bad is not None:
+                return bad
+            assert state.worktrees is not None
+            assert state.push_queue is not None
+            assert state.pending is not None
+            assert state.rate_limiter is not None
+            assert state.blocklist is not None
+            from data_olympus.tools_write import kb_propose_memory_fn
             resp = await _offload(
-                kb_record_event_fn,
-                audit_log=state.audit_log, event_type=body["event_type"],
-                workspace=body["workspace"],
+                kb_propose_memory_fn,
+                text=body["text"], tags=body.get("tags", []),
+                source_session=body["source_session"],
+                agent_identity=body["agent_identity"],
+                confidence=confidence,
+                confidence_threshold=state.config.confidence_threshold,
+                worktrees=state.worktrees, push_queue=state.push_queue,
+                pending=state.pending, rate_limiter=state.rate_limiter,
+                blocklist=state.blocklist,
+                remote_addr=request.client.host if request.client else "unknown",
+                audit_log=state.audit_log,
+                can_auto_commit=principal.can_auto_commit,
+                max_text_bytes=state.config.max_text_bytes,
+            )
+            status = _propose_status(resp.status)
+            return JSONResponse(resp.model_dump(), status_code=status)
+
+        @app.custom_route("/api/v1/propose/edit", methods=["POST"])
+        async def propose_edit(request: Request) -> JSONResponse:
+            principal, denied = _authorize(request, registry, CAP_PROPOSE)
+            if denied is not None:
+                return denied
+            if (off := _write_pipeline_ready(state)) is not None:
+                return off
+            body, big = await _read_json_capped(request, state.config.max_body_bytes)
+            if big is not None:
+                return big
+            if (bad := _missing_fields_response(
+                body,
+                ["target_path", "postimage", "base_commit",
+                 "source_session", "agent_identity", "confidence"],
+            )) is not None:
+                return bad
+            confidence, bad = _parse_confidence(body)
+            if bad is not None:
+                return bad
+            assert state.worktrees is not None
+            assert state.push_queue is not None
+            assert state.pending is not None
+            assert state.rate_limiter is not None
+            assert state.blocklist is not None
+            from data_olympus.tools_write import kb_propose_edit_fn
+            resp = await _offload(
+                kb_propose_edit_fn,
+                target_path=body["target_path"], postimage=body["postimage"],
+                base_commit=body["base_commit"],
+                base_blob_sha=body.get("base_blob_sha"),
+                target_file_hash=body.get("target_file_hash"),
+                reason=body.get("reason", ""),
+                source_session=body["source_session"],
+                agent_identity=body["agent_identity"],
+                confidence=confidence,
+                confidence_threshold=state.config.confidence_threshold,
+                worktrees=state.worktrees, push_queue=state.push_queue,
+                pending=state.pending, rate_limiter=state.rate_limiter,
+                blocklist=state.blocklist,
+                remote_addr=request.client.host if request.client else "unknown",
+                audit_log=state.audit_log,
+                can_auto_commit=principal.can_auto_commit,
+                max_postimage_bytes=state.config.max_postimage_bytes,
+            )
+            status = _propose_status(resp.status)
+            return JSONResponse(resp.model_dump(), status_code=status)
+
+        @app.custom_route("/api/v1/resolve/{pending_id}", methods=["POST"])
+        async def resolve_pending(request: Request) -> JSONResponse:
+            _principal, denied = _authorize(request, registry, CAP_RESOLVE)
+            if denied is not None:
+                return denied
+            if (off := _write_pipeline_ready(state)) is not None:
+                return off
+            pid = request.path_params["pending_id"]
+            body = await request.json()
+            if (bad := _missing_fields_response(body, ["decision"])) is not None:
+                return bad
+            assert state.worktrees is not None
+            assert state.push_queue is not None
+            assert state.pending is not None
+            from data_olympus.tools_write import kb_resolve_pending_fn
+            resp = await _offload(
+                kb_resolve_pending_fn,
+                pending_id=pid, decision=body["decision"],
+                edited_text=body.get("edited_text"),
+                worktrees=state.worktrees, push_queue=state.push_queue,
+                pending=state.pending,
+                source_session=body.get("source_session", "operator"),
+                agent_identity=body.get("agent_identity", "operator"),
+                audit_log=state.audit_log,
+            )
+            return JSONResponse(resp.model_dump())
+
+        @app.custom_route("/api/v1/pending", methods=["GET"])
+        async def list_pending(request: Request) -> JSONResponse:
+            # Observability routes leak target paths / agent identities, so when auth
+            # is configured they require an authenticated principal (open otherwise).
+            _principal, denied = _authorize(request, registry)
+            if denied is not None:
+                return denied
+            if state.pending is None:
+                return JSONResponse({"pending": []})
+            from data_olympus.tools_write import kb_list_pending_fn
+            resp = await _offload(kb_list_pending_fn, pending=state.pending)
+            return JSONResponse(resp.model_dump())
+
+        @app.custom_route("/api/v1/audit", methods=["GET"])
+        async def audit(request: Request) -> JSONResponse:
+            _principal, denied = _authorize(request, registry)
+            if denied is not None:
+                return denied
+            if state.audit_log is None:
+                return JSONResponse({"events": [], "returned": 0, "limit_hit": False})
+            from data_olympus.tools_audit import kb_audit_fn
+            qp = request.query_params
+            since = float(qp["since"]) if qp.get("since") else None
+            agent = qp.get("agent")
+            status_filter = qp.get("status")
+            limit = int(qp.get("limit", "100"))
+            resp = await _offload(kb_audit_fn, audit_log=state.audit_log, since=since,
+                                  agent=agent, status=status_filter, limit=limit)
+            return JSONResponse(resp.model_dump())
+
+        @app.custom_route("/api/v1/audit/verify", methods=["GET"])
+        async def audit_verify(request: Request) -> JSONResponse:
+            _principal, denied = _authorize(request, registry)
+            if denied is not None:
+                return denied
+            if state.audit_log is None:
+                return JSONResponse({"ok": True, "first_broken_index": -1})
+            ok, idx = await _offload(state.audit_log.verify)
+            return JSONResponse({"ok": ok, "first_broken_index": idx})
+
+        @app.custom_route("/api/v1/consult", methods=["POST"])
+        async def consult(request: Request) -> JSONResponse:
+            _principal, denied = _authorize(request, registry)
+            if denied is not None:
+                return denied
+            import time as _time
+
+            from data_olympus.tools_enforce import kb_consult_fn
+            body = await request.json()
+            if (bad := _missing_fields_response(
+                body, ["workspace", "source_session"],
+            )) is not None:
+                return bad
+            resp = await _offload(
+                kb_consult_fn,
+                idx=state.idx, classifier=state.classifier, ledger=state.ledger,
+                workspace=body["workspace"], intent=body.get("intent", ""),
+                source_session=body["source_session"],
                 agent_identity=body.get("agent_identity", "unknown"),
-                source_session=body.get("source_session", ""),
-                reason=body.get("reason", ""), now=_time.time())
-        except ValueError as e:
-            return JSONResponse({"recorded": False, "error": str(e)}, status_code=400)
-        return JSONResponse(resp.model_dump())
+                ttl_sec=state.config.consult_ttl_sec, now=_time.time(),
+                audit_log=state.audit_log,
+            )
+            return JSONResponse(resp.model_dump())
+
+        @app.custom_route("/api/v1/gate/check", methods=["POST"])
+        async def gate_check(request: Request) -> JSONResponse:
+            _principal, denied = _authorize(request, registry)
+            if denied is not None:
+                return denied
+            import time as _time
+
+            from data_olympus.tools_enforce import kb_gate_check_fn
+            body = await request.json()
+            if (bad := _missing_fields_response(
+                body, ["workspace", "session_id"],
+            )) is not None:
+                return bad
+            resp = await _offload(
+                kb_gate_check_fn,
+                classifier=state.classifier, ledger=state.ledger,
+                workspace=body["workspace"], session_id=body["session_id"],
+                tool_name=body.get("tool_name", ""),
+                action_path=body.get("action_path"),
+                action_diff=body.get("action_diff", ""),
+                now=_time.time(), ttl_sec=state.config.consult_ttl_sec,
+                audit_log=state.audit_log,
+            )
+            return JSONResponse(resp.model_dump())
+
+        @app.custom_route("/api/v1/compliance", methods=["GET"])
+        async def compliance(request: Request) -> JSONResponse:
+            # Enforcement aggregates are observability data; gate like /pending,
+            # /audit, /consult, /gate when auth is configured.
+            _principal, denied = _authorize(request, registry)
+            if denied is not None:
+                return denied
+            if state.audit_log is None:
+                return JSONResponse({"counts": {}, "by_agent": {}})
+            from data_olympus.tools_enforce import kb_compliance_fn
+            qp = request.query_params
+            since = float(qp["since"]) if qp.get("since") else None
+            agent = qp.get("agent")
+            resp = await _offload(
+                kb_compliance_fn, audit_log=state.audit_log, since=since, agent=agent)
+            return JSONResponse(resp.model_dump())
+
+        @app.custom_route("/api/v1/audit/event", methods=["POST"])
+        async def record_event(request: Request) -> JSONResponse:
+            _principal, denied = _authorize(request, registry, CAP_RECORD_EVENT)
+            if denied is not None:
+                return denied
+            if state.audit_log is None:
+                return JSONResponse({"recorded": False}, status_code=503)
+            import time as _time
+
+            body = await request.json()
+            if (bad := _missing_fields_response(body, ["event_type", "workspace"])) is not None:
+                return bad
+            from data_olympus.tools_enforce import kb_record_event_fn
+            try:
+                resp = await _offload(
+                    kb_record_event_fn,
+                    audit_log=state.audit_log, event_type=body["event_type"],
+                    workspace=body["workspace"],
+                    agent_identity=body.get("agent_identity", "unknown"),
+                    source_session=body.get("source_session", ""),
+                    reason=body.get("reason", ""), now=_time.time())
+            except ValueError as e:
+                return JSONResponse({"recorded": False, "error": str(e)}, status_code=400)
+            return JSONResponse(resp.model_dump())
 
     @app.custom_route("/api/v1/onboarding/status", methods=["GET"])
     async def onboarding_status(request: Request) -> JSONResponse:
@@ -556,52 +568,55 @@ def register_routes(
         )
         return JSONResponse(resp.model_dump())
 
-    @app.custom_route("/api/v1/onboarding/bootstrap", methods=["POST"])
-    async def onboarding_bootstrap(request: Request) -> JSONResponse:
-        principal, denied = _authorize(request, registry, CAP_BOOTSTRAP)
-        if denied is not None:
-            return denied
-        if (off := _write_pipeline_ready(state)) is not None:
-            return off
-        body, big = await _read_json_capped(request, state.config.max_body_bytes)
-        if big is not None:
-            return big
-        if (bad := _missing_fields_response(
-            body, ["workspace", "files", "source_session",
-                   "agent_identity", "confidence"],
-        )) is not None:
-            return bad
-        confidence, bad = _parse_confidence(body)
-        if bad is not None:
-            return bad
-        assert state.worktrees is not None
-        assert state.push_queue is not None
-        assert state.pending is not None
-        assert state.rate_limiter is not None
-        assert state.blocklist is not None
-        from data_olympus.tools_onboarding import kb_bootstrap_project_fn
-        resp = await _offload(
-            kb_bootstrap_project_fn,
-            idx=state.idx,
-            workspace=body["workspace"],
-            component=body.get("component"),
-            workspace_remote_url=body.get("workspace_remote_url"),
-            component_remote_url=body.get("component_remote_url"),
-            files=body["files"],
-            source_session=body["source_session"],
-            agent_identity=body["agent_identity"],
-            confidence=confidence,
-            confidence_threshold=state.config.confidence_threshold,
-            worktrees=state.worktrees, push_queue=state.push_queue,
-            pending=state.pending, rate_limiter=state.rate_limiter,
-            blocklist=state.blocklist, audit_log=state.audit_log,
-            remote_addr=request.client.host if request.client else "unknown",
-            can_auto_commit=principal.can_auto_commit,
-            max_postimage_bytes=state.config.max_postimage_bytes,
-            max_files=state.config.max_bootstrap_files,
-        )
-        status = _propose_status(resp.status)
-        return JSONResponse(resp.model_dump(), status_code=status)
+    if not read_only:
+        # Write route: bootstrapping a workspace is a commit. Absent on a
+        # read-only replica (issue #44).
+        @app.custom_route("/api/v1/onboarding/bootstrap", methods=["POST"])
+        async def onboarding_bootstrap(request: Request) -> JSONResponse:
+            principal, denied = _authorize(request, registry, CAP_BOOTSTRAP)
+            if denied is not None:
+                return denied
+            if (off := _write_pipeline_ready(state)) is not None:
+                return off
+            body, big = await _read_json_capped(request, state.config.max_body_bytes)
+            if big is not None:
+                return big
+            if (bad := _missing_fields_response(
+                body, ["workspace", "files", "source_session",
+                       "agent_identity", "confidence"],
+            )) is not None:
+                return bad
+            confidence, bad = _parse_confidence(body)
+            if bad is not None:
+                return bad
+            assert state.worktrees is not None
+            assert state.push_queue is not None
+            assert state.pending is not None
+            assert state.rate_limiter is not None
+            assert state.blocklist is not None
+            from data_olympus.tools_onboarding import kb_bootstrap_project_fn
+            resp = await _offload(
+                kb_bootstrap_project_fn,
+                idx=state.idx,
+                workspace=body["workspace"],
+                component=body.get("component"),
+                workspace_remote_url=body.get("workspace_remote_url"),
+                component_remote_url=body.get("component_remote_url"),
+                files=body["files"],
+                source_session=body["source_session"],
+                agent_identity=body["agent_identity"],
+                confidence=confidence,
+                confidence_threshold=state.config.confidence_threshold,
+                worktrees=state.worktrees, push_queue=state.push_queue,
+                pending=state.pending, rate_limiter=state.rate_limiter,
+                blocklist=state.blocklist, audit_log=state.audit_log,
+                remote_addr=request.client.host if request.client else "unknown",
+                can_auto_commit=principal.can_auto_commit,
+                max_postimage_bytes=state.config.max_postimage_bytes,
+                max_files=state.config.max_bootstrap_files,
+            )
+            status = _propose_status(resp.status)
+            return JSONResponse(resp.model_dump(), status_code=status)
 
     @app.custom_route("/api/v1/onboarding/playbook", methods=["GET"])
     async def onboarding_playbook(request: Request) -> JSONResponse:

--- a/src/data_olympus/server.py
+++ b/src/data_olympus/server.py
@@ -261,6 +261,14 @@ def build_app(
     )
     state = ServerState(idx=idx, git=git, config=config, ledger=ledger)
 
+    if config.read_only:
+        # Unambiguous startup marker: if a replica is misconfigured (e.g. built
+        # from an image that predates KB_READ_ONLY, or the flag failed to reach
+        # the pod), this line is absent from the logs and the misconfiguration
+        # is visible. A read-only replica never initialises the write pipeline
+        # below and never becomes a git writer.
+        log.warning("starting in READ-ONLY mode; write pipeline disabled")
+
     # A read-only replica sets kb_remote_url (so the git_pull_loop has a remote
     # to refresh from) but must NOT bring up the write pipeline.
     if config.kb_remote_url and not config.read_only:

--- a/src/data_olympus/server.py
+++ b/src/data_olympus/server.py
@@ -194,11 +194,18 @@ def build_app(
     session_idle_timeout_sec: int = 1800,
     session_reap_interval_sec: int = 60,
     status_weights: dict[str, float] | None = None,
+    read_only: bool = False,
 ) -> FastMCP:
     """Construct a FastMCP app with the read tools registered.
 
     If `bootstrap_now` is True (used in tests), the index is built synchronously
     before returning. In production main(), bootstrap happens via the lifespan hook.
+
+    When `read_only` is True the server runs as a scaling replica (issue #44):
+    only the read tools and read REST routes are registered, the write pipeline
+    (worktrees / push queue / pending) is not initialised, and no write or
+    enforcement-write tools/routes are exposed. The git_pull_loop still runs (in
+    main()) so the replica refreshes its own index snapshot from the git remote.
     """
     config_kwargs: dict[str, object] = dict(
         kb_main_path=kb_main_path,
@@ -229,6 +236,7 @@ def build_app(
         session_idle_timeout_sec=session_idle_timeout_sec,
         session_reap_interval_sec=session_reap_interval_sec,
         status_weights=status_weights,
+        read_only=read_only,
     )
     if audit_log_path is not None:
         config_kwargs["audit_log_path"] = audit_log_path
@@ -253,7 +261,9 @@ def build_app(
     )
     state = ServerState(idx=idx, git=git, config=config, ledger=ledger)
 
-    if config.kb_remote_url:
+    # A read-only replica sets kb_remote_url (so the git_pull_loop has a remote
+    # to refresh from) but must NOT bring up the write pipeline.
+    if config.kb_remote_url and not config.read_only:
         worktrees = WorktreeRegistry(git=git, worktree_root=config.worktree_root)
         push_queue = PushQueue(queue_root=config.push_queue_root)
         pending = PendingQueue(
@@ -273,7 +283,7 @@ def build_app(
         state.rate_limiter = rate_limiter
         state.blocklist = blocklist
 
-    if config.kb_remote_url:
+    if config.kb_remote_url and not config.read_only:
         audit_log = AuditLog(
             log_path=audit_log_path or config.audit_log_path,
             hmac_key=config.audit_hmac_key,
@@ -357,110 +367,6 @@ def build_app(
         return resp.model_dump()
 
     @app.tool()
-    def kb_propose_memory(
-        text: str, tags: list[str], source_session: str,
-        agent_identity: str, confidence: float,
-    ) -> dict[str, object]:
-        """Propose a new memory file. High confidence auto-commits and
-        enqueues for push; low confidence enters the pending queue for operator
-        review."""
-        if state.worktrees is None or state.push_queue is None or state.pending is None:
-            return {"status": "write_pipeline_disabled"}
-        assert state.worktrees is not None
-        assert state.push_queue is not None
-        assert state.pending is not None
-        assert state.rate_limiter is not None
-        assert state.blocklist is not None
-        from data_olympus.tools_write import kb_propose_memory_fn
-        resp = kb_propose_memory_fn(
-            text=text, tags=tags, source_session=source_session,
-            agent_identity=agent_identity, confidence=confidence,
-            confidence_threshold=state.config.confidence_threshold,
-            worktrees=state.worktrees, push_queue=state.push_queue,
-            pending=state.pending, rate_limiter=state.rate_limiter,
-            blocklist=state.blocklist, remote_addr="mcp",
-            audit_log=state.audit_log,
-            can_auto_commit=_current_principal.get().can_auto_commit,
-            max_text_bytes=state.config.max_text_bytes,
-        )
-        return resp.model_dump()
-
-    @app.tool()
-    def kb_propose_edit(
-        target_path: str, postimage: str, base_commit: str,
-        base_blob_sha: str | None, target_file_hash: str | None,
-        reason: str, source_session: str, agent_identity: str, confidence: float,
-    ) -> dict[str, object]:
-        """Propose an edit to an existing (or new) markdown file under an
-        indexed tier. High confidence auto-commits + queues for push; low
-        confidence enters the pending queue for operator review."""
-        if state.worktrees is None or state.push_queue is None or state.pending is None:
-            return {"status": "write_pipeline_disabled"}
-        assert state.worktrees is not None
-        assert state.push_queue is not None
-        assert state.pending is not None
-        assert state.rate_limiter is not None
-        assert state.blocklist is not None
-        from data_olympus.tools_write import kb_propose_edit_fn
-        resp = kb_propose_edit_fn(
-            target_path=target_path, postimage=postimage, base_commit=base_commit,
-            base_blob_sha=base_blob_sha, target_file_hash=target_file_hash,
-            reason=reason, source_session=source_session, agent_identity=agent_identity,
-            confidence=confidence,
-            confidence_threshold=state.config.confidence_threshold,
-            worktrees=state.worktrees, push_queue=state.push_queue,
-            pending=state.pending, rate_limiter=state.rate_limiter,
-            blocklist=state.blocklist, remote_addr="mcp",
-            audit_log=state.audit_log,
-            can_auto_commit=_current_principal.get().can_auto_commit,
-            max_postimage_bytes=state.config.max_postimage_bytes,
-        )
-        return resp.model_dump()
-
-    @app.tool()
-    def kb_resolve_pending(
-        pending_id: str, decision: str, edited_text: str | None = None,
-        source_session: str = "operator-resolve", agent_identity: str = "operator",
-    ) -> dict[str, object]:
-        """Resolve a pending proposal: approve (optionally with edited text) or
-        reject. Approval commits + enqueues for push."""
-        if state.worktrees is None or state.push_queue is None or state.pending is None:
-            return {"status": "write_pipeline_disabled"}
-        assert state.worktrees is not None
-        assert state.push_queue is not None
-        assert state.pending is not None
-        from data_olympus.tools_write import kb_resolve_pending_fn
-        resp = kb_resolve_pending_fn(
-            pending_id=pending_id, decision=decision, edited_text=edited_text,
-            worktrees=state.worktrees, push_queue=state.push_queue,
-            pending=state.pending,
-            source_session=source_session, agent_identity=agent_identity,
-            audit_log=state.audit_log,
-        )
-        return resp.model_dump()
-
-    @app.tool()
-    def kb_list_pending() -> dict[str, object]:
-        """List currently pending proposals awaiting operator decision."""
-        assert state.pending is not None
-        from data_olympus.tools_write import kb_list_pending_fn
-        resp = kb_list_pending_fn(pending=state.pending)
-        return resp.model_dump()
-
-    @app.tool()
-    def kb_audit(
-        since: float | None = None, agent: str | None = None,
-        status: str | None = None, limit: int = 100,
-    ) -> dict[str, object]:
-        """Return recent audit events, most-recent first. Optional filters:
-        since (unix ts), agent (agent_identity), status (event status)."""
-        assert state.audit_log is not None
-        from data_olympus.tools_audit import kb_audit_fn
-        resp = kb_audit_fn(audit_log=state.audit_log, since=since,
-                          agent=agent, status=status, limit=limit)
-        return resp.model_dump()
-
-    @app.tool()
     def kb_onboarding_status(
         workspace: str, component: str | None = None,
         workspace_remote_url: str | None = None,
@@ -473,42 +379,6 @@ def build_app(
             idx=state.idx, workspace=workspace, component=component,
             workspace_remote_url=workspace_remote_url,
             component_remote_url=component_remote_url,
-        )
-        return resp.model_dump()
-
-    @app.tool()
-    def kb_bootstrap_project(
-        workspace: str, files: list[dict[str, str]],
-        source_session: str, agent_identity: str, confidence: float,
-        component: str | None = None,
-        workspace_remote_url: str | None = None,
-        component_remote_url: str | None = None,
-    ) -> dict[str, object]:
-        """Bootstrap a new workspace/component. Only valid when status=absent.
-        High confidence commits atomically; low confidence enqueues pending."""
-        if state.worktrees is None or state.push_queue is None or state.pending is None:
-            return {"status": "write_pipeline_disabled"}
-        assert state.worktrees is not None
-        assert state.push_queue is not None
-        assert state.pending is not None
-        assert state.rate_limiter is not None
-        assert state.blocklist is not None
-        from data_olympus.tools_onboarding import kb_bootstrap_project_fn
-        resp = kb_bootstrap_project_fn(
-            idx=state.idx, workspace=workspace, component=component,
-            workspace_remote_url=workspace_remote_url,
-            component_remote_url=component_remote_url,
-            files=files,
-            source_session=source_session, agent_identity=agent_identity,
-            confidence=confidence,
-            confidence_threshold=state.config.confidence_threshold,
-            worktrees=state.worktrees, push_queue=state.push_queue,
-            pending=state.pending, rate_limiter=state.rate_limiter,
-            blocklist=state.blocklist, audit_log=state.audit_log,
-            remote_addr="mcp",
-            can_auto_commit=_current_principal.get().can_auto_commit,
-            max_postimage_bytes=state.config.max_postimage_bytes,
-            max_files=state.config.max_bootstrap_files,
         )
         return resp.model_dump()
 
@@ -532,74 +402,217 @@ def build_app(
             return {"status": "rejected_invalid_input", "error": str(e)}
         return resp.model_dump()
 
-    @app.tool()
-    def kb_consult(
-        workspace: str, intent: str, source_session: str,
-        agent_identity: str,
-    ) -> dict[str, object]:
-        """Record a consultation for (source_session, workspace) and return the
-        governing rules for the intent. Call before code/architectural work."""
-        import time as _time
+    if not read_only:
+        # Write + enforcement-write surface. A read-only replica
+        # (issue #44) exposes none of these tools.
+        @app.tool()
+        def kb_propose_memory(
+            text: str, tags: list[str], source_session: str,
+            agent_identity: str, confidence: float,
+        ) -> dict[str, object]:
+            """Propose a new memory file. High confidence auto-commits and
+            enqueues for push; low confidence enters the pending queue for operator
+            review."""
+            if state.worktrees is None or state.push_queue is None or state.pending is None:
+                return {"status": "write_pipeline_disabled"}
+            assert state.worktrees is not None
+            assert state.push_queue is not None
+            assert state.pending is not None
+            assert state.rate_limiter is not None
+            assert state.blocklist is not None
+            from data_olympus.tools_write import kb_propose_memory_fn
+            resp = kb_propose_memory_fn(
+                text=text, tags=tags, source_session=source_session,
+                agent_identity=agent_identity, confidence=confidence,
+                confidence_threshold=state.config.confidence_threshold,
+                worktrees=state.worktrees, push_queue=state.push_queue,
+                pending=state.pending, rate_limiter=state.rate_limiter,
+                blocklist=state.blocklist, remote_addr="mcp",
+                audit_log=state.audit_log,
+                can_auto_commit=_current_principal.get().can_auto_commit,
+                max_text_bytes=state.config.max_text_bytes,
+            )
+            return resp.model_dump()
 
-        from data_olympus.tools_enforce import kb_consult_fn
-        resp = kb_consult_fn(
-            idx=state.idx, classifier=state.classifier, ledger=state.ledger,
-            workspace=workspace, intent=intent, source_session=source_session,
-            agent_identity=agent_identity,
-            ttl_sec=state.config.consult_ttl_sec, now=_time.time(),
-            audit_log=state.audit_log,
-        )
-        return resp.model_dump()
+        @app.tool()
+        def kb_propose_edit(
+            target_path: str, postimage: str, base_commit: str,
+            base_blob_sha: str | None, target_file_hash: str | None,
+            reason: str, source_session: str, agent_identity: str, confidence: float,
+        ) -> dict[str, object]:
+            """Propose an edit to an existing (or new) markdown file under an
+            indexed tier. High confidence auto-commits + queues for push; low
+            confidence enters the pending queue for operator review."""
+            if state.worktrees is None or state.push_queue is None or state.pending is None:
+                return {"status": "write_pipeline_disabled"}
+            assert state.worktrees is not None
+            assert state.push_queue is not None
+            assert state.pending is not None
+            assert state.rate_limiter is not None
+            assert state.blocklist is not None
+            from data_olympus.tools_write import kb_propose_edit_fn
+            resp = kb_propose_edit_fn(
+                target_path=target_path, postimage=postimage, base_commit=base_commit,
+                base_blob_sha=base_blob_sha, target_file_hash=target_file_hash,
+                reason=reason, source_session=source_session, agent_identity=agent_identity,
+                confidence=confidence,
+                confidence_threshold=state.config.confidence_threshold,
+                worktrees=state.worktrees, push_queue=state.push_queue,
+                pending=state.pending, rate_limiter=state.rate_limiter,
+                blocklist=state.blocklist, remote_addr="mcp",
+                audit_log=state.audit_log,
+                can_auto_commit=_current_principal.get().can_auto_commit,
+                max_postimage_bytes=state.config.max_postimage_bytes,
+            )
+            return resp.model_dump()
 
-    @app.tool()
-    def kb_gate_check(
-        workspace: str, session_id: str, tool_name: str,
-        action_path: str | None = None, action_diff: str = "",
-    ) -> dict[str, object]:
-        """Return a verdict (allow | consult_required) for a pending code action.
-        Governed actions require a fresh consultation on record."""
-        import time as _time
+        @app.tool()
+        def kb_resolve_pending(
+            pending_id: str, decision: str, edited_text: str | None = None,
+            source_session: str = "operator-resolve", agent_identity: str = "operator",
+        ) -> dict[str, object]:
+            """Resolve a pending proposal: approve (optionally with edited text) or
+            reject. Approval commits + enqueues for push."""
+            if state.worktrees is None or state.push_queue is None or state.pending is None:
+                return {"status": "write_pipeline_disabled"}
+            assert state.worktrees is not None
+            assert state.push_queue is not None
+            assert state.pending is not None
+            from data_olympus.tools_write import kb_resolve_pending_fn
+            resp = kb_resolve_pending_fn(
+                pending_id=pending_id, decision=decision, edited_text=edited_text,
+                worktrees=state.worktrees, push_queue=state.push_queue,
+                pending=state.pending,
+                source_session=source_session, agent_identity=agent_identity,
+                audit_log=state.audit_log,
+            )
+            return resp.model_dump()
 
-        from data_olympus.tools_enforce import kb_gate_check_fn
-        resp = kb_gate_check_fn(
-            classifier=state.classifier, ledger=state.ledger,
-            workspace=workspace, session_id=session_id, tool_name=tool_name,
-            action_path=action_path, action_diff=action_diff,
-            now=_time.time(), ttl_sec=state.config.consult_ttl_sec,
-            audit_log=state.audit_log,
-        )
-        return resp.model_dump()
+        @app.tool()
+        def kb_list_pending() -> dict[str, object]:
+            """List currently pending proposals awaiting operator decision."""
+            assert state.pending is not None
+            from data_olympus.tools_write import kb_list_pending_fn
+            resp = kb_list_pending_fn(pending=state.pending)
+            return resp.model_dump()
 
-    @app.tool()
-    def kb_compliance(
-        since: float | None = None, agent: str | None = None,
-    ) -> dict[str, object]:
-        """Aggregate enforcement events (consult / gate_*) overall and per agent."""
-        if state.audit_log is None:
-            return {"counts": {}, "by_agent": {}}
-        from data_olympus.tools_enforce import kb_compliance_fn
-        resp = kb_compliance_fn(audit_log=state.audit_log, since=since, agent=agent)
-        return resp.model_dump()
+        @app.tool()
+        def kb_audit(
+            since: float | None = None, agent: str | None = None,
+            status: str | None = None, limit: int = 100,
+        ) -> dict[str, object]:
+            """Return recent audit events, most-recent first. Optional filters:
+            since (unix ts), agent (agent_identity), status (event status)."""
+            assert state.audit_log is not None
+            from data_olympus.tools_audit import kb_audit_fn
+            resp = kb_audit_fn(audit_log=state.audit_log, since=since,
+                              agent=agent, status=status, limit=limit)
+            return resp.model_dump()
 
-    @app.tool()
-    def kb_record_event(
-        event_type: str, workspace: str, agent_identity: str,
-        source_session: str, reason: str = "",
-    ) -> dict[str, object]:
-        """Record a gate_bypass or gate_degraded enforcement event in the audit."""
-        if state.audit_log is None:
-            return {"recorded": False, "event_type": event_type}
-        import time as _time
+        @app.tool()
+        def kb_bootstrap_project(
+            workspace: str, files: list[dict[str, str]],
+            source_session: str, agent_identity: str, confidence: float,
+            component: str | None = None,
+            workspace_remote_url: str | None = None,
+            component_remote_url: str | None = None,
+        ) -> dict[str, object]:
+            """Bootstrap a new workspace/component. Only valid when status=absent.
+            High confidence commits atomically; low confidence enqueues pending."""
+            if state.worktrees is None or state.push_queue is None or state.pending is None:
+                return {"status": "write_pipeline_disabled"}
+            assert state.worktrees is not None
+            assert state.push_queue is not None
+            assert state.pending is not None
+            assert state.rate_limiter is not None
+            assert state.blocklist is not None
+            from data_olympus.tools_onboarding import kb_bootstrap_project_fn
+            resp = kb_bootstrap_project_fn(
+                idx=state.idx, workspace=workspace, component=component,
+                workspace_remote_url=workspace_remote_url,
+                component_remote_url=component_remote_url,
+                files=files,
+                source_session=source_session, agent_identity=agent_identity,
+                confidence=confidence,
+                confidence_threshold=state.config.confidence_threshold,
+                worktrees=state.worktrees, push_queue=state.push_queue,
+                pending=state.pending, rate_limiter=state.rate_limiter,
+                blocklist=state.blocklist, audit_log=state.audit_log,
+                remote_addr="mcp",
+                can_auto_commit=_current_principal.get().can_auto_commit,
+                max_postimage_bytes=state.config.max_postimage_bytes,
+                max_files=state.config.max_bootstrap_files,
+            )
+            return resp.model_dump()
 
-        from data_olympus.tools_enforce import kb_record_event_fn
-        try:
-            resp = kb_record_event_fn(
-                audit_log=state.audit_log, event_type=event_type,
-                workspace=workspace, agent_identity=agent_identity,
-                source_session=source_session, reason=reason, now=_time.time())
-        except ValueError as e:
-            return {"recorded": False, "error": str(e)}
-        return resp.model_dump()
+        @app.tool()
+        def kb_consult(
+            workspace: str, intent: str, source_session: str,
+            agent_identity: str,
+        ) -> dict[str, object]:
+            """Record a consultation for (source_session, workspace) and return the
+            governing rules for the intent. Call before code/architectural work."""
+            import time as _time
+
+            from data_olympus.tools_enforce import kb_consult_fn
+            resp = kb_consult_fn(
+                idx=state.idx, classifier=state.classifier, ledger=state.ledger,
+                workspace=workspace, intent=intent, source_session=source_session,
+                agent_identity=agent_identity,
+                ttl_sec=state.config.consult_ttl_sec, now=_time.time(),
+                audit_log=state.audit_log,
+            )
+            return resp.model_dump()
+
+        @app.tool()
+        def kb_gate_check(
+            workspace: str, session_id: str, tool_name: str,
+            action_path: str | None = None, action_diff: str = "",
+        ) -> dict[str, object]:
+            """Return a verdict (allow | consult_required) for a pending code action.
+            Governed actions require a fresh consultation on record."""
+            import time as _time
+
+            from data_olympus.tools_enforce import kb_gate_check_fn
+            resp = kb_gate_check_fn(
+                classifier=state.classifier, ledger=state.ledger,
+                workspace=workspace, session_id=session_id, tool_name=tool_name,
+                action_path=action_path, action_diff=action_diff,
+                now=_time.time(), ttl_sec=state.config.consult_ttl_sec,
+                audit_log=state.audit_log,
+            )
+            return resp.model_dump()
+
+        @app.tool()
+        def kb_compliance(
+            since: float | None = None, agent: str | None = None,
+        ) -> dict[str, object]:
+            """Aggregate enforcement events (consult / gate_*) overall and per agent."""
+            if state.audit_log is None:
+                return {"counts": {}, "by_agent": {}}
+            from data_olympus.tools_enforce import kb_compliance_fn
+            resp = kb_compliance_fn(audit_log=state.audit_log, since=since, agent=agent)
+            return resp.model_dump()
+
+        @app.tool()
+        def kb_record_event(
+            event_type: str, workspace: str, agent_identity: str,
+            source_session: str, reason: str = "",
+        ) -> dict[str, object]:
+            """Record a gate_bypass or gate_degraded enforcement event in the audit."""
+            if state.audit_log is None:
+                return {"recorded": False, "event_type": event_type}
+            import time as _time
+
+            from data_olympus.tools_enforce import kb_record_event_fn
+            try:
+                resp = kb_record_event_fn(
+                    audit_log=state.audit_log, event_type=event_type,
+                    workspace=workspace, agent_identity=agent_identity,
+                    source_session=source_session, reason=reason, now=_time.time())
+            except ValueError as e:
+                return {"recorded": False, "error": str(e)}
+            return resp.model_dump()
 
     registry = PrincipalRegistry(auth_token=auth_token, principals=auth_principals)
     # MCP-transport auth: enforce write-tool capabilities (REST is enforced in
@@ -607,7 +620,7 @@ def build_app(
     app.add_middleware(MCPAuthMiddleware(registry))
 
     from data_olympus.rest_api import register_routes
-    register_routes(app, state, registry)
+    register_routes(app, state, registry, read_only=read_only)
 
     from data_olympus.prompts import register_prompts
     register_prompts(app)
@@ -655,6 +668,7 @@ def build_app_from_config(config: Config, *, bootstrap_now: bool = True) -> Fast
         session_idle_timeout_sec=config.session_idle_timeout_sec,
         session_reap_interval_sec=config.session_reap_interval_sec,
         status_weights=config.status_weights,
+        read_only=config.read_only,
     )
 
 
@@ -683,7 +697,11 @@ def main() -> None:
     app = build_app_from_config(config, bootstrap_now=True)
     # The state lives inside build_app's closure; expose via app attribute for the lifespan task
     state = app._dolympus_state  # type: ignore[attr-defined]  # set in build_app
-    log.info("starting streamable HTTP MCP on port %s", config.http_port)
+    log.info(
+        "starting streamable HTTP MCP on port %s (mode=%s)",
+        config.http_port,
+        "read-only replica" if config.read_only else "read-write",
+    )
 
     # Build the streamable-http ASGI app explicitly (rather than app.run_async)
     # so we own the app object: we install the session-activity middleware, wire

--- a/tests/test_read_only_mode.py
+++ b/tests/test_read_only_mode.py
@@ -1,0 +1,206 @@
+"""Read-only replica serving mode (issue #44).
+
+A replica set to KB_READ_ONLY refreshes its index from the git remote via the
+git_pull_loop but exposes ONLY the read surface: it registers the read tools
+(kb_search / kb_get / kb_list / kb_outline / kb_health) and read REST routes,
+and does NOT register write/enforcement-write tools or write REST routes, nor
+initialise the write pipeline (worktrees / push queue / pending).
+
+Default (KB_READ_ONLY unset) behaviour is unchanged and is covered elsewhere;
+here we only assert the read-only deltas plus one default-mode control.
+"""
+from __future__ import annotations
+
+import subprocess
+from typing import TYPE_CHECKING
+
+import httpx
+import pytest
+from fastmcp import Client
+
+import data_olympus.server as server
+from data_olympus.config import load_config
+from data_olympus.server import build_app
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+READ_TOOLS = {"kb_search", "kb_get", "kb_list", "kb_outline", "kb_health"}
+WRITE_OR_ENFORCE_TOOLS = {
+    "kb_propose_memory",
+    "kb_propose_edit",
+    "kb_resolve_pending",
+    "kb_list_pending",
+    "kb_audit",
+    "kb_bootstrap_project",
+    "kb_consult",
+    "kb_gate_check",
+    "kb_compliance",
+    "kb_record_event",
+}
+
+
+def _git_init(kb: Path) -> None:
+    env = {
+        "GIT_AUTHOR_NAME": "t",
+        "GIT_AUTHOR_EMAIL": "t@e.com",
+        "GIT_COMMITTER_NAME": "t",
+        "GIT_COMMITTER_EMAIL": "t@e.com",
+    }
+    subprocess.run(
+        ["git", "init", "--initial-branch=main"], cwd=str(kb), check=True,
+        capture_output=True, env=env,
+    )
+    subprocess.run(
+        ["git", "-C", str(kb), "add", "-A"], check=True, capture_output=True, env=env
+    )
+    subprocess.run(
+        ["git", "-C", str(kb), "commit", "-m", "init"], check=True,
+        capture_output=True, env=env,
+    )
+
+
+def _read_only_app(tmp_kb: Path, tmp_path: Path):
+    _git_init(tmp_kb)
+    # A replica sets KB_REMOTE_URL (so git_pull_loop has a remote to refresh
+    # from) yet must NOT bring up the write pipeline: read_only=True gates it.
+    return build_app(
+        kb_main_path=tmp_kb,
+        kb_index_path=tmp_path / "idx.db",
+        sync_interval_sec=60,
+        staleness_degraded_sec=600,
+        bootstrap_now=True,
+        kb_remote_url="dummy",
+        worktree_root=str(tmp_path / "wts"),
+        pending_root=str(tmp_path / "pending"),
+        push_queue_root=str(tmp_path / "pq"),
+        read_only=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_read_only_registers_only_read_tools(tmp_kb: Path, tmp_path: Path) -> None:
+    app = _read_only_app(tmp_kb, tmp_path)
+    tools = {t.name for t in await app.list_tools()}
+    assert tools >= READ_TOOLS
+    assert not (WRITE_OR_ENFORCE_TOOLS & tools), (
+        f"write/enforce tools leaked into read-only mode: "
+        f"{WRITE_OR_ENFORCE_TOOLS & tools}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_read_only_read_tool_round_trips(tmp_kb: Path, tmp_path: Path) -> None:
+    app = _read_only_app(tmp_kb, tmp_path)
+    async with Client(app) as client:
+        result = await client.call_tool("kb_search", {"query": "worktree", "limit": 5})
+        assert "STD-U-001" in str(result)
+
+
+@pytest.mark.asyncio
+async def test_read_only_write_pipeline_not_initialised(
+    tmp_kb: Path, tmp_path: Path
+) -> None:
+    app = _read_only_app(tmp_kb, tmp_path)
+    state = app._dolympus_state  # type: ignore[attr-defined]
+    assert state.config.read_only is True
+    assert state.worktrees is None
+    assert state.push_queue is None
+    assert state.pending is None
+    assert state.rate_limiter is None
+    assert state.blocklist is None
+
+
+@pytest.mark.asyncio
+async def test_read_only_read_routes_work(tmp_kb: Path, tmp_path: Path) -> None:
+    app = _read_only_app(tmp_kb, tmp_path)
+    transport = httpx.ASGITransport(app=app.http_app())
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        health = await client.get("/api/v1/health")
+        assert health.status_code == 200
+        search = await client.get("/api/v1/search", params={"q": "worktree"})
+        assert search.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_read_only_write_routes_absent(tmp_kb: Path, tmp_path: Path) -> None:
+    app = _read_only_app(tmp_kb, tmp_path)
+    transport = httpx.ASGITransport(app=app.http_app())
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        # Write and enforcement-write routes must not be registered -> 404.
+        for method, path, body in [
+            ("POST", "/api/v1/propose/memory", {"text": "x"}),
+            ("POST", "/api/v1/propose/edit", {"target_path": "x"}),
+            ("POST", "/api/v1/resolve/abc", {"decision": "approve"}),
+            ("POST", "/api/v1/onboarding/bootstrap", {"workspace": "w"}),
+            ("POST", "/api/v1/audit/event", {"event_type": "x", "workspace": "w"}),
+            ("POST", "/api/v1/consult", {"workspace": "w", "source_session": "s"}),
+            ("POST", "/api/v1/gate/check", {"workspace": "w", "session_id": "s"}),
+        ]:
+            resp = await client.request(method, path, json=body)
+            assert resp.status_code == 404, (
+                f"{method} {path} should be absent in read-only mode, got "
+                f"{resp.status_code}"
+            )
+
+
+@pytest.mark.asyncio
+async def test_default_mode_still_registers_write_tools(
+    tmp_kb: Path, tmp_path: Path
+) -> None:
+    """Control: with read_only unset (default) and a remote configured, the
+    write tools and pipeline are present exactly as before."""
+    _git_init(tmp_kb)
+    app = build_app(
+        kb_main_path=tmp_kb,
+        kb_index_path=tmp_path / "idx.db",
+        sync_interval_sec=60,
+        staleness_degraded_sec=600,
+        bootstrap_now=True,
+        kb_remote_url="dummy",
+        worktree_root=str(tmp_path / "wts"),
+        pending_root=str(tmp_path / "pending"),
+        push_queue_root=str(tmp_path / "pq"),
+    )
+    tools = {t.name for t in await app.list_tools()}
+    assert "kb_propose_memory" in tools
+    assert "kb_consult" in tools
+    state = app._dolympus_state  # type: ignore[attr-defined]
+    assert state.config.read_only is False
+    assert state.worktrees is not None
+
+
+def test_kb_read_only_env_parsing(
+    tmp_kb: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """KB_READ_ONLY is parsed as a truthy flag and reaches Config."""
+    monkeypatch.setenv("KB_MAIN_PATH", str(tmp_kb))
+    monkeypatch.setenv("KB_INDEX_PATH", str(tmp_path / "kb.db"))
+    monkeypatch.setenv("KB_READ_ONLY", "true")
+    assert load_config().read_only is True
+
+    monkeypatch.setenv("KB_READ_ONLY", "0")
+    assert load_config().read_only is False
+
+    monkeypatch.delenv("KB_READ_ONLY")
+    assert load_config().read_only is False
+
+
+def test_read_only_config_threads_through_build_app_from_config(
+    tmp_kb: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """load_config -> build_app_from_config carries read_only into app state."""
+    _git_init(tmp_kb)
+    monkeypatch.setenv("KB_MAIN_PATH", str(tmp_kb))
+    monkeypatch.setenv("KB_INDEX_PATH", str(tmp_path / "kb.db"))
+    monkeypatch.setenv("KB_READ_ONLY", "1")
+    monkeypatch.setenv("KB_REMOTE_URL", "dummy")
+    monkeypatch.setenv("KB_WORKTREE_ROOT", str(tmp_path / "wts"))
+    monkeypatch.setenv("KB_PENDING_ROOT", str(tmp_path / "pending"))
+    monkeypatch.setenv("KB_PUSH_QUEUE_ROOT", str(tmp_path / "pq"))
+
+    cfg = load_config()
+    app = server.build_app_from_config(cfg, bootstrap_now=False)
+    state = app._dolympus_state  # type: ignore[attr-defined]
+    assert state.config.read_only is True
+    assert state.worktrees is None

--- a/tests/test_read_only_mode.py
+++ b/tests/test_read_only_mode.py
@@ -145,6 +145,30 @@ async def test_read_only_write_routes_absent(tmp_kb: Path, tmp_path: Path) -> No
 
 
 @pytest.mark.asyncio
+async def test_read_only_observability_get_routes_absent(
+    tmp_kb: Path, tmp_path: Path
+) -> None:
+    """The observability GET routes sit behind the same read-only gate as the
+    write routes (register_routes' `if not read_only:` block), so a replica must
+    404 them too -- otherwise a replica would expose the writer's pending /
+    audit / compliance surface without the write pipeline that backs it."""
+    app = _read_only_app(tmp_kb, tmp_path)
+    transport = httpx.ASGITransport(app=app.http_app())
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        for path in [
+            "/api/v1/pending",
+            "/api/v1/audit",
+            "/api/v1/audit/verify",
+            "/api/v1/compliance",
+        ]:
+            resp = await client.get(path)
+            assert resp.status_code == 404, (
+                f"GET {path} should be absent in read-only mode, got "
+                f"{resp.status_code}"
+            )
+
+
+@pytest.mark.asyncio
 async def test_default_mode_still_registers_write_tools(
     tmp_kb: Path, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
Read-only replica serving mode. Based on `main` (this branch was built on
current main, which is why it targets main rather than the foundation branch).

`KB_READ_ONLY` drops the write/enforcement-write tools and REST routes, skips
the write pipeline and push/pending loops, and keeps `git_pull_loop` + the read
tools so a replica refreshes its own snapshot from the git remote. Default
(unset) behaviour is unchanged. Adds `deploy/k8s/read-replica/` (a Deployment,
3 replicas, own Service + NetworkPolicy).

## Integration note
This overlaps the foundation PR's rest_api.py/server.py changes; the two need
reconciling once the foundation lands. Design point for review: it treats the
enforcement plane (consult/gate) as write-side and disables it on replicas, so
replicas shed search load but not enforcement load.

Closes #44
