### PR TITLE
feat(release): automated release-cutter routine, SemVer tooling, and tag-on-bump CI

### DIFF
--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -1,0 +1,17 @@
+name: pr-title-lint
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+permissions:
+  contents: read
+jobs:
+  lint-title:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: astral-sh/setup-uv@v7
+      - run: uv venv --python 3.13
+      - name: Validate PR title is a Conventional Commit
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: uv run python scripts/lint_pr_title.py "$PR_TITLE"

--- a/.github/workflows/release-image-reusable.yml
+++ b/.github/workflows/release-image-reusable.yml
@@ -1,0 +1,62 @@
+# .github/workflows/release-image-reusable.yml
+name: build-and-push-image
+on:
+  workflow_call:
+    inputs:
+      tag:
+        description: "image tag to publish, e.g. v0.1.0 or edge"
+        required: true
+        type: string
+      move_latest:
+        description: "also move the :latest channel"
+        required: false
+        default: false
+        type: boolean
+jobs:
+  build-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Compute image tags
+        id: image-tag
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
+          MOVE_LATEST: ${{ inputs.move_latest }}
+        run: |
+          {
+            echo "tags<<EOF"
+            echo "ghcr.io/knaisoma/data-olympus:$INPUT_TAG"
+            if [ "$MOVE_LATEST" = "true" ]; then
+              echo "ghcr.io/knaisoma/data-olympus:latest"
+            fi
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: deploy/docker/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.image-tag.outputs.tags }}
+          labels: |
+            org.opencontainers.image.version=${{ inputs.tag }}
+            org.opencontainers.image.revision=${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -1,3 +1,4 @@
+# .github/workflows/release-image.yml
 name: Release Docker Image
 
 on:
@@ -12,63 +13,24 @@ on:
         default: "edge"
 
 jobs:
-  build-push:
-    runs-on: ubuntu-latest
+  # A real release is a pushed `v*` tag: publish the semver tag AND move `latest`.
+  # A manual workflow_dispatch (default `edge`) is a pre-release build: publish
+  # ONLY its tag, never move `latest`.
+  release:
+    if: github.event_name == 'push' && github.ref_type == 'tag'
+    uses: ./.github/workflows/release-image-reusable.yml
+    with:
+      tag: ${{ github.ref_name }}
+      move_latest: true
     permissions:
       contents: read
       packages: write
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-
-      - name: Log in to GHCR
-        uses: docker/login-action@v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Compute image tags
-        id: image-tag
-        env:
-          EVENT_NAME: ${{ github.event_name }}
-          REF_TYPE: ${{ github.ref_type }}
-          REF_NAME: ${{ github.ref_name }}
-          INPUT_TAG: ${{ inputs.tag }}
-        run: |
-          # A real release is a pushed `v*` tag: publish the semver tag AND move
-          # the `latest` channel. A manual workflow_dispatch (default `edge`) is a
-          # pre-release build: publish ONLY its tag and never move `latest`, so
-          # `latest` always means "last promoted release", not "last manual build".
-          if [ "$EVENT_NAME" = "push" ] && [ "$REF_TYPE" = "tag" ]; then
-            {
-              echo "tags<<EOF"
-              echo "ghcr.io/knaisoma/data-olympus:$REF_NAME"
-              echo "ghcr.io/knaisoma/data-olympus:latest"
-              echo "EOF"
-            } >> "$GITHUB_OUTPUT"
-          else
-            {
-              echo "tags<<EOF"
-              echo "ghcr.io/knaisoma/data-olympus:$INPUT_TAG"
-              echo "EOF"
-            } >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Build and push
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: deploy/docker/Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.image-tag.outputs.tags }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+  prerelease:
+    if: github.event_name == 'workflow_dispatch'
+    uses: ./.github/workflows/release-image-reusable.yml
+    with:
+      tag: ${{ inputs.tag }}
+      move_latest: false
+    permissions:
+      contents: read
+      packages: write

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,0 +1,50 @@
+# .github/workflows/tag-release.yml
+name: Tag release on version bump
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  decide:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      tag: ${{ steps.decide.outputs.tag }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - name: Decide tag from pyproject version
+        id: decide
+        run: |
+          TAG="$(python3 scripts/should_tag.py)"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+      - name: Create annotated tag + GitHub Release
+        if: steps.decide.outputs.tag != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.decide.outputs.tag }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "$TAG" -m "Release ${TAG#v}"
+          git push origin "$TAG"
+          NOTES="docs/releases/${TAG}.md"
+          if [ -f "$NOTES" ]; then
+            gh release create "$TAG" --title "$TAG" --notes-file "$NOTES"
+          else
+            gh release create "$TAG" --title "$TAG" --generate-notes
+          fi
+
+  build-image:
+    needs: decide
+    if: needs.decide.outputs.tag != ''
+    uses: ./.github/workflows/release-image-reusable.yml
+    with:
+      tag: ${{ needs.decide.outputs.tag }}
+      move_latest: true
+    permissions:
+      contents: read
+      packages: write

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -29,10 +29,23 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag -a "$TAG" -m "Release ${TAG#v}"
+          # Idempotent: a re-run after a partial failure must not hard-fail on an
+          # existing tag or release.
+          if ! git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
+            git tag -a "$TAG" -m "Release ${TAG#v}"
+          fi
+          # This tag is pushed with the default GITHUB_TOKEN on purpose. GitHub does not
+          # trigger workflows from GITHUB_TOKEN-created events, so release-image.yml
+          # (on: push tags v*) does not fire here, and the build-image job below builds
+          # the image instead. release-image.yml's tag trigger remains the manual-tag
+          # fallback path (STD-U-810 section 9) for a human-pushed tag. If this push is
+          # ever switched to a PAT or GitHub App token, release-image.yml will also fire
+          # and double-build plus double-move latest. Keep it on GITHUB_TOKEN.
           git push origin "$TAG"
           NOTES="docs/releases/${TAG}.md"
-          if [ -f "$NOTES" ]; then
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "release $TAG already exists, skipping"
+          elif [ -f "$NOTES" ]; then
             gh release create "$TAG" --title "$TAG" --notes-file "$NOTES"
           else
             gh release create "$TAG" --title "$TAG" --generate-notes

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -5,6 +5,12 @@ on:
   push:
     branches: [main]
 
+# Serialize release runs on main so two close pushes (or a manual rerun) do not
+# race on creating and pushing the same tag. Never cancel an in-flight release.
+concurrency:
+  group: tag-release-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   decide:
     runs-on: ubuntu-latest
@@ -21,16 +27,15 @@ jobs:
         run: |
           TAG="$(python3 scripts/should_tag.py)"
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
-      - name: Create annotated tag + GitHub Release
+      - name: Create and push annotated tag
         if: steps.decide.outputs.tag != ''
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ steps.decide.outputs.tag }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           # Idempotent: a re-run after a partial failure must not hard-fail on an
-          # existing tag or release.
+          # existing tag.
           if ! git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
             git tag -a "$TAG" -m "Release ${TAG#v}"
           fi
