### PR TITLE
feat(benchmarks): content-free real-corpus retrieval eval harness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,15 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Content-free real-corpus retrieval eval harness (`benchmarks/real_corpus_eval.py`
+  + `benchmarks/real_corpus_eval.md`). Point it at your own KB directory and a
+  labeled query set to measure what the optional local-embedding hybrid (issue
+  #42) adds over the lexical stack (FTS + synonym + co-occurrence expansion) on
+  your corpus; it prints only aggregate metrics (recall@k, MRR, recovered /
+  regressed counts) and never document text, so it is safe to run over a private
+  KB. The writeup includes a worked private-corpus example and an honest reading
+  positioning embeddings as opt-in rather than default-on.
+
 - Automated, human-gated release pipeline (conformant with the STD-U-810
   versioning standard). A daily `data-olympus-release-cutter` routine computes the
   SemVer bump from Conventional Commits and opens a release PR; merging that PR

--- a/benchmarks/real_corpus_eval.md
+++ b/benchmarks/real_corpus_eval.md
@@ -1,0 +1,70 @@
+# Real-corpus retrieval eval: lexical vs embedding-hybrid
+
+`real_corpus_eval.py` measures what the optional local-embedding hybrid (issue
+#42) adds over the lexical stack (FTS + synonym + co-occurrence expansion) **on
+your own KB**. It prints only aggregate metrics, never document text, so it is
+safe to run over a private corpus.
+
+## Run it on your KB
+
+```bash
+uv run --extra embeddings python -m benchmarks.real_corpus_eval \
+    --corpus /path/to/your/kb --queries queries.json --k 5
+```
+
+`queries.json` is a list of labeled queries:
+
+```json
+[
+  {"text": "how do we encrypt config secrets at rest", "gold_ids": ["GDEC-004"]},
+  {"text": "which role owns the tenant-isolation helpers", "gold_ids": ["STD-BN-201"]}
+]
+```
+
+`gold_ids` are the document ids the query should retrieve (the same ids
+`kb_search`/`kb_get` return). Build the set however you like; the more your
+queries paraphrase the target docs (different words, same intent) the more they
+test semantic retrieval rather than keyword matching.
+
+## Worked example (our internal KB)
+
+An illustrative run on our own knowledge base. This is a **private-corpus
+example**, not an independently reproducible benchmark: the corpus cannot be
+shared and the queries are LLM-authored. Run the harness on your KB for a number
+that reflects your content.
+
+- Corpus: 243 indexed governance docs.
+- Queries: 215, one per doc, each a natural-language **paraphrase** written to
+  avoid the doc's distinctive title terms (to create a lexical gap), applied
+  uniformly with no retriever-in-the-loop tuning.
+- Config: defaults (`--weight 0.35 --dense-count 10 --min-cosine 0.5`), no
+  hyperparameter tuning.
+
+| Metric | Lexical stack | Hybrid (+embeddings) | Delta |
+|---|---|---|---|
+| recall@5 | 0.898 | 0.916 | +0.019 |
+| recall@10 | 0.953 | 0.967 | +0.014 |
+| MRR | 0.756 | 0.770 | +0.013 |
+
+Hybrid **recovered 4 / 215** queries at k=5 and **regressed 0 / 215**. Three of
+the four recoveries were token-disjoint queries (zero title-token overlap with
+their gold doc) — the case dense retrieval is meant to help.
+
+## Honest reading
+
+- **The lexical stack is already strong** (~0.90 recall@5, ~0.95 recall@10) on
+  this corpus, even against deliberately paraphrased queries, because the target
+  concepts still surface in document bodies. That leaves little headroom.
+- **The embedding hybrid is a real but small, strictly non-harmful add** here:
+  it fixes the hardest token-disjoint queries and regressed nothing, but the
+  aggregate lift is ~2 points of recall (4 queries out of 215).
+- **So it ships as an opt-in, not a default.** On a corpus like this, the model
+  dependency, build-time embedding, and reduced interpretability are not worth a
+  ~2-point lift. Enable it (`KB_EMBEDDINGS_MODE`) when your corpus has genuine
+  semantic gaps — short, jargon-light, or heavily-paraphrased queries where the
+  target words rarely appear in the docs — and measure with this harness first.
+
+Caveats: n and the number of recoveries are small (4 events); the queries are
+LLM-authored paraphrases, not real user traffic; a larger local model or tuned
+threshold might move the number. The reproducible synthetic ablation lives in
+`benchmarks/governance_results/` and `benchmarks/generate_embeddings_ablation.py`.

--- a/benchmarks/real_corpus_eval.md
+++ b/benchmarks/real_corpus_eval.md
@@ -44,7 +44,7 @@ that reflects your content.
 |---|---|---|---|
 | recall@5 | 0.898 | 0.916 | +0.019 |
 | recall@10 | 0.953 | 0.967 | +0.014 |
-| MRR | 0.756 | 0.770 | +0.013 |
+| MRR@5 | 0.756 | 0.770 | +0.013 |
 
 Hybrid **recovered 4 / 215** queries at k=5 and **regressed 0 / 215**. Three of
 the four recoveries were token-disjoint queries (zero title-token overlap with

--- a/benchmarks/real_corpus_eval.py
+++ b/benchmarks/real_corpus_eval.py
@@ -22,18 +22,10 @@ from __future__ import annotations
 import argparse
 import json
 import statistics
+import sys
 from pathlib import Path
 
-
-def recall_at_k(ranked: list[str], gold: set[str], k: int) -> float:
-    return 1.0 if gold and any(r in gold for r in ranked[:k]) else 0.0
-
-
-def mrr(ranked: list[str], gold: set[str]) -> float:
-    for i, r in enumerate(ranked, 1):
-        if r in gold:
-            return 1.0 / i
-    return 0.0
+from benchmarks.metrics import mrr, recall_at_k
 
 
 def _build_expanders(index):  # noqa: ANN001 - Index, avoid import at module load
@@ -68,6 +60,8 @@ def main() -> None:
     raw = json.loads(Path(args.queries).read_text(encoding="utf-8"))
     queries = [q for q in raw if q.get("gold_ids")]
     print(f"corpus={corpus} queries={len(raw)} (labeled={len(queries)}) k={args.k}")
+    if not queries:
+        sys.exit("no labeled queries found: every entry has empty/missing gold_ids")
 
     with tempfile.TemporaryDirectory() as tmp:
         tmp_path = Path(tmp)
@@ -96,7 +90,7 @@ def main() -> None:
             gold = set(q["gold_ids"])
             lr = [h.id for h in lex.search(q["text"], limit=args.k)]
             hr = [h.id for h in hyb.search(q["text"], limit=args.k)]
-            lrec, hrec = recall_at_k(lr, gold, args.k), recall_at_k(hr, gold, args.k)
+            lrec, hrec = recall_at_k(lr, gold, k=args.k), recall_at_k(hr, gold, k=args.k)
             lex_recall.append(lrec)
             hyb_recall.append(hrec)
             lex_mrr.append(mrr(lr, gold))
@@ -108,7 +102,8 @@ def main() -> None:
     lm_m, hm_m = statistics.mean(lex_mrr), statistics.mean(hyb_mrr)
     print("\n== lexical stack vs hybrid (+embeddings), default config ==")
     print(f"  recall@{args.k}: {lr_m:.3f} -> {hr_m:.3f} ({hr_m - lr_m:+.3f})")
-    print(f"  MRR:        {lm_m:.3f} -> {hm_m:.3f} ({hm_m - lm_m:+.3f})")
+    # MRR is computed over the k-truncated ranking (limit=k above), i.e. MRR@k.
+    print(f"  MRR@{args.k}:     {lm_m:.3f} -> {hm_m:.3f} ({hm_m - lm_m:+.3f})")
     print(f"  hybrid recovered: {recovered}/{len(queries)}   regressed: {regressed}/{len(queries)}")
 
 

--- a/benchmarks/real_corpus_eval.py
+++ b/benchmarks/real_corpus_eval.py
@@ -3,7 +3,7 @@
 Point this at YOUR own KB directory and a query set to measure what the optional
 embedding hybrid (issue #42) adds over the lexical stack (FTS + synonym +
 co-occurrence expansion) on your corpus. It is deliberately content-free: it
-prints only aggregate metrics (recall@k, MRR, recovered/regressed counts), never
+prints only aggregate metrics (recall@k, MRR@k, recovered/regressed counts), never
 document text, so a run over a private KB leaks nothing.
 
     uv run --extra embeddings python -m benchmarks.real_corpus_eval \

--- a/benchmarks/real_corpus_eval.py
+++ b/benchmarks/real_corpus_eval.py
@@ -1,0 +1,116 @@
+"""Real-corpus retrieval eval: lexical stack vs local-embedding hybrid.
+
+Point this at YOUR own KB directory and a query set to measure what the optional
+embedding hybrid (issue #42) adds over the lexical stack (FTS + synonym +
+co-occurrence expansion) on your corpus. It is deliberately content-free: it
+prints only aggregate metrics (recall@k, MRR, recovered/regressed counts), never
+document text, so a run over a private KB leaks nothing.
+
+    uv run --extra embeddings python -m benchmarks.real_corpus_eval \
+        --corpus path/to/kb --queries queries.json [--k 5]
+
+``queries.json`` is a list of ``{"text": "...", "gold_ids": ["ID", ...]}``. A
+query with an empty ``gold_ids`` is skipped (unlabeled). See
+``benchmarks/real_corpus_eval.md`` for a worked example and an honest reading of
+what the hybrid does and does not buy you.
+
+The ``embeddings`` extra (fastembed) is required; the first run fetches a small
+local ONNX model (cached thereafter). No network at query time.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+from pathlib import Path
+
+
+def recall_at_k(ranked: list[str], gold: set[str], k: int) -> float:
+    return 1.0 if gold and any(r in gold for r in ranked[:k]) else 0.0
+
+
+def mrr(ranked: list[str], gold: set[str]) -> float:
+    for i, r in enumerate(ranked, 1):
+        if r in gold:
+            return 1.0 / i
+    return 0.0
+
+
+def _build_expanders(index):  # noqa: ANN001 - Index, avoid import at module load
+    from data_olympus.cooccurrence import (
+        DEFAULT_MAX_TERMS,
+        compose_expanders,
+        cooccurrence_enabled,
+    )
+    from data_olympus.query_expansion import default_query_expander
+
+    cooc = index.cooccurrence_expander() if cooccurrence_enabled() else None
+    return compose_expanders(default_query_expander(), cooc, max_terms=DEFAULT_MAX_TERMS)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--corpus", required=True, help="KB directory to index")
+    ap.add_argument("--queries", required=True, help="JSON list of {text, gold_ids}")
+    ap.add_argument("--k", type=int, default=5)
+    ap.add_argument("--model", default="BAAI/bge-small-en-v1.5")
+    ap.add_argument("--weight", type=float, default=0.35, help="cosine fraction of the blend")
+    ap.add_argument("--dense-count", type=int, default=10)
+    ap.add_argument("--min-cosine", type=float, default=0.5)
+    args = ap.parse_args()
+
+    import tempfile
+
+    from data_olympus.embeddings import EmbeddingsConfig, build_embedder
+    from data_olympus.index import Index
+
+    corpus = Path(args.corpus)
+    raw = json.loads(Path(args.queries).read_text(encoding="utf-8"))
+    queries = [q for q in raw if q.get("gold_ids")]
+    print(f"corpus={corpus} queries={len(raw)} (labeled={len(queries)}) k={args.k}")
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+
+        lex = Index(tmp_path / "lex.db")
+        n = lex.build(corpus, source_commit="real-corpus-eval").docs_indexed
+        lex.query_expander = _build_expanders(lex)
+        print(f"indexed {n} docs")
+
+        cfg = EmbeddingsConfig(model_name=args.model, weight=args.weight)
+        embedder = build_embedder(cfg)
+        hyb = Index(
+            tmp_path / "hyb.db", embeddings=cfg, embedder=embedder,
+            dense_candidate_count=args.dense_count, dense_min_cosine=args.min_cosine,
+        )
+        hyb.build(corpus, source_commit="real-corpus-eval")
+        hyb.query_expander = _build_expanders(hyb)
+        hyb.reranker = hyb.make_hybrid_reranker(embedder, weight=cfg.weight)
+
+        lex_recall: list[float] = []
+        lex_mrr: list[float] = []
+        hyb_recall: list[float] = []
+        hyb_mrr: list[float] = []
+        recovered = regressed = 0
+        for q in queries:
+            gold = set(q["gold_ids"])
+            lr = [h.id for h in lex.search(q["text"], limit=args.k)]
+            hr = [h.id for h in hyb.search(q["text"], limit=args.k)]
+            lrec, hrec = recall_at_k(lr, gold, args.k), recall_at_k(hr, gold, args.k)
+            lex_recall.append(lrec)
+            hyb_recall.append(hrec)
+            lex_mrr.append(mrr(lr, gold))
+            hyb_mrr.append(mrr(hr, gold))
+            recovered += int(hrec > lrec)
+            regressed += int(hrec < lrec)
+
+    lr_m, hr_m = statistics.mean(lex_recall), statistics.mean(hyb_recall)
+    lm_m, hm_m = statistics.mean(lex_mrr), statistics.mean(hyb_mrr)
+    print("\n== lexical stack vs hybrid (+embeddings), default config ==")
+    print(f"  recall@{args.k}: {lr_m:.3f} -> {hr_m:.3f} ({hr_m - lr_m:+.3f})")
+    print(f"  MRR:        {lm_m:.3f} -> {hm_m:.3f} ({hm_m - lm_m:+.3f})")
+    print(f"  hybrid recovered: {recovered}/{len(queries)}   regressed: {regressed}/{len(queries)}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Ships a **content-free** eval harness so anyone can measure, on their own KB,
what the optional local-embedding hybrid (#42) adds over the lexical stack
(FTS + synonym + co-occurrence expansion). Docs/benchmarks only — no runtime
behavior change.

- `benchmarks/real_corpus_eval.py` — point it at a corpus dir + a labeled
  queries JSON (`[{text, gold_ids}]`); it builds a lexical-stack index and a
  hybrid (+embeddings) index over a temp DB and reports recall@k, MRR, and
  recovered/regressed counts. It prints **only aggregate metrics, never document
  text**, so it is safe to run over a private KB.
- `benchmarks/real_corpus_eval.md` — usage, a worked private-corpus example, and
  an honest reading.

## Worked example (our internal KB, aggregate only)

243 indexed docs, 215 natural-language **paraphrase** queries (one per doc,
worded to avoid the doc's title terms), default config:

| Metric | Lexical stack | Hybrid (+embeddings) | Delta |
|---|---|---|---|
| recall@5 | 0.898 | 0.916 | +0.019 |
| recall@10 | 0.953 | 0.967 | +0.014 |
| MRR | 0.756 | 0.770 | +0.013 |

Hybrid recovered 4/215 (three token-disjoint) and regressed 0/215.

## Honest reading

The lexical stack is already strong (~0.90 recall@5) even on deliberately
paraphrased queries, so headroom is small. The embedding hybrid is a real but
small, strictly non-harmful add here — which is why it ships **opt-in**
(`KB_EMBEDDINGS_MODE`), not default-on. Enable it when your corpus has genuine
semantic gaps, and measure with this harness first.

No KB documents are published — only the generic harness code and aggregate
numbers.