### PR TITLE
feat(search): optional local-embedding hybrid ranking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,21 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   the corpus at `Index.build` (seconds for a small KB, no network at query
   time); storage cost is 384 x 4 bytes (~1.5 KB) per doc in `doc_vectors`.
   Install with `uv sync --extra embeddings`.
+  When enabled, `Index.search` now adds a semantic candidate SOURCE (not just a
+  reranker over the FTS pool): the top dense neighbours by query-doc cosine are
+  unioned into the FTS candidate pool before the hybrid blend, so a paraphrase
+  with ZERO lexical overlap (e.g. querying "car" against a corpus that only says
+  "automobile") is retrieved where bm25 alone returned nothing. A minimum-cosine
+  threshold guards abstention: an out-of-scope query whose nearest neighbour is
+  only weakly similar pulls in nothing. A dense-only candidate (absent from the
+  FTS results) is scored at the pool's worst (neutral-floor) bm25 so the blend
+  ranks it by its cosine component. Two new `Index` knobs (dense candidate count,
+  default 10; minimum cosine, default 0.5). With embeddings OFF (the default)
+  `search` is byte-for-byte pure FTS. Embeddings settings
+  (`KB_EMBEDDINGS_MODE`/`MODEL`/`WEIGHT`) are now read from env ONLY in
+  `load_config` and threaded into the `Index` (and its embedder) via `Config`;
+  the build and query paths no longer re-read the environment, so a programmatic
+  caller's `Config` values are honoured.
 - Trigram fuzzy-match fallback for typos and partial identifiers (issue #41). A
   secondary FTS5 table (`fts_trigram`, `trigram` tokenizer, schema v7) is built
   into the same tmp DB and swapped atomically with the primary FTS index, so it

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,29 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   labels), then publishes the GitHub Release.
   Process is documented in `.rules/versioning.md` and `.rules/release-routine.md`.
   No tags are ever cut unattended.