@@ -42,15 +47,11 @@ jobs:
           # ever switched to a PAT or GitHub App token, release-image.yml will also fire
           # and double-build plus double-move latest. Keep it on GITHUB_TOKEN.
           git push origin "$TAG"
-          NOTES="docs/releases/${TAG}.md"
-          if gh release view "$TAG" >/dev/null 2>&1; then
-            echo "release $TAG already exists, skipping"
-          elif [ -f "$NOTES" ]; then
-            gh release create "$TAG" --title "$TAG" --notes-file "$NOTES"
-          else
-            gh release create "$TAG" --title "$TAG" --generate-notes
-          fi
 
+  # Build and publish the image BEFORE the GitHub Release is created, so a
+  # published Release always has its image. If this build fails, the tag exists
+  # but no Release is published; a rerun is safe (tag creation and this build are
+  # both idempotent).
   build-image:
     needs: decide
     if: needs.decide.outputs.tag != ''
@@ -61,3 +62,28 @@ jobs:
     permissions:
       contents: read
       packages: write
+
+  release:
+    needs: [decide, build-image]
+    if: needs.decide.outputs.tag != ''
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v7
+      - name: Create GitHub Release (after the image is published)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.decide.outputs.tag }}
+        run: |
+          # Idempotent: skip if the release already exists (partial-failure rerun).
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "release $TAG already exists, skipping"
+            exit 0
+          fi
+          NOTES="docs/releases/${TAG}.md"
+          if [ -f "$NOTES" ]; then
+            gh release create "$TAG" --title "$TAG" --notes-file "$NOTES"
+          else
+            gh release create "$TAG" --title "$TAG" --generate-notes
+          fi

--- a/.rules/release-routine.md
+++ b/.rules/release-routine.md
@@ -1,0 +1,42 @@
+# data-olympus-release-cutter routine
+
+Status: active
+Since: 2026-07-01
+Schedule: cron `0 5 * * *` (05:00 UTC daily)
+Human gate: operator merges the release PR this routine opens. The routine never tags.
+
+## What it does each run
+
+1. Fetch `origin/main`. If HEAD is already on a `v*` tag, exit quietly (no work).
+2. Run `python3 scripts/compute_release.py`. If `releasable` is false, exit quietly.
+3. Quality gates (all must pass, else open a GitHub issue titled
+   "release blocked: <reason>" and stop, do not open a release PR):
+   - `uv run pytest -v`
+   - `uv run ruff check .`
+   - `uv run mypy src`
+   - `bats -r tests`
+   - a security review pass over `git diff <lasttag>..HEAD` (security-review skill)
+   - `kb_health` sanity check
+4. Read `next_version` and the `changes` buckets from the compute step.
+5. On a branch `chore/release-v<next_version>`:
+   - set `pyproject.toml` version to `<next_version>`
+   - in `CHANGELOG.md`, rename the `[Unreleased]` block to `[<next_version>] - <UTC date>`
+     and open a fresh empty `[Unreleased]` block above it
+   - write `docs/releases/v<next_version>.md` with exactly two H2 sections,
+     `## New features` and `## Fixed`, rewritten from the hand-written
+     `[Unreleased]` prose weighed against the commit `changes` buckets, in plain
+     language a non-technical reader understands. Omit a section if empty.
+6. Open a PR `chore/release-v<next_version>` -> `main`, title
+   `chore(release): v<next_version>`, label `release`. The PR body contains the
+   `docs/releases/v<next_version>.md` content followed by an
+   `## Announcement (draft)` block: a short upbeat paragraph, the two most
+   important items, and `<release-url-once-published>` as a placeholder link.
+7. Surface the PR to the operator as a Claude task for review. Stop. Do not merge,
+   do not tag.
+
+## Constraints
+
+- No em-dashes in any authored prose.
+- Never publish to any external platform; the announcement is a draft in the PR body.
+- Never run `git tag`; tagging is `tag-release.yml`'s job after the operator merges.
+- One open release PR at a time: if `chore/release-v*` is already open, update it.

--- a/.rules/versioning.md
+++ b/.rules/versioning.md
@@ -1,0 +1,42 @@
+# Rule: how data-olympus versions and releases
+
+Status: active
+Since: 2026-07-01
+Applies to: the data-olympus product (this repository)
+Governing standard: STD-U-810
+
+## Bump mapping (pre-1.0)
+
+data-olympus is pre-1.0. Conventional Commit types on commits since the last tag
+drive the bump:
+
+- `feat!:`, any `type!:`, or a `BREAKING CHANGE:` footer -> minor (breaking, needs migration; stays pre-1.0, e.g. 0.1.x -> 0.2.0)
+- `feat:` -> patch
+- `fix:` / `perf:` -> patch
+- `chore/docs/ci/build/refactor/test/style` -> no release, EXCEPT floored to patch when a functional path changed
+
+"Functional path" is the exact set `scripts/check_changelog.py` defines: `src/`,
+`bin/`, `deploy/`, and `SPEC.md`. This safety net guarantees source changes are
+never left unreleased even if the commit type is non-user-facing.
+
+The project stays pre-1.0 until `v1.0.0` is cut deliberately. When it reaches
+1.0, `bump_for` in `scripts/compute_release.py` switches breaking -> major and
+`feat:` -> minor, and this rule is updated.
+
+## Engine
+
+- `scripts/compute_release.py` computes the bump (single source of the rules).
+- The `data-olympus-release-cutter` routine (05:00 UTC daily) prepares a release
+  PR: it bumps `pyproject.toml`, renames the CHANGELOG `[Unreleased]` block, and
+  writes friendly notes to `docs/releases/vX.Y.Z.md`.
+- The human gate is the operator merging that PR.
+- `.github/workflows/tag-release.yml` cuts the annotated `vX.Y.Z` tag and GitHub
+  Release on merge (detected via the pyproject version bump), then builds the image.
+- `pyproject.toml` is the single version source of truth (STD-U-810 §11.4).
+
+## PR discipline
+
+- Squash-merge only; the PR title is the one Conventional Commit and is linted by
+  `.github/workflows/pr-title-lint.yml` (STD-U-810 §7.1 equivalent).
+- Every functional PR updates the CHANGELOG `[Unreleased]` block (see
+  `.rules/changelog-per-release.md`).

--- a/.rules/versioning.md
+++ b/.rules/versioning.md
@@ -30,8 +30,11 @@ The project stays pre-1.0 until `v1.0.0` is cut deliberately. When it reaches
   PR: it bumps `pyproject.toml`, renames the CHANGELOG `[Unreleased]` block, and
   writes friendly notes to `docs/releases/vX.Y.Z.md`.
 - The human gate is the operator merging that PR.
