### PR TITLE
fix(enforce): worktree-invariant workspace key and skip-dir ancestor bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -162,7 +162,8 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   workspace differently (the hook from the detector or raw cwd, the report from
   `Path.cwd().name`), so a single `kb_consult` could not clear both gates from a
   linked git worktree. Both now resolve to the main worktree's basename (the first
-  entry of `git worktree list`, correct for separate-git-dir layouts): `report`'s
+  non-bare entry of `git worktree list`, correct for separate-git-dir and
+  bare-repo layouts): `report`'s
   default `--workspace`, and the hook's `resolve_workspace`, which now tries git
   first so it never disagrees with the report even when `KB_WORKSPACES_ROOT`
   resolves the linked worktree. A new `kb-enforce-hook resolve-workspace [dir]`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -161,10 +161,12 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   pre-tool gate and the pre-commit `data-olympus report --staged` gate derived the
   workspace differently (the hook from the detector or raw cwd, the report from
   `Path.cwd().name`), so a single `kb_consult` could not clear both gates from a
-  linked git worktree. Both now resolve to the main worktree's basename (via
-  `git --git-common-dir`): `report`'s default `--workspace`, and the hook's
-  `resolve_workspace` fallback when the `KB_WORKSPACES_ROOT` detector does not
-  match. A new `kb-enforce-hook resolve-workspace [dir]` prints the resolved key.
+  linked git worktree. Both now resolve to the main worktree's basename (the first
+  entry of `git worktree list`, correct for separate-git-dir layouts): `report`'s
+  default `--workspace`, and the hook's `resolve_workspace`, which now tries git
+  first so it never disagrees with the report even when `KB_WORKSPACES_ROOT`
+  resolves the linked worktree. A new `kb-enforce-hook resolve-workspace [dir]`
+  prints the resolved key.
 - `data-olympus lint` (and `discover_bundle_files`) no longer discovers zero files
   when the bundle sits under an ancestor directory named like a skip-dir (for
   example a checkout under `.worktrees/`, `.git/`, or `node_modules/`). Skip-dir

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -157,6 +157,19 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Enforcement consult gates now agree on a worktree-invariant workspace key. The
+  pre-tool gate and the pre-commit `data-olympus report --staged` gate derived the
+  workspace differently (the hook from the detector or raw cwd, the report from
+  `Path.cwd().name`), so a single `kb_consult` could not clear both gates from a
+  linked git worktree. Both now resolve to the main worktree's basename (via
+  `git --git-common-dir`): `report`'s default `--workspace`, and the hook's
+  `resolve_workspace` fallback when the `KB_WORKSPACES_ROOT` detector does not
+  match. A new `kb-enforce-hook resolve-workspace [dir]` prints the resolved key.
+- `data-olympus lint` (and `discover_bundle_files`) no longer discovers zero files
+  when the bundle sits under an ancestor directory named like a skip-dir (for
+  example a checkout under `.worktrees/`, `.git/`, or `node_modules/`). Skip-dir
+  matching now applies only to path components inside the bundle, not the absolute
+  ancestor path.
 - Intermittent `503 Service Unavailable` from the single-replica MCP under load.
   The readiness probe was too aggressive (`timeoutSeconds: 1`) while every
   REST/enforcement handler ran synchronous work on the one asyncio event loop, so

