### PR TITLE
chore(release): v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-07-03
+
 ### Added
 
 - Content-free real-corpus retrieval eval harness (`benchmarks/real_corpus_eval.py`
@@ -375,5 +377,6 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `docs/adoption.md`: bring-your-own-KB guide (author, lint, index, serve, wire an agent).
 - `docs/comparison.md`: how data-olympus relates to OKF, enterprise catalogs, markdown KB tools, agent-context conventions, RAG, and ADR tooling.
 
-[Unreleased]: https://github.com/knaisoma/data-olympus/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/knaisoma/data-olympus/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/knaisoma/data-olympus/compare/v0.1.1...v0.2.0
 [0.1.0]: https://github.com/knaisoma/data-olympus/releases/tag/v0.1.0

--- a/docs/releases/v0.2.0.md
+++ b/docs/releases/v0.2.0.md
@@ -1,0 +1,63 @@
+# v0.2.0
+
+## New features
+
+- More relevant search out of the box. Results now favor current, in-force
+  guidance over older or retired versions of the same topic, an exact match on a
+  document id or tag jumps straight to the top, and common synonyms and acronyms
+  are matched automatically (searching "k8s" also finds "kubernetes"). These are
+  on by default. Searches can also be narrowed by status and by type.
+- Optional meaning-aware search. When an operator enables it, search can find the
+  right document even when your wording differs from the author's (for example,
+  "car" can surface a note that only says "automobile"). It runs entirely on the
+  local machine with no outside service and is off by default, so nothing changes
+  until it is turned on.
+- Optional typo-tolerant search. When enabled, a misspelled word or a partial
+  identifier still surfaces the closest matches instead of returning nothing. This
+  is off by default.
+- A privacy-safe way to measure search quality. A new benchmark can be pointed at
+  your own knowledge base to show how much the optional smarter search helps; it
+  reports only aggregate scores and never prints any document text, so it is safe
+  to run over private content.
+- Deployments can customize how documents are grouped and which folders accept
+  writes, with no code change. Note for upgrades: a deployment that relied on the
+  previous built-in folder names should set the new configuration to keep the same
+  grouping.
+- A guided onboarding flow that walks an assistant through setting up a new
+  project or component in the knowledge base, plus a helper that spots duplicated
+  local documents and suggests replacing them with a pointer to the shared source.
+- A mandatory consultation gate. The knowledge base can now require assistants
+  across different tools to check it before making code or design decisions, with
+  support for several assistant types and a safety net that flags changes made
+  without a check.
+- A read-only serving mode, so the service can run several interchangeable
+  read-only copies to handle more traffic.
+- Stronger built-in protection: clearer controls over who is allowed to write, a
+  tamper-evident audit trail that reveals any after-the-fact edits, tighter limits
+  that reject oversized or malformed requests, and hardened settings for the
+  sample Kubernetes deployment.
+- The project now type-checks its own source code in continuous integration,
+  catching a class of errors before a release goes out.
+- A fully automated, human-approved release process. The project now prepares its
+  own release notes and version bump for a person to review and approve before
+  anything is published.
+
+## Fixed
+
+- Occasional "service unavailable" errors when the service was busy. It now stays
+  responsive under load instead of briefly dropping out.
+- A steadily growing internal record that could use up memory over time is now
+  kept within sensible limits.
+- The `--help` command now prints usage instead of crashing on a fresh setup.
+- Problems syncing with the shared source are now reported clearly instead of
+  silently looking like everything is up to date.
+- Requests that cannot be served now return a clear, structured message instead of
+  an opaque internal error.
+- The audit trail now records the correct assistant name for each entry, so
+  per-assistant reporting is accurate.
+- The consultation gate now works consistently from a linked git worktree: a
+  single check clears both the edit-time and commit-time gates, instead of
+  needing to be repeated with different labels.
+- The bundle checker now finds files correctly even when the bundle sits inside a
+  folder like a git worktree; it no longer reports zero files (or a false pass)
+  in that case.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "data-olympus"
-version = "0.1.1"
+version = "0.2.0"
 description = "Governance-grade knowledge-base format (OKF-compatible) plus CLI and single-writer MCP server"
 requires-python = ">=3.13"
 license = { text = "Apache-2.0" }

--- a/uv.lock
+++ b/uv.lock
@@ -465,7 +465,7 @@ wheels = [
 
 [[package]]
 name = "data-olympus"
-version = "0.1.1"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
# v0.2.0

## New features

- Smarter search that understands meaning, not just exact words. A search can now
  find the right document even when you use a synonym, an acronym, or different
  wording than the author used (for example, searching "car" can surface a note
  that only says "automobile"). It runs entirely on the local machine with no
  outside service, and it stays off by default, so nothing changes until an
  operator turns it on.
- Typo-tolerant search. A misspelled word or a partial identifier now still
  surfaces the closest matches instead of returning nothing.
- More relevant result ordering. Current, in-force guidance now appears ahead of
  older or retired versions of the same topic, and an exact match on a document id
  or tag jumps straight to the top. Searches can also be narrowed by status and by
  type.
- A privacy-safe way to measure search quality. A new benchmark can be pointed at
  your own knowledge base to show how much the smarter search actually helps; it
  reports only aggregate scores and never prints any document text, so it is safe
  to run over private content.
- A guided onboarding flow that walks an assistant through setting up a new
  project or component in the knowledge base, plus a helper that spots duplicated
  local documents and suggests replacing them with a pointer to the shared source.
- A mandatory consultation gate. The knowledge base can now require assistants
  across different tools to check it before making code or design decisions, with
  support for several assistant types and a safety net that flags changes made
  without a check.
- A read-only serving mode, so the service can run several interchangeable
  read-only copies to handle more traffic.
- Stronger built-in protection: clearer controls over who is allowed to write, a
  tamper-evident audit trail that reveals any after-the-fact edits, tighter limits
  that reject oversized or malformed requests, and hardened settings for the
  sample Kubernetes deployment.
- A fully automated, human-approved release process. The project now prepares its
  own release notes and version bump for a person to review and approve before
  anything is published.

## Fixed

- Occasional "service unavailable" errors when the service was busy. It now stays
  responsive under load instead of briefly dropping out.
- A steadily growing internal record that could use up memory over time is now
  kept within sensible limits.
- The `--help` command now prints usage instead of crashing on a fresh setup.
- Problems syncing with the shared source are now reported clearly instead of
  silently looking like everything is up to date.
- Requests that cannot be served now return a clear, structured message instead of
  an opaque internal error.
- The audit trail now records the correct assistant name for each entry, so
  per-assistant reporting is accurate.
- The document checker no longer reports success when it actually found nothing to
  check.