-- `.github/workflows/tag-release.yml` cuts the annotated `vX.Y.Z` tag and GitHub
-  Release on merge (detected via the pyproject version bump), then builds the image.
+- `.github/workflows/tag-release.yml`, on merge (detected via the pyproject
+  version bump), cuts the annotated `vX.Y.Z` tag, builds the image, then
+  publishes the GitHub Release once the image is available. The tag decision is
+  reconcilable: a full rerun after a partial failure re-emits the tag while it
+  points at the current commit, so the idempotent image/release jobs finish.
 - `pyproject.toml` is the single version source of truth (STD-U-810 §11.4).
 
 ## PR discipline

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,18 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Automated, human-gated release pipeline (conformant with the STD-U-810
+  versioning standard). A daily `data-olympus-release-cutter` routine computes the
+  SemVer bump from Conventional Commits and opens a release PR; merging that PR
+  cuts an annotated `vX.Y.Z` tag, a GitHub Release, and the container image via
+  CI. New helpers `scripts/compute_release.py`, `scripts/should_tag.py`,
+  `scripts/lint_pr_title.py` (a PR-title Conventional Commit check enforced by
+  `.github/workflows/pr-title-lint.yml`), and `scripts/compute-version.sh` (preview
+  version plus invariant check). New `tag-release.yml` cuts the tag and Release on
+  a `pyproject.toml` version bump, then builds the image via a reusable
+  `release-image-reusable.yml` (which also stamps OCI version and revision labels).
+  Process is documented in `.rules/versioning.md` and `.rules/release-routine.md`.
+  No tags are ever cut unattended.
 - Search now short-circuits exact-id and exact-tag queries: a single-token query
   that is a document id (e.g. `STD-U-002`, or a path-derived id) is surfaced as
   the top hit via a direct lookup even when it is absent from the bm25 results,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,10 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   CI. New helpers `scripts/compute_release.py`, `scripts/should_tag.py`,
   `scripts/lint_pr_title.py` (a PR-title Conventional Commit check enforced by
   `.github/workflows/pr-title-lint.yml`), and `scripts/compute-version.sh` (preview
-  version plus invariant check). New `tag-release.yml` cuts the tag and Release on
-  a `pyproject.toml` version bump, then builds the image via a reusable
-  `release-image-reusable.yml` (which also stamps OCI version and revision labels).
+  version plus invariant check). New `tag-release.yml` cuts the tag on a
+  `pyproject.toml` version bump, builds the image via a reusable
+  `release-image-reusable.yml` (which also stamps OCI version and revision
+  labels), then publishes the GitHub Release.
   Process is documented in `.rules/versioning.md` and `.rules/release-routine.md`.
   No tags are ever cut unattended.
 - Search now short-circuits exact-id and exact-tag queries: a single-token query

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,3 +72,12 @@ Example: `feat(cli): add export command`
 ## Code of Conduct
 
 By contributing you agree to abide by the project's [Code of Conduct](CODE_OF_CONDUCT.md).
+
+## Releases
+
+Releases follow STD-U-810 and are documented in `.rules/versioning.md`. In short:
+
+- Merge PRs with squash-merge; the PR title must be a Conventional Commit.
+- A daily routine opens a release PR when `main` has releasable changes.
+- Merging the release PR cuts an annotated `vX.Y.Z` tag, a GitHub Release, and
+  the Docker image. No tags are cut by hand under normal operation.

--- a/docs/releases/README.md
+++ b/docs/releases/README.md
@@ -1,0 +1,6 @@
+# Release notes
+
+Each release has a user-facing notes file `vX.Y.Z.md` in this folder, authored by
+the `data-olympus-release-cutter` routine and used verbatim as the GitHub Release
+body. Two sections: New features and Fixed, written for a non-technical reader.
+The durable, structured record stays in the top-level `CHANGELOG.md`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "data-olympus"
-version = "0.1.0"
+version = "0.1.1"
 description = "Governance-grade knowledge-base format (OKF-compatible) plus CLI and single-writer MCP server"
 requires-python = ">=3.13"
 license = { text = "Apache-2.0" }