+- Optional local-embedding hybrid ranking (issue #42). Real paraphrase / synonymy
+  handling via a LOCAL ONNX MiniLM-class model (no external API, no query-time
+  network), blended with BM25. OFF by default (`KB_EMBEDDINGS_MODE`, default off):
+  with the feature off and the `embeddings` extra uninstalled, nothing imports
+  the embedding stack and the lexical product is byte-for-byte unchanged. When
+  enabled, each doc is embedded at `Index.build` time into a new `doc_vectors`
+  table (schema v8, float32 blobs) written into the same tmp DB and swapped
+  atomically, so vectors rebuild atomically with the rest of the index. A hybrid
+  reranker embeds the query once and blends NORMALISED bm25 with cosine over the
+  candidate hits' stored vectors, then re-sorts. It composes as the INNER layer
+  under the exact-id/exact-tag short-circuit (so an exact id/tag still wins) and
+  wraps the status prior (so an active doc still outranks the superseded one it
+  replaced); when disabled the reranker stack is exactly today's. If enabled but
+  the extra/model is unavailable, startup fails LOUDLY with an actionable message
+  rather than silently reverting to lexical-only. Config: `KB_EMBEDDINGS_MODE`
+  (on/off, default off), `KB_EMBEDDINGS_MODEL` (default `BAAI/bge-small-en-v1.5`,
+  384-dim), `KB_EMBEDDINGS_WEIGHT` (cosine fraction of the blend in [0, 1],
+  default 0.35). The extra pulls in `fastembed` (which bundles `onnxruntime`; no
+  torch); the default model is a ~33 MB quantised ONNX file fetched once at
+  enable time and cached locally. Build cost: one batched local embed pass over
+  the corpus at `Index.build` (seconds for a small KB, no network at query
+  time); storage cost is 384 x 4 bytes (~1.5 KB) per doc in `doc_vectors`.
+  Install with `uv sync --extra embeddings`.
 - Trigram fuzzy-match fallback for typos and partial identifiers (issue #41). A
   secondary FTS5 table (`fts_trigram`, `trigram` tokenizer, schema v7) is built
   into the same tmp DB and swapped atomically with the primary FTS index, so it

--- a/benchmarks/ablate.py
+++ b/benchmarks/ablate.py
@@ -248,21 +248,31 @@ def run_ablation(
     queries: list[GovQuery],
     tokenizer: Tokenizer,
     k: int = 5,
+    extra_configs: list[tuple[str, dict[str, object] | None, Index]] | None = None,
 ) -> AblationReport:
-    """Run all four ablation configs over governance queries.
+    """Run the ablation configs over governance queries.
 
     Returns an AblationReport with one AblationRow per (config, stratum) cell.
+    ``extra_configs`` appends caller-supplied ``(label, search_kwargs, index)``
+    rows run over the same queries. This is how the dense configs are added: an
+    index with query expanders (the lexical default) and one that also carries
+    per-doc vectors with the hybrid reranker, so the marginal value of embeddings
+    over the shipping lexical stack is measured directly. Empty ``search_kwargs``
+    means production default columns; the expanders/reranker live on the index.
     """
-    all_configs: list[tuple[str, dict[str, object] | None]] = [
-        *[(label, kwargs) for label, kwargs in _FTS_CONFIGS],
-        (_BM25_LABEL, None),
+    # Each entry is (label, search_kwargs | None, index_to_use).
+    all_configs: list[tuple[str, dict[str, object] | None, Index]] = [
+        *[(label, kwargs, idx) for label, kwargs in _FTS_CONFIGS],
+        (_BM25_LABEL, None, idx),
     ]
+    if extra_configs:
+        all_configs.extend(extra_configs)
 
     rows: list[AblationRow] = []
 
-    for config_label, search_kwargs in all_configs:
+    for config_label, search_kwargs, cfg_idx in all_configs:
         qr_list = _run_config(
-            queries, idx, corpus_root, tokenizer, k, search_kwargs
+            queries, cfg_idx, corpus_root, tokenizer, k, search_kwargs
         )
 
         # Group by stratum.
@@ -385,6 +395,37 @@ def write_ablation(report: AblationReport, out_dir: Path) -> None:
             "dense/semantic methods would be expected to do better."
         )
     lines.append("")
+
+    # Marginal value of embeddings: each "<base>+embeddings" config vs its base.
+    emb_configs = [c for c in configs if c.endswith("+embeddings")]
+    for emb in emb_configs:
+        base_label = emb[: -len("+embeddings")]
+        if not any(r.config == base_label for r in report.rows):
+            continue
+        lines += [f"## Marginal value of embeddings: {emb} vs {base_label}", ""]
+        for stratum in _STRATA_ORDER:
+            base = next(
+                (r for r in report.rows
+                 if r.config == base_label and r.stratum == stratum), None)
+            hyb = next(
+                (r for r in report.rows
+                 if r.config == emb and r.stratum == stratum), None)
+            if not (base and hyb):
+                continue
+            if stratum == "negative":
+                lines.append(
+                    f"**negative** false-positive rate: {base.false_positive_rate:.3f} "
+                    f"-> {hyb.false_positive_rate:.3f} (a dense blend can cost "
+                    "abstention by always having a nearest neighbour)."
+                )
+            else:
+                lines.append(
+                    f"**{stratum}** recall@{report.k}: {base.recall:.3f} -> "
+                    f"{hyb.recall:.3f} ({hyb.recall - base.recall:+.3f}); "
+                    f"mrr {base.mrr:.3f} -> {hyb.mrr:.3f} "
+                    f"({hyb.mrr - base.mrr:+.3f})."
+                )
+        lines.append("")
 
     # Negative-query false positive rate
     lines += ["## Negative queries — false positive / abstention", ""]

--- a/benchmarks/generate_embeddings_ablation.py
+++ b/benchmarks/generate_embeddings_ablation.py
@@ -67,12 +67,22 @@ def main() -> None:
         # Dense DB (embeddings on): stores per-doc vectors for the hybrid configs.
         os.environ["KB_EMBEDDINGS_MODE"] = "on"
         cfg = embeddings_config()
-        Index(tmp_path / "hyb.db").build(_CORPUS_DIR, source_commit="emb-ablation-hyb")
+        # Build vectors by THREADING the resolved config into the Index (reviewer
+        # concern 2), sharing one embedder, instead of relying on an env re-read.
         embedder = build_embedder(cfg)
+        Index(tmp_path / "hyb.db", embeddings=cfg, embedder=embedder).build(
+            _CORPUS_DIR, source_commit="emb-ablation-hyb"
+        )
         print(f"Dense index: vectors built, model={cfg.model_name}, weight={cfg.weight}.")
 
         def _hybrid(path: Path) -> Index:
-            i = Index(path)
+            # Thread the SAME resolved config + embedder into the Index so the
+            # dense candidate SOURCE (reviewer concern 1) is active: search()
+            # unions cosine neighbours into the FTS pool before the hybrid
+            # reranker blends. Without this, the reranker would only reorder the
+            # FTS pool, and a paraphrase with zero lexical overlap would never be
+            # retrieved (exactly the paraphrase_uncovered stratum).
+            i = Index(path, embeddings=cfg, embedder=embedder)
             i.reranker = i.make_hybrid_reranker(embedder, weight=cfg.weight)
             return i
 

--- a/benchmarks/generate_embeddings_ablation.py
+++ b/benchmarks/generate_embeddings_ablation.py
@@ -1,0 +1,128 @@
+"""Embeddings hybrid-vs-lexical governance ablation (issue #42).
+
+Builds two indexes over the committed governance corpus:
+- a LEXICAL index (embeddings off), and
+- a HYBRID index (KB_EMBEDDINGS_MODE=on so build() stores per-doc vectors, with
+  its reranker set to the dense blend),
+then runs the governance ablation with both so the marginal value of embeddings
+is measured on the same held-out queries. Writes
+benchmarks/governance_results/embeddings/ablation.{json,md}.
+
+Requires the optional `embeddings` extra and a local model (fetched once, cached).
+Run as:
+    KB_EMBEDDINGS_MODE=on uv run python -m benchmarks.generate_embeddings_ablation
+(the script sets the flag itself for the hybrid build regardless).
+"""
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).parent.parent
+_CORPUS_DIR = _REPO_ROOT / "benchmarks" / "governance"
+_QUERIES_PATH = _REPO_ROOT / "benchmarks" / "governance_queries.yaml"
+_RESULTS_DIR = _REPO_ROOT / "benchmarks" / "governance_results" / "embeddings"
+
+
+def main() -> None:
+    from benchmarks.ablate import run_ablation, write_ablation
+    from benchmarks.governance_queries import load_governance_queries
+    from benchmarks.tokenizer import SimpleTokenizer
+    from data_olympus.cooccurrence import (
+        DEFAULT_MAX_TERMS,
+        compose_expanders,
+        cooccurrence_enabled,
+    )
+    from data_olympus.embeddings import build_embedder, embeddings_config
+    from data_olympus.index import Index
+    from data_olympus.query_expansion import default_query_expander
+
+    if not _CORPUS_DIR.exists() or not _QUERIES_PATH.exists():
+        raise SystemExit(
+            "Missing committed governance artifacts; run "
+            "`uv run python -m benchmarks.generate_governance_artifacts` first."
+        )
+
+    queries = load_governance_queries(_QUERIES_PATH)
+    print(f"Loaded {len(queries)} governance queries.")
+
+    def _expanders(index: Index):
+        # Mirror build_app: synonym expansion then co-occurrence expansion.
+        cooc = index.cooccurrence_expander() if cooccurrence_enabled() else None
+        return compose_expanders(
+            default_query_expander(), cooc, max_terms=DEFAULT_MAX_TERMS
+        )
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+
+        # Lexical DB (embeddings off): serves the pure-FTS baseline and the full
+        # lexical stack (which only adds query expanders, no vectors).
+        os.environ.pop("KB_EMBEDDINGS_MODE", None)
+        lex = Index(tmp_path / "lex.db")
+        r = lex.build(_CORPUS_DIR, source_commit="emb-ablation-lex")
+        print(f"Lexical index: {r.docs_indexed} docs.")
+
+        # Dense DB (embeddings on): stores per-doc vectors for the hybrid configs.
+        os.environ["KB_EMBEDDINGS_MODE"] = "on"
+        cfg = embeddings_config()
+        Index(tmp_path / "hyb.db").build(_CORPUS_DIR, source_commit="emb-ablation-hyb")
+        embedder = build_embedder(cfg)
+        print(f"Dense index: vectors built, model={cfg.model_name}, weight={cfg.weight}.")
+
+        def _hybrid(path: Path) -> Index:
+            i = Index(path)
+            i.reranker = i.make_hybrid_reranker(embedder, weight=cfg.weight)
+            return i
+
+        # pure FTS + embeddings (ceiling of the dense lift over bare FTS)
+        hyb_pure = _hybrid(tmp_path / "hyb.db")
+        # full lexical stack (synonym + co-occurrence expansion) = shipping default
+        full_lex = Index(tmp_path / "lex.db")
+        full_lex.query_expander = _expanders(full_lex)
+        # full lexical stack + embeddings = proposed enhanced default
+        hyb_stack = _hybrid(tmp_path / "hyb.db")
+        hyb_stack.query_expander = _expanders(hyb_stack)
+
+        report = run_ablation(
+            corpus_root=_CORPUS_DIR,
+            idx=lex,
+            queries=queries,
+            tokenizer=SimpleTokenizer(),
+            k=5,
+            extra_configs=[
+                ("fts+applies_when+embeddings", {}, hyb_pure),
+                ("lexical-stack", {}, full_lex),
+                ("lexical-stack+embeddings", {}, hyb_stack),
+            ],
+        )
+
+    write_ablation(report, _RESULTS_DIR)
+    print(f"Wrote {_RESULTS_DIR / 'ablation.md'}")
+
+    # Console summary: the two head-to-heads that matter.
+    def _row(cfg_label: str, stratum: str):
+        return next((x for x in report.rows
+                     if x.config == cfg_label and x.stratum == stratum), None)
+
+    for base_label, emb_label in (
+        ("fts+applies_when", "fts+applies_when+embeddings"),
+        ("lexical-stack", "lexical-stack+embeddings"),
+    ):
+        print(f"\n== {emb_label} vs {base_label} ==")
+        for stratum in ("trigger_covered", "paraphrase_uncovered", "supersession",
+                        "negative", "ALL"):
+            base = _row(base_label, stratum)
+            hyb_r = _row(emb_label, stratum)
+            if base and hyb_r:
+                print(
+                    f"  {stratum:22} recall {base.recall:.3f} -> {hyb_r.recall:.3f} "
+                    f"({hyb_r.recall - base.recall:+.3f}) | mrr {base.mrr:.3f} -> "
+                    f"{hyb_r.mrr:.3f} | fp {base.false_positive_rate:.3f} -> "
+                    f"{hyb_r.false_positive_rate:.3f}"
+                )
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/governance_results/embeddings/ablation.json
+++ b/benchmarks/governance_results/embeddings/ablation.json
@@ -1,0 +1,405 @@
+{
+  "k": 5,
+  "rows": [
+    {
+      "config": "fts-no-metadata",
+      "stratum": "negative",
+      "recall": 0.0,
+      "mrr": 0.0,
+      "miss_rate": 1.0,
+      "false_positive_rate": 1.0,
+      "mean_tokens": 299,
+      "n": 5
+    },
+    {
+      "config": "fts-no-metadata",
+      "stratum": "paraphrase_uncovered",
+      "recall": 0.42857142857142855,
+      "mrr": 0.30634920634920637,
+      "miss_rate": 0.5714285714285714,
+      "false_positive_rate": 0.0,
+      "mean_tokens": 308.04761904761904,
+      "n": 42
+    },
+    {
+      "config": "fts-no-metadata",
+      "stratum": "supersession",
+      "recall": 1.0,
+      "mrr": 1.0,
+      "miss_rate": 0.0,
+      "false_positive_rate": 0.0,
+      "mean_tokens": 358,
+      "n": 3
+    },
+    {
+      "config": "fts-no-metadata",
+      "stratum": "trigger_covered",
+      "recall": 0.8666666666666667,
+      "mrr": 0.7188888888888889,
+      "miss_rate": 0.13333333333333333,
+      "false_positive_rate": 0.0,
+      "mean_tokens": 295.93333333333334,
+      "n": 15
+    },
+    {
+      "config": "fts-no-metadata",
+      "stratum": "ALL",
+      "recall": 0.5230769230769231,
+      "mrr": 0.41,
+      "miss_rate": 0.47692307692307695,
+      "false_positive_rate": 0.0,
+      "mean_tokens": 306.8615384615385,
+      "n": 65
+    },
+    {
+      "config": "fts+description",
+      "stratum": "negative",
+      "recall": 0.0,
+      "mrr": 0.0,
+      "miss_rate": 1.0,
+      "false_positive_rate": 1.0,
+      "mean_tokens": 296,
+      "n": 5
+    },
+    {
+      "config": "fts+description",
+      "stratum": "paraphrase_uncovered",
+      "recall": 0.4523809523809524,
+      "mrr": 0.3111111111111111,
+      "miss_rate": 0.5476190476190477,
+      "false_positive_rate": 0.0,
+      "mean_tokens": 306.4047619047619,
+      "n": 42
+    },
+    {
+      "config": "fts+description",
+      "stratum": "supersession",
+      "recall": 1.0,
+      "mrr": 1.0,
+      "miss_rate": 0.0,
+      "false_positive_rate": 0.0,
+      "mean_tokens": 350,
+      "n": 3
+    },
+    {
+      "config": "fts+description",
+      "stratum": "trigger_covered",
+      "recall": 0.8666666666666667,
+      "mrr": 0.7188888888888889,
+      "miss_rate": 0.13333333333333333,
+      "false_positive_rate": 0.0,
+      "mean_tokens": 295.93333333333334,
+      "n": 15
+    },
+    {
+      "config": "fts+description",
+      "stratum": "ALL",
+      "recall": 0.5384615384615384,
+      "mrr": 0.41307692307692306,
+      "miss_rate": 0.46153846153846156,
+      "false_positive_rate": 0.0,
+      "mean_tokens": 305.2,
+      "n": 65
+    },
+    {
+      "config": "fts+applies_when",
+      "stratum": "negative",
+      "recall": 0.0,
+      "mrr": 0.0,
+      "miss_rate": 1.0,
+      "false_positive_rate": 1.0,
+      "mean_tokens": 296,
+      "n": 5
+    },
+    {
+      "config": "fts+applies_when",
+      "stratum": "paraphrase_uncovered",
+      "recall": 0.4523809523809524,
+      "mrr": 0.3111111111111111,
+      "miss_rate": 0.5476190476190477,
+      "false_positive_rate": 0.0,
+      "mean_tokens": 306.5952380952381,
+      "n": 42
+    },
+    {
+      "config": "fts+applies_when",
+      "stratum": "supersession",
+      "recall": 1.0,
+      "mrr": 1.0,
+      "miss_rate": 0.0,
+      "false_positive_rate": 0.0,
+      "mean_tokens": 350,
+      "n": 3
+    },
+    {
+      "config": "fts+applies_when",
+      "stratum": "trigger_covered",
+      "recall": 1.0,
+      "mrr": 1.0,
+      "miss_rate": 0.0,
+      "false_positive_rate": 0.0,
+      "mean_tokens": 299.8,
+      "n": 15
+    },
+    {
+      "config": "fts+applies_when",
+      "stratum": "ALL",
+      "recall": 0.5692307692307692,
+      "mrr": 0.47794871794871796,
+      "miss_rate": 0.4307692307692308,
+      "false_positive_rate": 0.0,
+      "mean_tokens": 306.2153846153846,
+      "n": 65
+    },
+    {
+      "config": "fts+applies_when+abstain",
+      "stratum": "negative",
+      "recall": 0.0,
+      "mrr": 0.0,
+      "miss_rate": 1.0,
+      "false_positive_rate": 0.0,
+      "mean_tokens": 0,
+      "n": 5
+    },
+    {
+      "config": "fts+applies_when+abstain",
+      "stratum": "paraphrase_uncovered",
+      "recall": 0.2857142857142857,
+      "mrr": 0.24603174603174602,
+      "miss_rate": 0.7142857142857143,
+      "false_positive_rate": 0.0,
+      "mean_tokens": 177.85714285714286,
+      "n": 42
+    },
+    {
+      "config": "fts+applies_when+abstain",
+      "stratum": "supersession",
+      "recall": 1.0,
+      "mrr": 1.0,
+      "miss_rate": 0.0,
+      "false_positive_rate": 0.0,
+      "mean_tokens": 350,
+      "n": 3
+    },
+    {
+      "config": "fts+applies_when+abstain",
+      "stratum": "trigger_covered",
+      "recall": 1.0,
+      "mrr": 1.0,
+      "miss_rate": 0.0,
+      "false_positive_rate": 0.0,
+      "mean_tokens": 299.8,
+      "n": 15
+    },
+    {
+      "config": "fts+applies_when+abstain",
+      "stratum": "ALL",
+      "recall": 0.46153846153846156,
+      "mrr": 0.4358974358974359,
+      "miss_rate": 0.5384615384615384,
+      "false_positive_rate": 0.0,
+      "mean_tokens": 200.26153846153846,
+      "n": 65
+    },
+    {
+      "config": "bm25-baseline",
+      "stratum": "negative",
+      "recall": 0.0,
+      "mrr": 0.0,
+      "miss_rate": 1.0,
+      "false_positive_rate": 1.0,
+      "mean_tokens": 688,
+      "n": 5
+    },
+    {
+      "config": "bm25-baseline",
+      "stratum": "paraphrase_uncovered",
+      "recall": 0.40476190476190477,
+      "mrr": 0.25952380952380955,
+      "miss_rate": 0.5952380952380952,
+      "false_positive_rate": 0.0,
+      "mean_tokens": 659.5714285714286,
+      "n": 42
+    },
+    {
+      "config": "bm25-baseline",
+      "stratum": "supersession",
+      "recall": 1.0,
+      "mrr": 1.0,
+      "miss_rate": 0.0,
+      "false_positive_rate": 0.0,
+      "mean_tokens": 684,
+      "n": 3
+    },
+    {
+      "config": "bm25-baseline",
+      "stratum": "trigger_covered",
+      "recall": 1.0,
+      "mrr": 1.0,
+      "miss_rate": 0.0,
+      "false_positive_rate": 0.0,
+      "mean_tokens": 663.1333333333333,
+      "n": 15
+    },
+    {
+      "config": "bm25-baseline",
+      "stratum": "ALL",
+      "recall": 0.5384615384615384,
+      "mrr": 0.44461538461538463,
+      "miss_rate": 0.46153846153846156,
+      "false_positive_rate": 0.0,
+      "mean_tokens": 663.7076923076924,
+      "n": 65
+    },
+    {
+      "config": "fts+applies_when+embeddings",
+      "stratum": "negative",
+      "recall": 0.0,
+      "mrr": 0.0,
+      "miss_rate": 1.0,
+      "false_positive_rate": 1.0,
+      "mean_tokens": 296,
+      "n": 5
+    },
+    {
+      "config": "fts+applies_when+embeddings",
+      "stratum": "paraphrase_uncovered",
+      "recall": 0.6666666666666666,
+      "mrr": 0.39404761904761904,
+      "miss_rate": 0.3333333333333333,
+      "false_positive_rate": 0.0,
+      "mean_tokens": 312.07142857142856,
+      "n": 42
+    },
+    {
+      "config": "fts+applies_when+embeddings",
+      "stratum": "supersession",
+      "recall": 1.0,
+      "mrr": 1.0,
+      "miss_rate": 0.0,
+      "false_positive_rate": 0.0,
+      "mean_tokens": 353.3333333333333,
+      "n": 3
+    },
+    {
+      "config": "fts+applies_when+embeddings",
+      "stratum": "trigger_covered",
+      "recall": 1.0,
+      "mrr": 1.0,
+      "miss_rate": 0.0,
+      "false_positive_rate": 0.0,
+      "mean_tokens": 307.6,
+      "n": 15
+    },
+    {
+      "config": "fts+applies_when+embeddings",
+      "stratum": "ALL",
+      "recall": 0.7076923076923077,
+      "mrr": 0.5315384615384615,
+      "miss_rate": 0.2923076923076923,
+      "false_positive_rate": 0.0,
+      "mean_tokens": 311.7076923076923,
+      "n": 65
+    },
+    {
+      "config": "lexical-stack",
+      "stratum": "negative",
+      "recall": 0.0,
+      "mrr": 0.0,
+      "miss_rate": 1.0,
+      "false_positive_rate": 1.0,
+      "mean_tokens": 296,
+      "n": 5
+    },
+    {
+      "config": "lexical-stack",
+      "stratum": "paraphrase_uncovered",
+      "recall": 0.47619047619047616,
+      "mrr": 0.3468253968253968,
+      "miss_rate": 0.5238095238095238,
+      "false_positive_rate": 0.0,
+      "mean_tokens": 317.64285714285717,
+      "n": 42
+    },
+    {
+      "config": "lexical-stack",
+      "stratum": "supersession",
+      "recall": 1.0,
+      "mrr": 1.0,
+      "miss_rate": 0.0,
+      "false_positive_rate": 0.0,
+      "mean_tokens": 376,
+      "n": 3
+    },
+    {
+      "config": "lexical-stack",
+      "stratum": "trigger_covered",
+      "recall": 1.0,
+      "mrr": 1.0,
+      "miss_rate": 0.0,
+      "false_positive_rate": 0.0,
+      "mean_tokens": 299.8,
+      "n": 15
+    },
+    {
+      "config": "lexical-stack",
+      "stratum": "ALL",
+      "recall": 0.5846153846153846,
+      "mrr": 0.5010256410256411,
+      "miss_rate": 0.4153846153846154,
+      "false_positive_rate": 0.0,
+      "mean_tokens": 314.55384615384617,
+      "n": 65
+    },
+    {
+      "config": "lexical-stack+embeddings",
+      "stratum": "negative",
+      "recall": 0.0,
+      "mrr": 0.0,
+      "miss_rate": 1.0,
+      "false_positive_rate": 1.0,
+      "mean_tokens": 296,
+      "n": 5
+    },
+    {
+      "config": "lexical-stack+embeddings",
+      "stratum": "paraphrase_uncovered",
+      "recall": 0.6904761904761905,
+      "mrr": 0.42976190476190473,
+      "miss_rate": 0.30952380952380953,
+      "false_positive_rate": 0.0,
+      "mean_tokens": 323.04761904761904,
+      "n": 42
+    },
+    {
+      "config": "lexical-stack+embeddings",
+      "stratum": "supersession",
+      "recall": 1.0,
+      "mrr": 1.0,
+      "miss_rate": 0.0,
+      "false_positive_rate": 0.0,
+      "mean_tokens": 381,
+      "n": 3
+    },
+    {
+      "config": "lexical-stack+embeddings",
+      "stratum": "trigger_covered",
+      "recall": 1.0,
+      "mrr": 1.0,
+      "miss_rate": 0.0,
+      "false_positive_rate": 0.0,
+      "mean_tokens": 307.6,
+      "n": 15
+    },
+    {
+      "config": "lexical-stack+embeddings",
+      "stratum": "ALL",
+      "recall": 0.7230769230769231,
+      "mrr": 0.5546153846153846,
+      "miss_rate": 0.27692307692307694,
+      "false_positive_rate": 0.0,
+      "mean_tokens": 320.0769230769231,
+      "n": 65
+    }
+  ]
+}

--- a/benchmarks/governance_results/embeddings/ablation.md
+++ b/benchmarks/governance_results/embeddings/ablation.md
@@ -1,0 +1,86 @@
+# Governance Retrieval Ablation
+
+k=5. Four configs: fts-no-metadata, fts+description, fts+applies_when (production), bm25-baseline.
+
+## Per-config x per-stratum metrics
+
+| Config | Stratum | Recall@k | MRR | Miss Rate | FP Rate | Tokens | N |
+|--------|---------|----------|-----|-----------|---------|--------|---|
+| fts-no-metadata | trigger_covered | 0.867 | 0.719 | 0.133 | 0.000 | 295.9 | 15 |
+| fts-no-metadata | paraphrase_uncovered | 0.429 | 0.306 | 0.571 | 0.000 | 308.0 | 42 |
+| fts-no-metadata | supersession | 1.000 | 1.000 | 0.000 | 0.000 | 358.0 | 3 |
+| fts-no-metadata | negative | 0.000 | 0.000 | 1.000 | 1.000 | 299.0 | 5 |
+| fts-no-metadata | ALL | 0.523 | 0.410 | 0.477 | 0.000 | 306.9 | 65 |
+| fts+description | trigger_covered | 0.867 | 0.719 | 0.133 | 0.000 | 295.9 | 15 |
+| fts+description | paraphrase_uncovered | 0.452 | 0.311 | 0.548 | 0.000 | 306.4 | 42 |
+| fts+description | supersession | 1.000 | 1.000 | 0.000 | 0.000 | 350.0 | 3 |
+| fts+description | negative | 0.000 | 0.000 | 1.000 | 1.000 | 296.0 | 5 |
+| fts+description | ALL | 0.538 | 0.413 | 0.462 | 0.000 | 305.2 | 65 |
+| fts+applies_when | trigger_covered | 1.000 | 1.000 | 0.000 | 0.000 | 299.8 | 15 |
+| fts+applies_when | paraphrase_uncovered | 0.452 | 0.311 | 0.548 | 0.000 | 306.6 | 42 |
+| fts+applies_when | supersession | 1.000 | 1.000 | 0.000 | 0.000 | 350.0 | 3 |
+| fts+applies_when | negative | 0.000 | 0.000 | 1.000 | 1.000 | 296.0 | 5 |
+| fts+applies_when | ALL | 0.569 | 0.478 | 0.431 | 0.000 | 306.2 | 65 |
+| fts+applies_when+abstain | trigger_covered | 1.000 | 1.000 | 0.000 | 0.000 | 299.8 | 15 |
+| fts+applies_when+abstain | paraphrase_uncovered | 0.286 | 0.246 | 0.714 | 0.000 | 177.9 | 42 |
+| fts+applies_when+abstain | supersession | 1.000 | 1.000 | 0.000 | 0.000 | 350.0 | 3 |
+| fts+applies_when+abstain | negative | 0.000 | 0.000 | 1.000 | 0.000 | 0.0 | 5 |
+| fts+applies_when+abstain | ALL | 0.462 | 0.436 | 0.538 | 0.000 | 200.3 | 65 |
+| bm25-baseline | trigger_covered | 1.000 | 1.000 | 0.000 | 0.000 | 663.1 | 15 |
+| bm25-baseline | paraphrase_uncovered | 0.405 | 0.260 | 0.595 | 0.000 | 659.6 | 42 |
+| bm25-baseline | supersession | 1.000 | 1.000 | 0.000 | 0.000 | 684.0 | 3 |
+| bm25-baseline | negative | 0.000 | 0.000 | 1.000 | 1.000 | 688.0 | 5 |
+| bm25-baseline | ALL | 0.538 | 0.445 | 0.462 | 0.000 | 663.7 | 65 |
+| fts+applies_when+embeddings | trigger_covered | 1.000 | 1.000 | 0.000 | 0.000 | 307.6 | 15 |
+| fts+applies_when+embeddings | paraphrase_uncovered | 0.667 | 0.394 | 0.333 | 0.000 | 312.1 | 42 |
+| fts+applies_when+embeddings | supersession | 1.000 | 1.000 | 0.000 | 0.000 | 353.3 | 3 |
+| fts+applies_when+embeddings | negative | 0.000 | 0.000 | 1.000 | 1.000 | 296.0 | 5 |
+| fts+applies_when+embeddings | ALL | 0.708 | 0.532 | 0.292 | 0.000 | 311.7 | 65 |
+| lexical-stack | trigger_covered | 1.000 | 1.000 | 0.000 | 0.000 | 299.8 | 15 |
+| lexical-stack | paraphrase_uncovered | 0.476 | 0.347 | 0.524 | 0.000 | 317.6 | 42 |
+| lexical-stack | supersession | 1.000 | 1.000 | 0.000 | 0.000 | 376.0 | 3 |
+| lexical-stack | negative | 0.000 | 0.000 | 1.000 | 1.000 | 296.0 | 5 |
+| lexical-stack | ALL | 0.585 | 0.501 | 0.415 | 0.000 | 314.6 | 65 |
+| lexical-stack+embeddings | trigger_covered | 1.000 | 1.000 | 0.000 | 0.000 | 307.6 | 15 |
+| lexical-stack+embeddings | paraphrase_uncovered | 0.690 | 0.430 | 0.310 | 0.000 | 323.0 | 42 |
+| lexical-stack+embeddings | supersession | 1.000 | 1.000 | 0.000 | 0.000 | 381.0 | 3 |
+| lexical-stack+embeddings | negative | 0.000 | 0.000 | 1.000 | 1.000 | 296.0 | 5 |
+| lexical-stack+embeddings | ALL | 0.723 | 0.555 | 0.277 | 0.000 | 320.1 | 65 |
+
+## Marginal value of applies_when
+
+**trigger_covered** recall@5: fts-no-metadata=0.867, fts+description=0.867, fts+applies_when=1.000. Marginal gain over +description: +0.133. Marginal gain over no-metadata: +0.133.
+**paraphrase_uncovered** recall@5: fts-no-metadata=0.429, fts+description=0.452, fts+applies_when=0.452. Marginal gain over +description: +0.000. Marginal gain over no-metadata: +0.024.
+
+## Held-out (paraphrase_uncovered) — honest limit
+
+On `paraphrase_uncovered` queries (held-out intent phrasings with NO trigger term), fts+applies_when achieves recall=0.452, mrr=0.311. Curated `applies_when` metadata does not help here because the queries contain no lexical overlap with authored trigger terms. This stratum is the honest ceiling for keyword-based retrieval; dense/semantic methods would be expected to do better.
+
+## Marginal value of embeddings: fts+applies_when+embeddings vs fts+applies_when
+
+**trigger_covered** recall@5: 1.000 -> 1.000 (+0.000); mrr 1.000 -> 1.000 (+0.000).
+**paraphrase_uncovered** recall@5: 0.452 -> 0.667 (+0.214); mrr 0.311 -> 0.394 (+0.083).
+**supersession** recall@5: 1.000 -> 1.000 (+0.000); mrr 1.000 -> 1.000 (+0.000).
+**negative** false-positive rate: 1.000 -> 1.000 (a dense blend can cost abstention by always having a nearest neighbour).
+**ALL** recall@5: 0.569 -> 0.708 (+0.138); mrr 0.478 -> 0.532 (+0.054).
+
+## Marginal value of embeddings: lexical-stack+embeddings vs lexical-stack
+
+**trigger_covered** recall@5: 1.000 -> 1.000 (+0.000); mrr 1.000 -> 1.000 (+0.000).
+**paraphrase_uncovered** recall@5: 0.476 -> 0.690 (+0.214); mrr 0.347 -> 0.430 (+0.083).
+**supersession** recall@5: 1.000 -> 1.000 (+0.000); mrr 1.000 -> 1.000 (+0.000).
+**negative** false-positive rate: 1.000 -> 1.000 (a dense blend can cost abstention by always having a nearest neighbour).
+**ALL** recall@5: 0.585 -> 0.723 (+0.138); mrr 0.501 -> 0.555 (+0.054).
+
+## Negative queries — false positive / abstention
+
+- **fts-no-metadata**: 1.000 false-positive rate on 5 negative queries (returned anything at all when no governing rule exists).
+- **fts+description**: 1.000 false-positive rate on 5 negative queries (returned anything at all when no governing rule exists).
+- **fts+applies_when**: 1.000 false-positive rate on 5 negative queries (returned anything at all when no governing rule exists).
+- **fts+applies_when+abstain**: 0.000 false-positive rate on 5 negative queries (returned anything at all when no governing rule exists).
+- **bm25-baseline**: 1.000 false-positive rate on 5 negative queries (returned anything at all when no governing rule exists).
+- **fts+applies_when+embeddings**: 1.000 false-positive rate on 5 negative queries (returned anything at all when no governing rule exists).
+- **lexical-stack**: 1.000 false-positive rate on 5 negative queries (returned anything at all when no governing rule exists).
+- **lexical-stack+embeddings**: 1.000 false-positive rate on 5 negative queries (returned anything at all when no governing rule exists).
+
+_A governance tool should ideally abstain (return nothing) on queries with no governing rule. FP rate = 0.0 means perfect abstention; 1.0 means always returned results._

--- a/docs/serving.md
+++ b/docs/serving.md
@@ -191,6 +191,55 @@ Two environment variables tune it:
   - `off`: disable expansion entirely (the expander becomes a passthrough, so
     only the terms the user typed are matched).
 
+## Optional local-embedding hybrid ranking
+
+For real paraphrase / synonymy handling (a query that shares no tokens with the
+relevant doc, e.g. `car` for a doc about `automobile`), the server can blend BM25
+with LOCAL embedding similarity. This is **optional and OFF by default**: with
+the feature off and the `embeddings` extra uninstalled, nothing imports the
+embedding stack and the default lexical product is unchanged. There is **no
+external API and no network call at query time**; a small ONNX model runs
+in-process.
+
+When enabled, each document is embedded at index-build time and its vector is
+stored in a `doc_vectors` table (schema v8) written into the same tmp database
+and swapped atomically with the rest of the index, so vectors rebuild
+atomically. At query time a hybrid reranker embeds the query once and blends
+**normalised BM25** with **cosine similarity** over the candidate hits' stored
+vectors, then re-sorts. It composes UNDER the exact-id / exact-tag short-circuit
+(so an exact id or tag still ranks first) and wraps the status-aware rerank (so
+an active doc still outranks the superseded one it replaced). When disabled the
+reranker stack is exactly the status + id/tag behaviour described under **Search
+ranking**.
+
+Enable and tune it with:
+
+- `KB_EMBEDDINGS_MODE`: `on` to enable; any other value (including unset) leaves
+  it off.
+- `KB_EMBEDDINGS_MODEL`: the local model name (default `BAAI/bge-small-en-v1.5`,
+  a 384-dimensional MiniLM-class model). Any `fastembed`-supported model works.
+- `KB_EMBEDDINGS_WEIGHT`: the cosine fraction of the blended score, in `[0, 1]`
+  (default `0.35`). `0.0` is pure lexical (BM25) ordering, `1.0` is pure
+  semantic. A malformed or out-of-range value fails startup loudly.
+
+Install the extra to make the model runner available:
+
+```bash
+uv sync --extra embeddings   # or: pip install 'data-olympus[embeddings]'
+```
+
+The extra pulls in `fastembed`, which bundles `onnxruntime` (there is no torch
+dependency). The default model ships as a ~33 MB quantised ONNX file that is
+fetched once when the feature is first enabled and cached locally; after that
+there is no network access. If `KB_EMBEDDINGS_MODE=on` but the extra or the model
+is unavailable, **startup fails loudly** with an actionable message rather than
+silently reverting to lexical-only ranking.
+
+Cost: build adds one batched local embedding pass over the corpus (seconds for a
+small KB); storage adds `dim x 4` bytes per document in `doc_vectors` (~1.5 KB
+per doc for the 384-dim default). Query-time cost is one query embedding plus a
+cosine over the (bounded) candidate pool.
+
 ## Authentication and network security
 
 The server supports optional bearer-token authentication with a per-principal

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,14 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+# Optional local-embedding hybrid ranking (issue #42). NOT a core dependency:
+# with this extra uninstalled and KB_EMBEDDINGS_MODE unset, nothing imports the
+# embedding stack and the lexical product is unchanged. fastembed bundles a
+# quantised ONNX MiniLM-class model runner (onnxruntime), so there is NO torch
+# and no external API; the model is fetched once at enable time and cached.
+embeddings = [
+    "fastembed>=0.8,<0.9",
+]
 dev = [
     "pytest>=8.3",
     "pytest-asyncio>=0.24",
@@ -19,6 +27,10 @@ dev = [
     "ruff>=0.15.20",
     "mypy>=1.13",
     "types-PyYAML>=6.0",
+    # Exercise the embeddings path in CI (the feature stays off by default at
+    # runtime; the tests opt in via KB_EMBEDDINGS_MODE and skip if the model
+    # cannot be fetched in the sandbox).
+    "fastembed>=0.8,<0.9",
 ]
 bench = [
     "tiktoken>=0.8",

--- a/src/data_olympus/config.py
+++ b/src/data_olympus/config.py
@@ -68,6 +68,17 @@ class Config:
     # Index.search reads these to gate the query-time fallback.
     trigram_fallback_enabled: bool = False
     trigram_fallback_threshold: int = 3
+    # Optional local-embedding hybrid ranking (issue #42). Default OFF so the
+    # zero-dependency lexical mode stays the default and no embedding library is
+    # imported. When on, docs are embedded at build time (schema v8 doc_vectors)
+    # and a hybrid reranker blends normalised bm25 with query-doc cosine.
+    # ``embeddings_weight`` in [0, 1] is the cosine fraction of the blend;
+    # ``embeddings_model`` names the local ONNX model. Surfaced here for
+    # discoverability; the build path reads the same env vars directly (mirroring
+    # the trigram/co-occurrence features), so the CLI indexer honours them.
+    embeddings_enabled: bool = False
+    embeddings_weight: float = 0.35
+    embeddings_model: str = "BAAI/bge-small-en-v1.5"
 
 
 def _split_csv(raw: str) -> list[str]:
@@ -150,6 +161,14 @@ def load_config() -> Config:
     )
     trigram_enabled = _trigram_enabled()
     trigram_threshold = _trigram_threshold()
+    from data_olympus.embeddings import (
+        embeddings_config as _embeddings_config,
+    )
+    from data_olympus.embeddings import (
+        embeddings_enabled as _embeddings_enabled,
+    )
+    emb_enabled = _embeddings_enabled()
+    emb_cfg = _embeddings_config()
     return Config(
         kb_main_path=Path(os.environ.get("KB_MAIN_PATH", "/kb-main")),
         kb_index_path=Path(os.environ.get("KB_INDEX_PATH", "/index/kb.db")),
@@ -189,4 +208,7 @@ def load_config() -> Config:
         cooccurrence_min_pmi=float(cooc_params["min_pmi"]),
         trigram_fallback_enabled=trigram_enabled,
         trigram_fallback_threshold=trigram_threshold,
+        embeddings_enabled=emb_enabled,
+        embeddings_weight=emb_cfg.weight,
+        embeddings_model=emb_cfg.model_name,
     )

--- a/src/data_olympus/embeddings.py
+++ b/src/data_olympus/embeddings.py
@@ -1,0 +1,313 @@
+"""Optional local-embedding hybrid ranking (issue #42).
+
+Real paraphrase / synonymy handling via LOCAL embeddings, blended with BM25. No
+external API is ever called at query time; a small ONNX MiniLM-class model runs
+in-process. The feature is OFF by default and, when off, this module is the ONLY
+place that would touch the embedding libraries, and it imports them LAZILY
+(inside :func:`_load_text_embedding_cls`), so with the ``embeddings`` extra NOT
+installed and ``KB_EMBEDDINGS_MODE`` unset the default product is byte-for-byte
+unchanged and never imports ``fastembed`` / ``onnxruntime``.
+
+Design (mirrors ``trigram.py`` / ``cooccurrence.py``):
+
+- ``EMBEDDINGS_SCHEMA``: the ``doc_vectors`` table DDL, appended to the index
+  schema so it is created (and, via the tmp-DB build + ``os.replace``, swapped)
+  atomically with the primary FTS table. The table is created unconditionally
+  (an empty table costs nothing) but only POPULATED when the feature is enabled,
+  so a default build needs no embedding dependency.
+- ``embeddings_enabled`` / ``embeddings_config``: env config. ``KB_EMBEDDINGS_MODE``
+  gates the whole feature (default off); ``KB_EMBEDDINGS_MODEL`` and
+  ``KB_EMBEDDINGS_WEIGHT`` tune the model and blend weight.
+- ``build_embedder``: construct the local embedder, raising a LOUD, actionable
+  :class:`EmbeddingsUnavailableError` when the dep/model is missing rather than
+  silently falling back (which would hide misconfiguration).
+- ``serialize_vector`` / ``deserialize_vector`` / ``cosine``: pure-Python vector
+  storage + similarity, so the query-time blend needs no numpy.
+- ``make_hybrid_reranker``: blend NORMALISED bm25 with cosine over candidate
+  hits' stored vectors and re-sort. Composed as an INNER reranker under the
+  id/tag short-circuit in ``server.build_app`` so an exact id/tag still wins.
+
+Ranking discipline: the hybrid reranker only RE-ORDERS the existing candidate
+pool; it never drops a hit (a doc with no stored vector keeps its bm25
+contribution and a neutral cosine of 0). Because it is composed as ``inner``
+under the id/tag short-circuit, an exact-id or exact-tag query is unaffected.
+"""
+from __future__ import annotations
+
+import array
+import math
+import os
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from data_olympus.index import SearchHit
+
+
+# --- config ------------------------------------------------------------------
+
+# A small, local, ONNX MiniLM-class model. bge-small-en-v1.5 is 384-dim, emits
+# L2-normalised vectors, and ships as a quantised ONNX file (~33 MB) that
+# fastembed fetches once and caches; it needs no torch. A deployment can point
+# ``KB_EMBEDDINGS_MODEL`` at any fastembed-supported model.
+DEFAULT_MODEL_NAME = "BAAI/bge-small-en-v1.5"
+
+# Blend weight in [0, 1]: the fraction of the final score contributed by cosine
+# similarity; ``1 - weight`` is contributed by normalised bm25. 0.0 == pure
+# lexical (bm25) ordering, 1.0 == pure semantic (cosine). The default leans on
+# bm25 (the tuned lexical signal) while letting cosine rescue paraphrase misses.
+DEFAULT_WEIGHT = 0.35
+
+
+@dataclass(frozen=True, slots=True)
+class EmbeddingsConfig:
+    """Resolved embeddings configuration (model + blend weight)."""
+
+    model_name: str
+    weight: float
+
+
+class EmbeddingsUnavailableError(RuntimeError):
+    """Raised when embeddings are ENABLED but the dep/model cannot be loaded.
+
+    Carries an actionable message so a misconfigured deployment fails loudly at
+    startup instead of silently shipping default (lexical-only) ranking.
+    """
+
+
+def embeddings_enabled() -> bool:
+    """Whether local-embedding hybrid ranking is active. Default OFF.
+
+    ``KB_EMBEDDINGS_MODE=on`` (case-insensitive) enables it; any other value
+    (including unset) leaves it off so the zero-dependency lexical product is
+    unchanged and the embedding libraries are never imported.
+    """
+    return os.getenv("KB_EMBEDDINGS_MODE", "off").strip().lower() == "on"
+
+
+def embeddings_config() -> EmbeddingsConfig:
+    """Resolve the embeddings config from env, applying defaults.
+
+    ``KB_EMBEDDINGS_WEIGHT`` must parse to a float in [0, 1]; a malformed or
+    out-of-range value raises ``ValueError`` rather than silently clamping, so a
+    misconfigured blend fails loudly (matching ``KB_STATUS_WEIGHTS`` semantics).
+    """
+    model_name = os.getenv("KB_EMBEDDINGS_MODEL", "").strip() or DEFAULT_MODEL_NAME
+    raw_weight = os.getenv("KB_EMBEDDINGS_WEIGHT", "").strip()
+    if not raw_weight:
+        weight = DEFAULT_WEIGHT
+    else:
+        try:
+            weight = float(raw_weight)
+        except ValueError as e:
+            raise ValueError(
+                f"KB_EMBEDDINGS_WEIGHT must be a float in [0, 1]; got {raw_weight!r}"
+            ) from e
+        if not 0.0 <= weight <= 1.0:
+            raise ValueError(
+                f"KB_EMBEDDINGS_WEIGHT must be in [0, 1]; got {weight}"
+            )
+    return EmbeddingsConfig(model_name=model_name, weight=weight)
+
+
+# --- vector storage + similarity (pure Python, no numpy) ---------------------
+
+
+def serialize_vector(vec: list[float]) -> bytes:
+    """Pack a float vector into a compact little-endian float32 blob.
+
+    float32 halves the stored size versus float64 at a precision loss well below
+    the ranking signal. ``array`` keeps this dependency-free; the blob round-trips
+    through :func:`deserialize_vector`.
+    """
+    return array.array("f", vec).tobytes()
+
+
+def deserialize_vector(blob: bytes) -> list[float]:
+    """Unpack a float32 blob written by :func:`serialize_vector`."""
+    a = array.array("f")
+    a.frombytes(blob)
+    return list(a)
+
+
+def cosine(a: list[float], b: list[float]) -> float:
+    """Cosine similarity of two equal-length vectors, in [-1, 1].
+
+    A zero-norm vector has no direction, so its similarity is defined as 0 rather
+    than dividing by zero. A length mismatch is a programming error and raises.
+    """
+    if len(a) != len(b):
+        raise ValueError(f"vector length mismatch: {len(a)} != {len(b)}")
+    dot = 0.0
+    na = 0.0
+    nb = 0.0
+    for x, y in zip(a, b, strict=True):
+        dot += x * y
+        na += x * x
+        nb += y * y
+    if na == 0.0 or nb == 0.0:
+        return 0.0
+    return dot / (math.sqrt(na) * math.sqrt(nb))
+
+
+# --- embedder (lazy fastembed import) ----------------------------------------
+
+
+def _load_text_embedding_cls() -> Any:
+    """Import and return ``fastembed.TextEmbedding``.
+
+    Isolated so it can be monkeypatched in tests and so the import stays LAZY:
+    it runs only from :func:`build_embedder`, which is only reached when the
+    feature is enabled. With the feature off this line is never executed and
+    ``fastembed`` is never imported.
+    """
+    from fastembed import TextEmbedding
+
+    return TextEmbedding
+
+
+class Embedder:
+    """Thin wrapper over a local fastembed model.
+
+    Holds the loaded model and exposes ``embed_one`` (query) and ``embed_many``
+    (build) returning plain ``list[float]`` so the rest of the codebase stays
+    numpy-free. Construction is via :func:`build_embedder`.
+    """
+
+    def __init__(self, model: Any, *, model_name: str) -> None:
+        self._model = model
+        self.model_name = model_name
+
+    def embed_one(self, text: str) -> list[float]:
+        """Embed a single text into a plain float list."""
+        for vec in self._model.embed([text]):
+            return [float(x) for x in vec]
+        return []
+
+    def embed_many(self, texts: list[str]) -> list[list[float]]:
+        """Embed a batch, preserving input order."""
+        return [[float(x) for x in vec] for vec in self._model.embed(texts)]
+
+
+def build_embedder(config: EmbeddingsConfig) -> Embedder:
+    """Load the local embedding model, or fail loudly.
+
+    Raises :class:`EmbeddingsUnavailableError` with an actionable message when
+    the ``embeddings`` extra is not installed or the model cannot be loaded
+    (e.g. it could not be fetched to the local cache). The caller (startup path)
+    surfaces this so a misconfigured deployment fails visibly rather than
+    silently reverting to lexical-only ranking.
+    """
+    try:
+        text_embedding_cls = _load_text_embedding_cls()
+    except ImportError as e:
+        raise EmbeddingsUnavailableError(
+            "KB_EMBEDDINGS_MODE is on but the embeddings dependency is not "
+            "installed. Install the extra: `uv sync --extra embeddings` (or "
+            "`pip install 'data-olympus[embeddings]'`), or set KB_EMBEDDINGS_MODE=off "
+            f"to run lexical-only. Underlying import error: {e}"
+        ) from e
+    try:
+        model = text_embedding_cls(model_name=config.model_name)
+    except Exception as e:  # noqa: BLE001 - any load failure must fail loudly
+        raise EmbeddingsUnavailableError(
+            f"KB_EMBEDDINGS_MODE is on but the embedding model "
+            f"{config.model_name!r} could not be loaded (it is fetched once and "
+            f"cached; a first-run needs the model available). Set a cached "
+            f"KB_EMBEDDINGS_MODEL or KB_EMBEDDINGS_MODE=off. Underlying error: {e}"
+        ) from e
+    return Embedder(model, model_name=config.model_name)
+
+
+# --- SQLite persistence (built inside Index.build, read at query time) -------
+
+# One row per doc: the id (FK to docs.id) and its float32 vector blob. Created
+# unconditionally in the schema (empty when the feature is off) so a default
+# build needs no embedding dep; populated only when embeddings are enabled.
+EMBEDDINGS_SCHEMA = """
+CREATE TABLE IF NOT EXISTS doc_vectors (
+    id TEXT PRIMARY KEY,
+    vector BLOB NOT NULL
+);
+"""
+
+
+# --- hybrid reranker ---------------------------------------------------------
+
+
+def _normalise_bm25(hits: list[SearchHit]) -> dict[str, float]:
+    """Map each hit id to a bm25 GOODNESS in [0, 1] (1 == best in this pool).
+
+    search() orders bm25 ASCENDING (lower is better), so we invert: the minimum
+    (best) score maps to 1.0 and the maximum (worst) to 0.0. When all scores are
+    equal (single hit, or a synthetic neutral pool) every hit gets 1.0, so the
+    blend is decided purely by cosine, and there is no divide-by-zero.
+    """
+    if not hits:
+        return {}
+    scores = [h.score for h in hits]
+    lo = min(scores)
+    hi = max(scores)
+    spread = hi - lo
+    if spread == 0.0:
+        return {h.id: 1.0 for h in hits}
+    # goodness = 1 when score == lo (best), 0 when score == hi (worst).
+    return {h.id: (hi - h.score) / spread for h in hits}
+
+
+def make_hybrid_reranker(
+    *,
+    embed_query: Callable[[str], list[float] | None],
+    get_vector: Callable[[str], list[float] | None],
+    weight: float,
+) -> Callable[[str, list[SearchHit]], list[SearchHit]]:
+    """Build a reranker that blends normalised bm25 with query-doc cosine.
+
+    ``embed_query(query)`` returns the query vector (or ``None`` if it cannot be
+    embedded); ``get_vector(id)`` returns a stored doc vector (or ``None`` when
+    the doc has no vector). ``weight`` in [0, 1] is the cosine fraction of the
+    blended score (``1 - weight`` is bm25).
+
+    The blended score is::
+
+        blended = (1 - weight) * bm25_goodness + weight * cosine_component
+
+    where ``bm25_goodness`` is in [0, 1] (higher = better within this pool) and
+    ``cosine_component`` maps cosine [-1, 1] to [0, 1]. Hits are re-sorted by
+    blended score DESCENDING (higher = better) and the result is re-scored onto
+    the search()-native ascending-bm25 convention (negated blended score) so a
+    later stage that sorts ascending keeps the same order.
+
+    Discipline: no hit is dropped. A doc with no stored vector, or a query that
+    cannot be embedded, contributes a neutral cosine (the reranker degrades to
+    bm25 ordering for that case). The re-sort is stable for equal blended scores.
+    """
+
+    def reranker(query: str, hits: list[SearchHit]) -> list[SearchHit]:
+        if not hits:
+            return hits
+        from dataclasses import replace
+
+        qvec = embed_query(query)
+        bm25_goodness = _normalise_bm25(hits)
+
+        def blended(h: SearchHit) -> float:
+            good = bm25_goodness.get(h.id, 0.0)
+            cos_component = 0.0
+            if qvec is not None:
+                dvec = get_vector(h.id)
+                if dvec is not None and len(dvec) == len(qvec):
+                    # Map cosine [-1, 1] -> [0, 1].
+                    cos_component = (cosine(qvec, dvec) + 1.0) / 2.0
+            return (1.0 - weight) * good + weight * cos_component
+
+        scored = [(blended(h), i, h) for i, h in enumerate(hits)]
+        # Sort by blended DESC; ties keep incoming order via the enumerate index.
+        scored.sort(key=lambda t: (-t[0], t[1]))
+        # Re-score onto the ascending-bm25 convention (lower == better) so a
+        # downstream ascending sort agrees with this order: negate blended.
+        return [replace(h, score=-b) for b, _i, h in scored]
+
+    return reranker

--- a/src/data_olympus/index.py
+++ b/src/data_olympus/index.py
@@ -25,9 +25,10 @@ from data_olympus.cooccurrence import (
 from data_olympus.embeddings import (
     EMBEDDINGS_SCHEMA,
     Embedder,
+    EmbeddingsConfig,
+    build_embedder,
+    cosine,
     deserialize_vector,
-    embeddings_config,
-    embeddings_enabled,
     make_hybrid_reranker,
     serialize_vector,
 )
@@ -104,6 +105,18 @@ _RERANK_MAX_POOL = 200
 # a doc carries its topical signal; bounding it keeps a very long doc from
 # overrunning the model's context window and keeps build cost predictable.
 _EMBED_TEXT_MAX_CHARS = 4000
+
+# Dense (semantic) candidate SOURCE defaults (issue #42, reviewer concern 1).
+# When embeddings are enabled, search() unions the top-N docs by query-doc cosine
+# into the FTS candidate pool so a paraphrase with ZERO lexical overlap can still
+# retrieve its doc (bm25 alone never surfaces it). Two knobs, both config-driven:
+#   * DEFAULT_DENSE_CANDIDATE_COUNT: how many nearest neighbours to consider.
+#   * DEFAULT_DENSE_MIN_COSINE: a minimum cosine a neighbour must clear to be
+#     added. This is the abstention guard: a negative / out-of-scope query whose
+#     nearest neighbour is only weakly similar pulls in NOTHING, so the dense
+#     source does not blow up the false-positive rate on the negative stratum.
+DEFAULT_DENSE_CANDIDATE_COUNT = 10
+DEFAULT_DENSE_MIN_COSINE = 0.5
 
 # Status priors for the status-aware reranker (issue #37). search() orders by
 # bm25 ASCENDING (lower = better), so these deltas are ADDED to the raw score:
@@ -375,8 +388,25 @@ class Index:
         reranker: Callable[[str, list[SearchHit]], list[SearchHit]] | None = None,
         trigram_fallback: bool = False,
         trigram_fallback_threshold: int | None = None,
+        embeddings: EmbeddingsConfig | None = None,
+        embedder: Embedder | None = None,
+        dense_candidate_count: int = DEFAULT_DENSE_CANDIDATE_COUNT,
+        dense_min_cosine: float = DEFAULT_DENSE_MIN_COSINE,
     ) -> None:
         self._db_path = db_path
+        # Embeddings (issue #42) are threaded in from Config, NOT re-read from env
+        # here (reviewer concern 2): Config (via load_config) is the single source
+        # of truth for KB_EMBEDDINGS_MODE/MODEL/WEIGHT. ``embeddings`` being non-
+        # None is what turns the feature on for THIS index; ``embedder`` is the
+        # (lazily loadable) model shared between build() and the query-time dense
+        # source. When ``embeddings`` is None the embedding path is fully inert:
+        # build() stores no vectors and search() is byte-for-byte pure FTS.
+        self._embeddings = embeddings
+        self._embedder = embedder
+        # Dense candidate SOURCE knobs (reviewer concern 1). Only consulted when
+        # both an embeddings config and an embedder are present.
+        self._dense_candidate_count = dense_candidate_count
+        self._dense_min_cosine = dense_min_cosine
         # Trigram fuzzy-match fallback (issue #41). When enabled, a primary FTS
         # query that returns at or below ``trigram_fallback_threshold`` hits is
         # backfilled from the secondary trigram-tokenized table so a typo or a
@@ -412,6 +442,23 @@ class Index:
         # Test/observability counter: how many times the DB was actually read
         # (cache misses). Not part of the public contract.
         self._health_uncached_calls = 0
+
+    def _resolve_embedder(self) -> Embedder | None:
+        """Return the embedder to use, loading it from the threaded config once.
+
+        Returns None when embeddings are not configured for this index (feature
+        off). When configured, an explicitly-injected ``embedder`` (e.g. shared
+        with the query-time reranker, or a test double) is preferred; otherwise
+        the model is loaded from ``self._embeddings`` on first use and cached, so
+        build() and the query-time dense source share a single loaded model.
+        ``build_embedder`` raises loudly if the dep/model is unavailable, so a
+        misconfigured build fails visibly rather than silently shipping lexical.
+        """
+        if self._embeddings is None:
+            return None
+        if self._embedder is None:
+            self._embedder = build_embedder(self._embeddings)
+        return self._embedder
 
     def _connect(self) -> sqlite3.Connection:
         self._db_path.parent.mkdir(parents=True, exist_ok=True)
@@ -475,19 +522,20 @@ class Index:
             # walk; only populated when co-occurrence expansion is enabled.
             build_cooccurrence = cooccurrence_enabled()
             doc_token_sets: list[set[str]] = []
-            # Embedding vectors (issue #42). Only when the feature is enabled do
-            # we load the (optional) model and collect per-doc embedding text; a
-            # default build never touches the embedding dependency. Each entry is
-            # (doc_id, text_to_embed), embedded in one batch after the walk and
-            # written into the SAME tmp DB so vectors swap atomically with the
-            # rest of the index. build_embedder raises loudly if enabled but the
-            # dep/model is unavailable, so a misconfigured build fails visibly.
-            build_embeddings = embeddings_enabled()
+            # Embedding vectors (issue #42). Whether/what to embed is decided from
+            # the threaded ``self._embeddings`` config (reviewer concern 2), NOT
+            # from an env re-read: Config is the single source of truth. Only when
+            # a config is present do we load the (optional) model and collect
+            # per-doc embedding text; a default build never touches the embedding
+            # dependency. Each entry is (doc_id, text_to_embed), embedded in one
+            # batch after the walk and written into the SAME tmp DB so vectors
+            # swap atomically with the rest of the index. _resolve_embedder raises
+            # loudly if enabled but the dep/model is unavailable.
+            build_embeddings = self._embeddings is not None
             embedder: Embedder | None = None
             embed_inputs: list[tuple[str, str]] = []
             if build_embeddings:
-                from data_olympus.embeddings import build_embedder
-                embedder = build_embedder(embeddings_config())
+                embedder = self._resolve_embedder()
             for md in files_to_index:
                 rel = md.relative_to(kb_root)
                 doc = parse_file(md)
@@ -718,11 +766,72 @@ class Index:
                 )
         finally:
             conn.close()
+        # Stage 2c (dense candidate SOURCE, issue #42, reviewer concern 1). Only
+        # when embeddings are configured for this index (guarded on the embedder
+        # being present) do we ADD semantic neighbours to the pool; when off this
+        # whole block is skipped and search() is byte-for-byte pure FTS. A
+        # paraphrase with zero lexical overlap never entered the FTS pool above, so
+        # without this the hybrid reranker could not help it. The dense hits are
+        # UNIONED (dedup by id) into the pool; a dense-only hit (no bm25 score)
+        # gets a neutral floor score (the worst bm25 in the pool, or 0.0 for an
+        # empty pool) so the hybrid blend ranks it by its cosine component. The
+        # reranker below then blends and truncates to ``limit``.
+        if self._embeddings is not None:
+            hits = self._union_dense_candidates(
+                query,
+                hits,
+                dense_limit=self._dense_candidate_count,
+                tier=tier,
+                category=category,
+                status=status,
+                doc_type=doc_type,
+            )
         # Stage 3 (re-rank): optional hook reorders/rescores (default identity),
         # then truncate the (possibly wider / prepended) pool back to `limit`.
         if self.reranker is not None:
             hits = list(self.reranker(query, hits))[:limit]
         return hits
+
+    def _union_dense_candidates(
+        self,
+        query: str,
+        fts_hits: builtins.list[SearchHit],
+        *,
+        dense_limit: int,
+        tier: str | None,
+        category: str | None,
+        status: str | None,
+        doc_type: str | None,
+    ) -> builtins.list[SearchHit]:
+        """Union dense (cosine) candidates into the FTS pool (reviewer concern 1).
+
+        Dense hits already present in ``fts_hits`` (matched lexically too) are
+        dropped so an FTS hit keeps its real bm25 score. A dense-ONLY hit has no
+        bm25 signal, so it is given the worst (largest, since bm25 is ordered
+        ascending) score in the current pool as a neutral floor; the hybrid
+        reranker then decides its rank purely by its cosine component. With an
+        empty FTS pool the floor is 0.0 (a finite, ordered anchor). Dense-only
+        hits are APPENDED after the FTS hits; the reranker re-sorts the whole pool.
+        """
+        dense = self.dense_candidates(
+            query,
+            limit=dense_limit,
+            min_cosine=self._dense_min_cosine,
+            tier=tier,
+            category=category,
+            status=status,
+            doc_type=doc_type,
+        )
+        if not dense:
+            return fts_hits
+        seen = {h.id for h in fts_hits}
+        # Worst (largest) bm25 in the pool as the neutral floor for dense-only
+        # hits; 0.0 when the FTS pool is empty so scores stay finite and ordered.
+        floor = max((h.score for h in fts_hits), default=0.0)
+        appended = [
+            replace(h, score=floor) for h in dense if h.id not in seen
+        ]
+        return [*fts_hits, *appended]
 
     def _build_match_expr(self, terms: list[str], columns: list[str] | None) -> str:
         """Match stage: build the FTS5 MATCH expression from query terms.
@@ -875,6 +984,100 @@ class Index:
         if row is None:
             return None
         return deserialize_vector(row["vector"])
+
+    def dense_candidates(
+        self,
+        query: str,
+        *,
+        limit: int,
+        min_cosine: float,
+        tier: str | None = None,
+        category: str | None = None,
+        status: str | None = None,
+        doc_type: str | None = None,
+    ) -> builtins.list[SearchHit]:
+        """Return up to ``limit`` docs most similar to ``query`` by cosine (issue #42).
+
+        This is the semantic candidate SOURCE that reviewer concern 1 requires: a
+        paraphrase with zero lexical overlap never enters the FTS pool, so search()
+        unions these dense hits in before the reranker runs. Reuses ``cosine`` over
+        the stored ``doc_vectors`` (read via the same deserialize path as
+        ``get_vector``). Only neighbours clearing ``min_cosine`` are returned, so a
+        negative / out-of-scope query whose nearest doc is only weakly similar pulls
+        in nothing (abstention guard). The same tier/category/status/doc_type
+        filters are applied so a filtered search does not leak an off-facet doc.
+
+        Returns the empty list when embeddings are not configured, the query cannot
+        be embedded, or the index predates the ``doc_vectors`` table. Each hit
+        carries its cosine in ``score`` (higher = better here); search() re-scores
+        dense-only hits onto the bm25 convention before the blend.
+        """
+        embedder = self._resolve_embedder()
+        if embedder is None or limit <= 0 or not self._db_path.exists():
+            return []
+        qvec = embedder.embed_one(query) if query.strip() else None
+        if not qvec:
+            return []
+        where = ["dv.vector IS NOT NULL"]
+        params: list[object] = []
+        if tier:
+            where.append("docs.tier = ?")
+            params.append(tier)
+        if category:
+            where.append("docs.category = ?")
+            params.append(category)
+        if status:
+            where.append("docs.status = ?")
+            params.append(status)
+        if doc_type:
+            where.append("docs.type = ?")
+            params.append(doc_type)
+        sql = f"""
+            SELECT
+                dv.id AS id,
+                dv.vector AS vector,
+                docs.path AS path,
+                COALESCE(docs.title, '') AS title,
+                COALESCE(docs.status, '') AS status,
+                COALESCE(docs.type, '') AS doc_type,
+                COALESCE(docs.description, '') AS description
+            FROM doc_vectors dv
+            JOIN docs ON docs.id = dv.id
+            WHERE {' AND '.join(where)}
+        """
+        conn = self._connect()
+        try:
+            rows = conn.execute(sql, params).fetchall()
+        except sqlite3.OperationalError:
+            # doc_vectors table absent (index predates schema v8): no dense source.
+            return []
+        finally:
+            conn.close()
+        scored: list[tuple[float, SearchHit]] = []
+        for r in rows:
+            dvec = deserialize_vector(r["vector"])
+            if len(dvec) != len(qvec):
+                continue
+            sim = cosine(qvec, dvec)
+            if sim < min_cosine:
+                continue
+            scored.append(
+                (
+                    sim,
+                    SearchHit(
+                        id=r["id"],
+                        path=r["path"],
+                        title=r["title"],
+                        snippet=r["description"],
+                        score=sim,
+                        status=r["status"],
+                        doc_type=r["doc_type"],
+                    ),
+                )
+            )
+        # Strongest cosine first, then truncate to ``limit``.
+        scored.sort(key=lambda t: -t[0])
+        return [hit for _sim, hit in scored[:limit]]
 
     def make_hybrid_reranker(
         self, embedder: Embedder, *, weight: float,

--- a/src/data_olympus/index.py
+++ b/src/data_olympus/index.py
@@ -22,6 +22,15 @@ from data_olympus.cooccurrence import (
     tokenize_doc,
     write_cooccurrence_table,
 )
+from data_olympus.embeddings import (
+    EMBEDDINGS_SCHEMA,
+    Embedder,
+    deserialize_vector,
+    embeddings_config,
+    embeddings_enabled,
+    make_hybrid_reranker,
+    serialize_vector,
+)
 from data_olympus.markdown_parse import parse_file
 from data_olympus.trigram import (
     DEFAULT_FALLBACK_THRESHOLD as DEFAULT_TRIGRAM_FALLBACK_THRESHOLD,
@@ -66,14 +75,15 @@ CREATE TABLE IF NOT EXISTS meta (
     key TEXT PRIMARY KEY,
     value TEXT
 );
-""" + RELATED_TERMS_SCHEMA + TRIGRAM_FTS_SCHEMA
+""" + RELATED_TERMS_SCHEMA + TRIGRAM_FTS_SCHEMA + EMBEDDINGS_SCHEMA
 
 # Informational only; recorded in the meta table for observability. Rebuild
 # is guaranteed by bootstrap_now=True calling Index.build() unconditionally
 # on container start, not by a version-mismatch check.
 # v6 adds the related_terms co-occurrence table (issue #40).
 # v7 adds the fts_trigram fuzzy-match table (issue #41).
-_SCHEMA_VERSION = "7"
+# v8 adds the doc_vectors table (issue #42, populated only when embeddings on).
+_SCHEMA_VERSION = "8"
 
 
 # fts column order (excluding the UNINDEXED id at position 0).
@@ -89,6 +99,11 @@ _DEFAULT_BM25_WEIGHTS: tuple[float, ...] = (0.0, 10.0, 5.0, 10.0, 4.0, 1.0)
 _RERANK_OVERFETCH_FACTOR = 5
 _RERANK_MIN_POOL = 50
 _RERANK_MAX_POOL = 200
+
+# Cap on the characters embedded per doc at build time (issue #42). The head of
+# a doc carries its topical signal; bounding it keeps a very long doc from
+# overrunning the model's context window and keeps build cost predictable.
+_EMBED_TEXT_MAX_CHARS = 4000
 
 # Status priors for the status-aware reranker (issue #37). search() orders by
 # bm25 ASCENDING (lower = better), so these deltas are ADDED to the raw score:
@@ -460,6 +475,19 @@ class Index:
             # walk; only populated when co-occurrence expansion is enabled.
             build_cooccurrence = cooccurrence_enabled()
             doc_token_sets: list[set[str]] = []
+            # Embedding vectors (issue #42). Only when the feature is enabled do
+            # we load the (optional) model and collect per-doc embedding text; a
+            # default build never touches the embedding dependency. Each entry is
+            # (doc_id, text_to_embed), embedded in one batch after the walk and
+            # written into the SAME tmp DB so vectors swap atomically with the
+            # rest of the index. build_embedder raises loudly if enabled but the
+            # dep/model is unavailable, so a misconfigured build fails visibly.
+            build_embeddings = embeddings_enabled()
+            embedder: Embedder | None = None
+            embed_inputs: list[tuple[str, str]] = []
+            if build_embeddings:
+                from data_olympus.embeddings import build_embedder
+                embedder = build_embedder(embeddings_config())
             for md in files_to_index:
                 rel = md.relative_to(kb_root)
                 doc = parse_file(md)
@@ -498,7 +526,27 @@ class Index:
                     doc_token_sets.append(
                         tokenize_doc(doc.title, tags_str, doc.description, doc.body)
                     )
+                if build_embeddings:
+                    # Embed title + description + body: the retrievable semantic
+                    # content of the doc. Bounded to keep a huge doc from blowing
+                    # the model's context; the head carries the topical signal.
+                    embed_text = "\n".join(
+                        p for p in (doc.title, doc.description, doc.body) if p
+                    )[:_EMBED_TEXT_MAX_CHARS]
+                    embed_inputs.append((doc_id, embed_text))
                 count += 1
+            # Embedding vectors (issue #42): one batched embed of all docs, then
+            # persist into the tmp DB. Kept inside the build so vectors are part
+            # of the same atomic swap and a query never sees a half-built table.
+            if build_embeddings and embedder is not None and embed_inputs:
+                vectors = embedder.embed_many([t for _id, t in embed_inputs])
+                conn.executemany(
+                    "INSERT OR REPLACE INTO doc_vectors (id, vector) VALUES (?, ?)",
+                    [
+                        (doc_id, serialize_vector(vec))
+                        for (doc_id, _t), vec in zip(embed_inputs, vectors, strict=True)
+                    ],
+                )
             # Co-occurrence / PMI table (issue #40). Built into the SAME tmp DB
             # and swapped atomically with the rest of the index below, so a query
             # never sees a half-built related_terms table.
@@ -800,6 +848,50 @@ class Index:
             lambda term, kk: self.related_terms(term, limit=kk),
             k=k,
             max_terms=max_terms,
+        )
+
+    def get_vector(self, id: str) -> builtins.list[float] | None:
+        """Return the stored embedding vector for ``id``, or None (issue #42).
+
+        Reads the ``doc_vectors`` table populated at build time only when the
+        embeddings feature was enabled. A build that predates the table, a doc
+        with no vector, or the feature being off all yield None (the hybrid
+        reranker treats a missing vector as a neutral cosine, never a drop).
+        Opens a per-call connection so it always reads the atomically-swapped
+        current index.
+        """
+        if not self._db_path.exists():
+            return None
+        conn = self._connect()
+        try:
+            row = conn.execute(
+                "SELECT vector FROM doc_vectors WHERE id = ?", (id,)
+            ).fetchone()
+        except sqlite3.OperationalError:
+            # Table absent (index predates the schema); degrade to no vector.
+            return None
+        finally:
+            conn.close()
+        if row is None:
+            return None
+        return deserialize_vector(row["vector"])
+
+    def make_hybrid_reranker(
+        self, embedder: Embedder, *, weight: float,
+    ) -> Callable[[str, list[SearchHit]], list[SearchHit]]:
+        """Return a hybrid reranker bound to this index's stored vectors.
+
+        Blends normalised bm25 with query-doc cosine (issue #42). ``embedder``
+        embeds the query once per search; ``weight`` in [0, 1] is the cosine
+        fraction of the blended score. The query is embedded lazily (only when a
+        search actually runs), and a query the model cannot embed degrades to
+        bm25 ordering. Compose this as the ``inner`` reranker under the id/tag
+        short-circuit so an exact id/tag still wins (see server.build_app).
+        """
+        return make_hybrid_reranker(
+            embed_query=lambda q: embedder.embed_one(q) if q.strip() else None,
+            get_vector=self.get_vector,
+            weight=weight,
         )
 
     def get(self, id: str) -> IndexedDoc | None:

--- a/src/data_olympus/server.py
+++ b/src/data_olympus/server.py
@@ -30,7 +30,7 @@ from data_olympus.cooccurrence import (
 )
 from data_olympus.enforce_policy import ConsultationLedger, IntentClassifier
 from data_olympus.git_ops import GitOps
-from data_olympus.index import Index, make_status_reranker
+from data_olympus.index import Index, SearchHit, make_status_reranker
 from data_olympus.pending import PendingQueue
 from data_olympus.principals import (
     AUTH_REQUIRED_TOOLS,
@@ -200,6 +200,9 @@ def build_app(
     session_reap_interval_sec: int = 60,
     status_weights: dict[str, float] | None = None,
     read_only: bool = False,
+    embeddings_enabled: bool = False,
+    embeddings_weight: float = 0.35,
+    embeddings_model: str = "BAAI/bge-small-en-v1.5",
 ) -> FastMCP:
     """Construct a FastMCP app with the read tools registered.
 
@@ -242,6 +245,9 @@ def build_app(
         session_reap_interval_sec=session_reap_interval_sec,
         status_weights=status_weights,
         read_only=read_only,
+        embeddings_enabled=embeddings_enabled,
+        embeddings_weight=embeddings_weight,
+        embeddings_model=embeddings_model,
     )
     if audit_log_path is not None:
         config_kwargs["audit_log_path"] = audit_log_path
@@ -269,9 +275,32 @@ def build_app(
     idx.query_expander = compose_expanders(
         synonym_expander, cooc_expander, max_terms=DEFAULT_MAX_TERMS
     )
-    idx.reranker = make_id_tag_reranker(
-        idx, inner=make_status_reranker(config.status_weights)
-    )
+    # Re-rank stack (innermost first): status prior -> optional hybrid embedding
+    # blend (issue #42) -> id/tag short-circuit (outermost). The hybrid layer,
+    # when enabled, blends normalised bm25 with query-doc cosine over the
+    # candidate pool; it is composed as the ``inner`` of the id/tag short-circuit
+    # so an exact id/tag still wins, and it wraps the status reranker so an active
+    # doc still outranks the superseded one among semantically-blended hits. When
+    # disabled the stack is exactly today's (status inner, id/tag outer). The
+    # embedder is loaded once here (loud failure if enabled but unavailable).
+    status_reranker = make_status_reranker(config.status_weights)
+    inner_reranker = status_reranker
+    if config.embeddings_enabled:
+        from data_olympus.embeddings import build_embedder, embeddings_config
+        embedder = build_embedder(embeddings_config())
+        hybrid_reranker = idx.make_hybrid_reranker(
+            embedder, weight=config.embeddings_weight
+        )
+
+        def _status_then_hybrid(
+            query: str, hits: list[SearchHit]
+        ) -> list[SearchHit]:
+            # Status prior first (so an active doc's boost feeds the blend's bm25
+            # component), then the semantic blend re-sorts the pool.
+            return hybrid_reranker(query, list(status_reranker(query, hits)))
+
+        inner_reranker = _status_then_hybrid
+    idx.reranker = make_id_tag_reranker(idx, inner=inner_reranker)
     git = GitOps(kb_main_path)
     # retention_sec = the consult TTL: an entry older than that can never be
     # fresh, so it is safe to evict and keeps the ledger bounded (see
@@ -697,6 +726,9 @@ def build_app_from_config(config: Config, *, bootstrap_now: bool = True) -> Fast
         session_reap_interval_sec=config.session_reap_interval_sec,
         status_weights=config.status_weights,
         read_only=config.read_only,
+        embeddings_enabled=config.embeddings_enabled,
+        embeddings_weight=config.embeddings_weight,
+        embeddings_model=config.embeddings_model,
     )
 
 

--- a/src/data_olympus/server.py
+++ b/src/data_olympus/server.py
@@ -28,6 +28,7 @@ from data_olympus.cooccurrence import (
     compose_expanders,
     cooccurrence_enabled,
 )
+from data_olympus.embeddings import EmbeddingsConfig, build_embedder
 from data_olympus.enforce_policy import ConsultationLedger, IntentClassifier
 from data_olympus.git_ops import GitOps
 from data_olympus.index import Index, SearchHit, make_status_reranker
@@ -265,10 +266,25 @@ def build_app(
     # (issue #37) as its ``inner``, so among the remaining hits an active doc
     # still outranks the superseded one it replaced. status_weights=None uses the
     # built-in map; KB_STATUS_WEIGHTS overrides it.
+    # Embeddings (issue #42) are resolved ONCE here from Config (reviewer concern
+    # 2), never re-read from env on the enabled path. The resolved EmbeddingsConfig
+    # and the shared embedder are threaded into the Index so build() embeds the
+    # corpus and search()'s dense candidate source both honour the programmatic
+    # Config, not KB_EMBEDDINGS_* env. The embedder is loaded once (loud failure if
+    # enabled but unavailable) and reused by the hybrid reranker below.
+    emb_config: EmbeddingsConfig | None = None
+    embedder = None
+    if config.embeddings_enabled:
+        emb_config = EmbeddingsConfig(
+            model_name=config.embeddings_model, weight=config.embeddings_weight
+        )
+        embedder = build_embedder(emb_config)
     idx = Index(
         kb_index_path,
         trigram_fallback=config.trigram_fallback_enabled,
         trigram_fallback_threshold=config.trigram_fallback_threshold,
+        embeddings=emb_config,
+        embedder=embedder,
     )
     synonym_expander = default_query_expander()
     cooc_expander = idx.cooccurrence_expander() if cooccurrence_enabled() else None
@@ -285,9 +301,7 @@ def build_app(
     # embedder is loaded once here (loud failure if enabled but unavailable).
     status_reranker = make_status_reranker(config.status_weights)
     inner_reranker = status_reranker
-    if config.embeddings_enabled:
-        from data_olympus.embeddings import build_embedder, embeddings_config
-        embedder = build_embedder(embeddings_config())
+    if config.embeddings_enabled and embedder is not None:
         hybrid_reranker = idx.make_hybrid_reranker(
             embedder, weight=config.embeddings_weight
         )

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -1,0 +1,266 @@
+"""Optional local-embedding hybrid ranking (issue #42).
+
+The feature is OFF by default (``KB_EMBEDDINGS_MODE`` unset) so the zero-
+dependency lexical product is unchanged and the embedding libraries are never
+imported. When enabled, each doc is embedded at ``Index.build`` time into a new
+``doc_vectors`` table (schema v8) written into the same tmp DB and swapped
+atomically; a hybrid reranker then blends NORMALISED bm25 with cosine similarity
+over the candidate hits' stored vectors.
+
+Tests split into two groups:
+
+- Pure-logic tests (no model download): vector (de)serialisation, cosine, the
+  hybrid blend math, config gating, and the loud-failure-when-misconfigured
+  contract. These always run.
+- Model-backed integration tests: build vectors and beat BM25 on a paraphrase
+  query. These require the ``embeddings`` extra AND a downloadable/cached model,
+  so they SKIP when the model/dep is unavailable rather than making the suite
+  flaky (issue #42 acceptance allows this).
+"""
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from data_olympus import embeddings as emb
+from data_olympus.index import SearchHit
+
+# --- config gating -----------------------------------------------------------
+
+
+def test_embeddings_disabled_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("KB_EMBEDDINGS_MODE", raising=False)
+    assert emb.embeddings_enabled() is False
+
+
+@pytest.mark.parametrize("value", ["on", "On", "ON"])
+def test_embeddings_enabled_when_on(
+    monkeypatch: pytest.MonkeyPatch, value: str
+) -> None:
+    monkeypatch.setenv("KB_EMBEDDINGS_MODE", value)
+    assert emb.embeddings_enabled() is True
+
+
+@pytest.mark.parametrize("value", ["off", "", "0", "false", "yes"])
+def test_embeddings_off_for_other_values(
+    monkeypatch: pytest.MonkeyPatch, value: str
+) -> None:
+    monkeypatch.setenv("KB_EMBEDDINGS_MODE", value)
+    assert emb.embeddings_enabled() is False
+
+
+def test_embeddings_config_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("KB_EMBEDDINGS_MODEL", raising=False)
+    monkeypatch.delenv("KB_EMBEDDINGS_WEIGHT", raising=False)
+    cfg = emb.embeddings_config()
+    assert cfg.model_name == emb.DEFAULT_MODEL_NAME
+    assert cfg.weight == emb.DEFAULT_WEIGHT
+
+
+def test_embeddings_config_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("KB_EMBEDDINGS_MODEL", "some/other-model")
+    monkeypatch.setenv("KB_EMBEDDINGS_WEIGHT", "0.75")
+    cfg = emb.embeddings_config()
+    assert cfg.model_name == "some/other-model"
+    assert cfg.weight == 0.75
+
+
+@pytest.mark.parametrize("bad", ["-0.1", "1.5", "abc"])
+def test_embeddings_weight_out_of_range_raises(
+    monkeypatch: pytest.MonkeyPatch, bad: str
+) -> None:
+    monkeypatch.setenv("KB_EMBEDDINGS_WEIGHT", bad)
+    with pytest.raises(ValueError):
+        emb.embeddings_config()
+
+
+# --- vector (de)serialisation ------------------------------------------------
+
+
+def test_vector_roundtrip() -> None:
+    v = [0.1, -0.2, 0.3, 0.0, 1.5]
+    blob = emb.serialize_vector(v)
+    assert isinstance(blob, bytes)
+    out = emb.deserialize_vector(blob)
+    assert len(out) == len(v)
+    for a, b in zip(v, out, strict=True):
+        assert a == pytest.approx(b, abs=1e-6)
+
+
+def test_empty_vector_roundtrip() -> None:
+    assert emb.deserialize_vector(emb.serialize_vector([])) == []
+
+
+# --- cosine similarity -------------------------------------------------------
+
+
+def test_cosine_identical_is_one() -> None:
+    v = [1.0, 2.0, 3.0]
+    assert emb.cosine(v, v) == pytest.approx(1.0)
+
+
+def test_cosine_orthogonal_is_zero() -> None:
+    assert emb.cosine([1.0, 0.0], [0.0, 1.0]) == pytest.approx(0.0)
+
+
+def test_cosine_opposite_is_minus_one() -> None:
+    assert emb.cosine([1.0, 0.0], [-1.0, 0.0]) == pytest.approx(-1.0)
+
+
+def test_cosine_zero_vector_is_zero() -> None:
+    # A zero-norm vector cannot have a direction; define similarity as 0 rather
+    # than dividing by zero.
+    assert emb.cosine([0.0, 0.0], [1.0, 1.0]) == 0.0
+
+
+def test_cosine_length_mismatch_raises() -> None:
+    with pytest.raises(ValueError):
+        emb.cosine([1.0, 2.0], [1.0, 2.0, 3.0])
+
+
+# --- hybrid reranker (pure math, no model) -----------------------------------
+
+
+def _hit(doc_id: str, score: float) -> SearchHit:
+    return SearchHit(id=doc_id, path=f"{doc_id}.md", title=doc_id, snippet="", score=score)
+
+
+def test_hybrid_reranker_promotes_semantic_match() -> None:
+    """A doc that BM25 ranks second but is semantically closest to the query is
+    lifted to the top when the blend weight favours cosine."""
+    # BM25: A best (-5.0), B worse (-1.0). Lower is better.
+    hits = [_hit("A", -5.0), _hit("B", -1.0)]
+    # Query embeds close to B, far from A.
+    query_vec = [1.0, 0.0]
+    vectors = {"A": [0.0, 1.0], "B": [1.0, 0.0]}
+    reranker = emb.make_hybrid_reranker(
+        embed_query=lambda _q: query_vec,
+        get_vector=vectors.get,
+        weight=1.0,  # pure cosine
+    )
+    out = reranker("anything", hits)
+    assert [h.id for h in out] == ["B", "A"]
+
+
+def test_hybrid_reranker_weight_zero_preserves_bm25_order() -> None:
+    hits = [_hit("A", -5.0), _hit("B", -1.0)]
+    reranker = emb.make_hybrid_reranker(
+        embed_query=lambda _q: [1.0, 0.0],
+        get_vector={"A": [0.0, 1.0], "B": [1.0, 0.0]}.get,
+        weight=0.0,  # pure bm25
+    )
+    out = reranker("anything", hits)
+    assert [h.id for h in out] == ["A", "B"]
+
+
+def test_hybrid_reranker_missing_vector_uses_bm25_only_component() -> None:
+    """A hit whose doc has no stored vector must not be dropped; it keeps its
+    bm25 contribution and a neutral (zero) cosine contribution."""
+    hits = [_hit("A", -5.0), _hit("B", -1.0)]
+    reranker = emb.make_hybrid_reranker(
+        embed_query=lambda _q: [1.0, 0.0],
+        get_vector={"A": [1.0, 0.0]}.get,  # B missing
+        weight=0.5,
+    )
+    out = reranker("anything", hits)
+    assert {h.id for h in out} == {"A", "B"}
+    assert len(out) == 2
+
+
+def test_hybrid_reranker_empty_hits() -> None:
+    reranker = emb.make_hybrid_reranker(
+        embed_query=lambda _q: [1.0, 0.0], get_vector={}.get, weight=0.5
+    )
+    assert reranker("q", []) == []
+
+
+def test_hybrid_reranker_single_hit_no_normalisation_error() -> None:
+    """A single hit has zero bm25 spread; normalisation must not divide by zero."""
+    hits = [_hit("A", -3.0)]
+    reranker = emb.make_hybrid_reranker(
+        embed_query=lambda _q: [1.0, 0.0],
+        get_vector={"A": [1.0, 0.0]}.get,
+        weight=0.5,
+    )
+    out = reranker("q", hits)
+    assert [h.id for h in out] == ["A"]
+
+
+def test_hybrid_reranker_embed_query_none_is_passthrough() -> None:
+    """If the query cannot be embedded (embedder returned None), fall back to the
+    incoming bm25 order rather than raising."""
+    hits = [_hit("A", -5.0), _hit("B", -1.0)]
+    reranker = emb.make_hybrid_reranker(
+        embed_query=lambda _q: None,
+        get_vector={"A": [0.0, 1.0], "B": [1.0, 0.0]}.get,
+        weight=1.0,
+    )
+    out = reranker("q", hits)
+    assert [h.id for h in out] == ["A", "B"]
+
+
+# --- loud failure when enabled but unavailable -------------------------------
+
+
+def test_require_embedder_raises_clear_message_when_dep_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the feature is enabled but fastembed cannot be imported, startup must
+    fail loudly with an actionable message (not silently fall back)."""
+
+    def _boom(*_a: object, **_k: object) -> object:
+        raise ImportError("No module named 'fastembed'")
+
+    monkeypatch.setattr(emb, "_load_text_embedding_cls", _boom)
+    with pytest.raises(emb.EmbeddingsUnavailableError) as ei:
+        emb.build_embedder(emb.EmbeddingsConfig(model_name="x", weight=0.5))
+    msg = str(ei.value)
+    assert "embeddings" in msg.lower()
+    assert "install" in msg.lower() or "extra" in msg.lower()
+
+
+# --- schema constant ---------------------------------------------------------
+
+
+def test_schema_defines_doc_vectors_table() -> None:
+    assert "doc_vectors" in emb.EMBEDDINGS_SCHEMA
+    assert "vector" in emb.EMBEDDINGS_SCHEMA
+
+
+# --- helper for the model-gated integration tests ----------------------------
+
+
+def _model_available() -> bool:
+    """True when fastembed imports AND a model can be loaded/cached locally.
+
+    Kept cheap: import guard first, then a single tiny embedding call. Any
+    failure (missing dep, no network for the one-time model fetch) returns False
+    so the integration tests SKIP rather than fail.
+    """
+    try:
+        cfg = emb.EmbeddingsConfig(
+            model_name=emb.DEFAULT_MODEL_NAME, weight=emb.DEFAULT_WEIGHT
+        )
+        embedder = emb.build_embedder(cfg)
+        vec = embedder.embed_one("smoke test")
+    except Exception:
+        return False
+    return bool(vec) and len(vec) > 0
+
+
+_MODEL = _model_available()
+_needs_model = pytest.mark.skipif(
+    not _MODEL, reason="embeddings model/dep unavailable (no fastembed or no model fetch)"
+)
+
+
+@_needs_model
+def test_embed_one_returns_unit_ish_vector() -> None:
+    cfg = emb.embeddings_config()
+    embedder = emb.build_embedder(cfg)
+    v = embedder.embed_one("kubernetes deployment rollout")
+    assert len(v) > 0
+    # bge models emit normalised vectors; norm ~= 1.
+    norm = math.sqrt(sum(x * x for x in v))
+    assert norm == pytest.approx(1.0, abs=0.05)

--- a/tests/test_embeddings_index.py
+++ b/tests/test_embeddings_index.py
@@ -1,0 +1,205 @@
+"""Build-time vectors + hybrid ranking wired through Index (issue #42).
+
+These tests exercise the enabled path end to end:
+
+- ``Index.build`` populates the ``doc_vectors`` table (schema v8) only when the
+  feature is enabled, into the same tmp DB, swapped atomically.
+- The build does NOT create/require vectors when the feature is off (default),
+  so the zero-dependency lexical product is unchanged.
+- A hybrid reranker built from the index beats BM25-only on a paraphrase query
+  whose relevant doc shares no tokens with the query.
+
+The model-backed cases SKIP when the embeddings dep/model is unavailable (see
+``test_embeddings._MODEL``) rather than making the suite flaky.
+"""
+from __future__ import annotations
+
+import sqlite3
+from typing import TYPE_CHECKING
+
+from data_olympus import embeddings as emb
+from data_olympus.index import Index
+
+from .test_embeddings import _needs_model
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    import pytest
+
+
+def _write(kb: Path, name: str, body: str, *, doc_id: str) -> None:
+    (kb / name).write_text(f"---\nid: {doc_id}\n---\n{body}\n", encoding="utf-8")
+
+
+def _paraphrase_kb(kb: Path) -> None:
+    # The relevant doc for the query "car" shares no tokens with "automobile".
+    _write(
+        kb,
+        "auto.md",
+        "An automobile is a wheeled motor vehicle used for transportation.",
+        doc_id="DOC-AUTO",
+    )
+    _write(
+        kb,
+        "banana.md",
+        "A banana smoothie recipe with yoghurt and honey and ice.",
+        doc_id="DOC-BANANA",
+    )
+    _write(
+        kb,
+        "python.md",
+        "Python packaging with uv and pyproject metadata and wheels.",
+        doc_id="DOC-PYTHON",
+    )
+
+
+def _table_names(db: Path) -> set[str]:
+    conn = sqlite3.connect(db)
+    try:
+        rows = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type IN ('table','view')"
+        ).fetchall()
+    finally:
+        conn.close()
+    return {r[0] for r in rows}
+
+
+def _vector_count(db: Path) -> int:
+    conn = sqlite3.connect(db)
+    try:
+        return int(conn.execute("SELECT COUNT(*) FROM doc_vectors").fetchone()[0])
+    finally:
+        conn.close()
+
+
+# --- default OFF: no vectors, no dep required --------------------------------
+
+
+def test_build_default_off_has_no_vectors(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("KB_EMBEDDINGS_MODE", raising=False)
+    kb = tmp_path / "kb"
+    kb.mkdir()
+    _paraphrase_kb(kb)
+    db = tmp_path / "kb.db"
+    idx = Index(db)
+    idx.build(kb, source_commit="c0")
+    # The doc_vectors table exists in the schema (created empty) but must hold no
+    # rows when the feature is off, and no embedding library is needed.
+    assert _vector_count(db) == 0
+
+
+def test_schema_version_is_v8(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("KB_EMBEDDINGS_MODE", raising=False)
+    kb = tmp_path / "kb"
+    kb.mkdir()
+    _write(kb, "a.md", "hello world", doc_id="DOC-A")
+    db = tmp_path / "kb.db"
+    Index(db).build(kb, source_commit="c0")
+    conn = sqlite3.connect(db)
+    try:
+        row = conn.execute(
+            "SELECT value FROM meta WHERE key='schema_version'"
+        ).fetchone()
+    finally:
+        conn.close()
+    assert row[0] == "8"
+
+
+def test_doc_vectors_table_present_in_schema(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("KB_EMBEDDINGS_MODE", raising=False)
+    kb = tmp_path / "kb"
+    kb.mkdir()
+    _write(kb, "a.md", "hello world", doc_id="DOC-A")
+    db = tmp_path / "kb.db"
+    Index(db).build(kb, source_commit="c0")
+    assert "doc_vectors" in _table_names(db)
+
+
+# --- enabled: vectors built, atomic rebuild ----------------------------------
+
+
+@_needs_model
+def test_build_enabled_populates_vectors(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("KB_EMBEDDINGS_MODE", "on")
+    kb = tmp_path / "kb"
+    kb.mkdir()
+    _paraphrase_kb(kb)
+    db = tmp_path / "kb.db"
+    Index(db).build(kb, source_commit="c0")
+    assert _vector_count(db) == 3
+    # Each stored vector deserialises to a non-empty float list.
+    conn = sqlite3.connect(db)
+    try:
+        rows = conn.execute("SELECT id, vector FROM doc_vectors").fetchall()
+    finally:
+        conn.close()
+    for _id, blob in rows:
+        assert len(emb.deserialize_vector(blob)) > 0
+
+
+@_needs_model
+def test_vectors_rebuild_atomically(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("KB_EMBEDDINGS_MODE", "on")
+    kb = tmp_path / "kb"
+    kb.mkdir()
+    _paraphrase_kb(kb)
+    db = tmp_path / "kb.db"
+    idx = Index(db)
+    idx.build(kb, source_commit="c0")
+    first = _vector_count(db)
+    assert first == 3
+    # Remove a doc and rebuild: the swapped DB reflects the new corpus exactly
+    # (no stale vectors, no leftover tmp files).
+    (kb / "banana.md").unlink()
+    idx.build(kb, source_commit="c1")
+    assert _vector_count(db) == 2
+    leftover = list(tmp_path.glob("kb.db.tmp.*"))
+    assert leftover == []
+
+
+@_needs_model
+def test_hybrid_beats_bm25_on_paraphrase(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The core acceptance test: a query with NO shared tokens with the target
+    doc retrieves it via hybrid ranking, where BM25-only would miss it."""
+    monkeypatch.setenv("KB_EMBEDDINGS_MODE", "on")
+    kb = tmp_path / "kb"
+    kb.mkdir()
+    _paraphrase_kb(kb)
+    db = tmp_path / "kb.db"
+    idx = Index(db)
+    idx.build(kb, source_commit="c0")
+
+    # BM25-only: "car" shares no token with "automobile ... vehicle", so the
+    # lexical index returns nothing for it.
+    bm25_hits = idx.search("car", limit=3)
+    assert not any(h.id == "DOC-AUTO" for h in bm25_hits)
+
+    # Hybrid: embed the corpus-wide candidate pool and blend. We drive the
+    # reranker directly over ALL docs (the server composes it into the stack;
+    # here we assert the ranking capability in isolation).
+    cfg = emb.embeddings_config()
+    embedder = emb.build_embedder(cfg)
+    reranker = idx.make_hybrid_reranker(embedder, weight=1.0)
+    # Candidate pool = every doc as a neutral-bm25 hit, so ranking is decided by
+    # cosine alone (weight=1.0). This mirrors how the reranker rescues a doc that
+    # bm25 could not surface.
+    from data_olympus.index import SearchHit
+    pool = [
+        SearchHit(id=i, path=f"{i}.md", title=i, snippet="", score=0.0)
+        for i in ("DOC-AUTO", "DOC-BANANA", "DOC-PYTHON")
+    ]
+    ranked = reranker("car", pool)
+    assert ranked[0].id == "DOC-AUTO"

--- a/tests/test_embeddings_index.py
+++ b/tests/test_embeddings_index.py
@@ -73,6 +73,97 @@ def _vector_count(db: Path) -> int:
         conn.close()
 
 
+class _StubEmbedder:
+    """Deterministic 2-d embedder for model-free tests of the Config-threaded
+    build and dense-source paths. Maps a keyword to a fixed unit vector so cosine
+    is predictable; unknown text maps to a distinct direction."""
+
+    model_name = "stub"
+
+    def _vec(self, text: str) -> list[float]:
+        t = text.lower()
+        if "car" in t or "automobile" in t or "vehicle" in t:
+            return [1.0, 0.0]
+        if "banana" in t or "smoothie" in t:
+            return [0.0, 1.0]
+        return [0.0, 1.0]  # unrelated: orthogonal to the "car" direction
+
+    def embed_one(self, text: str) -> list[float]:
+        return self._vec(text)
+
+    def embed_many(self, texts: list[str]) -> list[list[float]]:
+        return [self._vec(t) for t in texts]
+
+
+def test_build_uses_threaded_config_not_env(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Reviewer concern 2: build() embeds when a Config is threaded in, even with
+    KB_EMBEDDINGS_MODE UNSET (env off). Config is the single source of truth."""
+    monkeypatch.delenv("KB_EMBEDDINGS_MODE", raising=False)
+    kb = tmp_path / "kb"
+    kb.mkdir()
+    _paraphrase_kb(kb)
+    db = tmp_path / "kb.db"
+    cfg = emb.EmbeddingsConfig(model_name="stub", weight=0.5)
+    Index(db, embeddings=cfg, embedder=_StubEmbedder()).build(kb, source_commit="c0")
+    # Env said off, but the threaded Config turned it on: vectors are stored.
+    assert _vector_count(db) == 3
+
+
+def test_build_off_ignores_env_on(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Reviewer concern 2 (converse): with NO Config threaded in, build() stores
+    no vectors even when KB_EMBEDDINGS_MODE=on in env; the env is not consulted."""
+    monkeypatch.setenv("KB_EMBEDDINGS_MODE", "on")
+    kb = tmp_path / "kb"
+    kb.mkdir()
+    _paraphrase_kb(kb)
+    db = tmp_path / "kb.db"
+    Index(db).build(kb, source_commit="c0")  # no embeddings config
+    assert _vector_count(db) == 0
+
+
+def test_dense_source_unions_tokenless_hit_model_free(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Reviewer concern 1, model-free: search("car") returns DOC-AUTO via the
+    dense candidate source even though bm25 finds nothing, using a stub embedder
+    so the assertion is deterministic and needs no model download."""
+    monkeypatch.delenv("KB_EMBEDDINGS_MODE", raising=False)
+    kb = tmp_path / "kb"
+    kb.mkdir()
+    _paraphrase_kb(kb)
+    db = tmp_path / "kb.db"
+    cfg = emb.EmbeddingsConfig(model_name="stub", weight=1.0)
+    embedder = _StubEmbedder()
+    idx = Index(db, embeddings=cfg, embedder=embedder, dense_min_cosine=0.5)
+    idx.reranker = idx.make_hybrid_reranker(embedder, weight=1.0)
+    idx.build(kb, source_commit="c0")
+    ids = [h.id for h in idx.search("car", limit=3)]
+    assert "DOC-AUTO" in ids, ids
+    # The banana doc is orthogonal to the "car" query (cosine 0 < 0.5), so the
+    # threshold keeps it out of the dense source.
+    dense = idx.dense_candidates("car", limit=5, min_cosine=0.5)
+    assert {h.id for h in dense} == {"DOC-AUTO"}
+
+
+def test_search_off_is_pure_fts_model_free(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Reviewer concern 1 CRITICAL: with embeddings OFF (no config), search() is
+    byte-for-byte pure FTS. "car" returns nothing; the dense path is never run."""
+    monkeypatch.setenv("KB_EMBEDDINGS_MODE", "on")  # env on, but no Config
+    kb = tmp_path / "kb"
+    kb.mkdir()
+    _paraphrase_kb(kb)
+    db = tmp_path / "kb.db"
+    idx = Index(db)  # no embeddings config -> feature inert
+    idx.build(kb, source_commit="c0")
+    assert idx.search("car", limit=3) == []
+
+
 # --- default OFF: no vectors, no dep required --------------------------------
 
 
@@ -129,12 +220,13 @@ def test_doc_vectors_table_present_in_schema(
 def test_build_enabled_populates_vectors(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    monkeypatch.setenv("KB_EMBEDDINGS_MODE", "on")
+    monkeypatch.delenv("KB_EMBEDDINGS_MODE", raising=False)
     kb = tmp_path / "kb"
     kb.mkdir()
     _paraphrase_kb(kb)
     db = tmp_path / "kb.db"
-    Index(db).build(kb, source_commit="c0")
+    cfg = emb.embeddings_config()
+    Index(db, embeddings=cfg).build(kb, source_commit="c0")
     assert _vector_count(db) == 3
     # Each stored vector deserialises to a non-empty float list.
     conn = sqlite3.connect(db)
@@ -150,12 +242,13 @@ def test_build_enabled_populates_vectors(
 def test_vectors_rebuild_atomically(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    monkeypatch.setenv("KB_EMBEDDINGS_MODE", "on")
+    monkeypatch.delenv("KB_EMBEDDINGS_MODE", raising=False)
     kb = tmp_path / "kb"
     kb.mkdir()
     _paraphrase_kb(kb)
     db = tmp_path / "kb.db"
-    idx = Index(db)
+    cfg = emb.embeddings_config()
+    idx = Index(db, embeddings=cfg)
     idx.build(kb, source_commit="c0")
     first = _vector_count(db)
     assert first == 3
@@ -169,37 +262,72 @@ def test_vectors_rebuild_atomically(
 
 
 @_needs_model
-def test_hybrid_beats_bm25_on_paraphrase(
+def test_bm25_only_misses_tokenless_paraphrase(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """The core acceptance test: a query with NO shared tokens with the target
-    doc retrieves it via hybrid ranking, where BM25-only would miss it."""
-    monkeypatch.setenv("KB_EMBEDDINGS_MODE", "on")
+    """BM25-only baseline: "car" shares no token with "automobile ... vehicle",
+    so a lexical-only index cannot surface DOC-AUTO. This is the gap the dense
+    candidate source closes (see test_public_search_retrieves_tokenless_paraphrase)."""
+    monkeypatch.delenv("KB_EMBEDDINGS_MODE", raising=False)
     kb = tmp_path / "kb"
     kb.mkdir()
     _paraphrase_kb(kb)
     db = tmp_path / "kb.db"
-    idx = Index(db)
+    idx = Index(db)  # no embeddings config: pure FTS
+    idx.build(kb, source_commit="c0")
+    hits = idx.search("car", limit=3)
+    assert not any(h.id == "DOC-AUTO" for h in hits)
+
+
+@_needs_model
+def test_public_search_retrieves_tokenless_paraphrase(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Acceptance test (reviewer concern 1): the PUBLIC ``Index.search("car")``
+    returns the automobile doc when embeddings are enabled, even though "car"
+    shares NO token with the corpus. This exercises the shipped search path (the
+    dense candidate SOURCE unioned into the FTS pool + hybrid blend), not a
+    hand-built pool driven through the reranker in isolation."""
+    monkeypatch.delenv("KB_EMBEDDINGS_MODE", raising=False)  # prove Config, not env
+    kb = tmp_path / "kb"
+    kb.mkdir()
+    _paraphrase_kb(kb)
+    db = tmp_path / "kb.db"
+    cfg = emb.EmbeddingsConfig(model_name=emb.DEFAULT_MODEL_NAME, weight=0.5)
+    embedder = emb.build_embedder(cfg)
+    idx = Index(db, embeddings=cfg, embedder=embedder)
+    idx.reranker = idx.make_hybrid_reranker(embedder, weight=cfg.weight)
     idx.build(kb, source_commit="c0")
 
-    # BM25-only: "car" shares no token with "automobile ... vehicle", so the
-    # lexical index returns nothing for it.
-    bm25_hits = idx.search("car", limit=3)
-    assert not any(h.id == "DOC-AUTO" for h in bm25_hits)
+    hits = idx.search("car", limit=3)
+    ids = [h.id for h in hits]
+    # The dense source pulled DOC-AUTO into the pool and the blend ranked it.
+    assert "DOC-AUTO" in ids, ids
 
-    # Hybrid: embed the corpus-wide candidate pool and blend. We drive the
-    # reranker directly over ALL docs (the server composes it into the stack;
-    # here we assert the ranking capability in isolation).
-    cfg = emb.embeddings_config()
+
+@_needs_model
+def test_public_search_negative_query_not_pulled_in(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The dense source's min-cosine threshold protects abstention: an unrelated
+    query far from every doc must NOT drag a doc in. If it did, the negative-
+    stratum false-positive rate would blow up (reviewer concern 1)."""
+    monkeypatch.delenv("KB_EMBEDDINGS_MODE", raising=False)
+    kb = tmp_path / "kb"
+    kb.mkdir()
+    _paraphrase_kb(kb)
+    db = tmp_path / "kb.db"
+    cfg = emb.EmbeddingsConfig(model_name=emb.DEFAULT_MODEL_NAME, weight=0.5)
     embedder = emb.build_embedder(cfg)
-    reranker = idx.make_hybrid_reranker(embedder, weight=1.0)
-    # Candidate pool = every doc as a neutral-bm25 hit, so ranking is decided by
-    # cosine alone (weight=1.0). This mirrors how the reranker rescues a doc that
-    # bm25 could not surface.
-    from data_olympus.index import SearchHit
-    pool = [
-        SearchHit(id=i, path=f"{i}.md", title=i, snippet="", score=0.0)
-        for i in ("DOC-AUTO", "DOC-BANANA", "DOC-PYTHON")
-    ]
-    ranked = reranker("car", pool)
-    assert ranked[0].id == "DOC-AUTO"
+    # A high threshold so only genuinely-similar neighbours are admitted; an
+    # out-of-domain query clears it for nothing.
+    idx = Index(db, embeddings=cfg, embedder=embedder, dense_min_cosine=0.9)
+    idx.reranker = idx.make_hybrid_reranker(embedder, weight=cfg.weight)
+    idx.build(kb, source_commit="c0")
+
+    dense = idx.dense_candidates(
+        "quantum chromodynamics lattice gauge theory",
+        limit=5,
+        min_cosine=0.9,
+    )
+    assert dense == []

--- a/tests/test_embeddings_wiring.py
+++ b/tests/test_embeddings_wiring.py
@@ -119,3 +119,32 @@ def test_enabled_active_still_outranks_superseded(
     hits = idx.search("caching", limit=5)
     order = [h.id for h in hits]
     assert order.index("STD-U-001") < order.index("STD-U-002")
+
+
+@_needs_model
+def test_config_model_honored_over_env(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Reviewer concern 2: the programmatic ``embeddings_model`` passed via
+    build_app/Config is the single source of truth. Even when the environment
+    names a DIFFERENT model, the Index (and its embedder) must use the Config
+    value, not re-read ``KB_EMBEDDINGS_MODEL`` from env."""
+    # Env names a bogus model that would fail to load if it were consulted.
+    monkeypatch.setenv("KB_EMBEDDINGS_MODE", "on")
+    monkeypatch.setenv("KB_EMBEDDINGS_MODEL", "env/nonexistent-model-should-be-ignored")
+    kb = tmp_path / "kb"
+    kb.mkdir()
+    _kb(kb)
+    # If the enabled path re-read env, build_embedder would raise on the bogus
+    # env model; instead it must honour the real Config model and succeed.
+    app = _build(
+        kb,
+        tmp_path / "kb.db",
+        embeddings_enabled=True,
+        embeddings_model="BAAI/bge-small-en-v1.5",
+        embeddings_weight=0.3,
+    )
+    idx = app._dolympus_state.idx  # type: ignore[attr-defined]
+    embedder = idx._resolve_embedder()  # type: ignore[attr-defined]
+    assert embedder is not None
+    assert embedder.model_name == "BAAI/bge-small-en-v1.5"

--- a/tests/test_embeddings_wiring.py
+++ b/tests/test_embeddings_wiring.py
@@ -1,0 +1,121 @@
+"""build_app reranker-stack composition for embeddings (issue #42).
+
+Verifies:
+
+- Default OFF: no embedding library is imported and an exact-id / exact-tag /
+  status ordering is exactly today's behaviour (the hybrid layer is absent).
+- Enabled: the hybrid layer composes UNDER the id/tag short-circuit, so an exact
+  id still wins, and the status prior still applies. Enabled cases SKIP when the
+  model/dep is unavailable.
+"""
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING
+
+from data_olympus.server import build_app
+
+from .test_embeddings import _needs_model
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    import pytest
+
+
+def _kb(kb: Path) -> None:
+    (kb / "std.md").write_text(
+        "---\nid: STD-U-001\nstatus: active\n---\nCaching policy for services.\n",
+        encoding="utf-8",
+    )
+    (kb / "old.md").write_text(
+        "---\nid: STD-U-002\nstatus: superseded\n---\nOld caching guidance.\n",
+        encoding="utf-8",
+    )
+
+
+def _build(kb: Path, index_path: Path, **kw: object) -> object:
+    return build_app(
+        kb_main_path=kb,
+        kb_index_path=index_path,
+        sync_interval_sec=60,
+        staleness_degraded_sec=600,
+        bootstrap_now=True,
+        **kw,  # type: ignore[arg-type]
+    )
+
+
+def test_default_off_does_not_import_fastembed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("KB_EMBEDDINGS_MODE", raising=False)
+    # Drop any prior import so we can prove the default path never triggers one.
+    monkeypatch.delitem(sys.modules, "fastembed", raising=False)
+    kb = tmp_path / "kb"
+    kb.mkdir()
+    _kb(kb)
+    _build(kb, tmp_path / "kb.db", embeddings_enabled=False)
+    assert "fastembed" not in sys.modules
+
+
+def test_default_off_exact_id_still_wins(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("KB_EMBEDDINGS_MODE", raising=False)
+    kb = tmp_path / "kb"
+    kb.mkdir()
+    _kb(kb)
+    app = _build(kb, tmp_path / "kb.db", embeddings_enabled=False)
+    idx = app._dolympus_state.idx  # type: ignore[attr-defined]
+    hits = idx.search("STD-U-001", limit=5)
+    assert hits[0].id == "STD-U-001"
+
+
+def test_default_off_active_outranks_superseded(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("KB_EMBEDDINGS_MODE", raising=False)
+    kb = tmp_path / "kb"
+    kb.mkdir()
+    _kb(kb)
+    app = _build(kb, tmp_path / "kb.db", embeddings_enabled=False)
+    idx = app._dolympus_state.idx  # type: ignore[attr-defined]
+    hits = idx.search("caching", limit=5)
+    order = [h.id for h in hits]
+    # Both match "caching"; the active doc must outrank the superseded one.
+    assert order.index("STD-U-001") < order.index("STD-U-002")
+
+
+@_needs_model
+def test_enabled_exact_id_still_wins(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("KB_EMBEDDINGS_MODE", "on")
+    kb = tmp_path / "kb"
+    kb.mkdir()
+    _kb(kb)
+    app = _build(
+        kb, tmp_path / "kb.db", embeddings_enabled=True, embeddings_weight=0.5
+    )
+    idx = app._dolympus_state.idx  # type: ignore[attr-defined]
+    # Exact id must still short-circuit to the top even with the hybrid blend
+    # active (id/tag reranker wraps the hybrid layer as inner).
+    hits = idx.search("STD-U-001", limit=5)
+    assert hits[0].id == "STD-U-001"
+
+
+@_needs_model
+def test_enabled_active_still_outranks_superseded(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("KB_EMBEDDINGS_MODE", "on")
+    kb = tmp_path / "kb"
+    kb.mkdir()
+    _kb(kb)
+    app = _build(
+        kb, tmp_path / "kb.db", embeddings_enabled=True, embeddings_weight=0.3
+    )
+    idx = app._dolympus_state.idx  # type: ignore[attr-defined]
+    hits = idx.search("caching", limit=5)
+    order = [h.id for h in hits]
+    assert order.index("STD-U-001") < order.index("STD-U-002")

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -127,8 +127,8 @@ def test_index_records_schema_version(tmp_kb: Path, tmp_index_path: Path) -> Non
     row = conn.execute("SELECT value FROM meta WHERE key = 'schema_version'").fetchone()
     conn.close()
     assert row is not None
-    assert row[0] == "7", (
-        f"schema_version must be '7' after the fts_trigram fuzzy-match table; "
+    assert row[0] == "8", (
+        f"schema_version must be '8' after the doc_vectors embeddings table; "
         f"got {row[0]!r}"
     )
 

--- a/tests/test_trigram.py
+++ b/tests/test_trigram.py
@@ -71,7 +71,12 @@ def test_trigram_table_created_at_build(tmp_kb: Path, tmp_index_path: Path) -> N
     assert row is not None, "build() must create the fts_trigram virtual table"
 
 
-def test_schema_version_bumped_to_7(tmp_kb: Path, tmp_index_path: Path) -> None:
+def test_schema_version_at_least_7_with_trigram(
+    tmp_kb: Path, tmp_index_path: Path
+) -> None:
+    # The trigram table (fts_trigram) landed at schema v7. Later features bump
+    # the version further (v8 adds doc_vectors), so assert the trigram table is
+    # present AND the recorded version is at least 7 rather than pinning to 7.
     idx = Index(tmp_index_path)
     idx.build(tmp_kb, source_commit="x")
     conn = sqlite3.connect(tmp_index_path)
@@ -79,10 +84,14 @@ def test_schema_version_bumped_to_7(tmp_kb: Path, tmp_index_path: Path) -> None:
         row = conn.execute(
             "SELECT value FROM meta WHERE key = 'schema_version'"
         ).fetchone()
+        has_trigram = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='fts_trigram'"
+        ).fetchone()
     finally:
         conn.close()
-    assert row is not None and row[0] == "7", (
-        "schema_version must be '7' after the trigram table is added; "
+    assert has_trigram is not None, "fts_trigram table must exist"
+    assert row is not None and int(row[0]) >= 7, (
+        "schema_version must be >= 7 once the trigram table exists; "
         f"got {row[0] if row else None!r}"
     )
 

--- a/uv.lock
+++ b/uv.lock
@@ -389,7 +389,7 @@ name = "cuda-bindings"
 version = "13.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder", marker = "python_full_version >= '3.15' or sys_platform != 'win32'" },
+    { name = "cuda-pathfinder" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cc/6e/2394f8163360f8391f8f1b7e72d300a82724edb81a7b7084c799fbd4c91f/cuda_bindings-13.3.1-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9efb21c1ee64981e184b9e0ba5eb3179e5ba3d4b51665a6cb52b8ef3d01a7cbf", size = 5920504, upload-time = "2026-05-29T23:11:56.883Z" },
@@ -418,34 +418,34 @@ wheels = [
 
 [package.optional-dependencies]
 cudart = [
-    { name = "nvidia-cuda-runtime", marker = "(python_full_version >= '3.15' and sys_platform == 'win32') or sys_platform == 'linux'" },
+    { name = "nvidia-cuda-runtime" },
 ]
 cufft = [
-    { name = "nvidia-cufft", marker = "(python_full_version >= '3.15' and sys_platform == 'win32') or sys_platform == 'linux'" },
+    { name = "nvidia-cufft" },
 ]
 cufile = [
-    { name = "nvidia-cufile", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cufile" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti", marker = "(python_full_version >= '3.15' and sys_platform == 'win32') or sys_platform == 'linux'" },
+    { name = "nvidia-cuda-cupti" },
 ]
 curand = [
-    { name = "nvidia-curand", marker = "(python_full_version >= '3.15' and sys_platform == 'win32') or sys_platform == 'linux'" },
+    { name = "nvidia-curand" },
 ]
 cusolver = [
-    { name = "nvidia-cusolver", marker = "(python_full_version >= '3.15' and sys_platform == 'win32') or sys_platform == 'linux'" },
+    { name = "nvidia-cusolver" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse", marker = "(python_full_version >= '3.15' and sys_platform == 'win32') or sys_platform == 'linux'" },
+    { name = "nvidia-cusparse" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink", marker = "(python_full_version >= '3.15' and sys_platform == 'win32') or sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc", marker = "(python_full_version >= '3.15' and sys_platform == 'win32') or sys_platform == 'linux'" },
+    { name = "nvidia-cuda-nvrtc" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx", marker = "(python_full_version >= '3.15' and sys_platform == 'win32') or sys_platform == 'linux'" },
+    { name = "nvidia-nvtx" },
 ]
 
 [[package]]
@@ -480,6 +480,7 @@ bench = [
     { name = "tiktoken" },
 ]
 dev = [
+    { name = "fastembed" },
     { name = "httpx" },
     { name = "mypy" },
     { name = "pytest" },
@@ -488,9 +489,14 @@ dev = [
     { name = "ruff" },
     { name = "types-pyyaml" },
 ]
+embeddings = [
+    { name = "fastembed" },
+]
 
 [package.metadata]
 requires-dist = [
+    { name = "fastembed", marker = "extra == 'dev'", specifier = ">=0.8,<0.9" },
+    { name = "fastembed", marker = "extra == 'embeddings'", specifier = ">=0.8,<0.9" },
     { name = "fastmcp", specifier = ">=3.2.0,<4" },
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.13" },
@@ -505,7 +511,7 @@ requires-dist = [
     { name = "tiktoken", marker = "extra == 'bench'", specifier = ">=0.8" },
     { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0" },
 ]
-provides-extras = ["dev", "bench"]
+provides-extras = ["embeddings", "dev", "bench"]
 
 [[package]]
 name = "dnspython"
@@ -545,6 +551,27 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
+]
+
+[[package]]
+name = "fastembed"
+version = "0.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+    { name = "loguru" },
+    { name = "mmh3" },
+    { name = "numpy" },
+    { name = "onnxruntime" },
+    { name = "pillow" },
+    { name = "py-rust-stemmers" },
+    { name = "requests" },
+    { name = "tokenizers" },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/26/25/58865e36b6e8a9a0d0ff905b5601aa30db97956327c0df42ec4ed6accc21/fastembed-0.8.0.tar.gz", hash = "sha256:75966edfa8b006ee78514c726bd7f6a50721dadc89305279052be9db72fd53e8", size = 75115, upload-time = "2026-03-23T16:34:41.699Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/e8/26b7d78bb8972498c467ca34cb12ee2e60d26ba5eae6d8443189a1af37a5/fastembed-0.8.0-py3-none-any.whl", hash = "sha256:40bee672657574a1009e35ec50030a55f2b426842cb011845379817641bbbbd0", size = 116572, upload-time = "2026-03-23T16:34:40.69Z" },
 ]
 
 [[package]]
@@ -617,6 +644,14 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e6/dc/be6cbe99670cd6e4ad387123647cb08e0c32975e223f82551e914c5568a6/filelock-3.29.4.tar.gz", hash = "sha256:10cdb3656fc44541cdf30652a93fb10ec6b05325620eb316bd26893e4201538a", size = 63028, upload-time = "2026-06-13T16:12:00.744Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/13/37/a065dc3bd6e49423a6532c642ca7378d3f467b1ef44c2800c937af7f9739/filelock-3.29.4-py3-none-any.whl", hash = "sha256:dac1648087d5115554850d113e7dd8c83ab2d38e3435dde2d4f163847e57b767", size = 42757, upload-time = "2026-06-13T16:11:59.582Z" },
+]
+
+[[package]]
+name = "flatbuffers"
+version = "25.12.19"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/2d/d2a548598be01649e2d46231d151a6c56d10b964d94043a335ae56ea2d92/flatbuffers-25.12.19-py2.py3-none-any.whl", hash = "sha256:7634f50c427838bb021c2d66a3d1168e9d199b0607e6329399f04846d42e20b4", size = 26661, upload-time = "2025-12-19T23:16:13.622Z" },
 ]
 
 [[package]]
@@ -944,6 +979,19 @@ wheels = [
 ]
 
 [[package]]
+name = "loguru"
+version = "0.7.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "win32-setctime", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3a/05/a1dae3dffd1116099471c643b8924f5aa6524411dc6c63fdae648c4f1aca/loguru-0.7.3.tar.gz", hash = "sha256:19480589e77d47b8d85b2c827ad95d49bf31b0dcde16593892eb51dd18706eb6", size = 63559, upload-time = "2024-12-06T11:20:56.608Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/29/0348de65b8cc732daa3e33e67806420b2ae89bdce2b04af740289c5c6c8c/loguru-0.7.3-py3-none-any.whl", hash = "sha256:31a33c10c8e1e10422bfd431aeb5d351c7cf7fa671e3c4df004162264b28220c", size = 61595, upload-time = "2024-12-06T11:20:54.538Z" },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "4.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1039,6 +1087,72 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "mmh3"
+version = "5.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/91/1a/edb23803a168f070ded7a3014c6d706f63b90c84ccc024f89d794a3b7a6d/mmh3-5.2.1.tar.gz", hash = "sha256:bbea5b775f0ac84945191fb83f845a6fd9a21a03ea7f2e187defac7e401616ad", size = 33775, upload-time = "2026-03-05T15:55:57.716Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/25/a5/9daa0508a1569a54130f6198d5462a92deda870043624aa3ea72721aa765/mmh3-5.2.1-cp313-cp313-android_21_arm64_v8a.whl", hash = "sha256:723b2681ed4cc07d3401bbea9c201ad4f2a4ca6ba8cddaff6789f715dd2b391e", size = 40832, upload-time = "2026-03-05T15:54:43.212Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/6b/3230c6d80c1f4b766dedf280a92c2241e99f87c1504ff74205ec8cebe451/mmh3-5.2.1-cp313-cp313-android_21_x86_64.whl", hash = "sha256:3619473a0e0d329fd4aec8075628f8f616be2da41605300696206d6f36920c3d", size = 41964, upload-time = "2026-03-05T15:54:44.204Z" },
+    { url = "https://files.pythonhosted.org/packages/62/fb/648bfddb74a872004b6ee751551bfdda783fe6d70d2e9723bad84dbe5311/mmh3-5.2.1-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:e48d4dbe0f88e53081da605ae68644e5182752803bbc2beb228cca7f1c4454d6", size = 39114, upload-time = "2026-03-05T15:54:45.205Z" },
+    { url = "https://files.pythonhosted.org/packages/95/c2/ab7901f87af438468b496728d11264cb397b3574d41506e71b92128e0373/mmh3-5.2.1-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:a482ac121de6973897c92c2f31defc6bafb11c83825109275cffce54bb64933f", size = 39819, upload-time = "2026-03-05T15:54:46.509Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/ed/6f88dda0df67de1612f2e130ffea34cf84aaee5bff5b0aff4dbff2babe34/mmh3-5.2.1-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:17fbb47f0885ace8327ce1235d0416dc86a211dcd8cc1e703f41523be32cfec8", size = 40330, upload-time = "2026-03-05T15:54:47.864Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/66/7516d23f53cdf90f43fce24ab80c28f45e6851d78b46bef8c02084edf583/mmh3-5.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:d51fde50a77f81330523562e3c2734ffdca9c4c9e9d355478117905e1cfe16c6", size = 56078, upload-time = "2026-03-05T15:54:48.9Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/34/4d152fdf4a91a132cb226b671f11c6b796eada9ab78080fb5ce1e95adaab/mmh3-5.2.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:19bbd3b841174ae6ed588536ab5e1b1fe83d046e668602c20266547298d939a9", size = 40498, upload-time = "2026-03-05T15:54:49.942Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/4c/8e3af1b6d85a299767ec97bd923f12b06267089c1472c27c1696870d1175/mmh3-5.2.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:be77c402d5e882b6fbacfd90823f13da8e0a69658405a39a569c6b58fdb17b03", size = 40033, upload-time = "2026-03-05T15:54:50.994Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/f2/966ea560e32578d453c9e9db53d602cbb1d0da27317e232afa7c38ceba11/mmh3-5.2.1-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:fd96476f04db5ceba1cfa0f21228f67c1f7402296f0e73fee3513aa680ad237b", size = 97320, upload-time = "2026-03-05T15:54:52.072Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/0d/2c5f9893b38aeb6b034d1a44ecd55a010148054f6a516abe53b5e4057297/mmh3-5.2.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:707151644085dd0f20fe4f4b573d28e5130c4aaa5f587e95b60989c5926653b5", size = 103299, upload-time = "2026-03-05T15:54:53.569Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/fc/2ebaef4a4d4376f89761274dc274035ffd96006ab496b4ee5af9b08f21a9/mmh3-5.2.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3737303ca9ea0f7cb83028781148fcda4f1dac7821db0c47672971dabcf63593", size = 106222, upload-time = "2026-03-05T15:54:55.092Z" },
+    { url = "https://files.pythonhosted.org/packages/57/09/ea7ffe126d0ba0406622602a2d05e1e1a6841cc92fc322eb576c95b27fad/mmh3-5.2.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2778fed822d7db23ac5008b181441af0c869455b2e7d001f4019636ac31b6fe4", size = 113048, upload-time = "2026-03-05T15:54:56.305Z" },
+    { url = "https://files.pythonhosted.org/packages/85/57/9447032edf93a64aa9bef4d9aa596400b1756f40411890f77a284f6293ca/mmh3-5.2.1-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d57dea657357230cc780e13920d7fa7db059d58fe721c80020f94476da4ca0a1", size = 120742, upload-time = "2026-03-05T15:54:57.453Z" },
+    { url = "https://files.pythonhosted.org/packages/53/82/a86cc87cc88c92e9e1a598fee509f0409435b57879a6129bf3b3e40513c7/mmh3-5.2.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:169e0d178cb59314456ab30772429a802b25d13227088085b0d49b9fe1533104", size = 99132, upload-time = "2026-03-05T15:54:58.583Z" },
+    { url = "https://files.pythonhosted.org/packages/54/f7/6b16eb1b40ee89bb740698735574536bc20d6cdafc65ae702ea235578e05/mmh3-5.2.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:7e4e1f580033335c6f76d1e0d6b56baf009d1a64d6a4816347e4271ba951f46d", size = 98686, upload-time = "2026-03-05T15:55:00.078Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/88/a601e9f32ad1410f438a6d0544298ea621f989bd34a0731a7190f7dec799/mmh3-5.2.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:2bd9f19f7f1fcebd74e830f4af0f28adad4975d40d80620be19ffb2b2af56c9f", size = 106479, upload-time = "2026-03-05T15:55:01.532Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/5c/ce29ae3dfc4feec4007a437a1b7435fb9507532a25147602cd5b52be86db/mmh3-5.2.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:c88653877aeb514c089d1b3d473451677b8b9a6d1497dbddf1ae7934518b06d2", size = 110030, upload-time = "2026-03-05T15:55:02.934Z" },
+    { url = "https://files.pythonhosted.org/packages/13/30/ae444ef2ff87c805d525da4fa63d27cda4fe8a48e77003a036b8461cfd5c/mmh3-5.2.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:fceef7fe67c81e1585198215e42ad3fdba3a25644beda8fbdaf85f4d7b93175a", size = 97536, upload-time = "2026-03-05T15:55:04.135Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f9/dc3787ee5c813cc27fe79f45ad4500d9b5437f23a7402435cc34e07c7718/mmh3-5.2.1-cp313-cp313-win32.whl", hash = "sha256:54b64fb2433bc71488e7a449603bf8bd31fbcf9cb56fbe1eb6d459e90b86c37b", size = 40769, upload-time = "2026-03-05T15:55:05.277Z" },
+    { url = "https://files.pythonhosted.org/packages/43/67/850e0b5a1e97799822ebfc4ca0e8c6ece3ed8baf7dcdf64de817dfdda2ca/mmh3-5.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:cae6383181f1e345317742d2ddd88f9e7d2682fa4c9432e3a74e47d92dce0229", size = 41563, upload-time = "2026-03-05T15:55:06.283Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/cc/98c90b28e1da5458e19fbfaf4adb5289208d3bfccd45dd14eab216a2f0bb/mmh3-5.2.1-cp313-cp313-win_arm64.whl", hash = "sha256:022aa1a528604e6c83d0a7705fdef0b5355d897a9e0fa3a8d26709ceaa06965d", size = 39310, upload-time = "2026-03-05T15:55:07.323Z" },
+    { url = "https://files.pythonhosted.org/packages/63/b4/65bc1fb2bb7f83e91c30865023b1847cf89a5f237165575e8c83aa536584/mmh3-5.2.1-cp314-cp314-android_24_arm64_v8a.whl", hash = "sha256:d771f085fcdf4035786adfb1d8db026df1eb4b41dac1c3d070d1e49512843227", size = 40794, upload-time = "2026-03-05T15:55:09.773Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/86/7168b3d83be8eb553897b1fac9da8bbb06568e5cfe555ffc329ebb46f59d/mmh3-5.2.1-cp314-cp314-android_24_x86_64.whl", hash = "sha256:7f196cd7910d71e9d9860da0ff7a77f64d22c1ad931f1dd18559a06e03109fc0", size = 41923, upload-time = "2026-03-05T15:55:10.924Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/9b/b653ab611c9060ce8ff0ba25c0226757755725e789292f3ca138a58082cd/mmh3-5.2.1-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:b1f12bd684887a0a5d55e6363ca87056f361e45451105012d329b86ec19dbe0b", size = 39131, upload-time = "2026-03-05T15:55:11.961Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/b4/5a2e0d34ab4d33543f01121e832395ea510132ea8e52cdf63926d9d81754/mmh3-5.2.1-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:d106493a60dcb4aef35a0fac85105e150a11cf8bc2b0d388f5a33272d756c966", size = 39825, upload-time = "2026-03-05T15:55:13.013Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/69/81699a8f39a3f8d368bec6443435c0c392df0d200ad915bf0d222b588e03/mmh3-5.2.1-cp314-cp314-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:44983e45310ee5b9f73397350251cdf6e63a466406a105f1d16cb5baa659270b", size = 40344, upload-time = "2026-03-05T15:55:14.026Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/b3/71c8c775807606e8fd8acc5c69016e1caf3200d50b50b6dd4b40ce10b76c/mmh3-5.2.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:368625fb01666655985391dbad3860dc0ba7c0d6b9125819f3121ee7292b4ac8", size = 56291, upload-time = "2026-03-05T15:55:15.137Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/75/2c24517d4b2ce9e4917362d24f274d3d541346af764430249ddcc4cb3a08/mmh3-5.2.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:72d1cc63bcc91e14933f77d51b3df899d6a07d184ec515ea7f56bff659e124d7", size = 40575, upload-time = "2026-03-05T15:55:16.518Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/b9/e4a360164365ac9f07a25f0f7928e3a66eb9ecc989384060747aa170e6aa/mmh3-5.2.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:e8b4b5580280b9265af3e0409974fb79c64cf7523632d03fbf11df18f8b0181e", size = 40052, upload-time = "2026-03-05T15:55:17.735Z" },
+    { url = "https://files.pythonhosted.org/packages/97/ca/120d92223a7546131bbbc31c9174168ee7a73b1366f5463ffe69d9e691fe/mmh3-5.2.1-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:4cbbde66f1183db040daede83dd86c06d663c5bb2af6de1142b7c8c37923dd74", size = 97311, upload-time = "2026-03-05T15:55:18.959Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/71/c1a60c1652b8813ef9de6d289784847355417ee0f2980bca002fe87f4ae5/mmh3-5.2.1-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:8ff038d52ef6aa0f309feeba00c5095c9118d0abf787e8e8454d6048db2037fc", size = 103279, upload-time = "2026-03-05T15:55:20.448Z" },
+    { url = "https://files.pythonhosted.org/packages/48/29/ad97f4be1509cdcb28ae32c15593ce7c415db47ace37f8fad35b493faa9a/mmh3-5.2.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a4130d0b9ce5fad6af07421b1aecc7e079519f70d6c05729ab871794eded8617", size = 106290, upload-time = "2026-03-05T15:55:21.6Z" },
+    { url = "https://files.pythonhosted.org/packages/77/29/1f86d22e281bd8827ba373600a4a8b0c0eae5ca6aa55b9a8c26d2a34decc/mmh3-5.2.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f6e0bfe77d238308839699944164b96a2eeccaf55f2af400f54dc20669d8d5f2", size = 113116, upload-time = "2026-03-05T15:55:22.826Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/7c/339971ea7ed4c12d98f421f13db3ea576a9114082ccb59d2d1a0f00ccac1/mmh3-5.2.1-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f963eafc0a77a6c0562397da004f5876a9bcf7265a7bcc3205e29636bc4a1312", size = 120740, upload-time = "2026-03-05T15:55:24.3Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/92/3c7c4bdb8e926bb3c972d1e2907d77960c1c4b250b41e8366cf20c6e4373/mmh3-5.2.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:92883836caf50d5255be03d988d75bc93e3f86ba247b7ca137347c323f731deb", size = 99143, upload-time = "2026-03-05T15:55:25.456Z" },
+    { url = "https://files.pythonhosted.org/packages/df/0a/33dd8706e732458c8375eae63c981292de07a406bad4ec03e5269654aa2c/mmh3-5.2.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:57b52603e89355ff318025dd55158f6e71396c0f1f609d548e9ea9c94cc6ce0a", size = 98703, upload-time = "2026-03-05T15:55:26.723Z" },
+    { url = "https://files.pythonhosted.org/packages/51/04/76bbce05df76cbc3d396f13b2ea5b1578ef02b6a5187e132c6c33f99d596/mmh3-5.2.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:f40a95186a72fa0b67d15fef0f157bfcda00b4f59c8a07cbe5530d41ac35d105", size = 106484, upload-time = "2026-03-05T15:55:28.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/8f/c6e204a2c70b719c1f62ffd9da27aef2dddcba875ea9c31ca0e87b975a46/mmh3-5.2.1-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:58370d05d033ee97224c81263af123dea3d931025030fd34b61227a768a8858a", size = 110012, upload-time = "2026-03-05T15:55:29.532Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/37/7181efd8e39db386c1ebc3e6b7d1f702a09d7c1197a6f2742ed6b5c16597/mmh3-5.2.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7be6dfb49e48fd0a7d91ff758a2b51336f1cd21f9d44b20f6801f072bd080cdd", size = 97508, upload-time = "2026-03-05T15:55:31.01Z" },
+    { url = "https://files.pythonhosted.org/packages/42/0f/afa7ca2615fd85e1469474bb860e381443d0b868c083b62b41cb1d7ca32f/mmh3-5.2.1-cp314-cp314-win32.whl", hash = "sha256:54fe8518abe06a4c3852754bfd498b30cc58e667f376c513eac89a244ce781a4", size = 41387, upload-time = "2026-03-05T15:55:32.403Z" },
+    { url = "https://files.pythonhosted.org/packages/71/0d/46d42a260ee1357db3d486e6c7a692e303c017968e14865e00efa10d09fc/mmh3-5.2.1-cp314-cp314-win_amd64.whl", hash = "sha256:3f796b535008708846044c43302719c6956f39ca2d93f2edda5319e79a29efbb", size = 42101, upload-time = "2026-03-05T15:55:33.646Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/7b/848a8378059d96501a41159fca90d6a99e89736b0afbe8e8edffeac8c74b/mmh3-5.2.1-cp314-cp314-win_arm64.whl", hash = "sha256:cd471ede0d802dd936b6fab28188302b2d497f68436025857ca72cd3810423fe", size = 39836, upload-time = "2026-03-05T15:55:35.026Z" },
+    { url = "https://files.pythonhosted.org/packages/27/61/1dabea76c011ba8547c25d30c91c0ec22544487a8750997a27a0c9e1180b/mmh3-5.2.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:5174a697ce042fa77c407e05efe41e03aa56dae9ec67388055820fb48cf4c3ba", size = 57727, upload-time = "2026-03-05T15:55:36.162Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/32/731185950d1cf2d5e28979cc8593016ba1619a295faba10dda664a4931b5/mmh3-5.2.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:0a3984146e414684a6be2862d84fcb1035f4984851cb81b26d933bab6119bf00", size = 41308, upload-time = "2026-03-05T15:55:37.254Z" },
+    { url = "https://files.pythonhosted.org/packages/76/aa/66c76801c24b8c9418b4edde9b5e57c75e72c94e29c48f707e3962534f18/mmh3-5.2.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:bd6e7d363aa93bd3421b30b6af97064daf47bc96005bddba67c5ffbc6df426b8", size = 40758, upload-time = "2026-03-05T15:55:38.61Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/bb/79a1f638a02f0ae389f706d13891e2fbf7d8c0a22ecde67ba828951bb60a/mmh3-5.2.1-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:113f78e7463a36dbbcea05bfe688efd7fa759d0f0c56e73c974d60dcfec3dfcc", size = 109670, upload-time = "2026-03-05T15:55:40.13Z" },
+    { url = "https://files.pythonhosted.org/packages/26/94/8cd0e187a288985bcfc79bf5144d1d712df9dee74365f59d26e3a1865be6/mmh3-5.2.1-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:7e8ec5f606e0809426d2440e0683509fb605a8820a21ebd120dcdba61b74ef7f", size = 117399, upload-time = "2026-03-05T15:55:42.076Z" },
+    { url = "https://files.pythonhosted.org/packages/42/94/dfea6059bd5c5beda565f58a4096e43f4858fb6d2862806b8bbd12cbb284/mmh3-5.2.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:22b0f9971ec4e07e8223f2beebe96a6cfc779d940b6f27d26604040dd74d3a44", size = 120386, upload-time = "2026-03-05T15:55:43.481Z" },
+    { url = "https://files.pythonhosted.org/packages/47/cb/f9c45e62aaa67220179f487772461d891bb582bb2f9783c944832c60efd9/mmh3-5.2.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:85ffc9920ffc39c5eee1e3ac9100c913a0973996fbad5111f939bbda49204bb7", size = 125924, upload-time = "2026-03-05T15:55:44.638Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/83/fe54a4a7c11bc9f623dfc1707decd034245602b076dfc1dcc771a4163170/mmh3-5.2.1-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:7aec798c2b01aaa65a55f1124f3405804184373abb318a3091325aece235f67c", size = 135280, upload-time = "2026-03-05T15:55:45.866Z" },
+    { url = "https://files.pythonhosted.org/packages/97/67/fe7e9e9c143daddd210cd22aef89cbc425d58ecf238d2b7d9eb0da974105/mmh3-5.2.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:55dbbd8ffbc40d1697d5e2d0375b08599dae8746b0b08dea05eee4ce81648fac", size = 110050, upload-time = "2026-03-05T15:55:47.074Z" },
+    { url = "https://files.pythonhosted.org/packages/43/c4/6d4b09fcbef80794de447c9378e39eefc047156b290fa3dd2d5257ca8227/mmh3-5.2.1-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:6c85c38a279ca9295a69b9b088a2e48aa49737bb1b34e6a9dc6297c110e8d912", size = 111158, upload-time = "2026-03-05T15:55:48.239Z" },
+    { url = "https://files.pythonhosted.org/packages/81/a6/ca51c864bdb30524beb055a6d8826db3906af0834ec8c41d097a6e8573d5/mmh3-5.2.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:6290289fa5fb4c70fd7f72016e03633d60388185483ff3b162912c81205ae2cf", size = 116890, upload-time = "2026-03-05T15:55:49.405Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/04/5a1fe2e2ad843d03e89af25238cbc4f6840a8bb6c4329a98ab694c71deda/mmh3-5.2.1-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:4fc6cd65dc4d2fdb2625e288939a3566e36127a84811a4913f02f3d5931da52d", size = 123121, upload-time = "2026-03-05T15:55:50.61Z" },
+    { url = "https://files.pythonhosted.org/packages/af/4d/3c820c6f4897afd25905270a9f2330a23f77a207ea7356f7aadace7273c0/mmh3-5.2.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:623f938f6a039536cc02b7582a07a080f13fdfd48f87e63201d92d7e34d09a18", size = 110187, upload-time = "2026-03-05T15:55:52.143Z" },
+    { url = "https://files.pythonhosted.org/packages/21/54/1d71cd143752361c0aebef16ad3f55926a6faf7b112d355745c1f8a25f7f/mmh3-5.2.1-cp314-cp314t-win32.whl", hash = "sha256:29bc3973676ae334412efdd367fcd11d036b7be3efc1ce2407ef8676dabfeb82", size = 41934, upload-time = "2026-03-05T15:55:53.564Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/e4/63a2a88f31d93dea03947cccc2a076946857e799ea4f7acdecbf43b324aa/mmh3-5.2.1-cp314-cp314t-win_amd64.whl", hash = "sha256:28cfab66577000b9505a0d068c731aee7ca85cd26d4d63881fab17857e0fe1fb", size = 43036, upload-time = "2026-03-05T15:55:55.252Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/0f/59204bf136d1201f8d7884cfbaf7498c5b4674e87a4c693f9bde63741ce1/mmh3-5.2.1-cp314-cp314t-win_arm64.whl", hash = "sha256:dfd51b4c56b673dfbc43d7d27ef857dd91124801e2806c69bb45585ce0fa019b", size = 40391, upload-time = "2026-03-05T15:55:56.697Z" },
 ]
 
 [[package]]
@@ -1168,7 +1282,7 @@ name = "nvidia-cublas"
 version = "13.1.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cuda-nvrtc", marker = "python_full_version >= '3.15' or sys_platform != 'win32'" },
+    { name = "nvidia-cuda-nvrtc" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/a1/0bd24ee8c8d03adac032fd2909426a00c88f8c57961b1277ded97f91119f/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b7a210458267ac818974c53038fbec2e969d5c99f305ab15c72522fa9f001dd5", size = 542848918, upload-time = "2026-04-08T18:46:22.985Z" },
@@ -1207,7 +1321,7 @@ name = "nvidia-cudnn-cu13"
 version = "9.20.0.48"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas", marker = "python_full_version >= '3.15' or sys_platform != 'win32'" },
+    { name = "nvidia-cublas" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/c5/83384d846b2fd17c44bd499b36c75a45ed4f095fbbb2252294e89cea5c5c/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:e31454ae00094b0c55319d9d15b6fa2fc50a9e1c0f5c8c80fb75258234e731e1", size = 444574296, upload-time = "2026-03-09T19:28:27.751Z" },
@@ -1219,7 +1333,7 @@ name = "nvidia-cufft"
 version = "12.0.0.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink", marker = "python_full_version >= '3.15' or sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
@@ -1249,9 +1363,9 @@ name = "nvidia-cusolver"
 version = "12.0.4.66"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas", marker = "python_full_version >= '3.15' or sys_platform != 'win32'" },
-    { name = "nvidia-cusparse", marker = "python_full_version >= '3.15' or sys_platform != 'win32'" },
-    { name = "nvidia-nvjitlink", marker = "python_full_version >= '3.15' or sys_platform != 'win32'" },
+    { name = "nvidia-cublas" },
+    { name = "nvidia-cusparse" },
+    { name = "nvidia-nvjitlink" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
@@ -1263,7 +1377,7 @@ name = "nvidia-cusparse"
 version = "12.6.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink", marker = "python_full_version >= '3.15' or sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
@@ -1313,6 +1427,33 @@ source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/f3/d86c845465a2723ad7e1e5c36dcd75ddb82898b3f53be47ebd429fb2fa5d/nvidia_nvtx-13.0.85-py3-none-manylinux1_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:4936d1d6780fbe68db454f5e72a42ff64d1fd6397df9f363ae786930fd5c1cd4", size = 148047, upload-time = "2025-09-04T08:29:01.761Z" },
     { url = "https://files.pythonhosted.org/packages/a8/64/3708a90d1ebe202ffdeb7185f878a3c84d15c2b2c31858da2ce0583e2def/nvidia_nvtx-13.0.85-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cb7780edb6b14107373c835bf8b72e7a178bac7367e23da7acb108f973f157a6", size = 148878, upload-time = "2025-09-04T08:28:53.627Z" },
+]
+
+[[package]]
+name = "onnxruntime"
+version = "1.27.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "flatbuffers" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "protobuf" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/2b/54208fd03ad410480bc17edf4869376362da8bbf46fe186ddf4cb5cc20fe/onnxruntime-1.27.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:b3e5b58b8c89c2b20e086e890aa9527377e5c240dc3ecc1640d18e07705eeb1c", size = 18432958, upload-time = "2026-06-15T22:42:53.105Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/24fc51fcbb126da6d032372314e47b55c3faad58f2aa78c0e199ccd20b9c/onnxruntime-1.27.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:48b3d87eb560ff6a772240506f3c78d6d27c63cafedd5c775672e1194f968cfd", size = 16438180, upload-time = "2026-06-15T22:42:43.093Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/19/14929c3c2fe0b79b41cce24463062bf3afa4cdd3c19dccf00319caa92bff/onnxruntime-1.27.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6872443f236a554921cda6f318c900e2d0c226792cf3534d00e5057c6926e5d2", size = 18658445, upload-time = "2026-06-15T22:43:08.053Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/76/59ed932b0244acd7bbbd6449480053a6d958ea66357f022f932872e19287/onnxruntime-1.27.0-cp313-cp313-win_amd64.whl", hash = "sha256:760021bca514d64a811837820d351a08a41741f16f8b4c26450da708fecf14e6", size = 13357856, upload-time = "2026-06-15T22:43:37.315Z" },
+    { url = "https://files.pythonhosted.org/packages/79/51/d1ec60ec7b1e2ae2d7340ba52b8a13529140039cd4407ba8dddbbc046582/onnxruntime-1.27.0-cp313-cp313-win_arm64.whl", hash = "sha256:2fdfa9df40a0ded0028ce6f9cd863264237f3970559dea2b81456e9ac4622b94", size = 13104412, upload-time = "2026-06-15T22:43:27.457Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/7d/e6bb1c6445c94f708c38cd8fbb7bf0264108c33498b9445c93e60fe6d329/onnxruntime-1.27.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:54c0c4e9202c36c4ecdb1f3443f5dfbfd5ee3b54d1362c4b4c6134110e74fb32", size = 16443331, upload-time = "2026-06-15T22:42:45.649Z" },
+    { url = "https://files.pythonhosted.org/packages/72/1b/b18b31e806eabc41077810199fbbb36fbc2d5f19912416e5ccfbf73053d1/onnxruntime-1.27.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1b215aa662c8f983f7d6dedafe65a9be72c26e5338e0fe98b3e0422c32c85428", size = 18670967, upload-time = "2026-06-15T22:43:10.621Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/37/48ab79c39b58a7c9f6f5aac1fa0ff2b993eb2643393d6ed9e839ddb6f347/onnxruntime-1.27.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:0874edc171f470fc4dd2bbb60bc0989612ed1a8b89b365cda016630a93227f13", size = 18433941, upload-time = "2026-06-15T22:42:58.867Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/24/d535ca8a09dbf697f853377c8dc0820dbcaae5f334316b400b953afbcba8/onnxruntime-1.27.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5b51c014cf1a4fcd93c29a97eac8071fa27710dae05a4d0380bb60a66d60a62c", size = 16439970, upload-time = "2026-06-15T22:42:48.023Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/b1/ea9ee80c0bdaa4efb13f29f8c236f3740f6655e8c092a2d119515a5a652c/onnxruntime-1.27.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:445fb702ea5241ba813a3ce2febe2e9408a64f6ad2eb610924322c536165f7cd", size = 18659240, upload-time = "2026-06-15T22:43:13.165Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/f2/1404507d76a21940e8bf46f414e3d1abd94dc888cb89a30f4a540275846f/onnxruntime-1.27.0-cp314-cp314-win_amd64.whl", hash = "sha256:49e416be0d717338b6d041b99911b716d70c397d277056450724f93bdded3fc2", size = 13685306, upload-time = "2026-06-15T22:43:40.416Z" },
+    { url = "https://files.pythonhosted.org/packages/10/e5/ca5cf012ccccb806c70e94aadfebca5606acc62b33eb88cec13352d0778f/onnxruntime-1.27.0-cp314-cp314-win_arm64.whl", hash = "sha256:856032937dd3bc7a7c141909c8d7ae4fde3e3f59bddf061ae627b9a051bda95c", size = 13456280, upload-time = "2026-06-15T22:43:29.693Z" },
+    { url = "https://files.pythonhosted.org/packages/67/7b/dca330a8397e9d816c976d7aed4e24a4a2d279bb1e551e3d0221d1389b1d/onnxruntime-1.27.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c6197a02e3f620c4dc13cff51b80672409fc1ffab3aa2593911b19fd322ff48b", size = 16443274, upload-time = "2026-06-15T22:42:50.467Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/f6/2bac21f722aa45d876d4a51f26bd0ef30e704068a3cd5021a5a7cd784271/onnxruntime-1.27.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:370d211e1ceeac4cd5f45301655463ac59e27cdc74d9f7aeb2d19ff4b7a76715", size = 18670781, upload-time = "2026-06-15T22:43:17.151Z" },
 ]
 
 [[package]]
@@ -1367,6 +1508,68 @@ wheels = [
 ]
 
 [[package]]
+name = "pillow"
+version = "12.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1c/3d/bb7fca845737cf9d7dbde16ed1843984665ff2e0a518f5db43e77ec540b9/pillow-12.3.0.tar.gz", hash = "sha256:3b8182a766685eaa002637e28b4ec8d6b18819a0c71f579bf0dbaa5830297cce", size = 47025035, upload-time = "2026-07-01T11:56:38.965Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/ac/31fb64e1e7efb5a4b50cd3d92049ba89ac6e4d8d3bb6a74e15048ca3353e/pillow-12.3.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:21900ce7ba264168cd50defae43cd75d25c833ad4ad6e73ffc5596d12e25ac89", size = 4161684, upload-time = "2026-07-01T11:54:25.934Z" },
+    { url = "https://files.pythonhosted.org/packages/87/b4/9805e23d2b4d77842b468513841fda254ee42f0289d25088340e4ff46e2d/pillow-12.3.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:4e8c2a84d977f50b9daed6eeaf3baef67d00d5d74d932288f02cb94518ee3ace", size = 4255487, upload-time = "2026-07-01T11:54:27.935Z" },
+    { url = "https://files.pythonhosted.org/packages/df/39/ecf519435a200c693fe053a6ee4d835b41cf963a4dfc2551c4e637cb2a71/pillow-12.3.0-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:ae26d61dfa7a47befdc7572b521024e8745f3d809bd95ca9505a7bba9ef849ec", size = 3696433, upload-time = "2026-07-01T11:54:29.813Z" },
+    { url = "https://files.pythonhosted.org/packages/42/92/2fc3ffad878ae8dd5469ec1bc8eb83b71f48e13efdf68f02709003982a32/pillow-12.3.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:7a743ff716f746fc19a9557f60dab1600d4613255f8a7aeb3cdde4db7eb15a66", size = 5345889, upload-time = "2026-07-01T11:54:31.97Z" },
+    { url = "https://files.pythonhosted.org/packages/10/76/8803c13605b763d33d156c4678fc77f8443389c0c51c8aef707bb02015f4/pillow-12.3.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d69141514cc30b774ceea5e3ed3a6635c8d8a96edf664689b890f4089111fb35", size = 4780109, upload-time = "2026-07-01T11:54:34.026Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/01/e18aff37cb0b4aac47ac90f016d347a49aca667ef97f190b06ac2aabc928/pillow-12.3.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f7401aebd7f581d7f83a439d87d474999317ee099218e5ad25d125290990ba65", size = 6263736, upload-time = "2026-07-01T11:54:36.131Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/62/de5bdd77d935331f4f802edc11e4d82950f642caad6cb2f949837b8560e2/pillow-12.3.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0847a763afefb695bc912d7c131e7e0632d4edc1d8698f58ddabec8e46b8b6d3", size = 6937129, upload-time = "2026-07-01T11:54:38.216Z" },
+    { url = "https://files.pythonhosted.org/packages/70/4d/105627a13300c5e0df1d174230b32fd1273062c96f7745fd552b945d1e1d/pillow-12.3.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:571b9fcb07b97ef3a492028fb3d2dc0993ca23a06138b0315286566d29ef718a", size = 6339562, upload-time = "2026-07-01T11:54:40.354Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/1d/f13de01a553988ab895ba1c722e06cf3144d4f57656fd5b81b6d881f1179/pillow-12.3.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:756c768d0c9c2955feb7a56c37ea24aea2e369f8d36a88da270b6a9f19e62b5e", size = 7049439, upload-time = "2026-07-01T11:54:42.489Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/f9/066794cca041b969964f779ee5fa66a9498bbf34248ac39c5d7954e4198f/pillow-12.3.0-cp313-cp313-win32.whl", hash = "sha256:a876864214e136f0eb367788dbd7df045f4806801518e2cfe9e13229cfe06d8f", size = 6473287, upload-time = "2026-07-01T11:54:44.9Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/9b/7a58e61d62be561da3a356fe2384d4059a6345fc130e23ef1c36a5b81d24/pillow-12.3.0-cp313-cp313-win_amd64.whl", hash = "sha256:1cca606cd25738df4ed873d5ad46bbdb3d83b5cbca291f6b4ff13a4df6b0bbe8", size = 7239691, upload-time = "2026-07-01T11:54:47.141Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/b0/c4ed4f0ef8f8fa5ee8351537db6650bb8189f7e118842978dd6589065692/pillow-12.3.0-cp313-cp313-win_arm64.whl", hash = "sha256:b629de27fda84b42cde7edef0d85f13b958b47f6e9bbcbba9b673c562a89bd8b", size = 2568185, upload-time = "2026-07-01T11:54:49.137Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/01/001f65b68192f0228cc1dbbc8d2530ab5d58b61037ba0587f946fea607cd/pillow-12.3.0-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:9cf95fe4d0f84c82d282745d9bb08ad9f926efa00be4697e767b814ce40d4330", size = 4161736, upload-time = "2026-07-01T11:54:51.156Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/d2/0219746d0fd16fc8a84498e79452375be3797d3ce4044596ce565164b84f/pillow-12.3.0-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:8728f216dcdb6e6d555cf971cb34076139ad74b31fc2c14da4fafc741c5f6217", size = 4255435, upload-time = "2026-07-01T11:54:53.414Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/02/8d0bc62ef0302318c46ff2a512822d2610e81c7aa46c9b3abe6cbaca5ad0/pillow-12.3.0-cp314-cp314-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:a45650e8ce7fafffd731db8550230db6b0d306d181a90b67d3e6bca2f1990930", size = 3696262, upload-time = "2026-07-01T11:54:55.739Z" },
+    { url = "https://files.pythonhosted.org/packages/85/e2/73c77d218410b14f5f2d565e8a998d5317b7b9c75368d29985139f7a46f0/pillow-12.3.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:ba54cfebe86920a559a7c4d6b9050791c20513650a1952ebe3368c7dc70306f8", size = 5350344, upload-time = "2026-07-01T11:54:57.657Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/da/32c752228ae345f489e3a42499d817b6c3996da7e8a3bc7a04fc806b243b/pillow-12.3.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:e158cb00350dc278f3b91551101aa7d12415a66ebf2c91d8d5ac14e56ddd3ad0", size = 4780131, upload-time = "2026-07-01T11:54:59.713Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/9d/8b2c807dbef61a5197c047afe99823787eb66f63daf9fb2432f91d6f0462/pillow-12.3.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e9aeb04d6aef139de265b29683e119b638208f88cf73cdd1658aa07221165321", size = 6263757, upload-time = "2026-07-01T11:55:01.778Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/44/c85361f65dbe00eea8576ee467c768d25129989efb76e94f205e9ca9bb46/pillow-12.3.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:251bf95b67017e27b13d82f5b326234ca62d70f9cf4c2b9032de2358a3b12c7b", size = 6936962, upload-time = "2026-07-01T11:55:03.93Z" },
+    { url = "https://files.pythonhosted.org/packages/18/7e/e483414b35800b86b6f08dbbc7803fb5cd52c4d6f897f47d53ea2c7e6f65/pillow-12.3.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:fe3cca2e4e8a592be0f269a1ca4835c25199d9f3ce815c8491048f785b0a0198", size = 6339171, upload-time = "2026-07-01T11:55:05.989Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/f4/68c491844841ede6bed70189546b3ee9731cf9f2cbad396faff5e1ccba45/pillow-12.3.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:23aceaa007d6172b02c277f0cd359c79492bbb14f7072b4ede9fbcaf20648130", size = 7048116, upload-time = "2026-07-01T11:55:08.131Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/34/77f3f793fed8efc7d243f21b33c5a3f0d1c97ee70346d3db855587e155ff/pillow-12.3.0-cp314-cp314-win32.whl", hash = "sha256:af8d94b0db561cf68b88a267c5c44b49e134f525d0dc2cb7ed413a66bc23559a", size = 6467209, upload-time = "2026-07-01T11:55:10.408Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/e0/492879f69d94f91f60fc8cd05ba03650e9520afebb2fb7aa12777d7c7f38/pillow-12.3.0-cp314-cp314-win_amd64.whl", hash = "sha256:fdafc9cce40277e0f7a0feabce0ee50dd2fa1800f3b38015e51296b5e814048d", size = 7237707, upload-time = "2026-07-01T11:55:12.745Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/ac/6b11f2875f1c2ac040d84e1bbf9cf22a88038f901ca1037898b280b38365/pillow-12.3.0-cp314-cp314-win_arm64.whl", hash = "sha256:e91206ee562682b51b98ef4b26a6ef48fd84e15fd4c4bc5ec768eb641d206838", size = 2565995, upload-time = "2026-07-01T11:55:14.736Z" },
+    { url = "https://files.pythonhosted.org/packages/52/69/c2208e56af9bfc1913afb24020297a691eb1d4ef688474c8a04913f65e04/pillow-12.3.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:164b31cd1a0490ab6efae01aa5df49da7061be0af1b30e035b6e9a1bfe34ee6e", size = 5352503, upload-time = "2026-07-01T11:55:17.076Z" },
+    { url = "https://files.pythonhosted.org/packages/07/70/e5686d753e898a45d778ff1718dba8516ead6ab6b95d85fc8c4b70650cf2/pillow-12.3.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5afb51d599ea772b8365ae807ae557f18bccfe46ab261fd1c2a9ed700fc6eb17", size = 4782956, upload-time = "2026-07-01T11:55:19.448Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/37/25c6692f06927ee973ff18c8d9ee98ad0b4d84ee67a09610c2dd1447958e/pillow-12.3.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3edce1d53195db527e0191f84b71d02022de0540bf43a16ed734ed7537b07385", size = 6322855, upload-time = "2026-07-01T11:55:21.613Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/91/420637fcb8f1bc11029e403b4538e6694744428d8246118e45719f944556/pillow-12.3.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bf16ba1b4d0b6b7c8e534936632270cf70eb00dbe09005bc345b2677b726855c", size = 6989642, upload-time = "2026-07-01T11:55:24.006Z" },
+    { url = "https://files.pythonhosted.org/packages/10/08/b94d7811281ccf0d143a1cf768d1c49e1e54af63e7b708ab2ee3eb87face/pillow-12.3.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:24870b09b224f7ae3c39ed07d10e819d06f8720bc551847b1d623832b5b0e28d", size = 6391281, upload-time = "2026-07-01T11:55:26.252Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/87/24233f785f55474dc02ce3e739c5528a77e3a862e9333d1dd7a25cc31f70/pillow-12.3.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:30f2aa603c41533cc25c05acd0da21636e84a315768feb631c937177db558931", size = 7096716, upload-time = "2026-07-01T11:55:28.318Z" },
+    { url = "https://files.pythonhosted.org/packages/23/26/fcb2f6e37175b04f53570b59937867e2b80ee1685e744023153028fc14f9/pillow-12.3.0-cp314-cp314t-win32.whl", hash = "sha256:4b0a7fe987b14c31ebda6083f74f22b561fd3739bc0ac51e019622e3d72668c7", size = 6474125, upload-time = "2026-07-01T11:55:30.956Z" },
+    { url = "https://files.pythonhosted.org/packages/90/de/3634abee5f1c9e13c56787b7d5517b0ba8d6de51700b95578cf338349c9f/pillow-12.3.0-cp314-cp314t-win_amd64.whl", hash = "sha256:962864dc93511324d51ddbb5b9f8731bf71675b93ca612a07441896f4688fb8c", size = 7242939, upload-time = "2026-07-01T11:55:34.044Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/2a/fd13f8eb24de5714a6eb444a3d67e2842c6c576e159a43793adf23051351/pillow-12.3.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0740a512dc522224c77d9aa5a8d70d8b7d73fb91f2c21125d8d025d3b8990e45", size = 2567506, upload-time = "2026-07-01T11:55:35.988Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/dc/8fdce34ec725a33c81c6ba122b904d6b9024e50ea9ac7bede62fab54506c/pillow-12.3.0-cp315-cp315-ios_13_0_arm64_iphoneos.whl", hash = "sha256:0feb2e9d6ad6c9e3c06effe9d00f3f1e618a6643273576b016f591e9315a7139", size = 4162063, upload-time = "2026-07-01T11:55:37.941Z" },
+    { url = "https://files.pythonhosted.org/packages/76/66/2044b9a63d3b84ff048228dfcb7cd9bf0df983e8470971bf7d4c57b693de/pillow-12.3.0-cp315-cp315-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:9e881fca225083806662a5c43d627d215f258ff43c890f831966c7d7ba9c7402", size = 4255549, upload-time = "2026-07-01T11:55:40.022Z" },
+    { url = "https://files.pythonhosted.org/packages/52/7e/1f67e6f4ece6b582ee4b539decbcc9f848dc245a93ed8cd7338bafef72f1/pillow-12.3.0-cp315-cp315-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:4998562bf62a445225f22e07c896bb04b35b1b1f2eb6d760584c9c51d7a5f78c", size = 3696331, upload-time = "2026-07-01T11:55:41.98Z" },
+    { url = "https://files.pythonhosted.org/packages/12/40/d306fc2c8e4d45d7f175c77edca7063be7b86fe7fe6e68f4353bf71d808c/pillow-12.3.0-cp315-cp315-macosx_10_15_x86_64.whl", hash = "sha256:dc624f6bc473dacdf7ef7eb8678d0d08edf15cd94fad6ae5c7d6cc67a4e4902f", size = 5350370, upload-time = "2026-07-01T11:55:44.028Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/44/668fb1437e8ce420f62d6106eb66e44a5971602a4d794615bdf79315d82d/pillow-12.3.0-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:71d6097b330eea8fd15097780c8e89cb1a8ce7838669f48c5bacd6f663dd4701", size = 4780147, upload-time = "2026-07-01T11:55:46.073Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/08/93fa2e70e30a2d81547e481b6ee2bb9522117221fb1e0ce4b5df70967677/pillow-12.3.0-cp315-cp315-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:28ce87c5ab450a9dd970b52e5aca5fe63ed432d18a2eaddd1979a00a1ba24ace", size = 6273659, upload-time = "2026-07-01T11:55:48.264Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/6d/043e96ff814fc31a33077e4cba86082167db520c93632afdf2042febbb0c/pillow-12.3.0-cp315-cp315-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6b02afb9b97f65fbca5f31db6a2a3ba21aa93030225f150fa3f249717e938fb4", size = 6947439, upload-time = "2026-07-01T11:55:50.503Z" },
+    { url = "https://files.pythonhosted.org/packages/af/92/ba71d2ee2ac0edf3fa33bd9d5ee9ee080da70b1766f3ca3934f9938ddac9/pillow-12.3.0-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:1182d52bc2d5e5d7d0949503aa7e36d12f42205dc287e4883f407b1988820d39", size = 6353577, upload-time = "2026-07-01T11:55:52.697Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/ce/e63064e2122923ff687c8ad792d0d736a7b3920a56a46982e81a7fdd25d6/pillow-12.3.0-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:e795b7eb908249c4e43c7c99fac7c2c75dab0c43566e37db472a355f63693d71", size = 7060394, upload-time = "2026-07-01T11:55:55.149Z" },
+    { url = "https://files.pythonhosted.org/packages/54/76/a09cc3ccc8d773a7283d34c38bec1708f9e3cc932093cbc4c5e71ac4060b/pillow-12.3.0-cp315-cp315-win32.whl", hash = "sha256:57b3d78c95ba9059768b10e28b813002261d3f3dfc55cc48b0c988f625175827", size = 6467375, upload-time = "2026-07-01T11:55:57.769Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/03/1846c49ba3b1d5550392a4bbd06d6fb4578e1cd91a803198b5c90f5f7d53/pillow-12.3.0-cp315-cp315-win_amd64.whl", hash = "sha256:fa4ecea169a355be7a3ade2c783e2ed12f0e40d2c5621cda8b3297faf7fbb9f5", size = 7237048, upload-time = "2026-07-01T11:55:59.975Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/bb/89f35dcc79610423f9f195504d7def7f0d1416a711541b42867e25fe3412/pillow-12.3.0-cp315-cp315-win_arm64.whl", hash = "sha256:877c3f311ff35410f690861c4409e7ccbf0cd2f878e50628a28e5a0bb689e658", size = 2566006, upload-time = "2026-07-01T11:56:02.143Z" },
+    { url = "https://files.pythonhosted.org/packages/30/88/707027ba09942dfa2c28759b5c222d769290a41c6d20ea60ec250801941f/pillow-12.3.0-cp315-cp315t-macosx_10_15_x86_64.whl", hash = "sha256:e9871b1ffbfa9656b60aeee92ed5136a5742696006fa322b29ea3d8da0ecc9cf", size = 5352509, upload-time = "2026-07-01T11:56:04.2Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/6d/00352fa25332c2569cd387851f568cc5a4b75a9adbfb37ac4fbce4c02eec/pillow-12.3.0-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:53aa02d20d10c3d814d536aa4e5ac9b84ca0ff5a88377963b085ad6822f93e64", size = 4783167, upload-time = "2026-07-01T11:56:06.631Z" },
+    { url = "https://files.pythonhosted.org/packages/13/4f/9e049dfa21af7c22427275720e2490267ba8138120add5c4c574deb69782/pillow-12.3.0-cp315-cp315t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:446c34dcc4324b084a53b705127dc15717b22c5e140ae0a3c38349d4efec071e", size = 6329237, upload-time = "2026-07-01T11:56:08.868Z" },
+    { url = "https://files.pythonhosted.org/packages/36/16/cf6eeaae8d0fce8dd390a33437cf68c5d5bd73834a2bc6e2f14efda0ab45/pillow-12.3.0-cp315-cp315t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cf1845d02ad822a369a49f2bb9345b1614744267682e7a03527dc3bf6eea1777", size = 6997047, upload-time = "2026-07-01T11:56:11.379Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/69/dbf769bdd55f48bf5733cac28edc6364ffaa072ec9ba336266e4fe66be55/pillow-12.3.0-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:186941b6aef820ad110fb01fb06eb925374dc3a21b17e37ec9a53b250c6fe2d1", size = 6400440, upload-time = "2026-07-01T11:56:13.908Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/e1/ffc9cfc2eea0d178da8018e18e959301ad9d6bc9f3edb7181e748a474b97/pillow-12.3.0-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:f13c32a3abd6079a66d9526e18dad9b6d280384d49d7c54040cd57b6424041d9", size = 7105895, upload-time = "2026-07-01T11:56:16.575Z" },
+    { url = "https://files.pythonhosted.org/packages/18/f0/a5595c1e8c3ae44b9828cb2f0fa8155e5095ef04d6327b8f61cf44a3df85/pillow-12.3.0-cp315-cp315t-win32.whl", hash = "sha256:1657923d2d45afb66526e5b933e5b3052e6bdea196c90d3abb2424e18c77dae8", size = 6474384, upload-time = "2026-07-01T11:56:18.855Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/04/62bcd9f844984c5938d3b05264a61d797a29d3e0812341a8204af70bbdee/pillow-12.3.0-cp315-cp315t-win_amd64.whl", hash = "sha256:8cd2f7bdda092d99c9fc2fb7391354f306d01443d22785d0cbfafa2e2c8bb418", size = 7243537, upload-time = "2026-07-01T11:56:21.214Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/68/1f3066acedf37673694a7141381d8f811ae97f30d34413d236abe7d489f1/pillow-12.3.0-cp315-cp315t-win_arm64.whl", hash = "sha256:06ff022112bc9cbf83b60f8e028d94ad87b60621706487e65f673de61610ab59", size = 2567491, upload-time = "2026-07-01T11:56:23.506Z" },
+]
+
+[[package]]
 name = "platformdirs"
 version = "4.10.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1382,6 +1585,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "protobuf"
+version = "7.35.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/01/9ef0afd7999eb9badb3a768b4aedd78c86d4c65cfaf1958ab276199e76b4/protobuf-7.35.1.tar.gz", hash = "sha256:ce115a26fe0c39a2c29973d914d327e516a6455464489fe3cd1e51a1b354f81a", size = 458717, upload-time = "2026-06-11T21:55:40.257Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/03/8aeeb7458d22546bf64b5250ca1daeb5ff757d900e8e4a7476c6f0db843e/protobuf-7.35.1-cp310-abi3-macosx_10_9_universal2.whl", hash = "sha256:24f857477359a85c0c235261b8ba905fd51b2562f4a64ca1df5473f29850cbf6", size = 433226, upload-time = "2026-06-11T21:55:31.719Z" },
+    { url = "https://files.pythonhosted.org/packages/37/4b/dfb89eb0e652a1ff073c39a59fb5e3a83cfe9b57a2c83fa6d78270101767/protobuf-7.35.1-cp310-abi3-manylinux2014_aarch64.whl", hash = "sha256:11d6b0ec246892d85215b0a13ca6e0233cf5284b68f0ac02646427f4ff88a799", size = 328847, upload-time = "2026-06-11T21:55:34.035Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/58/dc12f2cd484951524af6e3382c785869b9b3fb5e52ee95ae23add53ee8f9/protobuf-7.35.1-cp310-abi3-manylinux2014_s390x.whl", hash = "sha256:b73f9489a4b8b1c9cb1f8ed951c736392592edb24b9d6819f36d2e10b171d5b4", size = 344030, upload-time = "2026-06-11T21:55:34.941Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/be/5b3cfe508bfab6761414ff944e3366eb13be4fd71efcd69450f89ba39f43/protobuf-7.35.1-cp310-abi3-manylinux2014_x86_64.whl", hash = "sha256:74758715c53d7158fb76caf4f0cfdacc5329a4b1bb994f865d6cf302d413a1c4", size = 327130, upload-time = "2026-06-11T21:55:35.921Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/bc/6d6c7ba8709c85f8f2c390b2b118d6fb08a783676a572271851bf45a7d22/protobuf-7.35.1-cp310-abi3-win32.whl", hash = "sha256:353652e4efd0bca5b5fc2656abf8307ef351f0cf938c9eba09f0e09c20a25c30", size = 428945, upload-time = "2026-06-11T21:55:37.034Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/19/8d0cb6f20a1ef7b18f1c8986ad5783f22f84cce39c6ce9a6e645ea55192e/protobuf-7.35.1-cp310-abi3-win_amd64.whl", hash = "sha256:230a75ddfc2de4806e56696ce9640c1cdfdb6543b7cfce98d42a4c0a0e7bdb87", size = 439996, upload-time = "2026-06-11T21:55:38.123Z" },
+    { url = "https://files.pythonhosted.org/packages/19/c7/5f7c636ec43e0c545e28d1f1db71990108306f7bdcb89f069ba97e428e7f/protobuf-7.35.1-py3-none-any.whl", hash = "sha256:4bc97768d8fe4ad6743c8a19403e314511ed9f6d13205b687e52421c023ac1b9", size = 171659, upload-time = "2026-06-11T21:55:39.155Z" },
 ]
 
 [[package]]
@@ -1407,6 +1625,34 @@ keyring = [
 ]
 memory = [
     { name = "cachetools" },
+]
+
+[[package]]
+name = "py-rust-stemmers"
+version = "0.1.8"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6b/c1/9763f9fb1cd73f9c317a83feeed6e0d4af320c6bbddab47b4a94f3a47d0c/py_rust_stemmers-0.1.8.tar.gz", hash = "sha256:6b0f6f48bc54d607aed802de872fcd5a71bae969a6760976dc78ce55e8eaf3da", size = 9732, upload-time = "2026-05-22T11:00:24.358Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/98/f078f3930311e7b6154ccdf9166c4e30a416c7d199e136b5f09265d58a35/py_rust_stemmers-0.1.8-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:5bd15b89203ecd886960e237124d1aa6e55498d76418c36c967d3b12168d43dc", size = 290427, upload-time = "2026-05-22T10:59:55.316Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/46/21d784a3f1db6a23051ffd5826d8ee667d26a64587c1cfbda0443ed87fff/py_rust_stemmers-0.1.8-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:6c92733b020534470ca5a0d7fe8b85c85622ff383d4f37fec75a1c677aa84921", size = 275628, upload-time = "2026-05-22T10:59:56.687Z" },
+    { url = "https://files.pythonhosted.org/packages/57/d5/701c73a4f6a7fecfd96a6588f0cafe98d6b0acde93adf8a2e45535f3d1d5/py_rust_stemmers-0.1.8-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9ab605a86c950ba7e8ab1392cf91296c0bec3084babb897a4aecf90a10c82395", size = 316656, upload-time = "2026-05-22T10:59:57.67Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/0d/c58fe98153cfdb6abf4dfb6ac335c923000d4af4e736080c3a3045b7aea7/py_rust_stemmers-0.1.8-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:21ed8055cec1f78d666afad8ffd7a51775ba419d2c615b8a1df7b32ca7f33e2b", size = 319377, upload-time = "2026-05-22T10:59:58.664Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/d7/e60d04849e90aa3ad457211cc4999c30401f433341f9a5588c12b81f9877/py_rust_stemmers-0.1.8-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ae773e1d01e9aa328d175f461475d0cd7074a82bfcc71de6dc5765e51f1cc9f7", size = 323719, upload-time = "2026-05-22T10:59:59.845Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/48/c0e4fb955db784cc354e0756354602f7043ff4c10fcbd9d901a2f8fe3239/py_rust_stemmers-0.1.8-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:5cc8fab9d0f1b274a26935a632362b8278f03e81b65e8b8644d5ca3f62a5a1a4", size = 324110, upload-time = "2026-05-22T11:00:01.26Z" },
+    { url = "https://files.pythonhosted.org/packages/48/eb/981b26baff37cf7a26ee206763cc4d2fb3e1db8f0f86ec030074431fae05/py_rust_stemmers-0.1.8-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:35570098da02eb439afcd7270a12bf850bbe874b85cb912e0fb2d87a6e703920", size = 494645, upload-time = "2026-05-22T11:00:02.737Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/af/f16e805b7aefc2257b192b83a89300c8360b0fdffd3dfefa92dee4ec9b15/py_rust_stemmers-0.1.8-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:0a68745d4b3c7f5abc778ca967e8711df6154873abcfe4e62a6631fa2363cc32", size = 596124, upload-time = "2026-05-22T11:00:04.499Z" },
+    { url = "https://files.pythonhosted.org/packages/76/8c/e7a2c940ba00e0792ae346aed5e755d51d37cf6d6853f6b141e5380e285d/py_rust_stemmers-0.1.8-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7cc0cc0b8eb45d2158c28ea43e2f338c110aad63052ad3bd00bc7446a595e12f", size = 541771, upload-time = "2026-05-22T11:00:06.081Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/a0/dd7c5fc6ade6d2a2a49e49937f06f2d488511454e8ab1b313d277ee8c3b1/py_rust_stemmers-0.1.8-cp313-cp313-win_amd64.whl", hash = "sha256:15af4e12e1288de2e5241eec375afc6ad6be4c125a28ca010599d9f92db23f01", size = 212438, upload-time = "2026-05-22T11:00:07.244Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/7e/f4346adfd44acbd7eaedcbd7d21b7f40ec9712e6c699e71fddad8dae6f8d/py_rust_stemmers-0.1.8-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:526b58958c6ffa36c4a805326cfb624ecbd665d16ba435027dbed0bcbcaa09d2", size = 290379, upload-time = "2026-05-22T11:00:08.192Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/d8/988fc3f5dc0dbbd4bf5909f50ff953ab55ee8b5f79a835d00e57847d3123/py_rust_stemmers-0.1.8-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:2b607f0b270951fb66479baf4b68716cc63a981585cbd898b0b6b5c359efde7e", size = 275458, upload-time = "2026-05-22T11:00:09.522Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/94/e04c8b6a8364bca1b368785cef143755dd2d1ffe74df8f8b47b075bb1043/py_rust_stemmers-0.1.8-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8b0327b151ab8a338fb54fdac114ba34394327fc1e2c4c425ad1caf2013e5de3", size = 314711, upload-time = "2026-05-22T11:00:10.878Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/cb/f59f9a80caa099cb6625a46c9a8e6e7e80bb3ed284f17e80245c8240a66e/py_rust_stemmers-0.1.8-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:dadd0e369703817fc7026987b3093f461f9f58d8dde74e689d546184bc8f3451", size = 319370, upload-time = "2026-05-22T11:00:11.961Z" },
+    { url = "https://files.pythonhosted.org/packages/06/59/8211cd0f56e53f7770debd9a78de37985fb5662ae66e3b7b380f4c79888b/py_rust_stemmers-0.1.8-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:245e2c61c52e073341893a9682cd1396b61047154548aee30bb1af3d8ed4b4cc", size = 321373, upload-time = "2026-05-22T11:00:13.213Z" },
+    { url = "https://files.pythonhosted.org/packages/10/72/fe33e614c114264d1ba54d39da4b5a4abeb6aedd0d26e5a8fd0637d6ddba/py_rust_stemmers-0.1.8-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:451ee1c02a3f5cf1e161b46ba9032cdda4ba10a8b03ff9ee61c1d34d42a0bc81", size = 321707, upload-time = "2026-05-22T11:00:14.177Z" },
+    { url = "https://files.pythonhosted.org/packages/91/f9/3cd18902fe2fa54557d3fe9132552256372d381c7aca71346163055d78b1/py_rust_stemmers-0.1.8-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:d396dd25c473c1bc4248c79cd223f4b36356b55a124652f015c6a001547f81ac", size = 492457, upload-time = "2026-05-22T11:00:15.245Z" },
+    { url = "https://files.pythonhosted.org/packages/90/d7/32c6d3995e7036b73683389de2771f4dbbf40de192b7efe73c2528ee1eb5/py_rust_stemmers-0.1.8-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:479c77c32d8be692f3cfcde7e19273f02ac81d6f45c6aef49887ef95cab7abbb", size = 596085, upload-time = "2026-05-22T11:00:16.404Z" },
+    { url = "https://files.pythonhosted.org/packages/00/8c/e68fa5d862ea6a27fced3535c25ea4eaa26ba1ce00dfef5841924c74b167/py_rust_stemmers-0.1.8-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:c786235275c5c2abb7f206b8236aee3ca0bc53c7497daf7fb7b01d3491469547", size = 539747, upload-time = "2026-05-22T11:00:17.414Z" },
+    { url = "https://files.pythonhosted.org/packages/44/48/aa584cf3772e01231641c95dc1aa73327a7d986c562639d78d0013733acf/py_rust_stemmers-0.1.8-cp314-cp314-win_amd64.whl", hash = "sha256:931d13570962b093417e5443a9d1bd63d73fa239ebb81e5b1d346663571403e4", size = 209636, upload-time = "2026-05-22T11:00:18.662Z" },
 ]
 
 [[package]]
@@ -2010,8 +2256,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography", marker = "python_full_version >= '3.15' or sys_platform != 'win32'" },
-    { name = "jeepney", marker = "python_full_version >= '3.15' or sys_platform != 'win32'" },
+    { name = "cryptography" },
+    { name = "jeepney" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [
@@ -2430,4 +2676,13 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/b6/b9afed2afadddaf5ebb2afa801abf4b0868f42f8539bfe4b071b5266c9fe/websockets-16.0-cp314-cp314t-win32.whl", hash = "sha256:5a4b4cc550cb665dd8a47f868c8d04c8230f857363ad3c9caf7a0c3bf8c61ca6", size = 178085, upload-time = "2026-01-10T09:23:33.816Z" },
     { url = "https://files.pythonhosted.org/packages/9f/3e/28135a24e384493fa804216b79a6a6759a38cc4ff59118787b9fb693df93/websockets-16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b14dc141ed6d2dde437cddb216004bcac6a1df0935d79656387bd41632ba0bbd", size = 178531, upload-time = "2026-01-10T09:23:35.016Z" },
     { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
+]
+
+[[package]]
+name = "win32-setctime"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b3/8f/705086c9d734d3b663af0e9bb3d4de6578d08f46b1b101c2442fd9aecaa2/win32_setctime-1.2.0.tar.gz", hash = "sha256:ae1fdf948f5640aae05c511ade119313fb6a30d7eabe25fef9764dca5873c4c0", size = 4867, upload-time = "2024-12-07T15:28:28.314Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/07/c6fe3ad3e685340704d314d765b7912993bcb8dc198f0e7a89382d37974b/win32_setctime-1.2.0-py3-none-any.whl", hash = "sha256:95d644c4e708aba81dc3704a116d8cbc974d70b3bdb8be1d150e36be6e9d1390", size = 4083, upload-time = "2024-12-07T15:28:26.465Z" },
 ]


### PR DESCRIPTION
Closes #42.

Optional local-embedding hybrid ranking. **Off by default**; the zero-dependency lexical product is unchanged and does not import any embedding code unless enabled.

## Dependency footprint (this is why it is an optional extra)
New `[project.optional-dependencies] embeddings = ["fastembed>=0.8,<0.9"]`. fastembed bundles a quantised ONNX MiniLM-class model runner on `onnxruntime` — **no torch, no external API**. Transitive additions (in `uv.lock`, dev-extra so CI can exercise it): onnxruntime, flatbuffers, protobuf, loguru, mmh3, pillow, py-rust-stemmers. Model (~small MiniLM, e.g. `BAAI/bge-small-en-v1.5`) is fetched once at enable time and cached; never at query time.

## Behaviour
- `KB_EMBEDDINGS_MODE=on` (default off): `Index.build()` embeds each doc and stores vectors in a new table (schema v8), written into the same tmp DB and swapped atomically with the FTS index.
- A hybrid reranker embeds the query once and blends normalised BM25 with cosine similarity. It composes **under** the exact-id/tag short-circuit and **after** the status prior, so an exact id/tag still wins and active docs keep their boost.
- Guarded imports: with the extra uninstalled and the flag off, nothing imports the embedding stack. Enabling the flag without the extra/model **fails loudly at startup**.
- Config: `KB_EMBEDDINGS_MODE`, `KB_EMBEDDINGS_WEIGHT` (blend, default 0.35), `KB_EMBEDDINGS_MODEL`.

## Verification
Full suite green locally except the known `test_lint` worktree artifact (passes in CI's clean checkout). Embedding integration tests skip when the model/dep is unavailable in the sandbox; CI (with network) exercises them. ruff + mypy clean.
