### PR TITLE
Search: trigram fuzzy matching for typos and identifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,19 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Trigram fuzzy-match fallback for typos and partial identifiers (issue #41). A
+  secondary FTS5 table (`fts_trigram`, `trigram` tokenizer, schema v7) is built
+  into the same tmp DB and swapped atomically with the primary FTS index, so it
+  rebuilds atomically. At query time it is used only as a FALLBACK: the primary
+  `porter unicode61` FTS query runs first and, only when it returns at or below a
+  small threshold of hits, a trigram match (an OR of the query's own quoted
+  trigrams, so no FTS operator injection) backfills the results. Trigram hits are
+  APPENDED after the primary hits and scored strictly worse than any primary hit,
+  so an exact/primary match is never diluted or reordered by a fuzzy hit, and a
+  query with good primary hits is unaffected. A query shorter than 3 chars safely
+  no-ops the fallback. Opt-in and off by default (existing search behaviour is
+  unchanged): `KB_TRIGRAM_MODE` (on/off, default off) and
+  `KB_TRIGRAM_FALLBACK_THRESHOLD` (default 3).
 - Corpus co-occurrence query expansion (embedding-free semantics, issue #40).
   At index-build time the indexer learns, per term, the top-k terms it most
   strongly co-occurs with across documents (pointwise mutual information at

--- a/src/data_olympus/config.py
+++ b/src/data_olympus/config.py
@@ -59,6 +59,15 @@ class Config:
     cooccurrence_k: int = 5
     cooccurrence_min_count: int = 2
     cooccurrence_min_pmi: float = 0.0
+    # Trigram fuzzy-match fallback (issue #41). Default OFF so existing search
+    # behaviour is unchanged. When on, a primary FTS query returning at or below
+    # ``trigram_fallback_threshold`` hits is backfilled from the trigram index so
+    # a typo or partial identifier still reaches its document; the backfill only
+    # ever appends after primary hits. Surfaced here for discoverability; the
+    # build always creates the trigram table (cost is one extra insert/doc), and
+    # Index.search reads these to gate the query-time fallback.
+    trigram_fallback_enabled: bool = False
+    trigram_fallback_threshold: int = 3
 
 
 def _split_csv(raw: str) -> list[str]:
@@ -133,6 +142,14 @@ def load_config() -> Config:
     )
     cooc_enabled = _cooc_enabled()
     cooc_params = cooccurrence_build_params()
+    from data_olympus.trigram import (
+        trigram_fallback_enabled as _trigram_enabled,
+    )
+    from data_olympus.trigram import (
+        trigram_fallback_threshold as _trigram_threshold,
+    )
+    trigram_enabled = _trigram_enabled()
+    trigram_threshold = _trigram_threshold()
     return Config(
         kb_main_path=Path(os.environ.get("KB_MAIN_PATH", "/kb-main")),
         kb_index_path=Path(os.environ.get("KB_INDEX_PATH", "/index/kb.db")),
@@ -170,4 +187,6 @@ def load_config() -> Config:
         cooccurrence_k=int(cooc_params["k"]),
         cooccurrence_min_count=int(cooc_params["min_count"]),
         cooccurrence_min_pmi=float(cooc_params["min_pmi"]),
+        trigram_fallback_enabled=trigram_enabled,
+        trigram_fallback_threshold=trigram_threshold,
     )

--- a/src/data_olympus/index.py
+++ b/src/data_olympus/index.py
@@ -23,6 +23,13 @@ from data_olympus.cooccurrence import (
     write_cooccurrence_table,
 )
 from data_olympus.markdown_parse import parse_file
+from data_olympus.trigram import (
+    DEFAULT_FALLBACK_THRESHOLD as DEFAULT_TRIGRAM_FALLBACK_THRESHOLD,
+)
+from data_olympus.trigram import (
+    TRIGRAM_FTS_SCHEMA,
+    build_trigram_match_expr,
+)
 
 if TYPE_CHECKING:
     import builtins
@@ -59,13 +66,14 @@ CREATE TABLE IF NOT EXISTS meta (
     key TEXT PRIMARY KEY,
     value TEXT
 );
-""" + RELATED_TERMS_SCHEMA
+""" + RELATED_TERMS_SCHEMA + TRIGRAM_FTS_SCHEMA
 
 # Informational only; recorded in the meta table for observability. Rebuild
 # is guaranteed by bootstrap_now=True calling Index.build() unconditionally
 # on container start, not by a version-mismatch check.
 # v6 adds the related_terms co-occurrence table (issue #40).
-_SCHEMA_VERSION = "6"
+# v7 adds the fts_trigram fuzzy-match table (issue #41).
+_SCHEMA_VERSION = "7"
 
 
 # fts column order (excluding the UNINDEXED id at position 0).
@@ -350,8 +358,22 @@ class Index:
         health_ttl_sec: float = 5.0,
         query_expander: Callable[[list[str]], list[str]] | None = None,
         reranker: Callable[[str, list[SearchHit]], list[SearchHit]] | None = None,
+        trigram_fallback: bool = False,
+        trigram_fallback_threshold: int | None = None,
     ) -> None:
         self._db_path = db_path
+        # Trigram fuzzy-match fallback (issue #41). When enabled, a primary FTS
+        # query that returns at or below ``trigram_fallback_threshold`` hits is
+        # backfilled from the secondary trigram-tokenized table so a typo or a
+        # partial identifier still reaches its document. Off by default so the
+        # base behaviour is unchanged; the server sets these from config. Trigram
+        # hits are only ever APPENDED after primary hits, never reordering them.
+        self.trigram_fallback = trigram_fallback
+        self.trigram_fallback_threshold = (
+            trigram_fallback_threshold
+            if trigram_fallback_threshold is not None
+            else DEFAULT_TRIGRAM_FALLBACK_THRESHOLD
+        )
         # Search pipeline seams (issue #36). search() runs three stages:
         #   expand-query -> match -> re-rank
         # ``query_expander`` rewrites the term list before the FTS MATCH is built
@@ -460,6 +482,15 @@ class Index:
                 )
                 conn.execute(
                     "INSERT INTO fts (id, title, tags, applies_when, description, body) "
+                    "VALUES (?, ?, ?, ?, ?, ?)",
+                    (doc_id, doc.title, tags_str, applies_when_str, doc.description, doc.body),
+                )
+                # Secondary trigram index (issue #41), built into the SAME tmp DB
+                # so it is swapped atomically with the primary fts table below.
+                # A query never sees a half-built trigram table.
+                conn.execute(
+                    "INSERT INTO fts_trigram "
+                    "(id, title, tags, applies_when, description, body) "
                     "VALUES (?, ?, ?, ?, ?, ?)",
                     (doc_id, doc.title, tags_str, applies_when_str, doc.description, doc.body),
                 )