--- a/scripts/compute-version.sh
+++ b/scripts/compute-version.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# STD-U-810 §5 version computation and §5.1 invariant check.
+set -euo pipefail
+
+compute() {
+  local dirty=""
+  if git describe --tags --long --match 'v*' >/dev/null 2>&1; then
+    local raw sha rest count tag base
+    raw=$(git describe --tags --long --match 'v*' --dirty)
+    case "$raw" in *-dirty) dirty=".dirty"; raw=${raw%-dirty};; esac
+    sha=${raw##*-g}
+    rest=${raw%-g*}          # v0.1.1-37
+    count=${rest##*-}        # 37
+    tag=${rest%-*}           # v0.1.1
+    base=${tag#v}            # 0.1.1
+    if [ "$count" = "0" ] && [ -z "$dirty" ]; then
+      echo "$base"
+    else
+      echo "${base}-dev.${count}+${sha}${dirty}"
+    fi
+  else
+    local sha count
+    sha=$(git rev-parse --short HEAD)
+    count=$(git rev-list --count HEAD)
+    git diff --quiet || dirty=".dirty"
+    echo "0.0.0-dev.${count}+${sha}${dirty}"
+  fi
+}
+
+check() {
+  local v on_tag="no"
+  v=$(compute)
+  if git describe --tags --exact-match --match 'v*' >/dev/null 2>&1; then
+    on_tag="yes"
+  fi
+  if [ "$on_tag" = "no" ] && [[ "$v" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "INVARIANT VIOLATION: non-tag commit emitted clean version $v" >&2
+    exit 1
+  fi
+  echo "invariant ok: $v"
+}
+
+case "${1:-version}" in
+  version) compute ;;
+  check) check ;;
+  *) echo "usage: $0 [version|check]" >&2; exit 2 ;;
+esac

--- a/scripts/compute_release.py
+++ b/scripts/compute_release.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Compute the next SemVer release from Conventional Commits since the last tag.
+
+Pure logic plus a thin git-driven CLI. Mapping is documented in
+`.rules/versioning.md` (STD-U-810 pre-1.0 semantics). This module is the single
+source of the bump rules; `should_tag.py` and `lint_pr_title.py` reuse its parser.
+"""
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+
+from scripts.check_changelog import _is_functional  # one definition of "functional"
+
+_SUBJECT_RE = re.compile(r"^(?P<type>[a-z]+)(?:\([^)]*\))?(?P<bang>!)?:\s")
+_BREAKING_FOOTER = re.compile(r"^BREAKING[ -]CHANGE:", re.MULTILINE)
+_FEATURE = "feat"
+_FIXES = ("fix", "perf")
+_NONE, _PATCH, _MINOR = 0, 1, 2
+_RANK_NAME = {_NONE: "none", _PATCH: "patch", _MINOR: "minor"}
+
+
+def classify(subject: str, body: str) -> tuple[str | None, bool]:
+    """Return (conventional type, is_breaking). type is None if not conventional."""
+    m = _SUBJECT_RE.match(subject)
+    if not m:
+        return None, False
+    breaking = bool(m.group("bang")) or bool(_BREAKING_FOOTER.search(body or ""))
+    return m.group("type"), breaking
+
+
+def bump_for(commits: list[tuple[str, str]], functional_changed: bool) -> tuple[str, dict]:
+    """commits: list of (subject, body). Returns (bump, changes buckets)."""
+    rank = _NONE
+    features: list[str] = []
+    fixes: list[str] = []
+    breaking: list[str] = []
+    for subject, body in commits:
+        ctype, is_breaking = classify(subject, body)
+        if ctype is None:
+            continue
+        if is_breaking:
+            breaking.append(subject)
+            rank = max(rank, _MINOR)
+        elif ctype == _FEATURE:
+            features.append(subject)
+            rank = max(rank, _PATCH)
+        elif ctype in _FIXES:
+            fixes.append(subject)
+            rank = max(rank, _PATCH)
+    if rank == _NONE and functional_changed:
+        rank = _PATCH  # functional-change safety net: never leave source unreleased
+    return _RANK_NAME[rank], {"features": features, "fixes": fixes, "breaking": breaking}
+
+
+def next_version(current: str, bump: str) -> str:
+    major, minor, patch = (int(x) for x in current.split("."))
+    if bump == "minor":
+        return f"{major}.{minor + 1}.0"
+    if bump == "patch":
+        return f"{major}.{minor}.{patch + 1}"
+    return current
+
+
+def _git(*args: str) -> str:
+    return subprocess.run(["git", *args], capture_output=True, text=True, check=True).stdout
+
+
+def _last_tag() -> str | None:
+    out = subprocess.run(
+        ["git", "describe", "--tags", "--abbrev=0", "--match", "v*"],
+        capture_output=True, text=True,
+    )
+    return out.stdout.strip() if out.returncode == 0 and out.stdout.strip() else None
+
+
+def _commits_since(tag: str | None) -> list[tuple[str, str]]:
+    rng = f"{tag}..HEAD" if tag else "HEAD"
+    fmt = "%s%x1f%b%x1e"
+    out = _git("log", "--no-merges", f"--format={fmt}", rng)
+    commits: list[tuple[str, str]] = []
+    for rec in out.split("\x1e"):
+        rec = rec.strip("\n")
+        if not rec:
+            continue
+        subject, _, body = rec.partition("\x1f")
+        commits.append((subject, body))
+    return commits
+
+
+def _changed_paths(tag: str | None) -> list[str]:
+    rng = f"{tag}..HEAD" if tag else "HEAD"
+    return [p for p in _git("diff", "--name-only", rng).splitlines() if p]
+
+
+def main() -> int:
+    tag = _last_tag()
+    current = tag[1:] if tag else "0.0.0"
+    commits = _commits_since(tag)
+    functional = any(_is_functional(p) for p in _changed_paths(tag))
+    bump, changes = bump_for(commits, functional)
+    print(json.dumps({
+        "releasable": bump != "none",
+        "bump": bump,
+        "current_version": current,
+        "next_version": next_version(current, bump),
+        "functional_changed": functional,
+        "changes": changes,
+    }, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/compute_release.py
+++ b/scripts/compute_release.py
@@ -10,8 +10,16 @@ from __future__ import annotations
 import json
 import re
 import subprocess
+import sys
+from pathlib import Path
 
-from scripts.check_changelog import _is_functional  # one definition of "functional"
+# Allow running as a plain script (python scripts/x.py): put repo root on the
+# path so `scripts.*` imports resolve the same way they do under pytest.
+_REPO_ROOT = str(Path(__file__).resolve().parent.parent)
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+from scripts.check_changelog import _is_functional  # noqa: E402  # one definition of "functional"
 
 _SUBJECT_RE = re.compile(r"^(?P<type>[a-z]+)(?:\([^)]*\))?(?P<bang>!)?:\s")
 _BREAKING_FOOTER = re.compile(r"^BREAKING[ -]CHANGE:", re.MULTILINE)

--- a/scripts/lint_pr_title.py
+++ b/scripts/lint_pr_title.py
@@ -8,8 +8,15 @@ the bump engine exactly.
 from __future__ import annotations
 
 import sys
+from pathlib import Path
 
-from scripts.compute_release import classify
+# Allow running as a plain script (python scripts/x.py): put repo root on the
+# path so `scripts.*` imports resolve the same way they do under pytest.
+_REPO_ROOT = str(Path(__file__).resolve().parent.parent)
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+from scripts.compute_release import classify  # noqa: E402
 
 _ALLOWED = {
     "feat", "fix", "perf", "chore", "docs",

--- a/scripts/lint_pr_title.py
+++ b/scripts/lint_pr_title.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""Validate that a PR title is a Conventional Commit.
+
+The repo has no Node toolchain, so this is the STD-U-810 §7.1 "commitlint or
+equivalent". It reuses compute_release's parser so the accepted grammar matches
+the bump engine exactly.
+"""
+from __future__ import annotations
+
+import sys
+
+from scripts.compute_release import classify
+
+_ALLOWED = {
+    "feat", "fix", "perf", "chore", "docs",
+    "refactor", "test", "ci", "build", "style", "revert",
+}
+
+
+def is_valid_title(title: str) -> bool:
+    ctype, _ = classify(title, "")
+    return ctype in _ALLOWED
+
+
+def main(argv: list[str]) -> int:
+    title = argv[0] if argv else ""
+    if is_valid_title(title):
+        print(f"PR title ok: {title}")
+        return 0
+    print(
+        f"Invalid PR title: {title!r}\n"
+        f"Must be a Conventional Commit: type(scope): subject, "
+        f"type in {sorted(_ALLOWED)}; add '!' or a 'BREAKING CHANGE:' footer for breaking.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/should_tag.py
+++ b/scripts/should_tag.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Emit the tag to create when pyproject's version has no matching v* tag.
+
+Used by tag-release.yml: after a release PR merges (bumping pyproject), the
+version exceeds the latest tag, so this emits `vX.Y.Z` for CI to create. Normal
+PRs never touch the version, so this emits nothing and no tag is cut.
+"""
+from __future__ import annotations
+
+import pathlib
+import re
+import subprocess
+
+_VERSION_RE = re.compile(r'^\s*version\s*=\s*"([^"]+)"', re.MULTILINE)
+
+
+def project_version(text: str) -> str:
+    m = _VERSION_RE.search(text)
+    if not m:
+        raise ValueError("no version declared in pyproject.toml")
+    return m.group(1)
+
+
+def tag_to_create(version: str, existing: set[str]) -> str | None:
+    tag = f"v{version}"
+    return None if tag in existing else tag
+
+
+def _existing_tags() -> set[str]:
+    out = subprocess.run(["git", "tag", "--list", "v*"], capture_output=True, text=True)
+    return set(out.stdout.split())
+
+
+def main() -> int:
+    version = project_version(pathlib.Path("pyproject.toml").read_text())
+    tag = tag_to_create(version, _existing_tags())
+    print(tag or "")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/should_tag.py
+++ b/scripts/should_tag.py
@@ -1,9 +1,16 @@
 #!/usr/bin/env python3
-"""Emit the tag to create when pyproject's version has no matching v* tag.
+"""Decide the release tag for tag-release.yml.
 
-Used by tag-release.yml: after a release PR merges (bumping pyproject), the
-version exceeds the latest tag, so this emits `vX.Y.Z` for CI to create. Normal
-PRs never touch the version, so this emits nothing and no tag is cut.
+After a release PR merges (bumping pyproject), the version has no matching tag,
+so this emits `vX.Y.Z` for CI to create, build, and release. Normal PRs never
+touch the version, so this emits nothing and no tag is cut.
+
+Crucially, it also emits the tag when it already exists AND points at the
+current commit. That is the "reconcile" case: a prior run created and pushed the
+tag but the image build or GitHub Release failed. Emitting the tag again lets the
+downstream (idempotent) build/release jobs re-run and finish the release, instead
+of being skipped on a full workflow rerun. When the tag exists on a different
+(older) commit, that is the steady state and this emits nothing.
 """
 from __future__ import annotations
 
@@ -40,15 +47,53 @@ def tag_to_create(version: str, existing: set[str]) -> str | None:
     return None if tag in existing else tag
 
 
+def release_action(
+    version: str,
+    existing: set[str],
+    tag_commit: str | None,
+    head_commit: str,
+) -> str | None:
+    """Return the tag to create-or-reconcile, or None for a no-op.
+
+    - tag missing -> emit (create, then build and release)
+    - tag exists and points at the current commit -> emit (reconcile a partial
+      release; the downstream tag/image/release steps are idempotent)
+    - tag exists on a different commit, or its commit is unknown -> None
+
+    `tag_commit` is the commit the existing tag points at, or None if the tag
+    does not exist (or could not be resolved).
+    """
+    to_create = tag_to_create(version, existing)
+    if to_create is not None:
+        return to_create
+    if tag_commit is not None and tag_commit == head_commit:
+        return f"v{version}"
+    return None
+
+
 def _existing_tags() -> set[str]:
     out = subprocess.run(["git", "tag", "--list", "v*"], capture_output=True, text=True)
     return set(out.stdout.split())
 
 
+def _tag_commit(tag: str) -> str | None:
+    """Return the commit the tag points at (dereferenced), or None if unresolved."""
+    out = subprocess.run(["git", "rev-list", "-n", "1", tag], capture_output=True, text=True)
+    commit = out.stdout.strip()
+    return commit if out.returncode == 0 and commit else None
+
+
+def _head_commit() -> str:
+    out = subprocess.run(["git", "rev-parse", "HEAD"], capture_output=True, text=True)
+    return out.stdout.strip()
+
+
 def main() -> int:
     version = project_version(pathlib.Path("pyproject.toml").read_text())
-    tag = tag_to_create(version, _existing_tags())
-    print(tag or "")
+    existing = _existing_tags()
+    tag = f"v{version}"
+    tag_commit = _tag_commit(tag) if tag in existing else None
+    print(release_action(version, existing, tag_commit, _head_commit()) or "")
     return 0
 
 

--- a/scripts/should_tag.py
+++ b/scripts/should_tag.py
@@ -11,14 +11,28 @@ import pathlib
 import re
 import subprocess
 
-_VERSION_RE = re.compile(r'^\s*version\s*=\s*"([^"]+)"', re.MULTILINE)
+_SECTION_RE = re.compile(r'^\s*\[([^\]]+)\]\s*$')
+_VERSION_RE = re.compile(r'^\s*version\s*=\s*"([^"]+)"')
 
 
 def project_version(text: str) -> str:
-    m = _VERSION_RE.search(text)
-    if not m:
-        raise ValueError("no version declared in pyproject.toml")
-    return m.group(1)
+    """Return the version declared under the [project] table.
+
+    Scoped to [project] so a same-named `version =` key under an unrelated
+    table (e.g. a [tool.*] config) is never mistaken for the project version.
+    """
+    in_project = False
+    for line in text.splitlines():
+        section_match = _SECTION_RE.match(line)
+        if section_match:
+            in_project = section_match.group(1).strip() == "project"
+            continue
+        if not in_project:
+            continue
+        version_match = _VERSION_RE.match(line)
+        if version_match:
+            return version_match.group(1)
+    raise ValueError("no version declared in [project] table of pyproject.toml")
 
 
 def tag_to_create(version: str, existing: set[str]) -> str | None:

--- a/tests/bats/compute-version.bats
+++ b/tests/bats/compute-version.bats
@@ -1,0 +1,47 @@
+# tests/bats/compute-version.bats
+setup() {
+  REPO="$(mktemp -d)"
+  SCRIPT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)/scripts/compute-version.sh"
+  cd "$REPO"
+  git init -q
+  git config user.email t@t.t
+  git config user.name t
+  git commit -q --allow-empty -m "feat: initial"
+}
+
+teardown() { rm -rf "$REPO"; }
+
+@test "exact tag emits clean X.Y.Z" {
+  git tag -a v0.1.0 -m "Release 0.1.0"
+  run "$SCRIPT" version
+  [ "$status" -eq 0 ]
+  [ "$output" = "0.1.0" ]
+}
+
+@test "commit past tag embeds dev count and sha" {
+  git tag -a v0.1.0 -m "Release 0.1.0"
+  git commit -q --allow-empty -m "fix: later"
+  run "$SCRIPT" version
+  [ "$status" -eq 0 ]
+  [[ "$output" == 0.1.0-dev.1+* ]]
+}
+
+@test "check passes on tagged commit" {
+  git tag -a v0.1.0 -m "Release 0.1.0"
+  run "$SCRIPT" check
+  [ "$status" -eq 0 ]
+}
+
+@test "check passes (non-clean) on commit past tag" {
+  git tag -a v0.1.0 -m "Release 0.1.0"
+  git commit -q --allow-empty -m "fix: later"
+  run "$SCRIPT" check
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"invariant ok"* ]]
+}
+
+@test "no-tags repo emits 0.0.0-dev" {
+  run "$SCRIPT" version
+  [ "$status" -eq 0 ]
+  [[ "$output" == 0.0.0-dev.* ]]
+}