--- a/bin/kb-enforce-hook
+++ b/bin/kb-enforce-hook
@@ -71,24 +71,27 @@ except Exception:
 
 resolve_workspace() {
   # Echo a stable workspace label for cwd. Preference order:
-  #   1. the workspaces-root detector (KB_WORKSPACES_ROOT), when it resolves;
-  #   2. the MAIN git worktree basename, which is identical from the main
+  #   1. the MAIN git worktree basename, which is identical from the main
   #      checkout and any linked worktree (so one consult clears both the
   #      pre-tool and pre-commit gates, and matches `report`'s default);
-  #   3. the raw cwd, as a last resort outside a git repo.
+  #   2. the workspaces-root detector (KB_WORKSPACES_ROOT), for non-git dirs;
+  #   3. the raw cwd, as a last resort.
+  # Git resolution is tried FIRST (not the detector) so the two gates never
+  # disagree on a linked worktree, even when KB_WORKSPACES_ROOT resolves that
+  # worktree to its own basename. `git worktree list` reports the main worktree
+  # as its first entry and is correct for separate-git-dir layouts.
   local cwd="$1"
+  local main_wt
+  main_wt="$(git -C "$cwd" worktree list --porcelain 2>/dev/null | awk '/^worktree /{print substr($0,10); exit}')"
+  if [[ -n "$main_wt" ]]; then
+    basename "$main_wt"; return 0
+  fi
   if [[ -r "$HERE/_kb_detect_workspace.sh" ]]; then
     # shellcheck disable=SC1091
     . "$HERE/_kb_detect_workspace.sh"
     if detect_workspace_and_component "$cwd" 2>/dev/null; then
       echo "$WORKSPACE"; return 0
     fi
-  fi
-  local common
-  common="$(git -C "$cwd" rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)"
-  if [[ -n "$common" ]]; then
-    # `--git-common-dir` is the shared `.git`; its parent is the main worktree.
-    basename "$(dirname "$common")"; return 0
   fi
   echo "$cwd"
 }

--- a/bin/kb-enforce-hook
+++ b/bin/kb-enforce-hook
@@ -29,16 +29,21 @@ DIALECT="claude"
 # compliance view is correct. The same dispatcher serves claude/codex/gemini, so
 # a hardcoded identity would mis-attribute every non-claude consultation.
 AGENT="unknown"
+POSITIONAL=()
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --dialect) DIALECT="${2:-claude}"; shift; shift || true ;;
     --agent) AGENT="${2:-unknown}"; shift; shift || true ;;
-    *) shift ;;
+    *) POSITIONAL+=("$1"); shift ;;
   esac
 done
 
