### PR TITLE
chore(release): adopt pre-1.0 features-as-minor bump mapping

### DIFF
--- a/.rules/versioning.md
+++ b/.rules/versioning.md
@@ -7,21 +7,29 @@ Governing standard: STD-U-810
 
 ## Bump mapping (pre-1.0)
 
-data-olympus is pre-1.0. Conventional Commit types on commits since the last tag
-drive the bump:
+data-olympus is pre-1.0. STD-U-810 §3.1.1 lets a pre-1.0 project adopt a
+features-as-minor mapping instead of the squashed default, provided the choice is
+documented in the project's local rules. data-olympus adopts it: a `feat:` drives
+a MINOR bump, so shipped features are visible in the version number. Conventional
+Commit types on commits since the last tag drive the bump:
 
-- `feat!:`, any `type!:`, or a `BREAKING CHANGE:` footer -> minor (breaking, needs migration; stays pre-1.0, e.g. 0.1.x -> 0.2.0)
-- `feat:` -> patch
+- `feat:` -> minor (new functionality; resets patch, e.g. 0.1.x -> 0.2.0)
+- `feat!:`, any `type!:`, or a `BREAKING CHANGE:` footer -> minor (a breaking change pre-1.0 stays pre-1.0; it does NOT force 1.0.0)
 - `fix:` / `perf:` -> patch
 - `chore/docs/ci/build/refactor/test/style` -> no release, EXCEPT floored to patch when a functional path changed
+
+This DEVIATES from the STD-U-810 §3.1.1 default (which maps pre-1.0 `feat:` to a
+patch); the deviation is the documented project choice §3.1.1 requires. Pre-1.0 a
+breaking change is a minor bump, not major, so the project stays in the `0.x`
+series until `v1.0.0` is cut deliberately.
 
 "Functional path" is the exact set `scripts/check_changelog.py` defines: `src/`,
 `bin/`, `deploy/`, and `SPEC.md`. This safety net guarantees source changes are
 never left unreleased even if the commit type is non-user-facing.
 
 The project stays pre-1.0 until `v1.0.0` is cut deliberately. When it reaches
-1.0, `bump_for` in `scripts/compute_release.py` switches breaking -> major and
-`feat:` -> minor, and this rule is updated.
+1.0, `bump_for` in `scripts/compute_release.py` switches breaking -> major
+(`feat:` already maps to minor), and this rule is updated.
 
 ## Engine
 

--- a/scripts/compute_release.py
+++ b/scripts/compute_release.py
@@ -53,7 +53,7 @@ def bump_for(commits: list[tuple[str, str]], functional_changed: bool) -> tuple[
             rank = max(rank, _MINOR)
         elif ctype == _FEATURE:
             features.append(subject)
-            rank = max(rank, _PATCH)
+            rank = max(rank, _MINOR)  # pre-1.0 features-as-minor (see .rules/versioning.md)
         elif ctype in _FIXES:
             fixes.append(subject)
             rank = max(rank, _PATCH)

--- a/tests/test_compute_release.py
+++ b/tests/test_compute_release.py
@@ -48,6 +48,24 @@ def test_breaking_bumps_minor_and_wins() -> None:
     assert changes["breaking"] == ["feat!: c"]
 
 
+def test_breaking_bang_alone_bumps_minor_not_major_pre_1_0() -> None:
+    # Isolated from feat->minor: a breaking change with NO feat commit must still
+    # map to minor (never major) pre-1.0. Guards the breaking branch on its own,
+    # so a regression there cannot hide behind a feature commit that is also minor.
+    bump, changes = bump_for([("refactor!: rework store", "")], functional_changed=False)
+    assert bump == "minor"
+    assert changes["breaking"] == ["refactor!: rework store"]
+
+
+def test_breaking_footer_alone_bumps_minor_not_major_pre_1_0() -> None:
+    bump, changes = bump_for(
+        [("refactor: rework store", "BREAKING CHANGE: migration required")],
+        functional_changed=False,
+    )
+    assert bump == "minor"
+    assert changes["breaking"] == ["refactor: rework store"]
+
+
 def test_chore_only_no_functional_change_is_none() -> None:
     bump, _ = bump_for([("chore: deps", ""), ("ci: bump", "")], functional_changed=False)
     assert bump == "none"

--- a/tests/test_compute_release.py
+++ b/tests/test_compute_release.py
@@ -29,9 +29,10 @@ def test_classify_non_conventional_returns_none() -> None:
     assert classify("Merge pull request #55 from x", "") == (None, False)
 
 
-def test_feat_bumps_patch_pre_1_0() -> None:
-    bump, changes = bump_for([("feat: x", "")], functional_changed=True)
-    assert bump == "patch"
+def test_feat_bumps_minor_pre_1_0() -> None:
+    # data-olympus adopts the features-as-minor mapping (STD-U-810 §3.1.1 opt-in).
+    bump, changes = bump_for([("feat: x", "")], functional_changed=False)
+    assert bump == "minor"
     assert changes["features"] == ["feat: x"]
 
 


### PR DESCRIPTION
Adopts a **features-as-minor** pre-1.0 bump mapping for data-olympus: a `feat:`
now drives a MINOR bump instead of a patch, so shipped features are visible in the
version number.

## Why

STD-U-810 §3.1.1 permits a pre-1.0 project to opt out of the squashed default
(where `feat:` maps to a patch) and adopt the features-as-minor mapping, **provided
the choice is documented in the project's local rules**. This PR records that
choice in `.rules/versioning.md` and switches the engine to match.

## Changes

- `scripts/compute_release.py` — `bump_for` maps `feat:` to minor (was patch).
- `.rules/versioning.md` — documents the adopted mapping and the §3.1.1 deviation.
- `tests/test_compute_release.py` — updates the feat-bump expectation to minor.

## Mapping after this change (pre-1.0)

- `feat:` -> minor
- `feat!:` / `BREAKING CHANGE:` -> minor (a breaking change pre-1.0 stays pre-1.0; it does not force 1.0.0)
- `fix:` / `perf:` -> patch
- other types -> none (floored to patch only when a functional path changed)

## One decision to confirm

Breaking changes are mapped to **minor** (kept pre-1.0), NOT major. The literal
"full §3.1 mapping" in STD-U-810 would make a breaking change bump to major, which
for a `0.x` project means jumping to `1.0.0` on the first breaking commit. That is
almost never intended for a pre-1.0 tool, so this PR keeps breaking at minor. If
you would rather follow the literal full mapping (breaking -> major -> 1.0.0), say
so and I will adjust `bump_for` and the rule.

## Not affected

This does not change the already-open v0.2.0 release PR (#62), which set the
`pyproject` version explicitly; the tag CI reads that version directly. This PR
only changes what the release-cutter computes for FUTURE releases.