--- a/tests/test_compute_release.py
+++ b/tests/test_compute_release.py
@@ -1,7 +1,14 @@
 """Pure logic for the SemVer release computation (STD-U-810 pre-1.0 mapping)."""
 from __future__ import annotations
 
+import json
+import pathlib
+import subprocess
+import sys
+
 from scripts.compute_release import bump_for, classify, next_version
+
+_REPO = pathlib.Path(__file__).resolve().parents[1]
 
 
 def test_classify_plain_feat() -> None:
@@ -65,3 +72,12 @@ def test_next_version_minor_resets_patch() -> None:
 
 def test_next_version_none_is_unchanged() -> None:
     assert next_version("0.1.1", "none") == "0.1.1"
+
+
+def test_script_runs_as_direct_path() -> None:
+    r = subprocess.run(
+        [sys.executable, "scripts/compute_release.py"],
+        cwd=_REPO, capture_output=True, text=True,
+    )
+    assert r.returncode == 0, r.stderr
+    assert json.loads(r.stdout).get("bump") in {"none", "patch", "minor"}

--- a/tests/test_compute_release.py
+++ b/tests/test_compute_release.py
@@ -1,0 +1,67 @@
+"""Pure logic for the SemVer release computation (STD-U-810 pre-1.0 mapping)."""
+from __future__ import annotations
+
+from scripts.compute_release import bump_for, classify, next_version
+
+
+def test_classify_plain_feat() -> None:
+    assert classify("feat(search): add synonyms", "") == ("feat", False)
+
+
+def test_classify_breaking_bang() -> None:
+    assert classify("feat(api)!: drop v0 endpoint", "") == ("feat", True)
+
+
+def test_classify_breaking_footer() -> None:
+    assert classify(
+        "refactor: rework store", "BREAKING CHANGE: migration required"
+    ) == ("refactor", True)
+
+
+def test_classify_non_conventional_returns_none() -> None:
+    assert classify("Merge pull request #55 from x", "") == (None, False)
+
+
+def test_feat_bumps_patch_pre_1_0() -> None:
+    bump, changes = bump_for([("feat: x", "")], functional_changed=True)
+    assert bump == "patch"
+    assert changes["features"] == ["feat: x"]
+
+
+def test_fix_bumps_patch() -> None:
+    bump, _ = bump_for([("fix: y", "")], functional_changed=True)
+    assert bump == "patch"
+
+
+def test_breaking_bumps_minor_and_wins() -> None:
+    commits = [("feat: a", ""), ("fix: b", ""), ("feat!: c", "")]
+    bump, changes = bump_for(commits, functional_changed=True)
+    assert bump == "minor"
+    assert changes["breaking"] == ["feat!: c"]
+
+
+def test_chore_only_no_functional_change_is_none() -> None:
+    bump, _ = bump_for([("chore: deps", ""), ("ci: bump", "")], functional_changed=False)
+    assert bump == "none"
+
+
+def test_chore_only_with_functional_change_floors_to_patch() -> None:
+    bump, _ = bump_for([("chore: touch src", "")], functional_changed=True)
+    assert bump == "patch"
+
+
+def test_non_conventional_commits_ignored() -> None:
+    bump, _ = bump_for([("Merge branch main", "")], functional_changed=False)
+    assert bump == "none"
+
+
+def test_next_version_patch() -> None:
+    assert next_version("0.1.1", "patch") == "0.1.2"
+
+
+def test_next_version_minor_resets_patch() -> None:
+    assert next_version("0.1.5", "minor") == "0.2.0"
+
+
+def test_next_version_none_is_unchanged() -> None:
+    assert next_version("0.1.1", "none") == "0.1.1"

