### PR TITLE
Search: corpus co-occurrence query expansion (embedding-free semantics)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,19 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Corpus co-occurrence query expansion (embedding-free semantics, issue #40).
+  At index-build time the indexer learns, per term, the top-k terms it most
+  strongly co-occurs with across documents (pointwise mutual information at
+  document granularity) into a bounded `related_terms` table (schema v6) built
+  into the same tmp DB and swapped atomically with the FTS index. At query time
+  a `query_expander` appends a term's related terms, down-weighted by appending
+  them after the originals so BM25 still favours typed terms, bounded to <= 32
+  terms. It composes WITH the synonym expander (issue #38) rather than replacing
+  it: synonyms run first, then co-occurrence broadens the synonym-expanded set
+  (`compose_expanders`). Config knobs: `KB_COOCCURRENCE_MODE` (on/off, default
+  on), `KB_COOCCURRENCE_K` (default 5), `KB_COOCCURRENCE_MIN_COUNT` (default 2),
+  `KB_COOCCURRENCE_MIN_PMI` (default 0.0). Stopword-like and short tokens are
+  skipped so the table stays focused and build cost negligible.
 - Search now short-circuits exact-id and exact-tag queries: a single-token query
   that is a document id (e.g. `STD-U-002`, or a path-derived id) is surfaced as
   the top hit via a direct lookup even when it is absent from the bm25 results,

--- a/src/data_olympus/config.py
+++ b/src/data_olympus/config.py
@@ -49,6 +49,16 @@ class Config:
     # weight boosts an in-force status, a positive one penalizes a retired one.
     status_weights: dict[str, float] | None = None
     read_only: bool = False
+    # Corpus co-occurrence query expansion (issue #40). Default ON. The build-time
+    # table is bounded by ``cooccurrence_k`` related terms per term above the
+    # ``cooccurrence_min_count`` / ``cooccurrence_min_pmi`` thresholds. These are
+    # surfaced here for discoverability; the build path in Index.build reads the
+    # same env vars directly (mirroring the synonym expander), so the CLI indexer
+    # honours them without threading Config through.
+    cooccurrence_enabled: bool = True
+    cooccurrence_k: int = 5
+    cooccurrence_min_count: int = 2
+    cooccurrence_min_pmi: float = 0.0
 
 
 def _split_csv(raw: str) -> list[str]:
@@ -115,6 +125,14 @@ def load_config() -> Config:
     session_reap_interval_sec = int(os.getenv("KB_SESSION_REAP_INTERVAL_SEC", "60"))
     status_weights = _load_status_weights(os.getenv("KB_STATUS_WEIGHTS", ""))
     read_only = _env_bool(os.getenv("KB_READ_ONLY", ""))
+    from data_olympus.cooccurrence import (
+        cooccurrence_build_params,
+    )
+    from data_olympus.cooccurrence import (
+        cooccurrence_enabled as _cooc_enabled,
+    )
+    cooc_enabled = _cooc_enabled()
+    cooc_params = cooccurrence_build_params()
     return Config(
         kb_main_path=Path(os.environ.get("KB_MAIN_PATH", "/kb-main")),
         kb_index_path=Path(os.environ.get("KB_INDEX_PATH", "/index/kb.db")),
@@ -148,4 +166,8 @@ def load_config() -> Config:
         session_reap_interval_sec=session_reap_interval_sec,
         status_weights=status_weights,
         read_only=read_only,
+        cooccurrence_enabled=cooc_enabled,
+        cooccurrence_k=int(cooc_params["k"]),
+        cooccurrence_min_count=int(cooc_params["min_count"]),
+        cooccurrence_min_pmi=float(cooc_params["min_pmi"]),
     )

--- a/src/data_olympus/cooccurrence.py
+++ b/src/data_olympus/cooccurrence.py
@@ -1,0 +1,342 @@
+"""Corpus co-occurrence query expansion (issue #40).
+
+Embedding-free semantic broadening. At index-build time we learn, for each
+reasonable term in the corpus, the handful of other terms it most strongly
+co-occurs with (measured by pointwise mutual information, PMI, at document
+granularity) and store a small bounded ``related_terms`` table alongside the
+FTS index. At query time an expander looks each query term up in that table and
+appends its top related terms, DOWN-WEIGHTED by appending them after the
+originals so BM25 still favours the terms the user actually typed.
+
+Why PMI over raw co-occurrence counts: raw counts are dominated by globally
+frequent tokens (every doc mentions "the", "a", "you"), so a raw-count table
+would relate every term to the same stopword-ish set. PMI normalises by the
+marginal frequencies, surfacing terms that co-occur *more than chance* -- the
+signal we want. Stopword-like and very short tokens are dropped up front so
+they neither pollute the table nor consume a related-term slot.
+
+Design constraints (see issue #40):
+- The table is built as part of ``Index.build`` into the same tmp DB and swapped
+  atomically, so a query never sees a half-built table.
+- Hard-bounded: top-k related terms per term (``k`` small, default 5) above a
+  minimum co-occurrence count and PMI threshold; only "reasonable" tokens (min
+  length, not a stopword, alphabetic-ish) are considered as heads or tails.
+- Build cost stays negligible at the current corpus scale: a single pass to
+  build per-doc token sets, then pair counting restricted to the kept
+  vocabulary.
+- Composes WITH the synonym expander (issue #38) rather than replacing it; see
+  ``compose_expanders``.
+- Configuration follows ``config.py``: ``KB_COOCCURRENCE_MODE`` (on/off),
+  ``KB_COOCCURRENCE_K``, ``KB_COOCCURRENCE_MIN_PMI``, ``KB_COOCCURRENCE_MIN_COUNT``.
+"""
+from __future__ import annotations
+
+import math
+import os
+import re
+from collections import Counter
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import sqlite3
+    from collections.abc import Callable, Iterable
+
+# Token = a run of letters (with internal digits allowed after the first letter,
+# so "k8s"/"utf8" survive) of at least MIN_TOKEN_LEN characters. Pure numbers and
+# punctuation-only runs are excluded. Matching is case-insensitive; tokens are
+# lower-cased.
+_TOKEN_RE = re.compile(r"[a-z][a-z0-9]{2,}")
+
+# Minimum token length to be a co-occurrence head or tail. Short tokens ("is",
+# "to", "db") carry little topical signal and already match literally without
+# expansion, so they are skipped to keep the table focused.
+MIN_TOKEN_LEN = 3
+
+# A compact, deployment-neutral English stopword set plus a few markdown/tech
+# filler words. Kept intentionally small: PMI already suppresses ubiquitous
+# tokens, this list just avoids wasting related-term slots on obvious noise.
+_STOPWORDS: frozenset[str] = frozenset({
+    "the", "and", "for", "are", "but", "not", "you", "all", "any", "can", "had",
+    "her", "was", "one", "our", "out", "day", "get", "has", "him", "his", "how",
+    "man", "new", "now", "old", "see", "two", "way", "who", "did", "its", "let",
+    "put", "say", "she", "too", "use", "this", "that", "with", "from", "they",
+    "will", "would", "there", "their", "what", "which", "when", "where", "while",
+    "about", "into", "your", "only", "other", "than", "then", "them", "these",
+    "those", "been", "being", "have", "also", "such", "very", "much", "more",
+    "most", "some", "many", "each", "both", "few", "own", "same", "over", "under",
+    "above", "below", "after", "before", "between", "because", "during",
+    "through", "against", "doc", "docs", "note", "notes", "via", "etc", "within",
+    "without", "upon", "per",
+})
+
+
+def is_reasonable_token(token: str) -> bool:
+    """True if ``token`` is a plausible co-occurrence head/tail.
+
+    Reasonable = at least ``MIN_TOKEN_LEN`` chars, matches the token shape (a
+    letter then letters/digits), and is not a stopword. The token is assumed to
+    already be lower-cased.
+    """
+    if len(token) < MIN_TOKEN_LEN:
+        return False
+    if token in _STOPWORDS:
+        return False
+    return bool(_TOKEN_RE.fullmatch(token))
+
+
+def tokenize_doc(*parts: str) -> set[str]:
+    """Return the SET of reasonable tokens in the given text parts.
+
+    A set (not a bag) because co-occurrence is measured at document granularity:
+    whether a term appears in a document, not how many times. Deduping per-doc
+    keeps a term that is repeated many times in one doc from dominating counts.
+    """
+    tokens: set[str] = set()
+    for part in parts:
+        for m in _TOKEN_RE.finditer(part.lower()):
+            tok = m.group(0)
+            if tok not in _STOPWORDS:
+                tokens.add(tok)
+    return tokens
+
+
+# Defaults for the bounded table. Kept small so both build cost and query-time
+# MATCH growth stay negligible.
+DEFAULT_K = 5
+DEFAULT_MIN_COUNT = 2
+DEFAULT_MIN_PMI = 0.0
+
+
+def build_cooccurrence_table(
+    doc_token_sets: Iterable[set[str]],
+    *,
+    k: int = DEFAULT_K,
+    min_count: int = DEFAULT_MIN_COUNT,
+    min_pmi: float = DEFAULT_MIN_PMI,
+) -> dict[str, list[str]]:
+    """Compute a bounded ``{term: [related...]}`` table from per-doc token sets.
+
+    For each unordered pair (a, b) co-occurring in at least ``min_count``
+    documents, the pointwise mutual information is::
+
+        pmi(a, b) = log( P(a, b) / (P(a) * P(b)) )
+                  = log( (c_ab * N) / (c_a * c_b) )
+
+    where ``N`` is the document count, ``c_a``/``c_b`` the per-term document
+    counts and ``c_ab`` the co-occurrence count. Pairs with ``pmi < min_pmi``
+    are dropped. For each term the top-``k`` partners by PMI (ties broken by
+    co-occurrence count, then alphabetically for determinism) are kept.
+
+    The result is directional in storage (both ``a -> b`` and ``b -> a`` are
+    emitted, each capped independently at k) so a lookup of either term finds the
+    other. Returns an order-stable dict; each value is at most ``k`` long.
+    """
+    materialised = [s for s in doc_token_sets if s]
+    n_docs = len(materialised)
+    if n_docs < 2 or k <= 0:
+        return {}
+
+    term_counts: Counter[str] = Counter()
+    pair_counts: Counter[tuple[str, str]] = Counter()
+    for tokens in materialised:
+        ordered = sorted(tokens)
+        for tok in ordered:
+            term_counts[tok] += 1
+        for i, a in enumerate(ordered):
+            for b in ordered[i + 1 :]:
+                pair_counts[(a, b)] += 1
+
+    # candidates[term] = list of (pmi, count, other)
+    candidates: dict[str, list[tuple[float, int, str]]] = {}
+    for (a, b), c_ab in pair_counts.items():
+        if c_ab < min_count:
+            continue
+        c_a = term_counts[a]
+        c_b = term_counts[b]
+        pmi = math.log((c_ab * n_docs) / (c_a * c_b))
+        if pmi < min_pmi:
+            continue
+        candidates.setdefault(a, []).append((pmi, c_ab, b))
+        candidates.setdefault(b, []).append((pmi, c_ab, a))
+
+    table: dict[str, list[str]] = {}
+    for term, partners in candidates.items():
+        # Sort by PMI desc, then count desc, then partner asc (deterministic).
+        partners.sort(key=lambda t: (-t[0], -t[1], t[2]))
+        table[term] = [other for _pmi, _c, other in partners[:k]]
+    return table
+
+
+# --- SQLite persistence (built inside Index.build, read at query time) --------
+
+RELATED_TERMS_SCHEMA = """
+CREATE TABLE IF NOT EXISTS related_terms (
+    term TEXT NOT NULL,
+    related TEXT NOT NULL,
+    rank INTEGER NOT NULL,
+    PRIMARY KEY (term, related)
+);
+CREATE INDEX IF NOT EXISTS idx_related_terms_term ON related_terms (term);
+"""
+
+
+def write_cooccurrence_table(
+    conn: sqlite3.Connection, table: dict[str, list[str]],
+) -> None:
+    """Populate the ``related_terms`` table on an open (tmp-build) connection.
+
+    Called from ``Index.build`` against the tmp DB before the atomic swap, so
+    the table is part of the same build and never seen half-populated. ``rank``
+    (0-based) preserves the PMI ordering so the query-time lookup can keep the
+    strongest partners first.
+    """
+    rows = [
+        (term, related, rank)
+        for term, partners in table.items()
+        for rank, related in enumerate(partners)
+    ]
+    if rows:
+        conn.executemany(
+            "INSERT OR REPLACE INTO related_terms (term, related, rank) "
+            "VALUES (?, ?, ?)",
+            rows,
+        )
+
+
+def lookup_related_terms(
+    conn: sqlite3.Connection, term: str, *, limit: int,
+) -> list[str]:
+    """Return up to ``limit`` related terms for ``term``, strongest first.
+
+    Reads the ``related_terms`` table; ordered by the stored ``rank`` so the
+    highest-PMI partners come first. An unknown term (or a build with no table)
+    yields the empty list.
+    """
+    if limit <= 0:
+        return []
+    rows = conn.execute(
+        "SELECT related FROM related_terms WHERE term = ? ORDER BY rank LIMIT ?",
+        (term.lower(), limit),
+    ).fetchall()
+    return [r[0] for r in rows]
+
+
+# --- query-time expander ------------------------------------------------------
+
+# Upper bound on the expanded term list, matching the synonym expander's cap so a
+# composed chain stays bounded regardless of how many related terms exist.
+DEFAULT_MAX_TERMS = 32
+
+
+def make_cooccurrence_expander(
+    lookup: Callable[[str, int], list[str]],
+    *,
+    k: int = DEFAULT_K,
+    max_terms: int = DEFAULT_MAX_TERMS,
+) -> Callable[[list[str]], list[str]]:
+    """Build a ``query_expander`` closure backed by a related-terms lookup.
+
+    ``lookup(term, k)`` returns the related terms for ``term`` (typically bound
+    to the live index DB via ``Index``). The returned callable keeps the original
+    terms first (order-stable, de-duplicated) and then appends related terms
+    (also de-duplicated, bounded by ``max_terms``). Originals are never dropped
+    by the cap; related terms are down-weighted purely by appending them after
+    the originals (BM25 OR-matching favours the earlier / user-typed terms).
+    """
+
+    def expander(terms: list[str]) -> list[str]:
+        out: list[str] = []
+        seen: set[str] = set()
+        for t in terms:
+            low = t.lower()
+            if low not in seen:
+                out.append(t)
+                seen.add(low)
+        # Append related terms for each ORIGINAL term (not the appended ones, to
+        # avoid a second-order expansion blow-up).
+        for t in terms:
+            if len(out) >= max_terms:
+                break
+            for related in lookup(t.lower(), k):
+                if len(out) >= max_terms:
+                    break
+                if related not in seen:
+                    out.append(related)
+                    seen.add(related)
+        return out
+
+    return expander
+
+
+# --- composition --------------------------------------------------------------
+
+
+def compose_expanders(
+    *expanders: Callable[[list[str]], list[str]] | None,
+    max_terms: int = DEFAULT_MAX_TERMS,
+) -> Callable[[list[str]], list[str]] | None:
+    """Chain query expanders left-to-right, feeding each output into the next.
+
+    ``None`` expanders are skipped. Returns ``None`` when nothing is left (so the
+    caller can treat "no expansion" uniformly). The composed output is
+    de-duplicated (case-insensitively, order-stable) and bounded by ``max_terms``
+    as a final safety net, so composing two bounded expanders can never exceed
+    the cap. Order matters: pass the synonym expander first, then the
+    co-occurrence expander, so co-occurrence broadens the synonym-expanded set.
+    """
+    active = [e for e in expanders if e is not None]
+    if not active:
+        return None
+
+    def composed(terms: list[str]) -> list[str]:
+        current = terms
+        for expander in active:
+            current = expander(current)
+        # Final de-dup + cap (case-insensitive, order-stable).
+        out: list[str] = []
+        seen: set[str] = set()
+        for t in current:
+            low = t.lower()
+            if low not in seen:
+                out.append(t)
+                seen.add(low)
+            if len(out) >= max_terms:
+                break
+        return out
+
+    return composed
+
+
+# --- env configuration --------------------------------------------------------
+
+
+def _env_int(name: str, default: int) -> int:
+    raw = os.getenv(name, "").strip()
+    if not raw:
+        return default
+    return int(raw)
+
+
+def _env_float(name: str, default: float) -> float:
+    raw = os.getenv(name, "").strip()
+    if not raw:
+        return default
+    return float(raw)
+
+
+def cooccurrence_enabled() -> bool:
+    """Whether co-occurrence expansion is active. Default ON.
+
+    ``KB_COOCCURRENCE_MODE=off`` disables it (both the build-time table and the
+    query-time expander); any other value (including unset) leaves it on.
+    """
+    return os.getenv("KB_COOCCURRENCE_MODE", "on").strip().lower() != "off"
+
+
+def cooccurrence_build_params() -> dict[str, int | float]:
+    """Build-time knobs from env: k, min_count, min_pmi (with sane defaults)."""
+    return {
+        "k": _env_int("KB_COOCCURRENCE_K", DEFAULT_K),
+        "min_count": _env_int("KB_COOCCURRENCE_MIN_COUNT", DEFAULT_MIN_COUNT),
+        "min_pmi": _env_float("KB_COOCCURRENCE_MIN_PMI", DEFAULT_MIN_PMI),
+    }

--- a/src/data_olympus/index.py
+++ b/src/data_olympus/index.py
@@ -10,6 +10,18 @@ import time
 from dataclasses import dataclass, field, replace
 from typing import TYPE_CHECKING, Any
 
+from data_olympus.cooccurrence import (
+    DEFAULT_K,
+    DEFAULT_MAX_TERMS,
+    RELATED_TERMS_SCHEMA,
+    build_cooccurrence_table,
+    cooccurrence_build_params,
+    cooccurrence_enabled,
+    lookup_related_terms,
+    make_cooccurrence_expander,
+    tokenize_doc,
+    write_cooccurrence_table,
+)
 from data_olympus.markdown_parse import parse_file
 
 if TYPE_CHECKING:
@@ -47,12 +59,13 @@ CREATE TABLE IF NOT EXISTS meta (
     key TEXT PRIMARY KEY,
     value TEXT
 );
-"""
+""" + RELATED_TERMS_SCHEMA
 
 # Informational only; recorded in the meta table for observability. Rebuild
 # is guaranteed by bootstrap_now=True calling Index.build() unconditionally
 # on container start, not by a version-mismatch check.
-_SCHEMA_VERSION = "5"
+# v6 adds the related_terms co-occurrence table (issue #40).
+_SCHEMA_VERSION = "6"
 
 
 # fts column order (excluding the UNINDEXED id at position 0).
@@ -420,6 +433,11 @@ class Index:
             conn.executescript(_SCHEMA)
             count = 0
             path_rules = _load_path_rules()
+            # Per-document token sets for the co-occurrence table (issue #40).
+            # Collected during the single indexing pass so the build stays one
+            # walk; only populated when co-occurrence expansion is enabled.
+            build_cooccurrence = cooccurrence_enabled()
+            doc_token_sets: list[set[str]] = []
             for md in files_to_index:
                 rel = md.relative_to(kb_root)
                 doc = parse_file(md)
@@ -445,7 +463,23 @@ class Index:
                     "VALUES (?, ?, ?, ?, ?, ?)",
                     (doc_id, doc.title, tags_str, applies_when_str, doc.description, doc.body),
                 )
+                if build_cooccurrence:
+                    doc_token_sets.append(
+                        tokenize_doc(doc.title, tags_str, doc.description, doc.body)
+                    )
                 count += 1
+            # Co-occurrence / PMI table (issue #40). Built into the SAME tmp DB
+            # and swapped atomically with the rest of the index below, so a query
+            # never sees a half-built related_terms table.
+            if build_cooccurrence:
+                params = cooccurrence_build_params()
+                table = build_cooccurrence_table(
+                    doc_token_sets,
+                    k=int(params["k"]),
+                    min_count=int(params["min_count"]),
+                    min_pmi=float(params["min_pmi"]),
+                )
+                write_cooccurrence_table(conn, table)
             now = time.time()
             conn.execute(
                 "INSERT OR REPLACE INTO meta (key, value) VALUES ('source_commit', ?)",
@@ -609,6 +643,44 @@ class Index:
                 raise ValueError(f"unknown fts column(s): {unknown}")
             return "{" + " ".join(columns) + "} : (" + quoted + ")"
         return quoted
+
+    def related_terms(self, term: str, *, limit: int) -> builtins.list[str]:
+        """Return up to ``limit`` corpus co-occurring terms for ``term``.
+
+        Reads the ``related_terms`` table populated at build time (issue #40),
+        strongest (highest-PMI) first. Opens a per-call connection so it always
+        reads the atomically-swapped current index. An index built before the
+        table existed (no ``related_terms`` table) or an unknown term yields the
+        empty list rather than raising. This is the query-time backing for the
+        co-occurrence expander wired via ``make_cooccurrence_expander``.
+        """
+        if limit <= 0 or not self._db_path.exists():
+            return []
+        conn = self._connect()
+        try:
+            return lookup_related_terms(conn, term, limit=limit)
+        except sqlite3.OperationalError:
+            # Table absent (index predates the schema); degrade to no expansion.
+            return []
+        finally:
+            conn.close()
+
+    def cooccurrence_expander(
+        self, *, k: int = DEFAULT_K, max_terms: int = DEFAULT_MAX_TERMS,
+    ) -> Callable[[list[str]], list[str]]:
+        """Return a ``query_expander`` backed by this index's related-terms table.
+
+        The expander appends, for each query term, up to ``k`` co-occurring terms
+        (down-weighted by appending after the originals), bounded overall by
+        ``max_terms``. Bound to ``self.related_terms`` so it always reads the
+        currently-swapped index. Compose it AFTER the synonym expander via
+        ``cooccurrence.compose_expanders``.
+        """
+        return make_cooccurrence_expander(
+            lambda term, kk: self.related_terms(term, limit=kk),
+            k=k,
+            max_terms=max_terms,
+        )
 
     def get(self, id: str) -> IndexedDoc | None:
         """Retrieve a single document by id. Returns None if not found."""

--- a/src/data_olympus/server.py
+++ b/src/data_olympus/server.py
@@ -23,6 +23,11 @@ if TYPE_CHECKING:
 from data_olympus.audit_log import AuditLog
 from data_olympus.auth import PathBlocklist
 from data_olympus.config import Config, load_config
+from data_olympus.cooccurrence import (
+    DEFAULT_MAX_TERMS,
+    compose_expanders,
+    cooccurrence_enabled,
+)
 from data_olympus.enforce_policy import ConsultationLedger, IntentClassifier
 from data_olympus.git_ops import GitOps
 from data_olympus.index import Index, make_status_reranker
@@ -242,13 +247,24 @@ def build_app(
         config_kwargs["audit_log_path"] = audit_log_path
     config = Config(**config_kwargs)  # type: ignore[arg-type]
     # Composed search wiring. Expand-query seam: synonym/acronym expansion (issue
-    # #38, KB_SYNONYMS / KB_SYNONYMS_MODE). Re-rank seam: the exact-id / exact-tag
-    # short-circuit (issue #39) runs outermost -- a single-token query that is a
-    # document id or an exact tag ranks that document first -- and delegates to the
-    # status-aware reranker (issue #37) as its ``inner``, so among the remaining
-    # hits an active doc still outranks the superseded one it replaced.
-    # status_weights=None uses the built-in map; KB_STATUS_WEIGHTS overrides it.
-    idx = Index(kb_index_path, query_expander=default_query_expander())
+    # #38, KB_SYNONYMS / KB_SYNONYMS_MODE) composed with corpus co-occurrence
+    # expansion (issue #40, KB_COOCCURRENCE_*). Synonyms run FIRST, then
+    # co-occurrence broadens the synonym-expanded set from the corpus-learned
+    # related_terms table; the composed output is de-duplicated and bounded.
+    # Co-occurrence is bound to this Index (it reads the swapped related_terms
+    # table), so we build ``idx`` first and set the composed expander after.
+    # Re-rank seam: the exact-id / exact-tag short-circuit (issue #39) runs
+    # outermost -- a single-token query that is a document id or an exact tag
+    # ranks that document first -- and delegates to the status-aware reranker
+    # (issue #37) as its ``inner``, so among the remaining hits an active doc
+    # still outranks the superseded one it replaced. status_weights=None uses the
+    # built-in map; KB_STATUS_WEIGHTS overrides it.
+    idx = Index(kb_index_path)
+    synonym_expander = default_query_expander()
+    cooc_expander = idx.cooccurrence_expander() if cooccurrence_enabled() else None
+    idx.query_expander = compose_expanders(
+        synonym_expander, cooc_expander, max_terms=DEFAULT_MAX_TERMS
+    )
     idx.reranker = make_id_tag_reranker(
         idx, inner=make_status_reranker(config.status_weights)
     )

--- a/tests/test_cooccurrence.py
+++ b/tests/test_cooccurrence.py
@@ -1,0 +1,349 @@
+"""Tests for corpus co-occurrence query expansion (issue #40).
+
+Embedding-free semantic broadening. At build time the index learns, per term,
+the handful of terms it most strongly co-occurs with (by PMI at document
+granularity) into a bounded ``related_terms`` table swapped atomically with the
+FTS index. At query time an expander appends those related terms (down-weighted)
+via the ``query_expander`` seam, broadening recall.
+
+These tests cover the pure table-builder + expander units, the SQLite
+persistence, an end-to-end index search proving an unambiguous association
+broadens recall while an unrelated query is unaffected, and the atomic rebuild.
+"""
+from __future__ import annotations
+
+import sqlite3
+from typing import TYPE_CHECKING
+
+from data_olympus.cooccurrence import (
+    build_cooccurrence_table,
+    compose_expanders,
+    cooccurrence_build_params,
+    cooccurrence_enabled,
+    is_reasonable_token,
+    lookup_related_terms,
+    make_cooccurrence_expander,
+    tokenize_doc,
+    write_cooccurrence_table,
+)
+from data_olympus.index import Index
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    import pytest
+
+
+# --- tokenization ------------------------------------------------------------
+
+
+def test_tokenize_drops_short_and_stopwords() -> None:
+    tokens = tokenize_doc("The quick kubernetes db is deployed via helm")
+    # "the", "is", "via" are stopwords; "db" is too short.
+    assert "kubernetes" in tokens
+    assert "quick" in tokens
+    assert "deployed" in tokens
+    assert "helm" in tokens
+    assert "the" not in tokens
+    assert "is" not in tokens
+    assert "db" not in tokens
+
+
+def test_tokenize_is_a_set_per_doc() -> None:
+    # A term repeated in one doc counts once (document granularity).
+    tokens = tokenize_doc("kafka kafka kafka streaming")
+    assert tokens == {"kafka", "streaming"}
+
+
+def test_is_reasonable_token() -> None:
+    assert is_reasonable_token("kubernetes")
+    assert is_reasonable_token("k8s")  # letter then digits
+    assert not is_reasonable_token("db")  # too short
+    assert not is_reasonable_token("the")  # stopword
+    assert not is_reasonable_token("123")  # not letter-initial
+
+
+# --- pure table builder ------------------------------------------------------
+
+
+def test_build_table_relates_cooccurring_terms() -> None:
+    # "helm" and "kubernetes" always appear together; "banana" never with them.
+    docs = [
+        {"helm", "kubernetes", "deploy"},
+        {"helm", "kubernetes", "chart"},
+        {"helm", "kubernetes", "release"},
+        {"banana", "fruit", "yellow"},
+        {"banana", "fruit", "smoothie"},
+    ]
+    table = build_cooccurrence_table(docs, k=5, min_count=2, min_pmi=0.0)
+    assert "kubernetes" in table["helm"]
+    assert "helm" in table["kubernetes"]
+    # The unrelated cluster does not leak in.
+    assert "banana" not in table.get("helm", [])
+    assert "helm" not in table.get("banana", [])
+
+
+def test_build_table_respects_top_k_bound() -> None:
+    # One hub term co-occurs with many others; each partner appears together with
+    # the hub often enough to clear min_count. top-k must cap the hub's list.
+    docs = []
+    partners = [f"term{i}" for i in range(10)]
+    for _ in range(3):
+        for p in partners:
+            docs.append({"hub", p})
+    table = build_cooccurrence_table(docs, k=3, min_count=2, min_pmi=-10.0)
+    assert len(table["hub"]) <= 3
+
+
+def test_build_table_honours_min_count() -> None:
+    # A pair co-occurring in only one doc is below min_count=2 and excluded.
+    docs = [{"alpha", "beta"}, {"gamma", "delta"}, {"gamma", "delta"}]
+    table = build_cooccurrence_table(docs, k=5, min_count=2, min_pmi=-10.0)
+    assert "beta" not in table.get("alpha", [])
+    assert "delta" in table.get("gamma", [])
+
+
+def test_build_table_empty_for_tiny_corpus() -> None:
+    assert build_cooccurrence_table([{"a", "b"}], k=5) == {}
+    assert build_cooccurrence_table([], k=5) == {}
+
+
+# --- SQLite persistence ------------------------------------------------------
+
+
+def test_write_and_lookup_related_terms(tmp_path: Path) -> None:
+    db = tmp_path / "t.db"
+    conn = sqlite3.connect(db)
+    from data_olympus.cooccurrence import RELATED_TERMS_SCHEMA
+
+    conn.executescript(RELATED_TERMS_SCHEMA)
+    write_cooccurrence_table(conn, {"helm": ["kubernetes", "chart"]})
+    conn.commit()
+    got = lookup_related_terms(conn, "helm", limit=5)
+    assert got == ["kubernetes", "chart"]  # rank order preserved
+    assert lookup_related_terms(conn, "unknown", limit=5) == []
+    conn.close()
+
+
+# --- pure expander -----------------------------------------------------------
+
+
+def test_expander_appends_related_after_originals() -> None:
+    lookup = {"helm": ["kubernetes"]}
+    expander = make_cooccurrence_expander(
+        lambda term, k: lookup.get(term, [])[:k], k=5
+    )
+    out = expander(["helm"])
+    assert out[0] == "helm"  # original first (down-weighting by position)
+    assert "kubernetes" in out
+
+
+def test_expander_is_bounded_and_deduped() -> None:
+    lookup = {"a": [f"r{i}" for i in range(50)]}
+    expander = make_cooccurrence_expander(
+        lambda term, k: lookup.get(term, [])[:k], k=50, max_terms=10
+    )
+    out = expander(["a"])
+    assert len(out) <= 10
+    assert len(out) == len(set(out))
+
+
+def test_expander_unaffected_for_unrelated_term() -> None:
+    expander = make_cooccurrence_expander(lambda _term, _k: [], k=5)
+    assert expander(["banana"]) == ["banana"]
+
+
+# --- composition -------------------------------------------------------------
+
+
+def test_compose_runs_left_to_right() -> None:
+    syn = make_cooccurrence_expander(
+        lambda term, k: {"k8s": ["kubernetes"]}.get(term, [])[:k], k=5
+    )
+    cooc = make_cooccurrence_expander(
+        lambda term, k: {"kubernetes": ["helm"]}.get(term, [])[:k], k=5
+    )
+    composed = compose_expanders(syn, cooc)
+    assert composed is not None
+    out = composed(["k8s"])
+    # synonym adds kubernetes, then cooccurrence (on the expanded set) adds helm.
+    assert out[0] == "k8s"
+    assert "kubernetes" in out
+    assert "helm" in out
+
+
+def test_compose_skips_none_and_returns_none_when_empty() -> None:
+    assert compose_expanders(None, None) is None
+    only = make_cooccurrence_expander(lambda _term, _k: [], k=5)
+    composed = compose_expanders(None, only)
+    assert composed is not None
+    assert composed(["x"]) == ["x"]
+
+
+def test_compose_bounds_total() -> None:
+    a = make_cooccurrence_expander(
+        lambda _term, k: [f"a{i}" for i in range(20)][:k], k=20, max_terms=100
+    )
+    b = make_cooccurrence_expander(
+        lambda _term, k: [f"b{i}" for i in range(20)][:k], k=20, max_terms=100
+    )
+    composed = compose_expanders(a, b, max_terms=8)
+    assert composed is not None
+    assert len(composed(["seed"])) <= 8
+
+
+# --- env config --------------------------------------------------------------
+
+
+def test_cooccurrence_enabled_default_on(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("KB_COOCCURRENCE_MODE", raising=False)
+    assert cooccurrence_enabled() is True
+    monkeypatch.setenv("KB_COOCCURRENCE_MODE", "off")
+    assert cooccurrence_enabled() is False
+    monkeypatch.setenv("KB_COOCCURRENCE_MODE", "on")
+    assert cooccurrence_enabled() is True
+
+
+def test_cooccurrence_build_params_from_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("KB_COOCCURRENCE_K", "3")
+    monkeypatch.setenv("KB_COOCCURRENCE_MIN_COUNT", "4")
+    monkeypatch.setenv("KB_COOCCURRENCE_MIN_PMI", "1.5")
+    params = cooccurrence_build_params()
+    assert params == {"k": 3, "min_count": 4, "min_pmi": 1.5}
+
+
+# --- end-to-end through Index ------------------------------------------------
+
+
+def _write_cooccurrence_corpus(kb: Path) -> None:
+    """A corpus where 'helm' and 'kubernetes' are unambiguously associated.
+
+    Multiple docs mention BOTH helm and kubernetes; one doc mentions kubernetes
+    WITHOUT helm. A search for 'helm' should, via co-occurrence expansion, also
+    surface the kubernetes-only doc. An unrelated 'banana' cluster is isolated.
+    """
+    d = kb / "universal" / "foundation"
+    d.mkdir(parents=True, exist_ok=True)
+    # Each helm doc pairs helm+kubernetes and adds DISTINCT filler, so no filler
+    # word co-occurs with helm as often as kubernetes does. That makes
+    # helm<->kubernetes the strongest (highest-count) association, so kubernetes
+    # wins a top-k slot unambiguously.
+    fillers = [
+        "chart templates release",
+        "deploy rollout upgrade",
+        "namespace values override",
+        "repository registry pull",
+    ]
+    for i, filler in enumerate(fillers):
+        (d / f"STD-HELM-{i}.md").write_text(
+            f"---\nid: STD-HELM-{i}\n---\n\n# Helm deployment {i}\n\n"
+            f"Using helm to install onto kubernetes. {filler}.\n",
+            encoding="utf-8",
+        )
+    # kubernetes WITHOUT the word helm -- only co-occurrence expansion reaches it.
+    (d / "STD-KUBEONLY.md").write_text(
+        "---\nid: STD-KUBEONLY\n---\n\n# Kubernetes operations\n\n"
+        "Operating kubernetes clusters: nodes, pods, and the kubernetes control "
+        "plane. Scaling kubernetes workloads across the kubernetes cluster.\n",
+        encoding="utf-8",
+    )
+    # Unrelated cluster -- must be unaffected by helm/kubernetes expansion.
+    (d / "STD-BANANA.md").write_text(
+        "---\nid: STD-BANANA\n---\n\n# Banana smoothies\n\n"
+        "A banana smoothie recipe: banana, yoghurt, honey. Blend the banana "
+        "until the smoothie is smooth.\n",
+        encoding="utf-8",
+    )
+
+
+def test_index_related_terms_populated_after_build(
+    tmp_path: Path, tmp_index_path: Path,
+) -> None:
+    kb = tmp_path / "kb"
+    kb.mkdir()
+    _write_cooccurrence_corpus(kb)
+    idx = Index(tmp_index_path)
+    idx.build(kb, source_commit="x")
+    related = idx.related_terms("helm", limit=5)
+    assert "kubernetes" in related
+
+
+def test_cooccurrence_expansion_broadens_recall(
+    tmp_path: Path, tmp_index_path: Path,
+) -> None:
+    kb = tmp_path / "kb"
+    kb.mkdir()
+    _write_cooccurrence_corpus(kb)
+
+    # Baseline: no expander -- 'helm' must NOT reach the kubernetes-only doc.
+    plain = Index(tmp_index_path)
+    plain.build(kb, source_commit="x")
+    plain_ids = {h.id for h in plain.search("helm", limit=20)}
+    assert "STD-KUBEONLY" not in plain_ids, (
+        "baseline should not reach the kubernetes-only doc from a helm query"
+    )
+
+    # With co-occurrence expansion: 'helm' expands to include 'kubernetes',
+    # reaching the kubernetes-only doc -- recall broadened.
+    expanded = Index(tmp_index_path)
+    expanded.query_expander = expanded.cooccurrence_expander()
+    expanded_ids = {h.id for h in expanded.search("helm", limit=20)}
+    assert "STD-KUBEONLY" in expanded_ids, (
+        "co-occurrence expansion should reach the kubernetes-only doc"
+    )
+
+    # An unrelated query is unaffected: 'banana' does not drag in helm/kube docs.
+    banana_ids = {h.id for h in expanded.search("banana", limit=20)}
+    assert banana_ids == {"STD-BANANA"}
+
+
+def test_related_terms_table_rebuilt_atomically(
+    tmp_path: Path, tmp_index_path: Path,
+) -> None:
+    """The related_terms table swaps atomically with the rest of the index.
+
+    An open connection to the old inode keeps seeing the OLD table while a
+    rebuild produces a new one; a fresh connection sees the new table. This
+    mirrors the FTS atomic-swap guarantee for the co-occurrence table.
+    """
+    kb = tmp_path / "kb"
+    kb.mkdir()
+    _write_cooccurrence_corpus(kb)
+    idx = Index(tmp_index_path)
+    idx.build(kb, source_commit="first")
+
+    # Hold a connection open to the current inode.
+    old_conn = sqlite3.connect(tmp_index_path)
+    old_inode = tmp_index_path.stat().st_ino
+    old_related = lookup_related_terms(old_conn, "helm", limit=5)
+    assert "kubernetes" in old_related
+
+    # Rebuild: the whole index (incl. related_terms) is swapped atomically.
+    idx.build(kb, source_commit="second")
+    assert tmp_index_path.stat().st_ino != old_inode, (
+        "os.replace should produce a new inode"
+    )
+
+    # The old connection still answers from the old inode's related_terms table.
+    assert lookup_related_terms(old_conn, "helm", limit=5) == old_related
+    old_conn.close()
+
+    # A fresh connection sees the new build's table (also well-formed).
+    new_conn = sqlite3.connect(tmp_index_path)
+    assert "kubernetes" in lookup_related_terms(new_conn, "helm", limit=5)
+    new_conn.close()
+
+
+def test_cooccurrence_disabled_skips_table(
+    tmp_path: Path, tmp_index_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("KB_COOCCURRENCE_MODE", "off")
+    kb = tmp_path / "kb"
+    kb.mkdir()
+    _write_cooccurrence_corpus(kb)
+    idx = Index(tmp_index_path)
+    idx.build(kb, source_commit="x")
+    # Disabled -> empty table -> no related terms.
+    assert idx.related_terms("helm", limit=5) == []

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -127,8 +127,9 @@ def test_index_records_schema_version(tmp_kb: Path, tmp_index_path: Path) -> Non
     row = conn.execute("SELECT value FROM meta WHERE key = 'schema_version'").fetchone()
     conn.close()
     assert row is not None
-    assert row[0] == "5", (
-        f"schema_version must be '5' after applies_when/description columns; got {row[0]!r}"
+    assert row[0] == "6", (
+        f"schema_version must be '6' after the related_terms co-occurrence table; "
+        f"got {row[0]!r}"
     )
 
 


### PR DESCRIPTION
Closes #40.

## What

Broadens recall by expanding a query with terms that co-occur with the query terms across the corpus, learned at index-build time, with **no embedding model**.

## How it works

**Build-time table (schema v6).** `Index.build()` computes term co-occurrence PMI (pointwise mutual information, at document granularity) across all indexed docs and writes a bounded `related_terms(term, related, rank)` table. Bounds: top-k related terms per term (default k=5) above a minimum co-occurrence count (default 2) and PMI threshold (default 0.0); only "reasonable" tokens are considered (>= 3 chars, not a stopword, letter-initial). The table is built into the **same tmp DB** and swapped atomically with the FTS index via the existing `os.replace`, so a query never sees a half-built table.

**Query-time expansion via the `query_expander` seam.** `Index.cooccurrence_expander()` returns an expander bound to the index that looks each query term up in `related_terms` and appends its top related terms, **down-weighted** by appending them after the originals (BM25 OR-matching favours the earlier / user-typed terms). The overall term list stays bounded (<= 32) and de-duplicated.

**Composition with synonyms (not replacement).** `compose_expanders()` chains expanders left-to-right. In `server.py build_app` the synonym expander (issue #38) runs **first**, then co-occurrence broadens the synonym-expanded set; the composed output is de-duplicated and capped. Co-occurrence is bound to the live `Index` so it always reads the atomically-swapped table.

## Config knobs (env, following `config.py`)

- `KB_COOCCURRENCE_MODE`: `on` (default) / `off` — disables both the build-time table and the query-time expander.
- `KB_COOCCURRENCE_K`: top-k related terms per term (default 5).
- `KB_COOCCURRENCE_MIN_COUNT`: minimum co-occurrence document count (default 2).
- `KB_COOCCURRENCE_MIN_PMI`: minimum PMI to keep a pair (default 0.0).

Surfaced on `Config` for discoverability; the build path reads the same env vars directly (mirroring the synonym expander) so the CLI indexer honours them.

## Tests

- Pure unit: tokenization/stopwords, PMI table builder (association, top-k bound, min-count), SQLite persistence, expander (append-after-originals, bounded/deduped, unrelated-unaffected), composition (left-to-right, bounds, None-skipping), env config.
- End-to-end: on an unambiguous corpus a `helm` query reaches a `kubernetes`-only doc **only** with co-occurrence expansion (baseline does not), while an unrelated `banana` query is unaffected.
- Atomicity: `related_terms` swaps atomically with the index (open old-inode connection keeps the old table; fresh connection sees the new one).
- Schema-version test updated to v6.

Build cost is negligible at current corpus scale (~130 ms for 100 docs, dwarfed by the per-file git-log calls already in `build()`).

## Notes

Full suite green (696 passed). The single failing test `tests/test_lint.py::test_example_bundle_discovery_matches_concept_files` is a **pre-existing environmental artifact**: `discover_bundle_files` skips any path containing `.worktrees`, so running the suite from inside a `.worktrees/` checkout skips the nested `example-bundle`. It passes in the primary (non-worktree) checkout on unmodified `main`, and this branch does not touch `lint.py`, `test_lint.py`, or `example-bundle`.