### PR TITLE
chore(release): v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.1.2] - 2026-07-02
+
 ### Added
 
 - Automated, human-gated release pipeline (conformant with the STD-U-810
@@ -350,5 +352,6 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `docs/adoption.md`: bring-your-own-KB guide (author, lint, index, serve, wire an agent).
 - `docs/comparison.md`: how data-olympus relates to OKF, enterprise catalogs, markdown KB tools, agent-context conventions, RAG, and ADR tooling.
 
-[Unreleased]: https://github.com/knaisoma/data-olympus/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/knaisoma/data-olympus/compare/v0.1.2...HEAD
+[0.1.2]: https://github.com/knaisoma/data-olympus/compare/v0.1.1...v0.1.2
 [0.1.0]: https://github.com/knaisoma/data-olympus/releases/tag/v0.1.0

--- a/docs/releases/v0.1.2.md
+++ b/docs/releases/v0.1.2.md
@@ -1,0 +1,48 @@
+# v0.1.2
+
+## New features
+
+- Smarter search that understands meaning, not just exact words. A search can now
+  find the right document even when you use a synonym, an acronym, or different
+  wording than the author used (for example, searching "car" can surface a note
+  that only says "automobile"). It runs entirely on the local machine with no
+  outside service, and it stays off by default, so nothing changes until an
+  operator turns it on.
+- Typo-tolerant search. A misspelled word or a partial identifier now still
+  surfaces the closest matches instead of returning nothing.
+- More relevant result ordering. Current, in-force guidance now appears ahead of
+  older or retired versions of the same topic, and an exact match on a document id
+  or tag jumps straight to the top. Searches can also be narrowed by status and by
+  type.
+- A guided onboarding flow that walks an assistant through setting up a new
+  project or component in the knowledge base, plus a helper that spots duplicated
+  local documents and suggests replacing them with a pointer to the shared source.
+- A mandatory consultation gate. The knowledge base can now require assistants
+  across different tools to check it before making code or design decisions, with
+  support for several assistant types and a safety net that flags changes made
+  without a check.
+- A read-only serving mode, so the service can run several interchangeable
+  read-only copies to handle more traffic.
+- Stronger built-in protection: clearer controls over who is allowed to write, a
+  tamper-evident audit trail that reveals any after-the-fact edits, tighter limits
+  that reject oversized or malformed requests, and hardened settings for the
+  sample Kubernetes deployment.
+- A fully automated, human-approved release process. The project now prepares its
+  own release notes and version bump for a person to review and approve before
+  anything is published.
+
+## Fixed
+
+- Occasional "service unavailable" errors when the service was busy. It now stays
+  responsive under load instead of briefly dropping out.
+- A steadily growing internal record that could use up memory over time is now
+  kept within sensible limits.
+- The `--help` command now prints usage instead of crashing on a fresh setup.
+- Problems syncing with the shared source are now reported clearly instead of
+  silently looking like everything is up to date.
+- Requests that cannot be served now return a clear, structured message instead of
+  an opaque internal error.
+- The audit trail now records the correct assistant name for each entry, so
+  per-assistant reporting is accurate.
+- The document checker no longer reports success when it actually found nothing to
+  check.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "data-olympus"
-version = "0.1.1"
+version = "0.1.2"
 description = "Governance-grade knowledge-base format (OKF-compatible) plus CLI and single-writer MCP server"
 requires-python = ">=3.13"
 license = { text = "Apache-2.0" }

--- a/uv.lock
+++ b/uv.lock
@@ -465,7 +465,7 @@ wheels = [
 
 [[package]]
 name = "data-olympus"
-version = "0.1.1"
+version = "0.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
# v0.1.2

## New features

- Smarter search that understands meaning, not just exact words. A search can now
  find the right document even when you use a synonym, an acronym, or different
  wording than the author used (for example, searching "car" can surface a note
  that only says "automobile"). It runs entirely on the local machine with no
  outside service, and it stays off by default, so nothing changes until an
  operator turns it on.
- Typo-tolerant search. A misspelled word or a partial identifier now still
  surfaces the closest matches instead of returning nothing.
- More relevant result ordering. Current, in-force guidance now appears ahead of
  older or retired versions of the same topic, and an exact match on a document id
  or tag jumps straight to the top. Searches can also be narrowed by status and by
  type.
- A guided onboarding flow that walks an assistant through setting up a new
  project or component in the knowledge base, plus a helper that spots duplicated
  local documents and suggests replacing them with a pointer to the shared source.
- A mandatory consultation gate. The knowledge base can now require assistants
  across different tools to check it before making code or design decisions, with
  support for several assistant types and a safety net that flags changes made
  without a check.
- A read-only serving mode, so the service can run several interchangeable
  read-only copies to handle more traffic.
- Stronger built-in protection: clearer controls over who is allowed to write, a
  tamper-evident audit trail that reveals any after-the-fact edits, tighter limits
  that reject oversized or malformed requests, and hardened settings for the
  sample Kubernetes deployment.
- A fully automated, human-approved release process. The project now prepares its
  own release notes and version bump for a person to review and approve before
  anything is published.

## Fixed

- Occasional "service unavailable" errors when the service was busy. It now stays
  responsive under load instead of briefly dropping out.
- A steadily growing internal record that could use up memory over time is now
  kept within sensible limits.
- The `--help` command now prints usage instead of crashing on a fresh setup.
- Problems syncing with the shared source are now reported clearly instead of
  silently looking like everything is up to date.
- Requests that cannot be served now return a clear, structured message instead of
  an opaque internal error.
- The audit trail now records the correct assistant name for each entry, so
  per-assistant reporting is accurate.
- The document checker no longer reports success when it actually found nothing to
  check.

## Announcement (draft)

data-olympus v0.1.2 is our most substantial release yet. Search got noticeably
smarter, the service got sturdier under load, and cutting a release is now an
automated flow that still waits for a human to approve each one. This is a draft;
do not post it anywhere.

- Meaning-aware search: find the right document even when your wording differs
  from the author's, running fully on the local machine and off by default.
- Read-only serving mode: run several interchangeable read-only copies to handle
  more traffic.

Read the full notes: <release-url-once-published>