--- a/tests/test_lint_pr_title.py
+++ b/tests/test_lint_pr_title.py
@@ -1,0 +1,24 @@
+"""Pure logic for the PR-title Conventional Commit check (STD-U-810 §7.1)."""
+from __future__ import annotations
+
+from scripts.lint_pr_title import is_valid_title
+
+
+def test_valid_feat() -> None:
+    assert is_valid_title("feat(search): add synonym expansion") is True
+
+
+def test_valid_breaking() -> None:
+    assert is_valid_title("feat(api)!: drop v0 endpoint") is True
+
+
+def test_invalid_unknown_type() -> None:
+    assert is_valid_title("update: stuff") is False
+
+
+def test_invalid_no_type() -> None:
+    assert is_valid_title("Add a new thing") is False
+
+
+def test_invalid_empty() -> None:
+    assert is_valid_title("") is False

--- a/tests/test_lint_pr_title.py
+++ b/tests/test_lint_pr_title.py
@@ -1,7 +1,13 @@
 """Pure logic for the PR-title Conventional Commit check (STD-U-810 §7.1)."""
 from __future__ import annotations
 
+import pathlib
+import subprocess
+import sys
+
 from scripts.lint_pr_title import is_valid_title
+
+_REPO = pathlib.Path(__file__).resolve().parents[1]
 
 
 def test_valid_feat() -> None:
@@ -22,3 +28,19 @@ def test_invalid_no_type() -> None:
 
 def test_invalid_empty() -> None:
     assert is_valid_title("") is False
+
+
+def test_script_runs_as_direct_path_valid() -> None:
+    r = subprocess.run(
+        [sys.executable, "scripts/lint_pr_title.py", "feat: x"],
+        cwd=_REPO, capture_output=True, text=True,
+    )
+    assert r.returncode == 0, r.stderr
+
+
+def test_script_runs_as_direct_path_invalid() -> None:
+    r = subprocess.run(
+        [sys.executable, "scripts/lint_pr_title.py", "nope: x"],
+        cwd=_REPO, capture_output=True, text=True,
+    )
+    assert r.returncode == 1

--- a/tests/test_should_tag.py
+++ b/tests/test_should_tag.py
@@ -1,0 +1,30 @@
+# tests/test_should_tag.py
+"""Pure logic for the tag-on-version-bump decision."""
+from __future__ import annotations
+
+import pytest
+
+from scripts.should_tag import project_version, tag_to_create
+
+PYPROJECT = '[project]\nname = "data-olympus"\nversion = "0.1.2"\n'
+
+
+def test_project_version_parsed() -> None:
+    assert project_version(PYPROJECT) == "0.1.2"
+
+
+def test_project_version_missing_raises() -> None:
+    with pytest.raises(ValueError):
+        project_version('[project]\nname = "x"\n')
+
+
+def test_tag_created_when_missing() -> None:
+    assert tag_to_create("0.1.2", {"v0.1.0", "v0.1.1"}) == "v0.1.2"
+
+
+def test_no_tag_when_present() -> None:
+    assert tag_to_create("0.1.1", {"v0.1.0", "v0.1.1"}) is None
+
+
+def test_no_tag_on_empty_repo_when_version_already_tagged() -> None:
+    assert tag_to_create("0.1.1", {"v0.1.1"}) is None

--- a/tests/test_should_tag.py
+++ b/tests/test_should_tag.py
@@ -18,6 +18,30 @@ def test_project_version_missing_raises() -> None:
         project_version('[project]\nname = "x"\n')
 
 
+def test_project_version_ignores_tool_table_version_before_project() -> None:
+    text = (
+        '[tool.something]\n'
+        'version = "9.9.9"\n'
+        '\n'
+        '[project]\n'
+        'name = "data-olympus"\n'
+        'version = "0.1.2"\n'
+    )
+    assert project_version(text) == "0.1.2"
+
+
+def test_project_version_ignores_tool_table_version_after_project() -> None:
+    text = (
+        '[project]\n'
+        'name = "data-olympus"\n'
+        'version = "0.1.2"\n'
+        '\n'
+        '[tool.something]\n'
+        'version = "9.9.9"\n'
+    )
+    assert project_version(text) == "0.1.2"
+
+
 def test_tag_created_when_missing() -> None:
     assert tag_to_create("0.1.2", {"v0.1.0", "v0.1.1"}) == "v0.1.2"
 

--- a/tests/test_should_tag.py
+++ b/tests/test_should_tag.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from scripts.should_tag import project_version, tag_to_create
+from scripts.should_tag import project_version, release_action, tag_to_create
 
 PYPROJECT = '[project]\nname = "data-olympus"\nversion = "0.1.2"\n'
 