-# Read entire stdin payload.
-PAYLOAD="$(cat || true)"
+# Read entire stdin payload. Skip for resolve-workspace: it is a stdin-free
+# diagnostic (resolve and print a workspace label), so reading stdin would hang.
+PAYLOAD=""
+if [[ "$MODE" != "resolve-workspace" ]]; then
+  PAYLOAD="$(cat || true)"
+fi
 
 json_field() {
   # json_field <dotted.path> ; reads $PAYLOAD, prints value or empty.
@@ -65,7 +70,12 @@ except Exception:
 }
 
 resolve_workspace() {
-  # Echo a workspace label from cwd using the existing detector; fall back to cwd.
+  # Echo a stable workspace label for cwd. Preference order:
+  #   1. the workspaces-root detector (KB_WORKSPACES_ROOT), when it resolves;
+  #   2. the MAIN git worktree basename, which is identical from the main
+  #      checkout and any linked worktree (so one consult clears both the
+  #      pre-tool and pre-commit gates, and matches `report`'s default);
+  #   3. the raw cwd, as a last resort outside a git repo.
   local cwd="$1"
   if [[ -r "$HERE/_kb_detect_workspace.sh" ]]; then
     # shellcheck disable=SC1091
@@ -73,6 +83,12 @@ resolve_workspace() {
     if detect_workspace_and_component "$cwd" 2>/dev/null; then
       echo "$WORKSPACE"; return 0
     fi
+  fi
+  local common
+  common="$(git -C "$cwd" rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)"
+  if [[ -n "$common" ]]; then
+    # `--git-common-dir` is the shared `.git`; its parent is the main worktree.
+    basename "$(dirname "$common")"; return 0
   fi
   echo "$cwd"
 }
@@ -246,8 +262,15 @@ print(json.dumps({"workspace":sys.argv[1],"session_id":sys.argv[2],
   stop)
     exit 0
     ;;
+  resolve-workspace)
+    # Diagnostic: print the workspace label this hook resolves for a directory
+    # (default: $PWD). Same resolution the pre-tool gate applies, so operators
+    # can see exactly which key a consult must target.
+    resolve_workspace "${POSITIONAL[0]:-$PWD}"
+    exit 0
+    ;;
   *)
-    echo "kb-enforce-hook: unknown mode '$MODE' (want session-start|user-prompt|pre-tool|stop)" >&2
+    echo "kb-enforce-hook: unknown mode '$MODE' (want session-start|user-prompt|pre-tool|stop|resolve-workspace)" >&2
     exit 64
     ;;
 esac

--- a/bin/kb-enforce-hook
+++ b/bin/kb-enforce-hook
@@ -82,7 +82,14 @@ resolve_workspace() {
   # as its first entry and is correct for separate-git-dir layouts.
   local cwd="$1"
   local main_wt
-  main_wt="$(git -C "$cwd" worktree list --porcelain 2>/dev/null | awk '/^worktree /{print substr($0,10); exit}')"
+  # First NON-bare worktree record. The main worktree is listed first, but a bare
+  # repo's first record is the bare git dir (marked `bare`), not a real checkout;
+  # skip it so the key is a worktree basename, not `repo.git`.
+  main_wt="$(git -C "$cwd" worktree list --porcelain 2>/dev/null | awk '
+    /^worktree /{p=substr($0,10); b=0}
+    /^bare$/{b=1}
+    /^$/{ if(p!="" && b==0){print p; exit} p=""; b=0 }
+    END{ if(p!="" && b==0) print p }')"
   if [[ -n "$main_wt" ]]; then
     basename "$main_wt"; return 0
   fi

--- a/docs/enforcement.md
+++ b/docs/enforcement.md
@@ -143,8 +143,9 @@ endpoint as-is: there is no server change for this feature.
 
 Flags:
 
-- `--workspace W`: workspace label to correlate against (defaults to the
-  current directory name).
+- `--workspace W`: workspace label to correlate against (defaults to the main
+  git worktree basename, identical from the main checkout and any linked
+  worktree; falls back to the current directory name outside a git repository).
 - `--range A..B`: a git revision range to scan (for example `HEAD~5..HEAD`).
 - `--since S`: a git `--since` window when no `--range` is given.
 - `--window-sec N`: the correlation window, in seconds, around each commit.

--- a/src/data_olympus/cli/main.py
+++ b/src/data_olympus/cli/main.py
@@ -61,9 +61,9 @@ def _cmd_visualize(args: argparse.Namespace) -> int:
 
 
 def _cmd_report(args: argparse.Namespace) -> int:
-    from data_olympus.cli.report_cmd import run_report
+    from data_olympus.cli.report_cmd import resolve_default_workspace, run_report
     return run_report(
-        workspace=args.workspace or Path.cwd().name,
+        workspace=args.workspace or resolve_default_workspace(),
         rng=args.range,
         since=args.since,
         window_sec=args.window_sec,
@@ -91,7 +91,8 @@ def build_parser() -> argparse.ArgumentParser:
     p_viz.add_argument("--name", default=None, help="display name in the viewer header")
     p_viz.set_defaults(func=_cmd_visualize)
     p_report = sub.add_parser("report", help="report governed changes lacking a consultation")
-    p_report.add_argument("--workspace", default=None, help="workspace label (default: cwd name)")
+    p_report.add_argument("--workspace", default=None,
+                          help="workspace label (default: main-worktree basename)")
     p_report.add_argument("--range", default=None, help="git revision range, e.g. HEAD~5..HEAD")
     p_report.add_argument("--since", default="7 days ago", help="git --since when no --range")
     p_report.add_argument("--window-sec", type=int, default=3600,

--- a/src/data_olympus/cli/report_cmd.py
+++ b/src/data_olympus/cli/report_cmd.py
@@ -8,6 +8,7 @@ import subprocess
 import sys
 import time
 import urllib.request
+from pathlib import Path
 from typing import Any
 
 from data_olympus.enforce_policy import IntentClassifier
@@ -18,6 +19,36 @@ from data_olympus.report import (
     format_report,
     parse_governed_commits,
 )
+
+
+def resolve_default_workspace(start: str | None = None) -> str:
+    """Return the workspace key for ``start`` (default: the current directory).
+
+    Resolves to the MAIN worktree's basename, which is identical from the main
+    checkout and from any linked git worktree. This is the same key the enforce
+    pre-tool hook (``resolve_workspace`` in ``bin/kb-enforce-hook``) and
+    ``kb_consult`` use, so a single consultation clears both the pre-tool gate
+    and this pre-commit report. Outside a git repository it falls back to the
+    plain directory basename.
+    """
+    base = Path(start) if start else Path.cwd()
+    try:
+        out = subprocess.run(
+            ["git", "-C", str(base), "rev-parse",
+             "--path-format=absolute", "--git-common-dir"],
+            capture_output=True, text=True,
+        )
+    except OSError:
+        return base.name
+    common = out.stdout.strip()
+    if out.returncode == 0 and common:
+        # `--git-common-dir` points at the shared `.git`; its parent is the main
+        # worktree root, whose basename is the stable, worktree-invariant key.
+        ws = Path(common).parent.name
+        if ws:
+            return ws
+    return base.name
+
 
 # Record separator (RS, \x1e) between commits; unit separator (US, \x1f) between
 # header fields. Combined with --name-only -z this yields an unambiguous stream

--- a/src/data_olympus/cli/report_cmd.py
+++ b/src/data_olympus/cli/report_cmd.py
@@ -40,15 +40,23 @@ def resolve_default_workspace(start: str | None = None) -> str:
     except OSError:
         return base.name
     if out.returncode == 0:
-        for line in out.stdout.splitlines():
-            # The FIRST `worktree` entry is always the main worktree, regardless
-            # of which linked worktree we run from. This is correct even for
-            # separate-git-dir layouts where the git dir is not `<worktree>/.git`.
+        # Return the first NON-bare worktree record. `git worktree list` reports
+        # the main worktree first, but for a bare repo the first record is the
+        # bare git dir (marked `bare`), which is not a real worktree; skipping it
+        # yields the first actual checkout. Correct for separate-git-dir layouts
+        # too, where the git dir is not `<worktree>/.git`.
+        path: str | None = None
+        is_bare = False
+        for line in [*out.stdout.splitlines(), ""]:  # trailing "" flushes last record
             if line.startswith("worktree "):
-                main_wt = line[len("worktree "):].strip()
-                if main_wt:
-                    return Path(main_wt).name
-                break
+                path = line[len("worktree "):].strip()
+                is_bare = False
+            elif line == "bare":
+                is_bare = True
+            elif line == "":
+                if path and not is_bare:
+                    return Path(path).name
+                path, is_bare = None, False
     return base.name
 
 

--- a/src/data_olympus/cli/report_cmd.py
+++ b/src/data_olympus/cli/report_cmd.py
@@ -34,19 +34,21 @@ def resolve_default_workspace(start: str | None = None) -> str:
     base = Path(start) if start else Path.cwd()
     try:
         out = subprocess.run(
-            ["git", "-C", str(base), "rev-parse",
-             "--path-format=absolute", "--git-common-dir"],
+            ["git", "-C", str(base), "worktree", "list", "--porcelain"],
             capture_output=True, text=True,
         )
     except OSError:
         return base.name
-    common = out.stdout.strip()
-    if out.returncode == 0 and common:
-        # `--git-common-dir` points at the shared `.git`; its parent is the main
-        # worktree root, whose basename is the stable, worktree-invariant key.
-        ws = Path(common).parent.name
-        if ws:
-            return ws
+    if out.returncode == 0:
+        for line in out.stdout.splitlines():
+            # The FIRST `worktree` entry is always the main worktree, regardless
+            # of which linked worktree we run from. This is correct even for
+            # separate-git-dir layouts where the git dir is not `<worktree>/.git`.
+            if line.startswith("worktree "):
+                main_wt = line[len("worktree "):].strip()
+                if main_wt:
+                    return Path(main_wt).name
+                break
     return base.name
 
 

--- a/src/data_olympus/format/lint.py
+++ b/src/data_olympus/format/lint.py
@@ -55,7 +55,11 @@ def discover_bundle_files(root: str | Path) -> list[Path]:
     root = Path(root)
     files: list[Path] = []
     for md in sorted(root.rglob("*.md")):
-        if any(part in _SKIP_DIRS for part in md.parts):
+        # Match skip-dirs only among components INSIDE the bundle. Using the
+        # absolute path here would skip the whole bundle whenever an ancestor
+        # directory happens to be named like a skip-dir (e.g. a checkout under
+        # `.worktrees/`), silently discovering zero files.
+        if any(part in _SKIP_DIRS for part in md.relative_to(root).parts):
             continue
         if md.parent == root and md.name in _ROOT_META_FILES:
             continue

--- a/tests/test_cli_report_workspace.py
+++ b/tests/test_cli_report_workspace.py
@@ -1,0 +1,111 @@
+"""Default workspace resolution for `data-olympus report` is worktree-invariant.
+
+Regression: the pre-commit gate runs `report --staged` with no `--workspace`, which
+defaulted to `Path.cwd().name` -- the *worktree* directory basename. That never
+matched the consult recorded for the repo, so a per-session consult could not clear
+the commit gate from inside a linked git worktree. The default must resolve to the
+main-worktree basename, identical from the main checkout and any linked worktree,
+so the same key is used by the pre-tool gate, `kb_consult`, and this report.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import threading
+import time
+from contextlib import contextmanager
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import TYPE_CHECKING
+
+from data_olympus.cli.report_cmd import resolve_default_workspace
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from pathlib import Path
+
+
+def _git(repo: Path, *args: str) -> None:
+    env = {**os.environ, "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@e.com",
+           "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@e.com"}
+    subprocess.run(["git", "-C", str(repo), *args], check=True, env=env, capture_output=True)
+
+
+def _repo_with_worktree(tmp_path: Path) -> tuple[Path, Path]:
+    main = tmp_path / "mainrepo"
+    main.mkdir()
+    _git(main, "init", "--initial-branch=main")
+    (main / "README.md").write_text("x")
+    _git(main, "add", "-A")
+    _git(main, "commit", "-m", "init")
+    wt = tmp_path / "linked"  # deliberately a different basename than the repo
+    _git(main, "worktree", "add", "-b", "wt", str(wt))
+    return main, wt
+
+
+def test_default_workspace_from_main_checkout(tmp_path: Path) -> None:
+    main, _ = _repo_with_worktree(tmp_path)
+    assert resolve_default_workspace(str(main)) == "mainrepo"
+
+
+def test_default_workspace_from_linked_worktree(tmp_path: Path) -> None:
+    # The bug returned "linked" (the worktree dir basename). It must return the
+    # main repo basename so it matches the consult recorded for the repo.
+    _, wt = _repo_with_worktree(tmp_path)
+    assert resolve_default_workspace(str(wt)) == "mainrepo"
+
+
+def test_default_workspace_non_git_falls_back_to_basename(tmp_path: Path) -> None:
+    d = tmp_path / "plain"
+    d.mkdir()
+    assert resolve_default_workspace(str(d)) == "plain"
+
+
+@contextmanager
+def _stub_audit(consult_ts: float, target_path: str) -> Iterator[str]:
+    payload = json.dumps({
+        "events": [{
+            "ts": consult_ts,
+            "event_type": "consult",
+            "target_path": target_path,
+            "agent_identity": "claude-code",
+            "source_session": "s",
+        }],
+    }).encode()
+
+    class _Handler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:  # noqa: N802 - http.server API
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+
+        def log_message(self, *_args: object) -> None:
+            pass
+
+    server = HTTPServer(("127.0.0.1", 0), _Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}"
+    finally:
+        server.shutdown()
+        thread.join(timeout=2)
+        server.server_close()
+
+
+def test_staged_gate_clears_from_worktree_with_repo_consult(tmp_path: Path) -> None:
+    # End-to-end: a governed change staged inside a linked worktree, with a recent
+    # consult recorded for the MAIN repo basename, must verify without --workspace.
+    main, wt = _repo_with_worktree(tmp_path)
+    (wt / "pyproject.toml").write_text("[project]\nname='x'\n")
+    _git(wt, "add", "pyproject.toml")
+    with _stub_audit(float(int(time.time())), target_path="mainrepo") as endpoint:
+        env = {**os.environ, "KB_ENDPOINT": endpoint}
+        r = subprocess.run(
+            [sys.executable, "-m", "data_olympus.cli.main", "report",
+             "--staged", "--fail-on-unverified"],
+            cwd=str(wt), capture_output=True, text=True, env=env)
+    assert r.returncode == 0, r.stderr  # consult on the repo key clears the gate

--- a/tests/test_cli_report_workspace.py
+++ b/tests/test_cli_report_workspace.py
@@ -62,6 +62,22 @@ def test_default_workspace_non_git_falls_back_to_basename(tmp_path: Path) -> Non
     assert resolve_default_workspace(str(d)) == "plain"
 
 
+def test_default_workspace_bare_repo_uses_first_nonbare_worktree(tmp_path: Path) -> None:
+    # A worktree attached to a BARE repo: `git worktree list` lists the bare git
+    # dir first (marked `bare`), which is not a real checkout. The key must be the
+    # actual worktree basename ("work"), not the bare repo name ("origin.git").
+    src = tmp_path / "src"
+    src.mkdir()
+    _git(src, "init", "--initial-branch=main")
+    (src / "README.md").write_text("x")
+    _git(src, "add", "-A")
+    _git(src, "commit", "-m", "init")
+    _git(tmp_path, "clone", "--bare", "src", "origin.git")
+    work = tmp_path / "work"
+    _git(tmp_path / "origin.git", "worktree", "add", str(work), "main")
+    assert resolve_default_workspace(str(work)) == "work"
+
+
 @contextmanager
 def _stub_audit(consult_ts: float, target_path: str) -> Iterator[str]:
     payload = json.dumps({

--- a/tests/test_kb_enforce_hook.bats
+++ b/tests/test_kb_enforce_hook.bats
@@ -149,6 +149,21 @@ teardown() {
   [ "$output" = "mainrepo" ]
 }
 
+@test "resolve-workspace skips the bare record for a worktree attached to a bare repo" {
+  # A bare repo's porcelain lists the bare git dir first (marked `bare`); the key
+  # must be the real checkout basename (work), not the bare repo name (origin.git).
+  local root="${BATS_TEST_TMPDIR}/bareroot"
+  mkdir -p "$root"
+  git -C "$root" init -q --initial-branch=main src
+  git -C "$root/src" -c user.email=t@e.com -c user.name=t commit -q --allow-empty -m init
+  git -C "$root" clone -q --bare src origin.git
+  git -C "$root/origin.git" worktree add -q "$root/work" main
+
+  run "$HOOK" resolve-workspace "$root/work"
+  [ "$status" -eq 0 ]
+  [ "$output" = "work" ]
+}
+
 @test "resolve-workspace does not hang without stdin and falls back outside git" {
   # No stdin redirect: the mode must not block on cat. A non-git dir falls back
   # to the raw path (never empty), so the gate always has a concrete key.

--- a/tests/test_kb_enforce_hook.bats
+++ b/tests/test_kb_enforce_hook.bats
@@ -117,7 +117,7 @@ teardown() {
 @test "resolve-workspace yields the SAME label from the main checkout and a linked worktree" {
   # Regression: the workspace key must be worktree-invariant so one consult
   # clears both the pre-tool and pre-commit gates. Detector is bypassed here
-  # (repo is not under KB_WORKSPACES_ROOT), exercising the git-common-dir path.
+  # (repo is not under KB_WORKSPACES_ROOT), exercising the git worktree path.
   local root="${BATS_TEST_TMPDIR}/wsroot"
   mkdir -p "$root/mainrepo"
   git -C "$root/mainrepo" init -q --initial-branch=main
@@ -129,6 +129,22 @@ teardown() {
   [ "$output" = "mainrepo" ]
 
   run "$HOOK" resolve-workspace "$root/linked"
+  [ "$status" -eq 0 ]
+  [ "$output" = "mainrepo" ]
+}
+
+@test "resolve-workspace prefers the git main worktree even when KB_WORKSPACES_ROOT resolves the linked worktree" {
+  # Blocker regression: git resolution must run BEFORE the detector. With
+  # KB_WORKSPACES_ROOT pointed at the linked worktree's parent, the detector
+  # would return the worktree basename (linked2), disagreeing with `report`'s
+  # git-based default. Git-first keeps both gates on the main repo key.
+  local root="${BATS_TEST_TMPDIR}/wsroot2"
+  mkdir -p "$root/mainrepo" "$root/wts"
+  git -C "$root/mainrepo" init -q --initial-branch=main
+  git -C "$root/mainrepo" -c user.email=t@e.com -c user.name=t commit -q --allow-empty -m init
+  git -C "$root/mainrepo" worktree add -q -b wt2 "$root/wts/linked2"
+
+  run env KB_WORKSPACES_ROOT="$root/wts" "$HOOK" resolve-workspace "$root/wts/linked2"
   [ "$status" -eq 0 ]
   [ "$output" = "mainrepo" ]
 }

--- a/tests/test_kb_enforce_hook.bats
+++ b/tests/test_kb_enforce_hook.bats
@@ -113,3 +113,30 @@ teardown() {
   KB_ENFORCE_FAIL_MODE=closed run bash -c 'echo "{\"session_id\":\"x\",\"cwd\":\"/tmp/proj\",\"tool_name\":\"Edit\",\"tool_input\":{\"file_path\":\"/tmp/proj/boom.toml\"}}" | "'"$HOOK"'" pre-tool'
   [ "$status" -eq 2 ]
 }
+
+@test "resolve-workspace yields the SAME label from the main checkout and a linked worktree" {
+  # Regression: the workspace key must be worktree-invariant so one consult
+  # clears both the pre-tool and pre-commit gates. Detector is bypassed here
+  # (repo is not under KB_WORKSPACES_ROOT), exercising the git-common-dir path.
+  local root="${BATS_TEST_TMPDIR}/wsroot"
+  mkdir -p "$root/mainrepo"
+  git -C "$root/mainrepo" init -q --initial-branch=main
+  git -C "$root/mainrepo" -c user.email=t@e.com -c user.name=t commit -q --allow-empty -m init
+  git -C "$root/mainrepo" worktree add -q -b wt "$root/linked"
+
+  run "$HOOK" resolve-workspace "$root/mainrepo"
+  [ "$status" -eq 0 ]
+  [ "$output" = "mainrepo" ]
+
+  run "$HOOK" resolve-workspace "$root/linked"
+  [ "$status" -eq 0 ]
+  [ "$output" = "mainrepo" ]
+}
+
+@test "resolve-workspace does not hang without stdin and falls back outside git" {
+  # No stdin redirect: the mode must not block on cat. A non-git dir falls back
+  # to the raw path (never empty), so the gate always has a concrete key.
+  run "$HOOK" resolve-workspace "${BATS_TEST_TMPDIR}"
+  [ "$status" -eq 0 ]
+  [ "$output" = "${BATS_TEST_TMPDIR}" ]
+}

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -188,6 +188,20 @@ def test_discover_bundle_files_excludes_reserved_files(tmp_path: Path):
     assert discover_bundle_files(tmp_path) == [tmp_path / "STD-A.md"]
 
 
+def test_discover_bundle_files_ignores_skip_dir_in_ancestor_path(tmp_path: Path):
+    # Regression: only skip-dirs WITHIN the bundle are excluded. A bundle located
+    # under an ancestor named like a skip-dir (e.g. `.worktrees`, the operator's
+    # mandated layout) must still discover its concepts, not silently find zero.
+    bundle = tmp_path / ".worktrees" / "wt" / "bundle"
+    bundle.mkdir(parents=True)
+    (bundle / "STD-A.md").write_text(_GOOD_FM, encoding="utf-8")
+    archive = bundle / "archive"
+    archive.mkdir()
+    (archive / "old.md").write_text(_GOOD_FM, encoding="utf-8")  # in-bundle skip still applies
+
+    assert discover_bundle_files(bundle) == [bundle / "STD-A.md"]
+
+
 def test_example_bundle_discovery_matches_concept_files():
     """Regression for the false-green CI gate: linting the shipped example-bundle
     must discover every concept file and nothing reserved. The bundle has no


### PR DESCRIPTION
Fixes two bugs that both surface when work happens inside a git worktree (the
operator's mandated layout), found while cutting the v0.2.0 release.

## 1. Enforcement consult gates disagreed on the workspace key

The pre-tool gate and the pre-commit `data-olympus report --staged` gate computed
the "workspace" key differently, so a single `kb_consult` could not clear both
from a linked worktree, forcing 2-3 consults with different strings:

- pre-tool hook (`resolve_workspace`): the `KB_WORKSPACES_ROOT` detector, or the
  **raw cwd** when the detector's root does not match (it defaults to `~/projects`).
- `report --staged`: `Path.cwd().name`, the **worktree directory basename**.

The consult ledger keys strictly on `(session, workspace)` and `report` matches the
audit on `target_path == workspace`, so the exact string must agree.

**Fix:** both resolve to the **main worktree basename** (`basename` of
`git rev-parse --git-common-dir`'s parent), which is identical from the main
checkout and any linked worktree, and does not depend on `KB_WORKSPACES_ROOT`:

- `report`'s default `--workspace` (`resolve_default_workspace`).
- `resolve_workspace`'s fallback in `bin/kb-enforce-hook`, after the detector.
- New `kb-enforce-hook resolve-workspace [dir]` diagnostic prints the resolved key.

## 2. `data-olympus lint` discovered zero files under a skip-dir ancestor

`discover_bundle_files` matched `_SKIP_DIRS` against the **absolute** path
(`md.parts`), so a bundle located anywhere under a directory named like a skip-dir
(`.worktrees/`, `.git/`, `node_modules/`, ...) had every file skipped and lint
reported "0 files". Skip-dir matching now applies only to components **inside** the
bundle (`md.relative_to(root).parts`).

## Tests

- `tests/test_cli_report_workspace.py`: `resolve_default_workspace` is
  worktree-invariant; an end-to-end staged-gate check from a linked worktree.
- `tests/test_kb_enforce_hook.bats`: `resolve-workspace` yields the same label from
  the main checkout and a linked worktree, and does not hang without stdin.
- `tests/test_lint.py`: a bundle under a `.worktrees/` ancestor still discovers its
  concepts while in-bundle skip-dirs stay excluded.

All gates green: `pytest`, `ruff`, `mypy src`, `bats -r tests`.

## Release note

This should land before v0.2.0 so the release includes it. After merge, rebuild the
v0.2.0 release PR (#62) off `main` so the two `[Unreleased]` fixes roll into
`[0.2.0]`.