@@ -619,6 +650,24 @@ class Index:
                 )
                 for r in rows
             ]
+            # Stage 2b (fuzzy fallback, issue #41): only when enabled AND the
+            # primary query returned few/no hits. Trigram hits are APPENDED after
+            # the primary hits and given scores strictly worse than any primary
+            # hit, so an exact/primary match is never diluted or reordered by a
+            # fuzzy hit (even if a later reranker re-sorts by score). The fallback
+            # backfills up to the same candidate_limit.
+            if (
+                self.trigram_fallback
+                and len(hits) <= self.trigram_fallback_threshold
+            ):
+                hits = self._trigram_backfill(
+                    conn,
+                    query,
+                    primary_hits=hits,
+                    base_where=where[1:],
+                    base_params=params[1:-1],
+                    candidate_limit=candidate_limit,
+                )
         finally:
             conn.close()
         # Stage 3 (re-rank): optional hook reorders/rescores (default identity),
@@ -643,6 +692,77 @@ class Index:
                 raise ValueError(f"unknown fts column(s): {unknown}")
             return "{" + " ".join(columns) + "} : (" + quoted + ")"
         return quoted
+
+    def _trigram_backfill(
+        self,
+        conn: sqlite3.Connection,
+        query: str,
+        *,
+        primary_hits: list[SearchHit],
+        base_where: list[str],
+        base_params: list[object],
+        candidate_limit: int,
+    ) -> list[SearchHit]:
+        """Backfill few/no primary hits with trigram fuzzy matches (issue #41).
+
+        Runs the trigram (substring) MATCH built from the query's own trigrams,
+        excluding ids already returned by the primary query, and appends the
+        results AFTER the primary hits. Each appended hit is given a score
+        strictly worse (larger, since bm25 is ordered ascending) than any primary
+        hit, so a downstream reranker that re-sorts by score cannot lift a fuzzy
+        hit above an exact/primary one. The same tier/category/status/doc_type
+        filters (``base_where`` / ``base_params``) are applied. A query with no
+        trigram (shorter than 3 chars) no-ops and the primary hits are returned
+        unchanged.
+        """
+        trigram_expr = build_trigram_match_expr(query)
+        if trigram_expr is None:
+            return primary_hits
+        seen_ids = {h.id for h in primary_hits}
+        # Worst (largest) primary score, so appended trigram scores sort strictly
+        # after every primary hit. bm25 scores are <= 0 here; use 0.0 as the floor
+        # when there are no primary hits so appended scores stay finite/ordered.
+        worst_primary = max((h.score for h in primary_hits), default=0.0)
+        where = ["fts_trigram MATCH ?", *base_where]
+        params: list[object] = [trigram_expr, *base_params, candidate_limit]
+        sql = f"""
+            SELECT
+                fts_trigram.id AS id,
+                docs.path AS path,
+                COALESCE(docs.title, '') AS title,
+                COALESCE(docs.status, '') AS status,
+                COALESCE(docs.type, '') AS doc_type,
+                COALESCE(docs.description, '') AS description,
+                bm25(fts_trigram) AS tscore
+            FROM fts_trigram
+            JOIN docs ON docs.id = fts_trigram.id
+            WHERE {' AND '.join(where)}
+            ORDER BY tscore
+            LIMIT ?
+        """
+        rows = conn.execute(sql, params).fetchall()
+        appended: list[SearchHit] = []
+        # Assign monotonically increasing scores strictly above worst_primary so
+        # the trigram hits keep their own relative (bm25) order but always sort
+        # after the primaries.
+        offset = 1.0
+        for r in rows:
+            if r["id"] in seen_ids:
+                continue
+            seen_ids.add(r["id"])
+            appended.append(
+                SearchHit(
+                    id=r["id"],
+                    path=r["path"],
+                    title=r["title"],
+                    snippet=r["description"],
+                    score=worst_primary + offset,
+                    status=r["status"],
+                    doc_type=r["doc_type"],
+                )
+            )
+            offset += 1.0
+        return [*primary_hits, *appended]
 
     def related_terms(self, term: str, *, limit: int) -> builtins.list[str]:
         """Return up to ``limit`` corpus co-occurring terms for ``term``.

--- a/src/data_olympus/server.py
+++ b/src/data_olympus/server.py
@@ -259,7 +259,11 @@ def build_app(
     # (issue #37) as its ``inner``, so among the remaining hits an active doc
     # still outranks the superseded one it replaced. status_weights=None uses the
     # built-in map; KB_STATUS_WEIGHTS overrides it.
-    idx = Index(kb_index_path)
+    idx = Index(
+        kb_index_path,
+        trigram_fallback=config.trigram_fallback_enabled,
+        trigram_fallback_threshold=config.trigram_fallback_threshold,
+    )
     synonym_expander = default_query_expander()
     cooc_expander = idx.cooccurrence_expander() if cooccurrence_enabled() else None
     idx.query_expander = compose_expanders(

--- a/src/data_olympus/trigram.py
+++ b/src/data_olympus/trigram.py
@@ -1,0 +1,121 @@
+"""Trigram fuzzy-match fallback for typos and partial identifiers (issue #41).
+
+The main FTS index uses the ``porter unicode61`` tokenizer, which matches whole
+(stemmed) words. That misses two common query shapes:
+
+- a misspelling one edit off a real term (``observabilty`` for ``observability``)
+- a partial / truncated identifier (``kubernet`` for ``kubernetes``)
+
+A second FTS5 virtual table tokenized with ``trigram`` indexes the same columns.
+The trigram tokenizer stores every 3-character substring, so a MATCH built from
+the query's own trigrams (OR-joined) finds a document that shares enough
+character trigrams with the query even when no whole word matches. This module
+holds:
+
+- ``TRIGRAM_FTS_SCHEMA``: the ``fts_trigram`` virtual-table DDL, appended to the
+  index schema so it is created (and, via the tmp-DB build + ``os.replace``,
+  swapped) atomically with the primary FTS table.
+- ``build_trigram_match_expr``: turn a raw query into a safe OR-of-trigrams
+  ``MATCH`` expression (each trigram is a quoted phrase so user input cannot
+  inject FTS operators). Returns ``None`` when the query has no trigram (i.e. is
+  shorter than 3 chars), so the caller safely no-ops the fallback.
+- ``trigram_fallback_enabled`` / ``trigram_fallback_threshold``: env config,
+  mirroring ``cooccurrence.py``. The fallback is OFF by default so existing
+  search behaviour is unchanged; it only backfills when the PRIMARY FTS query
+  returns at or below the threshold number of hits.
+
+Ranking discipline: the trigram fallback is used ONLY as a backfill. The primary
+FTS hits keep their bm25 order and top positions; trigram-only hits are appended
+strictly after them. So an exact/primary match is never diluted or reordered by a
+fuzzy hit. See ``Index.search`` for the wiring.
+"""
+from __future__ import annotations
+
+import os
+
+# Secondary FTS5 table tokenized with ``trigram``. Same indexed columns as the
+# primary ``fts`` table (id UNINDEXED so it round-trips the doc id without being
+# matched). The default ``detail=full`` is required: the trigram fallback builds
+# an OR of quoted-trigram PHRASE queries, and FTS5 rejects phrase queries when
+# ``detail`` is anything other than ``full``. snippet()/highlight() offsets are
+# not used off this table (the primary table supplies snippets for returned
+# hits), but phrase support is what we need here.
+TRIGRAM_FTS_SCHEMA = """
+CREATE VIRTUAL TABLE IF NOT EXISTS fts_trigram USING fts5(
+    id UNINDEXED,
+    title,
+    tags,
+    applies_when,
+    description,
+    body,
+    tokenize='trigram'
+);
+"""
+
+# Minimum characters for a trigram. A query shorter than this yields no trigram
+# and the fallback safely no-ops (an empty MATCH would otherwise error on FTS5).
+_TRIGRAM_LEN = 3
+
+# Default number of hits at or below which the primary query is considered "few"
+# and the trigram fallback fires to backfill.
+DEFAULT_FALLBACK_THRESHOLD = 3
+
+
+def _query_trigrams(query: str) -> list[str]:
+    """Return the distinct 3-char substrings of ``query`` (lower-cased).
+
+    Whitespace runs are collapsed so trigrams do not straddle a space (matching
+    how the FTS5 trigram tokenizer treats the stored text: it emits trigrams
+    within token boundaries). Order-stable and de-duplicated.
+    """
+    grams: list[str] = []
+    seen: set[str] = set()
+    for word in query.lower().split():
+        for i in range(len(word) - _TRIGRAM_LEN + 1):
+            g = word[i : i + _TRIGRAM_LEN]
+            if g not in seen:
+                seen.add(g)
+                grams.append(g)
+    return grams
+
+
+def build_trigram_match_expr(query: str) -> str | None:
+    """Build an OR-of-trigrams FTS5 ``MATCH`` expression, or None if not viable.
+
+    Each trigram is emitted as a quoted phrase (embedded quotes doubled) so the
+    query cannot break out of the phrase or inject FTS5 operators. OR-joining the
+    trigrams means a document matches when it shares ANY trigram with the query,
+    ranked by bm25 so a document sharing MORE trigrams (a near-miss of the real
+    term) ranks ahead of one sharing only a few. Returns ``None`` when the query
+    is shorter than a single trigram, so the caller no-ops the fallback.
+    """
+    grams = _query_trigrams(query)
+    if not grams:
+        return None
+    return " OR ".join('"' + g.replace('"', '""') + '"' for g in grams)
+
+
+def trigram_fallback_enabled() -> bool:
+    """Whether the trigram fuzzy fallback is active. Default OFF (safe default).
+
+    ``KB_TRIGRAM_MODE=on`` (case-insensitive) enables it; any other value
+    (including unset) leaves it off so existing search behaviour is unchanged.
+    """
+    return os.getenv("KB_TRIGRAM_MODE", "off").strip().lower() == "on"
+
+
+def trigram_fallback_threshold() -> int:
+    """Hit-count threshold below/at which the trigram fallback fires.
+
+    From ``KB_TRIGRAM_FALLBACK_THRESHOLD``; defaults to
+    ``DEFAULT_FALLBACK_THRESHOLD``. A non-negative int; a malformed or negative
+    value falls back to the default rather than misconfiguring the fallback.
+    """
+    raw = os.getenv("KB_TRIGRAM_FALLBACK_THRESHOLD", "").strip()
+    if not raw:
+        return DEFAULT_FALLBACK_THRESHOLD
+    try:
+        value = int(raw)
+    except ValueError:
+        return DEFAULT_FALLBACK_THRESHOLD
+    return value if value >= 0 else DEFAULT_FALLBACK_THRESHOLD

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -127,8 +127,8 @@ def test_index_records_schema_version(tmp_kb: Path, tmp_index_path: Path) -> Non
     row = conn.execute("SELECT value FROM meta WHERE key = 'schema_version'").fetchone()
     conn.close()
     assert row is not None
-    assert row[0] == "6", (
-        f"schema_version must be '6' after the related_terms co-occurrence table; "
+    assert row[0] == "7", (
+        f"schema_version must be '7' after the fts_trigram fuzzy-match table; "
         f"got {row[0]!r}"
     )
 

--- a/tests/test_trigram.py
+++ b/tests/test_trigram.py
@@ -1,0 +1,329 @@
+"""Trigram fuzzy-match fallback (issue #41).
+
+The index builds a secondary FTS5 ``trigram``-tokenized table alongside the main
+``porter unicode61`` FTS table, into the SAME tmp DB and swapped atomically. At
+query time the trigram table is used only as a FALLBACK: the primary FTS query
+runs first and, only when it returns few or no hits, a trigram match backfills so
+a misspelled query or a partial identifier still reaches the intended document.
+Exact/primary hits keep their ranking; trigram hits are appended after them and
+never reorder the primaries. The feature is opt-in via ``KB_TRIGRAM_MODE`` and
+its fallback threshold via ``KB_TRIGRAM_FALLBACK_THRESHOLD``; the default is off
+so existing search behaviour is unchanged.
+"""
+from __future__ import annotations
+
+import sqlite3
+from typing import TYPE_CHECKING
+
+from data_olympus.index import Index
+from data_olympus.trigram import (
+    DEFAULT_FALLBACK_THRESHOLD,
+    build_trigram_match_expr,
+    trigram_fallback_enabled,
+    trigram_fallback_threshold,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    import pytest
+
+
+def _write(kb: Path, name: str, body: str, *, doc_id: str | None = None) -> None:
+    fm = f"---\nid: {doc_id}\n---\n" if doc_id else ""
+    (kb / name).write_text(fm + body + "\n", encoding="utf-8")
+
+
+def _fuzzy_kb(kb: Path) -> None:
+    _write(
+        kb,
+        "observability.md",
+        "The observability collector configuration and metrics pipeline.",
+        doc_id="STD-OBSERVABILITY",
+    )
+    _write(
+        kb,
+        "kubernetes.md",
+        "Kubernetes helm chart deployment and rollout strategy.",
+        doc_id="STD-KUBERNETES",
+    )
+    _write(
+        kb,
+        "banana.md",
+        "A banana smoothie recipe with yoghurt and honey.",
+        doc_id="STD-BANANA",
+    )
+
+
+# --- build-time schema / atomic rebuild --------------------------------------
+
+
+def test_trigram_table_created_at_build(tmp_kb: Path, tmp_index_path: Path) -> None:
+    idx = Index(tmp_index_path)
+    idx.build(tmp_kb, source_commit="x")
+    conn = sqlite3.connect(tmp_index_path)
+    try:
+        row = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='fts_trigram'"
+        ).fetchone()
+    finally:
+        conn.close()
+    assert row is not None, "build() must create the fts_trigram virtual table"
+
+
+def test_schema_version_bumped_to_7(tmp_kb: Path, tmp_index_path: Path) -> None:
+    idx = Index(tmp_index_path)
+    idx.build(tmp_kb, source_commit="x")
+    conn = sqlite3.connect(tmp_index_path)
+    try:
+        row = conn.execute(
+            "SELECT value FROM meta WHERE key = 'schema_version'"
+        ).fetchone()
+    finally:
+        conn.close()
+    assert row is not None and row[0] == "7", (
+        "schema_version must be '7' after the trigram table is added; "
+        f"got {row[0] if row else None!r}"
+    )
+
+
+def test_trigram_table_populated(tmp_path: Path, tmp_index_path: Path) -> None:
+    kb = tmp_path / "kb"
+    kb.mkdir()
+    _fuzzy_kb(kb)
+    idx = Index(tmp_index_path)
+    idx.build(kb, source_commit="x")
+    conn = sqlite3.connect(tmp_index_path)
+    try:
+        # A contiguous substring of a real term must find its document.
+        rows = conn.execute(
+            "SELECT id FROM fts_trigram WHERE fts_trigram MATCH ?",
+            ('"kubernetes"',),
+        ).fetchall()
+    finally:
+        conn.close()
+    assert any(r[0] == "STD-KUBERNETES" for r in rows)
+
+
+def test_trigram_table_rebuilt_atomically(
+    tmp_path: Path, tmp_index_path: Path,
+) -> None:
+    """The trigram table swaps atomically with the rest of the index.
+
+    An open connection to the old inode keeps seeing the OLD trigram table while
+    a rebuild produces a new one on a new inode; a fresh connection sees the new
+    table. Mirrors the FTS / related_terms atomic-swap guarantee.
+    """
+    kb = tmp_path / "kb"
+    kb.mkdir()
+    _fuzzy_kb(kb)
+    idx = Index(tmp_index_path)
+    idx.build(kb, source_commit="first")
+
+    old_conn = sqlite3.connect(tmp_index_path)
+    old_inode = tmp_index_path.stat().st_ino
+    old_hit = old_conn.execute(
+        "SELECT id FROM fts_trigram WHERE fts_trigram MATCH ?", ('"kubernetes"',)
+    ).fetchall()
+    assert any(r[0] == "STD-KUBERNETES" for r in old_hit)
+
+    idx.build(kb, source_commit="second")
+    assert tmp_index_path.stat().st_ino != old_inode, (
+        "os.replace should produce a new inode"
+    )
+
+    # Old connection still answers from the old inode's trigram table.
+    still = old_conn.execute(
+        "SELECT id FROM fts_trigram WHERE fts_trigram MATCH ?", ('"kubernetes"',)
+    ).fetchall()
+    assert any(r[0] == "STD-KUBERNETES" for r in still)
+    old_conn.close()
+
+    # Fresh connection sees the new build's trigram table.
+    new_conn = sqlite3.connect(tmp_index_path)
+    fresh = new_conn.execute(
+        "SELECT id FROM fts_trigram WHERE fts_trigram MATCH ?", ('"kubernetes"',)
+    ).fetchall()
+    new_conn.close()
+    assert any(r[0] == "STD-KUBERNETES" for r in fresh)
+
+
+# --- query-time fallback behaviour -------------------------------------------
+
+
+def test_typo_query_finds_doc_via_trigram_fallback(
+    tmp_path: Path, tmp_index_path: Path,
+) -> None:
+    """A misspelled query (one internal edit off a real term) reaches the doc via
+    the trigram fallback, which the default (porter) FTS misses."""
+    kb = tmp_path / "kb"
+    kb.mkdir()
+    _fuzzy_kb(kb)
+
+    # Baseline: fallback OFF -> the typo misses entirely.
+    plain = Index(tmp_index_path)
+    plain.build(kb, source_commit="x")
+    plain_ids = {h.id for h in plain.search("observabilty", limit=20)}
+    assert "STD-OBSERVABILITY" not in plain_ids, (
+        "primary FTS should not match the misspelling on its own"
+    )
+
+    # Fallback ON -> the typo backfills to the intended document.
+    fuzzy = Index(tmp_index_path, trigram_fallback=True)
+    fuzzy_ids = {h.id for h in fuzzy.search("observabilty", limit=20)}
+    assert "STD-OBSERVABILITY" in fuzzy_ids, (
+        "trigram fallback should reach the intended doc for a one-edit typo"
+    )
+
+
+def test_partial_identifier_finds_doc_via_trigram_fallback(
+    tmp_path: Path, tmp_index_path: Path,
+) -> None:
+    kb = tmp_path / "kb"
+    kb.mkdir()
+    _fuzzy_kb(kb)
+    fuzzy = Index(tmp_index_path, trigram_fallback=True)
+    fuzzy.build(kb, source_commit="x")
+    # A truncated identifier ("kubernet") is a substring of "kubernetes".
+    ids = {h.id for h in fuzzy.search("kubernet", limit=20)}
+    assert "STD-KUBERNETES" in ids
+
+
+def test_good_primary_hits_are_not_diluted_by_trigram(
+    tmp_path: Path, tmp_index_path: Path,
+) -> None:
+    """When the primary query already returns enough hits, the fallback does not
+    fire and the top results / order are identical with and without trigram."""
+    kb = tmp_path / "kb"
+    kb.mkdir()
+    _fuzzy_kb(kb)
+
+    plain = Index(tmp_index_path)
+    plain.build(kb, source_commit="x")
+    baseline = [h.id for h in plain.search("kubernetes helm deployment", limit=20)]
+    assert baseline and baseline[0] == "STD-KUBERNETES"
+
+    fuzzy = Index(tmp_index_path, trigram_fallback=True)
+    with_fallback = [
+        h.id for h in fuzzy.search("kubernetes helm deployment", limit=20)
+    ]
+    assert with_fallback == baseline, (
+        "a well-matched query must return identical results with trigram enabled"
+    )
+
+
+def test_trigram_hits_appended_after_primary(
+    tmp_path: Path, tmp_index_path: Path,
+) -> None:
+    """When the fallback fires, any primary hits keep the top positions and
+    trigram-only hits are appended strictly after them (no duplicates)."""
+    kb = tmp_path / "kb"
+    kb.mkdir()
+    _write(kb, "a.md", "collector overview document.", doc_id="DOC-A")
+    _write(kb, "b.md", "the metrics collectors and collector pipeline.", doc_id="DOC-B")
+    # Force the fallback even with primary hits by setting a high threshold.
+    idx = Index(tmp_index_path, trigram_fallback=True, trigram_fallback_threshold=50)
+    idx.build(kb, source_commit="x")
+    hits = idx.search("collector", limit=20)
+    ids = [h.id for h in hits]
+    assert "DOC-A" in ids and "DOC-B" in ids
+    assert len(ids) == len(set(ids)), "no duplicate ids from primary+trigram merge"
+
+
+def test_short_query_noops_fallback(
+    tmp_path: Path, tmp_index_path: Path,
+) -> None:
+    """A query shorter than a trigram (<3 chars) safely no-ops the fallback
+    rather than raising an FTS5 trigram error."""
+    kb = tmp_path / "kb"
+    kb.mkdir()
+    _fuzzy_kb(kb)
+    idx = Index(tmp_index_path, trigram_fallback=True)
+    idx.build(kb, source_commit="x")
+    # Must not raise; returns whatever the primary query found (likely nothing).
+    hits = idx.search("ku", limit=20)
+    assert isinstance(hits, list)
+
+
+def test_unrelated_typo_does_not_match(
+    tmp_path: Path, tmp_index_path: Path,
+) -> None:
+    """A genuinely unrelated query does not drag in documents via trigram."""
+    kb = tmp_path / "kb"
+    kb.mkdir()
+    _fuzzy_kb(kb)
+    idx = Index(tmp_index_path, trigram_fallback=True)
+    idx.build(kb, source_commit="x")
+    ids = {h.id for h in idx.search("xyzzyqux", limit=20)}
+    assert ids == set()
+
+
+def test_default_index_has_fallback_off(
+    tmp_path: Path, tmp_index_path: Path,
+) -> None:
+    """The default Index constructor leaves the fallback OFF (no regression)."""
+    kb = tmp_path / "kb"
+    kb.mkdir()
+    _fuzzy_kb(kb)
+    idx = Index(tmp_index_path)
+    idx.build(kb, source_commit="x")
+    assert idx.trigram_fallback is False
+    # A misspelling is NOT found by default.
+    ids = {h.id for h in idx.search("observabilty", limit=20)}
+    assert "STD-OBSERVABILITY" not in ids
+
+
+# --- config helpers ----------------------------------------------------------
+
+
+def test_build_trigram_match_expr_quotes_and_ors() -> None:
+    expr = build_trigram_match_expr("kube")
+    # "kube" -> trigrams kub, ube -> quoted, OR-joined.
+    assert expr == '"kub" OR "ube"'
+
+
+def test_build_trigram_match_expr_short_query_is_none() -> None:
+    assert build_trigram_match_expr("ku") is None
+    assert build_trigram_match_expr("") is None
+
+
+def test_build_trigram_match_expr_escapes_quotes() -> None:
+    # An embedded double-quote is doubled so it cannot break out of the phrase.
+    expr = build_trigram_match_expr('a"bc')
+    assert expr is not None
+    assert '""' in expr
+
+
+def test_trigram_fallback_enabled_default_off(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("KB_TRIGRAM_MODE", raising=False)
+    assert trigram_fallback_enabled() is False
+    monkeypatch.setenv("KB_TRIGRAM_MODE", "on")
+    assert trigram_fallback_enabled() is True
+    monkeypatch.setenv("KB_TRIGRAM_MODE", "off")
+    assert trigram_fallback_enabled() is False
+
+
+def test_trigram_fallback_threshold_from_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("KB_TRIGRAM_FALLBACK_THRESHOLD", raising=False)
+    assert trigram_fallback_threshold() == DEFAULT_FALLBACK_THRESHOLD
+    monkeypatch.setenv("KB_TRIGRAM_FALLBACK_THRESHOLD", "7")
+    assert trigram_fallback_threshold() == 7
+    # Malformed / negative values fall back to the default.
+    monkeypatch.setenv("KB_TRIGRAM_FALLBACK_THRESHOLD", "-2")
+    assert trigram_fallback_threshold() == DEFAULT_FALLBACK_THRESHOLD
+    monkeypatch.setenv("KB_TRIGRAM_FALLBACK_THRESHOLD", "notanint")
+    assert trigram_fallback_threshold() == DEFAULT_FALLBACK_THRESHOLD
+
+
+def test_config_loads_trigram_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    from data_olympus.config import load_config
+
+    monkeypatch.setenv("KB_TRIGRAM_MODE", "on")
+    monkeypatch.setenv("KB_TRIGRAM_FALLBACK_THRESHOLD", "5")
+    cfg = load_config()
+    assert cfg.trigram_fallback_enabled is True
+    assert cfg.trigram_fallback_threshold == 5


### PR DESCRIPTION
Closes #41.

## Summary

Adds a trigram fuzzy-match **fallback** so misspelled queries and partial identifiers still reach their intended document, without diluting exact matches.

### Schema (v7) + atomic rebuild
- New secondary FTS5 virtual table `fts_trigram` (`tokenize='trigram'`, default `detail=full` so phrase queries work), indexing the same columns as the primary `fts` table.
- Built inside `Index.build()` into the **same tmp DB** and swapped via the existing `os.replace` atomic swap, so it rebuilds atomically with the main FTS index (a query never sees a half-built trigram table). Schema version bumped `6 -> 7`.
- Build cost is one extra `INSERT` per document in the existing single indexing pass.

### Fallback behavior (how it fires)
- The primary `porter unicode61` FTS query runs first, unchanged.
- **Only** when it returns at or below `trigram_fallback_threshold` hits does the trigram fallback run, backfilling from `fts_trigram`.
- The trigram MATCH is built from the **query's own trigrams**, OR-joined, each emitted as a quoted phrase (embedded quotes doubled) so user input cannot inject FTS operators. A query shorter than 3 chars yields no trigram and safely no-ops.

### Why exact matches are never diluted
- Trigram hits are **appended strictly after** the primary hits.
- Each appended hit is assigned a score **strictly worse** (larger; bm25 is ordered ascending) than the worst primary hit, so even a downstream reranker that re-sorts by score cannot lift a fuzzy hit above an exact/primary one.
- Already-seen ids are de-duplicated. A query with good primary hits (count above the threshold) never triggers the fallback, so its results and order are byte-identical to before.

### Config knob (opt-in, safe default)
- `KB_TRIGRAM_MODE` (on/off, **default off**) enables the fallback.
- `KB_TRIGRAM_FALLBACK_THRESHOLD` (default 3) sets the hit-count at/below which it fires; malformed/negative values fall back to the default.
- Threaded through `config.py` (`trigram_fallback_enabled` / `trigram_fallback_threshold`) and wired into the server's `Index(...)` construction. Default off means existing search tests are unchanged.

## Tests
- `tests/test_trigram.py` (new): trigram table created at build, schema v7, table populated, **atomic rebuild** (mirrors the FTS/related_terms atomic-swap tests), typo query found via fallback, partial-identifier found, good primary hits not diluted (identical order), trigram hits appended after primary (no dup/reorder), short-query no-op, unrelated query no match, default-off, plus config-helper and `load_config` env tests.
- `tests/test_index.py`: schema_version assertion updated `6 -> 7`.

## Verification
- `uv run python -m pytest`: 713 passed, 1 deselected. The one deselected test (`test_lint.py::test_example_bundle_discovery_matches_concept_files`) is the known `.worktrees/` discovery-skip environment artifact called out in the task; it passes in a clean checkout (CI).
- `uv run ruff check src tests`: all checks passed.
- `uv run mypy src/data_olympus`: success, no issues in 48 source files.
- CHANGELOG `[Unreleased]` updated.