@@ -52,3 +52,25 @@ def test_no_tag_when_present() -> None:
 
 def test_no_tag_on_empty_repo_when_version_already_tagged() -> None:
     assert tag_to_create("0.1.1", {"v0.1.1"}) is None
+
+
+def test_release_action_emits_when_tag_missing() -> None:
+    # No matching tag: create it (tag_commit is irrelevant when the tag is absent).
+    assert release_action("0.1.2", {"v0.1.1"}, tag_commit=None, head_commit="abc123") == "v0.1.2"
+
+
+def test_release_action_reconciles_when_tag_points_at_head() -> None:
+    # Tag exists and points at the current commit: emit so the idempotent
+    # downstream image/release jobs run and reconcile a partial release.
+    result = release_action("0.1.2", {"v0.1.2"}, tag_commit="abc123", head_commit="abc123")
+    assert result == "v0.1.2"
+
+
+def test_release_action_noop_when_tag_points_elsewhere() -> None:
+    # Steady state: the tag exists on an older commit; nothing to do.
+    assert release_action("0.1.2", {"v0.1.2"}, tag_commit="old789", head_commit="new456") is None
+
+
+def test_release_action_noop_when_tag_commit_unresolved() -> None:
+    # Tag is in the set but its commit could not be resolved: do not emit.
+    assert release_action("0.1.2", {"v0.1.2"}, tag_commit=None, head_commit="new456") is None

--- a/uv.lock
+++ b/uv.lock
@@ -389,7 +389,7 @@ name = "cuda-bindings"
 version = "13.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder" },
+    { name = "cuda-pathfinder", marker = "python_full_version >= '3.15' or sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cc/6e/2394f8163360f8391f8f1b7e72d300a82724edb81a7b7084c799fbd4c91f/cuda_bindings-13.3.1-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9efb21c1ee64981e184b9e0ba5eb3179e5ba3d4b51665a6cb52b8ef3d01a7cbf", size = 5920504, upload-time = "2026-05-29T23:11:56.883Z" },
@@ -418,34 +418,34 @@ wheels = [
 
 [package.optional-dependencies]
 cudart = [
-    { name = "nvidia-cuda-runtime" },
+    { name = "nvidia-cuda-runtime", marker = "(python_full_version >= '3.15' and sys_platform == 'win32') or sys_platform == 'linux'" },
 ]
 cufft = [
-    { name = "nvidia-cufft" },
+    { name = "nvidia-cufft", marker = "(python_full_version >= '3.15' and sys_platform == 'win32') or sys_platform == 'linux'" },
 ]
 cufile = [
-    { name = "nvidia-cufile" },
+    { name = "nvidia-cufile", marker = "sys_platform == 'linux'" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti" },
+    { name = "nvidia-cuda-cupti", marker = "(python_full_version >= '3.15' and sys_platform == 'win32') or sys_platform == 'linux'" },
 ]
 curand = [
-    { name = "nvidia-curand" },
+    { name = "nvidia-curand", marker = "(python_full_version >= '3.15' and sys_platform == 'win32') or sys_platform == 'linux'" },
 ]
 cusolver = [
-    { name = "nvidia-cusolver" },
+    { name = "nvidia-cusolver", marker = "(python_full_version >= '3.15' and sys_platform == 'win32') or sys_platform == 'linux'" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse" },
+    { name = "nvidia-cusparse", marker = "(python_full_version >= '3.15' and sys_platform == 'win32') or sys_platform == 'linux'" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "(python_full_version >= '3.15' and sys_platform == 'win32') or sys_platform == 'linux'" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc" },
+    { name = "nvidia-cuda-nvrtc", marker = "(python_full_version >= '3.15' and sys_platform == 'win32') or sys_platform == 'linux'" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx" },
+    { name = "nvidia-nvtx", marker = "(python_full_version >= '3.15' and sys_platform == 'win32') or sys_platform == 'linux'" },
 ]
 
 [[package]]
@@ -1168,7 +1168,7 @@ name = "nvidia-cublas"
 version = "13.1.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cuda-nvrtc" },
+    { name = "nvidia-cuda-nvrtc", marker = "python_full_version >= '3.15' or sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/a1/0bd24ee8c8d03adac032fd2909426a00c88f8c57961b1277ded97f91119f/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b7a210458267ac818974c53038fbec2e969d5c99f305ab15c72522fa9f001dd5", size = 542848918, upload-time = "2026-04-08T18:46:22.985Z" },
@@ -1207,7 +1207,7 @@ name = "nvidia-cudnn-cu13"
 version = "9.20.0.48"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas" },
+    { name = "nvidia-cublas", marker = "python_full_version >= '3.15' or sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/c5/83384d846b2fd17c44bd499b36c75a45ed4f095fbbb2252294e89cea5c5c/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:e31454ae00094b0c55319d9d15b6fa2fc50a9e1c0f5c8c80fb75258234e731e1", size = 444574296, upload-time = "2026-03-09T19:28:27.751Z" },
@@ -1219,7 +1219,7 @@ name = "nvidia-cufft"
 version = "12.0.0.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "python_full_version >= '3.15' or sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
@@ -1249,9 +1249,9 @@ name = "nvidia-cusolver"
 version = "12.0.4.66"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas" },
-    { name = "nvidia-cusparse" },
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-cublas", marker = "python_full_version >= '3.15' or sys_platform != 'win32'" },
+    { name = "nvidia-cusparse", marker = "python_full_version >= '3.15' or sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink", marker = "python_full_version >= '3.15' or sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
@@ -1263,7 +1263,7 @@ name = "nvidia-cusparse"
 version = "12.6.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "python_full_version >= '3.15' or sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
@@ -2010,8 +2010,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "jeepney" },
+    { name = "cryptography", marker = "python_full_version >= '3.15' or sys_platform != 'win32'" },
+    { name = "jeepney", marker = "python_full_version >= '3.15' or sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [

--- a/uv.lock
+++ b/uv.lock
@@ -389,7 +389,7 @@ name = "cuda-bindings"
 version = "13.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder", marker = "python_full_version >= '3.15' or sys_platform != 'win32'" },
+    { name = "cuda-pathfinder" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cc/6e/2394f8163360f8391f8f1b7e72d300a82724edb81a7b7084c799fbd4c91f/cuda_bindings-13.3.1-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9efb21c1ee64981e184b9e0ba5eb3179e5ba3d4b51665a6cb52b8ef3d01a7cbf", size = 5920504, upload-time = "2026-05-29T23:11:56.883Z" },
@@ -418,34 +418,34 @@ wheels = [
 
 [package.optional-dependencies]
 cudart = [
-    { name = "nvidia-cuda-runtime", marker = "(python_full_version >= '3.15' and sys_platform == 'win32') or sys_platform == 'linux'" },
+    { name = "nvidia-cuda-runtime" },
 ]
 cufft = [
-    { name = "nvidia-cufft", marker = "(python_full_version >= '3.15' and sys_platform == 'win32') or sys_platform == 'linux'" },
+    { name = "nvidia-cufft" },
 ]
 cufile = [
-    { name = "nvidia-cufile", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cufile" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti", marker = "(python_full_version >= '3.15' and sys_platform == 'win32') or sys_platform == 'linux'" },
+    { name = "nvidia-cuda-cupti" },
 ]
 curand = [
-    { name = "nvidia-curand", marker = "(python_full_version >= '3.15' and sys_platform == 'win32') or sys_platform == 'linux'" },
+    { name = "nvidia-curand" },
 ]
 cusolver = [
-    { name = "nvidia-cusolver", marker = "(python_full_version >= '3.15' and sys_platform == 'win32') or sys_platform == 'linux'" },
+    { name = "nvidia-cusolver" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse", marker = "(python_full_version >= '3.15' and sys_platform == 'win32') or sys_platform == 'linux'" },
+    { name = "nvidia-cusparse" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink", marker = "(python_full_version >= '3.15' and sys_platform == 'win32') or sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc", marker = "(python_full_version >= '3.15' and sys_platform == 'win32') or sys_platform == 'linux'" },
+    { name = "nvidia-cuda-nvrtc" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx", marker = "(python_full_version >= '3.15' and sys_platform == 'win32') or sys_platform == 'linux'" },
+    { name = "nvidia-nvtx" },
 ]
 
 [[package]]
@@ -465,7 +465,7 @@ wheels = [
 
 [[package]]
 name = "data-olympus"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },
@@ -1168,7 +1168,7 @@ name = "nvidia-cublas"
 version = "13.1.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cuda-nvrtc", marker = "python_full_version >= '3.15' or sys_platform != 'win32'" },
+    { name = "nvidia-cuda-nvrtc" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/a1/0bd24ee8c8d03adac032fd2909426a00c88f8c57961b1277ded97f91119f/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b7a210458267ac818974c53038fbec2e969d5c99f305ab15c72522fa9f001dd5", size = 542848918, upload-time = "2026-04-08T18:46:22.985Z" },
@@ -1207,7 +1207,7 @@ name = "nvidia-cudnn-cu13"
 version = "9.20.0.48"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas", marker = "python_full_version >= '3.15' or sys_platform != 'win32'" },
+    { name = "nvidia-cublas" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/c5/83384d846b2fd17c44bd499b36c75a45ed4f095fbbb2252294e89cea5c5c/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:e31454ae00094b0c55319d9d15b6fa2fc50a9e1c0f5c8c80fb75258234e731e1", size = 444574296, upload-time = "2026-03-09T19:28:27.751Z" },
@@ -1219,7 +1219,7 @@ name = "nvidia-cufft"
 version = "12.0.0.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink", marker = "python_full_version >= '3.15' or sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
@@ -1249,9 +1249,9 @@ name = "nvidia-cusolver"
 version = "12.0.4.66"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas", marker = "python_full_version >= '3.15' or sys_platform != 'win32'" },
-    { name = "nvidia-cusparse", marker = "python_full_version >= '3.15' or sys_platform != 'win32'" },
-    { name = "nvidia-nvjitlink", marker = "python_full_version >= '3.15' or sys_platform != 'win32'" },
+    { name = "nvidia-cublas" },
+    { name = "nvidia-cusparse" },
+    { name = "nvidia-nvjitlink" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
@@ -1263,7 +1263,7 @@ name = "nvidia-cusparse"
 version = "12.6.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink", marker = "python_full_version >= '3.15' or sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
@@ -2010,8 +2010,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography", marker = "python_full_version >= '3.15' or sys_platform != 'win32'" },
-    { name = "jeepney", marker = "python_full_version >= '3.15' or sys_platform != 'win32'" },
+    { name = "cryptography" },
+    { name = "jeepney" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [


### PR DESCRIPTION
## Summary

Adds a scheduled, human-gated release pipeline for data-olympus, conformant with STD-U-810. A daily `data-olympus-release-cutter` routine (05:00 UTC) detects a releasable `main`, runs quality gates, computes the SemVer bump from Conventional Commits, and opens a release PR with human-friendly notes. Merging that PR cuts an annotated `vX.Y.Z` tag and GitHub Release via CI, which builds the image. No tags are ever cut unattended.

## What is included

- **Bump engine** (`scripts/compute_release.py`): pre-1.0 mapping (`feat!:`/`BREAKING CHANGE:` -> minor; `feat:` -> patch; `fix:`/`perf:` -> patch; other types -> none, floored to patch only when a functional path `src/`, `bin/`, `deploy/`, `SPEC.md` changed). Single source of the parser grammar, reused by the two scripts below.
- **Tag decision** (`scripts/should_tag.py`): emits `vX.Y.Z` only when `pyproject.toml`'s `[project]` version has no matching tag.
- **PR-title lint** (`scripts/lint_pr_title.py` + `.github/workflows/pr-title-lint.yml`): the commitlint equivalent (no Node here); reuses the bump parser so the accepted grammar matches exactly. PR title flows via an env var, no shell interpolation.
- **Preview version** (`scripts/compute-version.sh`): STD-U-810 section 5 version string plus a `check` mode enforcing the section 5.1 invariant.
- **CI**: `tag-release.yml` cuts the annotated tag + Release on a version bump (idempotent, re-runnable), then builds the image via a new reusable `release-image-reusable.yml` (adds OCI version/revision labels). `release-image.yml` now calls the reusable workflow and keeps its tag trigger as the STD-U-810 section 9 manual-tag fallback.
- **Docs/config**: `.rules/versioning.md`, `.rules/release-routine.md`, `docs/releases/README.md`, a `CONTRIBUTING.md` Releases section, and a `pyproject.toml` version drift fix (`0.1.0` -> `0.1.1`, matching the latest tag).

## Design notes

- Human gate is the operator merging the release PR; the routine never runs `git tag` and never publishes externally (the social announcement is a draft in the PR body only).
- `pyproject.toml` is the single version source of truth. The tag-push uses the built-in `GITHUB_TOKEN` on purpose, so `release-image.yml` does not double-fire (documented inline in `tag-release.yml`).
- Scripts run both under pytest and as direct scripts (a `sys.path` shim, locked by subprocess regression tests).

## Follow-ups (not in this PR)

- Provision the live cron routine and run the first dry-run (expected first release `v0.1.2`). Post-merge, operator-gated.
- Confirm the repo allows `github-actions[bot]` to push `v*` tags.

## Type of change

- [x] Tool / code change (CLI, MCP server, `kb` client, deploy)
- [ ] Spec / format change (requires a linked Spec Proposal issue with maintainer sign-off)
- [x] Documentation
- [x] CI

## Checklist

- [x] Tests pass (`uv run pytest`)
- [x] `ruff` reports no errors (`uv run ruff check .`)
- [x] `data-olympus lint` exits 0 on any bundle touched by this PR (no bundle touched)
- [x] Documentation updated (if the changed behaviour is documented)
- [x] `SPEC.md` and the validator are consistent (required if the schema changed) (schema unchanged)
- [x] No em-dashes in any prose added or modified by this PR
- [x] No credentials or secrets committed
