### PR TITLE
fix(enforce): explicit-consult gate policy, actionable deny message, opencode gate fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Actionable gate deny message: the BLOCKED text (and the `consult_required`
+  verdict `reason`) now includes the exact workspace key, the session id (the one
+  parameter an agent cannot guess), and a copy-pasteable
+  `kb_consult(workspace=..., source_session=..., intent=...)` call.
+  `GateCheckResponse` gained `session_id` and `workspace` echo fields so MCP
+  callers see the gate key.
 - Write-pipeline visibility (issue #72, Wave 0). `kb_health` and `/health` now
   report the **live** pending-queue and push-queue sizes (previously hardwired to
   zero because the counters were static attributes that were never updated), plus
@@ -30,6 +36,21 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- **Enforcement gate policy: the gate now clears only on an explicit
+  consultation, not on any recent consult (behavioral change).** Previously the
+  gate meant "an HTTP call to `/consult` happened recently in this session", so
+  the per-agent installers' per-prompt auto-consults (Claude/Codex
+  `UserPromptSubmit`, Gemini `BeforeAgent`) kept the ledger perpetually fresh and
+  the gate only fired during autonomous stretches longer than the TTL. Consults
+  now carry a `trigger`: an **explicit** consult (a deliberate `kb_consult` call,
+  the default, and any old client that omits the field) clears the gate, while a
+  **prompt_hook** consult (the installer auto-consults, now marked as such) is
+  recorded for audit/compliance and injects rules but never clears the gate. A
+  prompt-hook consult never downgrades a still-fresh explicit consult. Deployments
+  that relied on the per-prompt auto-clear will now see the gate require an
+  explicit `kb_consult` before governed edits. Backward compatible for old
+  clients (a bare consult with no `trigger` counts as explicit). See
+  `docs/enforcement.md`.
 - Frozen push-queue entries (those that hit `max_attempts`) are now **skipped**
   by the retry loop instead of being retried every interval forever; the freeze
   is logged once at WARN and surfaced via `push_queue_frozen` in health. See
@@ -45,6 +66,26 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 > itself (rebase-retry redesign); that is tracked separately as Wave 1.
 ### Fixed
 
+- OpenCode gate (`data-olympus-gate.ts`): resolves the workspace to the main git
+  worktree **basename** (matching the key every other surface records consults
+  under) instead of the raw absolute path, which could never match; and passes
+  the tool arguments (command/patch/content) as `action_diff`, so bash and patch
+  actions are actually classified instead of the gate seeing empty everything and
+  allowing.
+- Enforcement hook (`bin/kb-enforce-hook`): a null `session_id` now renders as an
+  empty string instead of the literal `"None"` (which became a bogus ledger key);
+  the critical-path pre-tool gate now uses tight `--max-time 2 --connect-timeout 1`
+  timeouts; and the pre-tool payload is parsed once (base64-framed) instead of
+  spawning `python3` per field.
+- Anchored the installer tool matchers (`^(...)$`) so `Bash` no longer
+  substring-matches `BashOutput` (and likewise for the Codex and Gemini matchers).
+- `kb enforce doctor` now also verifies the managed marker/version in the live
+  settings file and that the hook dispatcher exists and is executable, and warns
+  (and fails) when the dispatcher resolves inside a `.worktrees/` or
+  `.claude/worktrees/` checkout, which dangles after pruning and silently fails
+  open.
+- Docs: `docs/enforcement.md` now states that Codex DOES gate Bash (matching the
+  installer) and documents the explicit-consult gate policy honestly.
 - `scripts/run-local.sh` no longer deletes an arbitrary user-supplied `$1`
   path. It previously ran `rm -rf "$KB_DIR"` unconditionally, so passing your
   own bundle's path as the first argument would silently delete it. The

--- a/bin/_kb_enforce.py
+++ b/bin/_kb_enforce.py
@@ -50,6 +50,54 @@ def _doctor_endpoint() -> tuple[bool, str]:
     return ok, f"endpoint {endpoint} reachable={ok}"
 
 
+def _hook_bin_in_worktree(hook_bin: str) -> bool:
+    """True when the dispatcher path resolves inside a git worktree checkout
+    (a `.worktrees/` or `.claude/worktrees/` segment). An install performed from
+    such a checkout dangles after the worktree is pruned and then silently fails
+    open, so doctor warns about it."""
+    parts = Path(hook_bin).resolve().parts
+    if ".worktrees" in parts:
+        return True
+    # `.claude/worktrees/<...>`: a `.claude` segment immediately followed by
+    # `worktrees`.
+    return any(
+        parts[i] == ".claude" and parts[i + 1] == "worktrees"
+        for i in range(len(parts) - 1)
+    )
+
+
+def _doctor_hook_bin() -> tuple[bool, list[str]]:
+    """Verify the installed hook dispatcher exists and is executable, and warn
+    when it resolves inside a worktree. Returns (ok, messages)."""
+    msgs: list[str] = []
+    exists = os.path.isfile(HOOK_BIN)
+    executable = exists and os.access(HOOK_BIN, os.X_OK)
+    if not exists:
+        msgs.append(f"hook command MISSING at {HOOK_BIN}")
+    elif not executable:
+        msgs.append(f"hook command present but NOT executable at {HOOK_BIN}")
+    else:
+        msgs.append(f"hook command present and executable at {HOOK_BIN}")
+    if _hook_bin_in_worktree(HOOK_BIN):
+        msgs.append(
+            f"WARNING: hook command resolves inside a worktree ({HOOK_BIN}); this "
+            "install will dangle and silently fail open once the worktree is "
+            "pruned. Re-run `kb enforce install` from the main checkout."
+        )
+    return executable, msgs
+
+
+def _managed_versions_in_hooks(data: dict) -> set:
+    """The set of managed-marker versions present in a JSON hooks map."""
+    return {
+        h[MARKER]
+        for blocks in data.get("hooks", {}).values()
+        for block in blocks
+        for h in block.get("hooks", [])
+        if MARKER in h
+    }
+
+
 class HookFileProvider:
     """A provider that writes MARKER-tagged hook entries into a JSON hooks map
     inside a target file (the map lives under the top-level 'hooks' key).
@@ -137,13 +185,7 @@ class HookFileProvider:
 
     def status(self, target: Path) -> int:
         data = _load_json(target)
-        versions = {
-            h[MARKER]
-            for blocks in data.get("hooks", {}).values()
-            for block in blocks
-            for h in block.get("hooks", [])
-            if MARKER in h
-        }
+        versions = _managed_versions_in_hooks(data)
         if not versions:
             print(f"{self.name}: not installed")
             return 0
@@ -151,10 +193,36 @@ class HookFileProvider:
         print(f"{self.name}: installed, tier={self.tier}, versions={sorted(versions)}{stale}")
         return 0
 
-    def doctor(self, _target: Path) -> int:
-        ok, msg = _doctor_endpoint()
-        print(f"doctor [{self.name}]: {msg}")
-        return 0 if ok else 1
+    def doctor(self, target: Path) -> int:
+        """Doctor now checks three things beyond endpoint reachability:
+        the managed marker/version is present in the LIVE settings file, the hook
+        dispatcher exists and is executable, and the dispatcher is not installed
+        from a worktree (which dangles after pruning and fails open)."""
+        ok_ep, msg_ep = _doctor_endpoint()
+        print(f"doctor [{self.name}]: {msg_ep}")
+
+        data = _load_json(target)
+        versions = _managed_versions_in_hooks(data)
+        if not versions:
+            print(f"doctor [{self.name}]: managed hook NOT installed in {target}")
+            ok_marker = False
+        elif SHIM_VERSION not in versions:
+            print(f"doctor [{self.name}]: managed hook in {target} is STALE "
+                  f"(found {sorted(versions)}, want {SHIM_VERSION}); run "
+                  "`kb enforce install`")
+            ok_marker = False
+        else:
+            print(f"doctor [{self.name}]: managed hook v{SHIM_VERSION} present in {target}")
+            ok_marker = True
+
+        ok_bin, bin_msgs = _doctor_hook_bin()
+        for m in bin_msgs:
+            print(f"doctor [{self.name}]: {m}")
+
+        # A worktree-installed hook is a real problem even if the file is currently
+        # present and executable, so fail doctor on it.
+        ok_worktree = not _hook_bin_in_worktree(HOOK_BIN)
+        return 0 if (ok_ep and ok_marker and ok_bin and ok_worktree) else 1
 
 
 def _claude_provider() -> HookFileProvider:
@@ -164,7 +232,10 @@ def _claude_provider() -> HookFileProvider:
         events=[
             ("SessionStart", "session-start", None),
             ("UserPromptSubmit", "user-prompt", None),
-            ("PreToolUse", "pre-tool", "Edit|Write|MultiEdit|NotebookEdit|Bash"),
+            # Anchored: the matcher is a regex, so an un-anchored alternation
+            # substring-matches unrelated tools (e.g. "Bash" matches "BashOutput",
+            # "Edit" matches "NotebookEditOther"). ^(...)$ gates exactly these.
+            ("PreToolUse", "pre-tool", "^(Edit|Write|MultiEdit|NotebookEdit|Bash)$"),
             ("Stop", "stop", None),
         ],
         dialect="claude",
@@ -186,7 +257,9 @@ def _codex_provider() -> HookFileProvider:
         events=[
             ("SessionStart", "session-start", None),
             ("UserPromptSubmit", "user-prompt", None),
-            ("PreToolUse", "pre-tool", "Edit|Write|MultiEdit|Bash"),
+            # Anchored (see the claude provider): keep the alternation exact so
+            # "Bash" does not also gate "BashOutput".
+            ("PreToolUse", "pre-tool", "^(Edit|Write|MultiEdit|Bash)$"),
             ("Stop", "stop", None),
         ],
         dialect="claude",  # Codex shares Claude's exit-2 deny contract
@@ -201,7 +274,8 @@ def _gemini_provider() -> HookFileProvider:
         events=[
             ("SessionStart", "session-start", None),
             ("BeforeAgent", "user-prompt", None),  # BeforeAgent carries `prompt`
-            ("BeforeTool", "pre-tool", "write_file|replace|run_shell_command"),
+            # Anchored to avoid substring matches against other Gemini tools.
+            ("BeforeTool", "pre-tool", "^(write_file|replace|run_shell_command)$"),
             ("Stop", "stop", None),
         ],
         dialect="gemini",
@@ -254,10 +328,22 @@ class OpenCodeProvider:
         print(f"opencode: installed, tier=hard, versions=['{ver}']{stale}")
         return 0
 
-    def doctor(self, _target: Path) -> int:
-        ok, msg = _doctor_endpoint()
+    def doctor(self, target: Path) -> int:
+        ok_ep, msg = _doctor_endpoint()
         print(f"doctor [opencode]: {msg}")
-        return 0 if ok else 1
+        dest = target / PLUGIN_NAME
+        installed = dest.exists() and "data-olympus-enforce (managed)" in dest.read_text()
+        if installed:
+            print(f"doctor [opencode]: managed plugin present at {dest}")
+        else:
+            print(f"doctor [opencode]: managed plugin NOT installed at {dest}")
+        # The plugin source lives beside this installer; warn if it (and so the
+        # install source) resolves inside a worktree.
+        ok_worktree = not _hook_bin_in_worktree(str(PLUGIN_SRC))
+        if not ok_worktree:
+            print(f"doctor [opencode]: WARNING: plugin source resolves inside a "
+                  f"worktree ({PLUGIN_SRC}); re-install from the main checkout.")
+        return 0 if (ok_ep and installed and ok_worktree) else 1
 
 
 IBEGIN = "<!-- >>> data-olympus enforce (managed) >>> -->"

--- a/bin/kb-enforce-hook
+++ b/bin/kb-enforce-hook
@@ -47,24 +47,32 @@ fi
 
 json_field() {
   # json_field <dotted.path> ; reads $PAYLOAD, prints value or empty.
+  # JSON null and missing keys BOTH emit an empty string (never the literal
+  # "None"): a null session_id must not become the ledger key "None".
   python3 -c 'import json,sys
 p=sys.argv[1].split(".")
 try:
     d=json.loads(sys.stdin.read() or "{}")
     for k in p:
         d=d.get(k, "") if isinstance(d, dict) else ""
-    print(d if isinstance(d,str) else (d if d is None else json.dumps(d)))
+    if d is None:
+        print("")
+    else:
+        print(d if isinstance(d,str) else json.dumps(d))
 except Exception:
     print("")' "$1" <<<"$PAYLOAD"
 }
 
 json_field_from() {
-  # json_field_from <json-string> <key>
+  # json_field_from <json-string> <key> ; null/missing -> empty string.
   python3 -c 'import json,sys
 try:
     d=json.loads(sys.argv[1] or "{}")
     v=d.get(sys.argv[2], "")
-    print(v if isinstance(v,str) else json.dumps(v))
+    if v is None:
+        print("")
+    else:
+        print(v if isinstance(v,str) else json.dumps(v))
 except Exception:
     print("")' "$1" "$2"
 }
@@ -121,9 +129,19 @@ post_json() {
   if [[ -n "$KB_AUTH_TOKEN" ]]; then
     auth_k_arg=(-K <(printf 'header = "Authorization: Bearer %s"\n' "$KB_AUTH_TOKEN"))
   fi
+  # Timeouts: the pre-tool gate is on the agent's critical path (it blocks every
+  # governed edit), so it sets tight CURL_MAX_TIME/CURL_CONNECT_TIMEOUT to fail
+  # fast to the fail-mode switch rather than stalling the tool call. Other callers
+  # (user-prompt injection) keep the looser default.
+  local max_time="${CURL_MAX_TIME:-5}"
+  local connect_arg=()
+  if [[ -n "${CURL_CONNECT_TIMEOUT:-}" ]]; then
+    connect_arg=(--connect-timeout "$CURL_CONNECT_TIMEOUT")
+  fi
   # Guard the array expansion: under `set -u`, "${arr[@]}" on an empty array is
   # an unbound-variable error on bash 3.2 (macOS default).
-  if RESP_CODE=$(curl --silent --max-time 5 \
+  if RESP_CODE=$(curl --silent --max-time "$max_time" \
+      ${connect_arg[@]+"${connect_arg[@]}"} \
       -H "Content-Type: application/json" \
       ${auth_k_arg[@]+"${auth_k_arg[@]}"} \
       --data "$body" \
@@ -192,9 +210,15 @@ case "$MODE" in
     CWD="$(json_field cwd)"
     PROMPT="$(json_field prompt)"
     WS="$(resolve_workspace "$CWD")"
+    # trigger=prompt_hook: this consult is the installer's per-prompt auto-consult
+    # (UserPromptSubmit / Gemini BeforeAgent), NOT a deliberate agent kb_consult.
+    # It is recorded for audit/compliance and its rules are still injected, but it
+    # does NOT clear the gate: only an explicit kb_consult call does. Without this
+    # marker every user prompt would refresh the ledger and the gate would fire
+    # only during autonomous stretches longer than the TTL.
     BODY="$(python3 -c 'import json,sys
 print(json.dumps({"workspace":sys.argv[1],"intent":sys.argv[2],
-"source_session":sys.argv[3],"agent_identity":sys.argv[4]}))' "$WS" "$PROMPT" "$SESSION" "$AGENT")"
+"source_session":sys.argv[3],"agent_identity":sys.argv[4],"trigger":"prompt_hook"}))' "$WS" "$PROMPT" "$SESSION" "$AGENT")"
     # Prompt-rule injection is best-effort and never blocks: any failure
     # (connection error OR non-2xx) just means no injected rules this turn.
     if ! post_json "$KB_ENDPOINT/api/v1/consult" "$BODY" || ! is_2xx "$RESP_CODE"; then
@@ -215,22 +239,41 @@ print("\n".join(lines))')"
     exit 0
     ;;
   pre-tool)
-    SESSION="$(json_field session_id)"
-    CWD="$(json_field cwd)"
-    TOOL="$(json_field tool_name)"
-    FPATH="$(json_field tool_input.file_path)"
-    WS="$(resolve_workspace "$CWD")"
-    # action_diff: the change content (Write.content, Edit.new_string, Bash.command),
-    # capped so the gate body stays bounded. Lets the classifier use diff signals
-    # and classify shell commands.
-    ADIFF="$(printf '%s' "$PAYLOAD" | python3 -c 'import json,sys
+    # Single parse of the hook payload: emit session_id, cwd, tool_name, file_path
+    # and the capped action_diff, each base64-encoded on its own line (base64 is
+    # newline/tab-safe, so a multi-line diff or command survives the read). This
+    # replaces four separate json_field spawns plus the ADIFF spawn with one
+    # python3 invocation on the pre-tool critical path.
+    #   action_diff: the change content (Write.content, Edit.new_string,
+    #   Bash.command), capped at 4000 chars so the gate body stays bounded, so the
+    #   classifier can use diff signals and classify shell commands.
+    {
+      IFS= read -r SESSION_B64
+      IFS= read -r CWD_B64
+      IFS= read -r TOOL_B64
+      IFS= read -r FPATH_B64
+      IFS= read -r ADIFF_B64
+    } < <(printf '%s' "$PAYLOAD" | python3 -c 'import base64,json,sys
+def enc(v):
+    return base64.b64encode((v or "").encode("utf-8","replace")).decode("ascii")
 try:
     d=json.loads(sys.stdin.read() or "{}")
-    ti=d.get("tool_input",{}) if isinstance(d.get("tool_input"),dict) else {}
-    val=ti.get("content") or ti.get("new_string") or ti.get("command") or ""
-    print(val[:4000])
+    if not isinstance(d,dict): d={}
 except Exception:
-    print("")')"
+    d={}
+ti=d.get("tool_input",{}) if isinstance(d.get("tool_input"),dict) else {}
+diff=ti.get("content") or ti.get("new_string") or ti.get("command") or ""
+if not isinstance(diff,str): diff=""
+for v in (d.get("session_id"), d.get("cwd"), d.get("tool_name"),
+          ti.get("file_path"), diff[:4000]):
+    print(enc(v if isinstance(v,str) else ""))')
+    b64d() { printf '%s' "$1" | base64 --decode 2>/dev/null || true; }
+    SESSION="$(b64d "$SESSION_B64")"
+    CWD="$(b64d "$CWD_B64")"
+    TOOL="$(b64d "$TOOL_B64")"
+    FPATH="$(b64d "$FPATH_B64")"
+    ADIFF="$(b64d "$ADIFF_B64")"
+    WS="$(resolve_workspace "$CWD")"
     BODY="$(python3 -c 'import json,sys
 print(json.dumps({"workspace":sys.argv[1],"session_id":sys.argv[2],
 "tool_name":sys.argv[3],"action_path":sys.argv[4],"action_diff":sys.argv[5]}))' "$WS" "$SESSION" "$TOOL" "$FPATH" "$ADIFF")"
@@ -240,6 +283,10 @@ print(json.dumps({"workspace":sys.argv[1],"session_id":sys.argv[2],
     # full connection failure (cannot record) from a reachable-but-degraded gate.
     GATE_AVAILABLE=1
     REACHED=1
+    # Tight timeouts on the critical-path gate: fail fast to the fail-mode switch
+    # instead of stalling every governed edit for up to 5s on a slow/down server.
+    CURL_MAX_TIME=2 CURL_CONNECT_TIMEOUT=1
+    export CURL_MAX_TIME CURL_CONNECT_TIMEOUT
     if ! post_json "$KB_ENDPOINT/api/v1/gate/check" "$BODY"; then
       GATE_AVAILABLE=0; REACHED=0
     elif ! is_2xx "$RESP_CODE"; then
@@ -264,7 +311,11 @@ print(json.dumps({"workspace":sys.argv[1],"session_id":sys.argv[2],
       exit 0
     fi
     if [[ "$VERDICT" == "consult_required" ]]; then
-      emit_deny "[KB] BLOCKED: this is a governed change. Call kb_consult for '$WS' first, then retry."
+      # Actionable deny: include the exact workspace key AND the session id (the
+      # one value the agent cannot guess) plus a copy-pasteable kb_consult call.
+      # A null/empty session_id echoes as empty (json_field already emits "" for
+      # JSON null), never the literal "None".
+      emit_deny "[KB] BLOCKED: this is a governed change and no explicit consultation is on record. Call kb_consult(workspace='$WS', source_session='$SESSION', intent='<what you are doing>') then retry."
     fi
     # Only reached when 2xx AND verdict == allow.
     exit 0

--- a/bin/opencode/data-olympus-gate.ts
+++ b/bin/opencode/data-olympus-gate.ts
@@ -1,6 +1,8 @@
 // data-olympus-enforce (managed) v1 -- installed by `kb enforce install --agent opencode`.
 // Gates file-mutating tools through the data-olympus gate. Remove via
 // `kb enforce uninstall --agent opencode`.
+import { execFileSync } from "node:child_process"
+import { basename } from "node:path"
 import type { Plugin, Hooks } from "@opencode-ai/plugin"
 
 const ENDPOINT = process.env.KB_ENDPOINT ?? "http://localhost:8080"
@@ -9,22 +11,67 @@ const TOKEN = process.env.KB_AUTH_TOKEN ?? ""
 // Gate mutating tools. "bash" is included because shell-driven writes surface as bash.
 const GATED = new Set(["edit", "write", "patch", "multiedit", "bash"])
 
+// Resolve the workspace key the SAME way bin/kb-enforce-hook's resolve_workspace
+// does: the MAIN git worktree basename (worktree-invariant, so a consult recorded
+// from the main checkout clears the gate from any linked worktree too), matching
+// the basename key used by every other surface. Falls back to the basename of the
+// worktree/directory path, then the raw path, so the key is never empty.
+// Previously this sent the raw absolute `worktree ?? directory` path, which could
+// never match consults recorded under the basename key everywhere else.
+export function resolveWorkspace(dir: string): string {
+  try {
+    const out = execFileSync("git", ["-C", dir, "worktree", "list", "--porcelain"], {
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "ignore"],
+    })
+    // First NON-bare worktree record; the main worktree is listed first. Skip a
+    // leading bare record (a bare repo's first entry is the bare git dir).
+    let path: string | undefined
+    let bare = false
+    for (const line of out.split("\n")) {
+      if (line.startsWith("worktree ")) {
+        path = line.slice("worktree ".length)
+        bare = false
+      } else if (line === "bare") {
+        bare = true
+      } else if (line === "") {
+        if (path && !bare) return basename(path)
+        path = undefined
+        bare = false
+      }
+    }
+    if (path && !bare) return basename(path)
+  } catch {
+    // not a git repo / git unavailable -> fall through to basename of the path
+  }
+  return basename(dir) || dir
+}
+
 export const DataOlympusGate: Plugin = async ({ directory, worktree }) => {
+  const workspace = resolveWorkspace(worktree ?? directory)
   return {
     "tool.execute.before": async (input, output) => {
       if (!GATED.has(input.tool)) return
       const headers: Record<string, string> = { "content-type": "application/json" }
       if (TOKEN) headers["authorization"] = `Bearer ${TOKEN}`
+      // action_diff: the change content, so the gate classifier sees a real signal
+      // for bash (the command) and patch (the diff) which carry no file path.
+      // Capped at 4000 chars to bound the request body (mirrors kb-enforce-hook).
+      const args = output.args ?? {}
+      const rawDiff =
+        (args.content ?? args.newString ?? args.new_string ?? args.command ?? args.patch ?? "") as string
+      const actionDiff = typeof rawDiff === "string" ? rawDiff.slice(0, 4000) : ""
       let verdict: string | undefined
       try {
         const res = await fetch(`${ENDPOINT}/api/v1/gate/check`, {
           method: "POST",
           headers,
           body: JSON.stringify({
-            workspace: worktree ?? directory,
+            workspace,
             session_id: input.sessionID,
             tool_name: input.tool,
-            action_path: (output.args && (output.args.filePath ?? output.args.path)) ?? "",
+            action_path: (args.filePath ?? args.path) ?? "",
+            action_diff: actionDiff,
           }),
           signal: AbortSignal.timeout(5000),
         })
@@ -41,9 +88,13 @@ export const DataOlympusGate: Plugin = async ({ directory, worktree }) => {
         return // fail open
       }
       if (verdict === "consult_required") {
+        // Actionable deny: echo the exact workspace key and session id (the one
+        // value the agent cannot guess) so the clearing call is copy-pasteable.
         throw new Error(
-          `BLOCKED by data-olympus: '${input.tool}' requires KB consultation. ` +
-          `Call the kb_consult MCP tool for this workspace, then retry.`,
+          `BLOCKED by data-olympus: '${input.tool}' is a governed change with no ` +
+          `explicit consultation on record. Call ` +
+          `kb_consult(workspace='${workspace}', source_session='${input.sessionID}', ` +
+          `intent='<what you are doing>') then retry.`,
         )
       }
     },

--- a/docs/enforcement.md
+++ b/docs/enforcement.md
@@ -4,6 +4,34 @@ data-olympus can act as an enforced gate for code and architectural decisions,
 not only an advisory knowledge base. Enforcement is per-agent: it runs in each
 agent's hook surface, driven by a shared policy core in the server.
 
+## Gate policy: only an explicit consult clears the gate
+
+The gate means "the agent explicitly consulted the governing rules for this
+work", not merely "an HTTP call to /consult happened recently in this session".
+Two kinds of consult are recorded:
+
+- **Explicit consult** (`trigger: "explicit"`, the default): a deliberate
+  `kb_consult` MCP call (or a `POST /api/v1/consult` with no `trigger`, since an
+  old client sending a bare consult is always a real agent action). Only an
+  explicit consult that is still fresh (within `KB_CONSULT_TTL_SEC`) satisfies
+  the gate for its `(session_id, workspace)` pair.
+- **Prompt-hook consult** (`trigger: "prompt_hook"`): the auto-consult the
+  per-agent installers fire on every user turn (Claude/Codex `UserPromptSubmit`,
+  Gemini `BeforeAgent`) to inject governing rules into the turn's context. It is
+  recorded for audit/compliance and its rules are still injected, but it **never
+  clears the gate**. Otherwise every user prompt would refresh the ledger and the
+  gate would fire only during autonomous stretches longer than the TTL.
+
+A prompt-hook consult never downgrades a still-fresh explicit consult on the same
+`(session, workspace)`: the ledger tracks the last explicit consult separately, so
+interleaved prompt-hook consults cannot un-clear a gate an explicit consult
+cleared.
+
+There is no deadlock for legitimately non-governed intents: `kb_gate_check` only
+requires a consult for actions the classifier deems governed, and any explicit
+consult (governed or not) records a fresh explicit timestamp, so an agent can
+always clear the gate by calling `kb_consult` and then retrying.
+
 ## Server endpoints
 
 - `POST /api/v1/consult`: record a consultation for `(source_session, workspace)`
@@ -12,6 +40,9 @@ agent's hook surface, driven by a shared policy core in the server.
   - `intent`
   - `source_session`
   - `agent_identity`
+  - `trigger` (optional; `"explicit"` default, or `"prompt_hook"` for an
+    installer auto-consult — see the gate policy above). Omitting it is treated as
+    `"explicit"` for backward compatibility.
 - `POST /api/v1/gate/check`: verdict (`allow` | `consult_required`) for a pending
   code action. Body:
   - `workspace`
@@ -19,6 +50,11 @@ agent's hook surface, driven by a shared policy core in the server.
   - `tool_name`
   - `action_path`
   - `action_diff` (optional)
+
+  The response echoes `session_id` and `workspace` (the exact gate key) alongside
+  the verdict and reason, so a blocked MCP caller can build the clearing
+  `kb_consult` call without guessing the session id. When blocked, `reason`
+  contains a copy-pasteable `kb_consult(...)` instruction.
 - `GET /api/v1/compliance`: aggregated enforcement-event counts.
 
 The same three are exposed as the `kb_consult`, `kb_gate_check`, and
@@ -42,6 +78,15 @@ kb enforce uninstall --agent claude-code # surgical removal of the managed block
 The installer writes a managed hook block (SessionStart, UserPromptSubmit,
 PreToolUse, Stop) into `~/.claude/settings.json`, tagged so re-runs never
 duplicate entries and uninstall never touches operator-authored settings.
+
+`kb enforce doctor` verifies more than endpoint reachability. It also checks that
+the managed marker at the current shim version is present in the live settings
+file, that the hook dispatcher (`bin/kb-enforce-hook`, or the OpenCode plugin
+file) exists and is executable, and it WARNS and fails when the dispatcher path
+resolves inside a `.worktrees/` or `.claude/worktrees/` checkout: an install
+performed from a worktree dangles after the worktree is pruned and then silently
+fails open. If doctor warns about a worktree install, re-run
+`kb enforce install` from the main checkout.
 
 ## Per-agent providers
 
@@ -90,13 +135,23 @@ existing `~/.codex/hooks.json`, preserving any operator-authored hooks.
 
 These caveats are deliberate and documented, not bugs:
 
-- Codex gates `Edit`, `Write`, and `MultiEdit`, but NOT the Bash tool. A
-  shell-driven write run through Bash bypasses the Codex gate.
+- Codex gates `Edit`, `Write`, `MultiEdit`, AND `Bash`. Bash is gated so a
+  shell-driven write or a dependency-install command run through Bash does not
+  bypass the gate. (Bash carries no file path, so only diff/command signals such
+  as install commands classify it; see the path note below.)
+- Claude Code gates `Edit`, `Write`, `MultiEdit`, `NotebookEdit`, and `Bash`.
+  The tool matchers are anchored (`^(...)$`) so they match exactly those tool
+  names and do not substring-match unrelated tools such as `BashOutput`.
 - OpenCode gates `edit`, `write`, `patch`, `multiedit`, and `bash`, but
   batch-tool writes are not gated. The plugin gates `bash` specifically to
   narrow this gap. Note that `bash` and `patch` actions carry no file path, so
-  path-governed rules cannot classify them: for those two tools the gate is
-  advisory (it cannot match a path-scoped governing rule).
+  path-governed rules cannot classify them: for those two tools the gate keys off
+  the command/patch content (passed as `action_diff`), not a file path.
+  The OpenCode plugin resolves the workspace key to the main git worktree
+  basename (the same worktree-invariant key every other surface uses), so a
+  consult recorded from the main checkout clears the OpenCode gate too; it no
+  longer sends the raw absolute directory path (which could never match a
+  consult keyed by basename).
 
 ### Copilot IDE is repo-scoped (CWD side effect)
 

--- a/docs/enforcement.md
+++ b/docs/enforcement.md
@@ -96,8 +96,8 @@ tiers below are honest about what each surface can and cannot block.
 
 | Agent | Tier | What it does |
 |---|---|---|
-| Claude Code | hard | PreToolUse hook blocks governed `Edit`/`Write`/`MultiEdit`/`NotebookEdit` (exit 2 deny). |
-| Codex | hard | PreToolUse hook blocks governed `Edit`/`Write`/`MultiEdit` (exit 2 deny). See the trust note below. |
+| Claude Code | hard | PreToolUse hook blocks governed `Edit`/`Write`/`MultiEdit`/`NotebookEdit`/`Bash` (exit 2 deny). |
+| Codex | hard | PreToolUse hook blocks governed `Edit`/`Write`/`MultiEdit`/`Bash` (exit 2 deny). See the trust note below. |
 | Gemini | hard | BeforeTool hook blocks governed `write_file`/`replace`/`run_shell_command` (JSON-stdout deny). |
 | OpenCode | hard (with caveat) | `tool.execute.before` plugin throws to abort governed `edit`/`write`/`patch`/`multiedit`/`bash`. See caveats below. |
 | Copilot CLI | soft | Managed instructions block (advisory) plus MCP; compliance is observed via the audit log, not blocked. |

--- a/src/data_olympus/enforce_policy.py
+++ b/src/data_olympus/enforce_policy.py
@@ -99,12 +99,29 @@ class IntentClassifier:
         return ClassifyResult(is_governed_decision=bool(signals), signals=signals)
 
 
+# Consultation trigger provenance. "explicit" is a deliberate agent call to
+# kb_consult (the MCP tool default, and any old client that sends no trigger).
+# "prompt_hook" is an installer-driven UserPromptSubmit/BeforeAgent auto-consult:
+# recorded for audit/compliance but NOT sufficient to clear the gate, because it
+# fires on every user turn and would otherwise keep the ledger perpetually fresh.
+EXPLICIT_TRIGGER = "explicit"
+PROMPT_HOOK_TRIGGER = "prompt_hook"
+
+
 @dataclass
 class LedgerEntry:
-    """A recorded consultation for a (session, workspace) pair."""
+    """A recorded consultation for a (session, workspace) pair.
+
+    ``consulted_at`` is the last touch of ANY trigger (used for retention/TTL of
+    the row itself and audit). ``explicit_at`` is the last EXPLICIT consult, or
+    None if only prompt-hook auto-consults have been recorded. The gate clears on
+    ``explicit_at`` freshness so a prompt-hook auto-consult (which fires every
+    turn) can never satisfy the gate, while an explicit consult is not silently
+    downgraded by a later prompt-hook consult on the same (session, workspace)."""
 
     consulted_at: float
     rule_ids: list[str]
+    explicit_at: float | None = None
 
 
 log = logging.getLogger("data_olympus")
@@ -160,9 +177,16 @@ class ConsultationLedger:
                 rows = json.load(f)
             for row in rows:
                 key = (row["session_id"], row["workspace"])
+                # Back-compat: a ledger persisted before the trigger split has no
+                # explicit_at. Treat those legacy rows as explicit (they were all
+                # gate-clearing under the old policy), so a server upgrade does not
+                # spuriously re-block a session that already consulted.
+                consulted_at = float(row["consulted_at"])
+                explicit_at = row.get("explicit_at", consulted_at)
                 self._entries[key] = LedgerEntry(
-                    consulted_at=float(row["consulted_at"]),
+                    consulted_at=consulted_at,
                     rule_ids=list(row.get("rule_ids", [])),
+                    explicit_at=None if explicit_at is None else float(explicit_at),
                 )
         except Exception as exc:  # noqa: BLE001 - corrupt file -> empty, never crash
             log.warning("consultation ledger at %s unreadable, starting empty: %s",
@@ -174,7 +198,8 @@ class ConsultationLedger:
             return
         rows = [
             {"session_id": s, "workspace": w,
-             "consulted_at": e.consulted_at, "rule_ids": e.rule_ids}
+             "consulted_at": e.consulted_at, "rule_ids": e.rule_ids,
+             "explicit_at": e.explicit_at}
             for (s, w), e in self._entries.items()
         ]
         d = os.path.dirname(self._path) or "."
@@ -215,23 +240,57 @@ class ConsultationLedger:
             self._entries = dict(newest)
 
     def record(
-        self, *, session_id: str, workspace: str, rule_ids: list[str], now: float
+        self,
+        *,
+        session_id: str,
+        workspace: str,
+        rule_ids: list[str],
+        now: float,
+        trigger: str = EXPLICIT_TRIGGER,
     ) -> None:
+        """Record a consultation. ``trigger`` is EXPLICIT_TRIGGER (a deliberate
+        agent consult that clears the gate) or PROMPT_HOOK_TRIGGER (an installer
+        auto-consult that is audited but never clears the gate).
+
+        A prompt-hook record refreshes ``consulted_at`` (row liveness/audit) but
+        carries forward any existing ``explicit_at`` so it cannot downgrade a
+        still-fresh explicit consult into a non-clearing one."""
         with self._lock:
+            prior = self._entries.get((session_id, workspace))
+            if trigger == EXPLICIT_TRIGGER:
+                explicit_at: float | None = now
+            else:
+                explicit_at = prior.explicit_at if prior is not None else None
             self._entries[(session_id, workspace)] = LedgerEntry(
-                consulted_at=now, rule_ids=list(rule_ids)
+                consulted_at=now, rule_ids=list(rule_ids), explicit_at=explicit_at
             )
             self._evict(now)
             self._save()
 
     def is_fresh(
-        self, *, session_id: str, workspace: str, now: float, ttl_sec: float
+        self,
+        *,
+        session_id: str,
+        workspace: str,
+        now: float,
+        ttl_sec: float,
+        require_explicit: bool = True,
     ) -> bool:
+        """True when a fresh consult is on record for (session, workspace).
+
+        With ``require_explicit`` (the gate's default) only an explicit consult
+        within ``ttl_sec`` counts: a prompt-hook auto-consult never clears the
+        gate. With ``require_explicit=False`` any consult (explicit or prompt
+        hook) within the TTL counts (used where the mere fact of a recent consult,
+        not its provenance, matters)."""
         with self._lock:
             entry = self._entries.get((session_id, workspace))
         if entry is None:
             return False
-        return (now - entry.consulted_at) <= ttl_sec
+        ts = entry.explicit_at if require_explicit else entry.consulted_at
+        if ts is None:
+            return False
+        return (now - ts) <= ttl_sec
 
     def get(self, *, session_id: str, workspace: str) -> LedgerEntry | None:
         with self._lock:

--- a/src/data_olympus/models.py
+++ b/src/data_olympus/models.py
@@ -224,11 +224,17 @@ class ConsultResponse(BaseModel):
 
 
 class GateCheckResponse(BaseModel):
-    """kb_gate_check verdict for a pending code action."""
+    """kb_gate_check verdict for a pending code action.
+
+    ``session_id`` and ``workspace`` echo the exact gate key back so an MCP
+    caller that is blocked can construct the clearing kb_consult call without
+    guessing either value (the session id in particular is not agent-guessable)."""
 
     verdict: str  # 'allow' | 'consult_required'
     reason: str = ""
     rules: list[SearchHitModel] = []
+    session_id: str = ""
+    workspace: str = ""
 
 
 class ComplianceResponse(BaseModel):

--- a/src/data_olympus/rest_api.py
+++ b/src/data_olympus/rest_api.py
@@ -486,6 +486,10 @@ def register_routes(
                 agent_identity=body.get("agent_identity", "unknown"),
                 ttl_sec=state.config.consult_ttl_sec, now=_time.time(),
                 audit_log=state.audit_log,
+                # Optional: installers mark prompt-hook auto-consults so they are
+                # audited but never clear the gate. Omitted -> explicit (old
+                # clients are real agent calls).
+                trigger=body.get("trigger", "explicit"),
             )
             return JSONResponse(resp.model_dump())
 

--- a/src/data_olympus/server.py
+++ b/src/data_olympus/server.py
@@ -656,10 +656,12 @@ def build_app(
         @app.tool()
         def kb_consult(
             workspace: str, intent: str, source_session: str,
-            agent_identity: str,
+            agent_identity: str, trigger: str = "explicit",
         ) -> dict[str, object]:
             """Record a consultation for (source_session, workspace) and return the
-            governing rules for the intent. Call before code/architectural work."""
+            governing rules for the intent. Call before code/architectural work.
+            trigger is 'explicit' (default: a deliberate consult, clears the gate)
+            or 'prompt_hook' (an installer auto-consult: audited, never clears)."""
             import time as _time
 
             from data_olympus.tools_enforce import kb_consult_fn
@@ -668,7 +670,7 @@ def build_app(
                 workspace=workspace, intent=intent, source_session=source_session,
                 agent_identity=agent_identity,
                 ttl_sec=state.config.consult_ttl_sec, now=_time.time(),
-                audit_log=state.audit_log,
+                audit_log=state.audit_log, trigger=trigger,
             )
             return resp.model_dump()
 

--- a/src/data_olympus/tools_enforce.py
+++ b/src/data_olympus/tools_enforce.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from data_olympus.enforce_policy import EXPLICIT_TRIGGER, PROMPT_HOOK_TRIGGER
 from data_olympus.models import (
     ComplianceResponse,
     ConsultResponse,
@@ -24,6 +25,21 @@ ENFORCE_EVENT_TYPES = (
     "consult", "gate_allow", "gate_block", "gate_bypass", "gate_degraded",
 )
 
+# Accepted consult triggers; anything else is coerced to explicit (fail-safe:
+# an unknown trigger is treated as a real agent consult, never silently dropped
+# to a non-clearing prompt-hook consult).
+_TRIGGERS = (EXPLICIT_TRIGGER, PROMPT_HOOK_TRIGGER)
+
+
+def _deny_instruction(*, workspace: str, session_id: str) -> str:
+    """The copy-pasteable remediation an agent must run to clear the gate. Echoes
+    the exact workspace key and session id (the one parameter an agent cannot
+    guess) so the fix does not require the agent to invent either value."""
+    return (
+        f"Call kb_consult(workspace='{workspace}', source_session='{session_id}', "
+        f"intent='<what you are doing>') then retry."
+    )
+
 
 def kb_consult_fn(
     *,
@@ -38,9 +54,17 @@ def kb_consult_fn(
     now: float,
     audit_log: AuditLog | None = None,
     limit: int = 5,
+    trigger: str = EXPLICIT_TRIGGER,
 ) -> ConsultResponse:
     """Classify the intent, retrieve governing rules when governed, and record a
-    consultation in the ledger keyed by (source_session, workspace)."""
+    consultation in the ledger keyed by (source_session, workspace).
+
+    ``trigger`` distinguishes a deliberate agent consult (EXPLICIT_TRIGGER, the
+    default, which clears the gate) from an installer prompt-hook auto-consult
+    (PROMPT_HOOK_TRIGGER, recorded for audit/compliance but never gate-clearing).
+    Old clients that omit the field are treated as explicit, since a bare consult
+    call is always a real agent action."""
+    trigger = trigger if trigger in _TRIGGERS else EXPLICIT_TRIGGER
     result = classifier.classify(intent=intent)
     rules = []
     rule_ids: list[str] = []
@@ -49,13 +73,14 @@ def kb_consult_fn(
         rules = list(search.hits)
         rule_ids = [h.id for h in search.hits]
     ledger.record(
-        session_id=source_session, workspace=workspace, rule_ids=rule_ids, now=now
+        session_id=source_session, workspace=workspace, rule_ids=rule_ids, now=now,
+        trigger=trigger,
     )
     if audit_log is not None:
         audit_log.append({
             "ts": now, "event_type": "consult", "status": "recorded",
             "agent_identity": agent_identity, "source_session": source_session,
-            "target_path": workspace,
+            "target_path": workspace, "trigger": trigger,
             "reason": ",".join(result.signals) if result.signals else "",
         })
     return ConsultResponse(
@@ -81,9 +106,17 @@ def kb_gate_check_fn(
     a fresh consultation on record for (session_id, workspace)."""
     result = classifier.classify(action_path=action_path, action_diff=action_diff)
     if not result.is_governed_decision:
-        return GateCheckResponse(verdict="allow", reason="action not governed")
+        return GateCheckResponse(
+            verdict="allow", reason="action not governed",
+            session_id=session_id, workspace=workspace,
+        )
+    # Gate policy: only a fresh EXPLICIT consult clears the gate. A prompt-hook
+    # auto-consult is recorded (audit/compliance) but never satisfies this check,
+    # so the gate means "the agent explicitly consulted", not "an HTTP call
+    # happened this session".
     fresh = ledger.is_fresh(
-        session_id=session_id, workspace=workspace, now=now, ttl_sec=ttl_sec
+        session_id=session_id, workspace=workspace, now=now, ttl_sec=ttl_sec,
+        require_explicit=True,
     )
     if fresh:
         if audit_log is not None:
@@ -93,7 +126,8 @@ def kb_gate_check_fn(
                 "reason": ",".join(result.signals),
             })
         return GateCheckResponse(
-            verdict="allow", reason="fresh consultation on record"
+            verdict="allow", reason="fresh explicit consultation on record",
+            session_id=session_id, workspace=workspace,
         )
     if audit_log is not None:
         audit_log.append({
@@ -103,7 +137,11 @@ def kb_gate_check_fn(
         })
     return GateCheckResponse(
         verdict="consult_required",
-        reason="governed action without a fresh consultation; call kb_consult first",
+        reason=(
+            "governed action without a fresh explicit consultation. "
+            + _deny_instruction(workspace=workspace, session_id=session_id)
+        ),
+        session_id=session_id, workspace=workspace,
     )
 
 

--- a/tests/test_enforce_gate_policy.py
+++ b/tests/test_enforce_gate_policy.py
@@ -1,0 +1,155 @@
+# tests/test_enforce_gate_policy.py
+"""Gate policy tests for the explicit-vs-prompt_hook consult distinction (WP0c).
+
+The gate must mean "the agent explicitly consulted", not "an HTTP call happened
+this session". These tests pin that policy: an explicit consult clears the gate,
+a prompt_hook consult does not, a non-governed explicit consult still clears, TTL
+expiry re-blocks, and a prompt_hook consult never downgrades a fresh explicit one.
+"""
+from __future__ import annotations
+
+from data_olympus.enforce_policy import (
+    EXPLICIT_TRIGGER,
+    PROMPT_HOOK_TRIGGER,
+    ConsultationLedger,
+    IntentClassifier,
+)
+from data_olympus.tools_enforce import kb_consult_fn, kb_gate_check_fn
+
+
+class _FakeIndex:
+    def search(self, query, limit=20, tier=None, category=None, status=None, doc_type=None):  # noqa: ARG002
+        return []
+
+    def health(self):
+        return {"source_commit": "deadbeef"}
+
+
+def _gate(led: ConsultationLedger, *, now: float, path="/p/pyproject.toml"):
+    return kb_gate_check_fn(
+        classifier=IntentClassifier(), ledger=led,
+        workspace="proj", session_id="s1", tool_name="Edit",
+        action_path=path, action_diff="", now=now, ttl_sec=300.0,
+    )
+
+
+def test_explicit_consult_clears_the_gate() -> None:
+    led = ConsultationLedger()
+    kb_consult_fn(
+        idx=_FakeIndex(), classifier=IntentClassifier(), ledger=led,
+        workspace="proj", intent="choose a dependency", source_session="s1",
+        agent_identity="claude", ttl_sec=300.0, now=1000.0,
+        trigger=EXPLICIT_TRIGGER,
+    )
+    assert _gate(led, now=1100.0).verdict == "allow"
+
+
+def test_prompt_hook_consult_does_not_clear_the_gate() -> None:
+    led = ConsultationLedger()
+    # A prompt-hook auto-consult is recorded but must NOT satisfy the gate.
+    kb_consult_fn(
+        idx=_FakeIndex(), classifier=IntentClassifier(), ledger=led,
+        workspace="proj", intent="choose a dependency", source_session="s1",
+        agent_identity="claude", ttl_sec=300.0, now=1000.0,
+        trigger=PROMPT_HOOK_TRIGGER,
+    )
+    resp = _gate(led, now=1100.0)
+    assert resp.verdict == "consult_required"
+
+
+def test_non_governed_explicit_consult_still_clears_the_gate() -> None:
+    """No deadlock: an intent with zero governing rules still records a fresh
+    explicit consult, so the agent can always clear the gate by consulting."""
+    led = ConsultationLedger()
+    resp = kb_consult_fn(
+        idx=_FakeIndex(), classifier=IntentClassifier(), ledger=led,
+        workspace="proj", intent="say hello",  # not governed -> no rules
+        source_session="s1", agent_identity="claude", ttl_sec=300.0, now=1000.0,
+        trigger=EXPLICIT_TRIGGER,
+    )
+    assert resp.is_governed_decision is False
+    assert _gate(led, now=1100.0).verdict == "allow"
+
+
+def test_explicit_consult_expires_after_ttl() -> None:
+    led = ConsultationLedger()
+    kb_consult_fn(
+        idx=_FakeIndex(), classifier=IntentClassifier(), ledger=led,
+        workspace="proj", intent="choose a dependency", source_session="s1",
+        agent_identity="claude", ttl_sec=300.0, now=1000.0,
+        trigger=EXPLICIT_TRIGGER,
+    )
+    # 301s later the explicit consult is stale; the gate re-blocks.
+    assert _gate(led, now=1301.0).verdict == "consult_required"
+
+
+def test_prompt_hook_does_not_downgrade_a_fresh_explicit_consult() -> None:
+    """An explicit consult clears the gate; a later prompt-hook consult on the
+    same (session, workspace) must not un-clear it."""
+    led = ConsultationLedger()
+    kb_consult_fn(
+        idx=_FakeIndex(), classifier=IntentClassifier(), ledger=led,
+        workspace="proj", intent="choose a dependency", source_session="s1",
+        agent_identity="claude", ttl_sec=300.0, now=1000.0,
+        trigger=EXPLICIT_TRIGGER,
+    )
+    # A per-turn prompt-hook consult fires shortly after.
+    kb_consult_fn(
+        idx=_FakeIndex(), classifier=IntentClassifier(), ledger=led,
+        workspace="proj", intent="do the thing", source_session="s1",
+        agent_identity="claude", ttl_sec=300.0, now=1010.0,
+        trigger=PROMPT_HOOK_TRIGGER,
+    )
+    # The explicit consult (t=1000) is still fresh at t=1100; gate stays clear.
+    assert _gate(led, now=1100.0).verdict == "allow"
+
+
+def test_missing_trigger_is_treated_as_explicit() -> None:
+    """Backward compatibility: an old client that omits trigger is a real agent
+    call and must clear the gate (default explicit)."""
+    led = ConsultationLedger()
+    kb_consult_fn(
+        idx=_FakeIndex(), classifier=IntentClassifier(), ledger=led,
+        workspace="proj", intent="choose a dependency", source_session="s1",
+        agent_identity="claude", ttl_sec=300.0, now=1000.0,
+        # no trigger kwarg
+    )
+    assert _gate(led, now=1100.0).verdict == "allow"
+
+
+def test_unknown_trigger_coerced_to_explicit() -> None:
+    led = ConsultationLedger()
+    kb_consult_fn(
+        idx=_FakeIndex(), classifier=IntentClassifier(), ledger=led,
+        workspace="proj", intent="choose a dependency", source_session="s1",
+        agent_identity="claude", ttl_sec=300.0, now=1000.0,
+        trigger="garbage",
+    )
+    assert _gate(led, now=1100.0).verdict == "allow"
+
+
+def test_deny_reason_contains_session_and_workspace_and_instruction() -> None:
+    """The blocked verdict's reason must be actionable: it names the workspace,
+    the session id, and a copy-pasteable kb_consult call."""
+    led = ConsultationLedger()
+    resp = kb_gate_check_fn(
+        classifier=IntentClassifier(), ledger=led,
+        workspace="my-proj", session_id="sess-xyz", tool_name="Edit",
+        action_path="/p/pyproject.toml", action_diff="", now=1000.0, ttl_sec=300.0,
+    )
+    assert resp.verdict == "consult_required"
+    assert "my-proj" in resp.reason
+    assert "sess-xyz" in resp.reason
+    assert "kb_consult(" in resp.reason
+    # The echo fields must carry the exact gate key back to MCP callers.
+    assert resp.session_id == "sess-xyz"
+    assert resp.workspace == "my-proj"
+
+
+def test_allow_response_also_echoes_session_and_workspace() -> None:
+    led = ConsultationLedger()
+    led.record(session_id="s1", workspace="proj", rule_ids=[], now=1000.0)
+    resp = _gate(led, now=1100.0)
+    assert resp.verdict == "allow"
+    assert resp.session_id == "s1"
+    assert resp.workspace == "proj"

--- a/tests/test_enforce_ledger_trigger.py
+++ b/tests/test_enforce_ledger_trigger.py
@@ -1,0 +1,69 @@
+# tests/test_enforce_ledger_trigger.py
+"""ConsultationLedger trigger semantics (WP0c): explicit_at tracking, the
+require_explicit freshness switch, no-downgrade, and persistence round-trip."""
+from __future__ import annotations
+
+import json
+
+from data_olympus.enforce_policy import (
+    EXPLICIT_TRIGGER,
+    PROMPT_HOOK_TRIGGER,
+    ConsultationLedger,
+)
+
+
+def test_explicit_record_sets_explicit_at() -> None:
+    led = ConsultationLedger()
+    led.record(session_id="s", workspace="w", rule_ids=[], now=100.0,
+               trigger=EXPLICIT_TRIGGER)
+    e = led.get(session_id="s", workspace="w")
+    assert e is not None
+    assert e.explicit_at == 100.0
+    assert led.is_fresh(session_id="s", workspace="w", now=200.0, ttl_sec=300.0)
+
+
+def test_prompt_hook_record_leaves_explicit_at_none() -> None:
+    led = ConsultationLedger()
+    led.record(session_id="s", workspace="w", rule_ids=[], now=100.0,
+               trigger=PROMPT_HOOK_TRIGGER)
+    e = led.get(session_id="s", workspace="w")
+    assert e is not None
+    assert e.explicit_at is None
+    # require_explicit (gate default) -> not fresh; require_explicit=False -> fresh.
+    assert not led.is_fresh(session_id="s", workspace="w", now=200.0, ttl_sec=300.0)
+    assert led.is_fresh(session_id="s", workspace="w", now=200.0, ttl_sec=300.0,
+                        require_explicit=False)
+
+
+def test_prompt_hook_does_not_downgrade_explicit_at() -> None:
+    led = ConsultationLedger()
+    led.record(session_id="s", workspace="w", rule_ids=[], now=100.0,
+               trigger=EXPLICIT_TRIGGER)
+    led.record(session_id="s", workspace="w", rule_ids=[], now=110.0,
+               trigger=PROMPT_HOOK_TRIGGER)
+    e = led.get(session_id="s", workspace="w")
+    assert e is not None
+    assert e.explicit_at == 100.0  # preserved, not overwritten
+    assert e.consulted_at == 110.0  # row liveness refreshed
+    assert led.is_fresh(session_id="s", workspace="w", now=200.0, ttl_sec=300.0)
+
+
+def test_persistence_round_trips_explicit_at(tmp_path) -> None:
+    p = tmp_path / "ledger.json"
+    led = ConsultationLedger(str(p))
+    led.record(session_id="s", workspace="w", rule_ids=["R1"], now=100.0,
+               trigger=EXPLICIT_TRIGGER)
+    led2 = ConsultationLedger(str(p))
+    assert led2.is_fresh(session_id="s", workspace="w", now=200.0, ttl_sec=300.0)
+
+
+def test_legacy_persisted_row_without_explicit_at_counts_as_explicit(tmp_path) -> None:
+    """A ledger written before the trigger split (no explicit_at key) must load
+    its rows as explicit so a server upgrade does not spuriously re-block."""
+    p = tmp_path / "ledger.json"
+    p.write_text(json.dumps([
+        {"session_id": "s", "workspace": "w", "consulted_at": 100.0,
+         "rule_ids": []},
+    ]))
+    led = ConsultationLedger(str(p))
+    assert led.is_fresh(session_id="s", workspace="w", now=200.0, ttl_sec=300.0)

--- a/tests/test_kb_enforce_doctor.py
+++ b/tests/test_kb_enforce_doctor.py
@@ -1,0 +1,99 @@
+"""Doctor hardening tests for the kb enforce installer (WP0c).
+
+doctor now verifies the managed marker/version in the live settings file, that
+the hook dispatcher exists and is executable, and warns+fails when the dispatcher
+resolves inside a worktree checkout (which dangles after pruning and fails open).
+"""
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import io
+import json
+from pathlib import Path
+
+HELPER = Path(__file__).resolve().parents[1] / "bin" / "_kb_enforce.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("_kb_enforce_under_test", HELPER)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_hook_bin_in_worktree_detects_worktrees_segment() -> None:
+    mod = _load_module()
+    assert mod._hook_bin_in_worktree("/repo/.worktrees/foo/bin/kb-enforce-hook")
+    assert mod._hook_bin_in_worktree("/repo/.claude/worktrees/foo/bin/kb-enforce-hook")
+    assert not mod._hook_bin_in_worktree("/repo/bin/kb-enforce-hook")
+
+
+def test_doctor_fails_when_marker_absent(tmp_path, monkeypatch) -> None:
+    """doctor reports the managed hook missing when the live settings file has no
+    marker, and fails (non-zero) even if we point HOOK_BIN at a real executable."""
+    mod = _load_module()
+    settings = tmp_path / "settings.json"
+    settings.write_text("{}")
+    # Point HOOK_BIN at a real executable OUTSIDE any worktree so the only failure
+    # is the missing marker (and the down endpoint).
+    fake_bin = tmp_path / "kb-enforce-hook"
+    fake_bin.write_text("#!/bin/sh\n")
+    fake_bin.chmod(0o755)
+    monkeypatch.setattr(mod, "HOOK_BIN", str(fake_bin))
+    monkeypatch.setenv("KB_ENDPOINT", "http://127.0.0.1:1")
+    prov = mod._claude_provider()
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        rc = prov.doctor(settings)
+    out = buf.getvalue()
+    assert rc != 0
+    assert "not installed" in out.lower()
+
+
+def test_doctor_warns_when_hook_bin_in_worktree(tmp_path, monkeypatch) -> None:
+    mod = _load_module()
+    settings = tmp_path / "settings.json"
+    settings.write_text("{}")
+    # Install a valid marker into settings first so the ONLY structural failure is
+    # the worktree-resolved dispatcher.
+    prov = mod._claude_provider()
+    prov.install(settings)
+    wt_bin = tmp_path / ".worktrees" / "b" / "kb-enforce-hook"
+    wt_bin.parent.mkdir(parents=True)
+    wt_bin.write_text("#!/bin/sh\n")
+    wt_bin.chmod(0o755)
+    monkeypatch.setattr(mod, "HOOK_BIN", str(wt_bin))
+    monkeypatch.setenv("KB_ENDPOINT", "http://127.0.0.1:1")
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        rc = prov.doctor(settings)
+    out = buf.getvalue()
+    assert rc != 0
+    assert "worktree" in out.lower()
+
+
+def test_doctor_reports_missing_hook_bin(tmp_path, monkeypatch) -> None:
+    mod = _load_module()
+    settings = tmp_path / "settings.json"
+    settings.write_text("{}")
+    prov = mod._claude_provider()
+    prov.install(settings)
+    monkeypatch.setattr(mod, "HOOK_BIN", str(tmp_path / "does-not-exist"))
+    monkeypatch.setenv("KB_ENDPOINT", "http://127.0.0.1:1")
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        rc = prov.doctor(settings)
+    out = buf.getvalue()
+    assert rc != 0
+    assert "missing" in out.lower()
+
+
+def test_managed_versions_helper_reads_markers(tmp_path) -> None:
+    mod = _load_module()
+    settings = tmp_path / "settings.json"
+    settings.write_text("{}")
+    mod._claude_provider().install(settings)
+    data = json.loads(settings.read_text())
+    versions = mod._managed_versions_in_hooks(data)
+    assert mod.SHIM_VERSION in versions

--- a/tests/test_kb_enforce_gemini.py
+++ b/tests/test_kb_enforce_gemini.py
@@ -27,9 +27,10 @@ def test_gemini_install_preserves_mcp_and_uses_dialect(tmp_path):
     blob = json.dumps(data)
     assert "--dialect gemini" in blob                       # gemini command form
     assert "--agent gemini" in blob                         # consult audit records gemini
-    # BeforeTool gates the mutating tools
+    # BeforeTool gates the mutating tools; matcher is anchored so it matches
+    # exactly these tool names (no substring match against other tools).
     bt = data["hooks"]["BeforeTool"][0]
-    assert bt["matcher"] == "write_file|replace|run_shell_command"
+    assert bt["matcher"] == "^(write_file|replace|run_shell_command)$"
 
 
 def test_gemini_uninstall_surgical(tmp_path):

--- a/tests/test_kb_enforce_hook.bats
+++ b/tests/test_kb_enforce_hook.bats
@@ -82,6 +82,44 @@ teardown() {
   [[ "$output" == *"consult"* ]]
 }
 
+@test "pre-tool deny message is actionable: session id + workspace + copy-pasteable kb_consult" {
+  # The deny must echo the session id (the one param the agent cannot guess) and
+  # the workspace key inside a copy-pasteable kb_consult(...) call.
+  run bash -c 'echo "{\"session_id\":\"blockme\",\"cwd\":\"/tmp/proj\",\"tool_name\":\"Edit\",\"tool_input\":{\"file_path\":\"/tmp/proj/pyproject.toml\"}}" | "'"$HOOK"'" pre-tool'
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"kb_consult(workspace="* ]]
+  [[ "$output" == *"source_session='blockme'"* ]]
+}
+
+@test "pre-tool with a null session_id emits empty (never the literal None)" {
+  # json_field must render JSON null as "" so the deny/consult key is empty, not
+  # the literal string "None".
+  run bash -c 'echo "{\"session_id\":null,\"cwd\":\"/tmp/proj\",\"tool_name\":\"Edit\",\"tool_input\":{\"file_path\":\"/tmp/proj/pyproject.toml\"}}" | "'"$HOOK"'" pre-tool'
+  [ "$status" -eq 2 ]
+  [[ "$output" != *"None"* ]]
+  [[ "$output" == *"source_session=''"* ]]
+}
+
+@test "user-prompt consult body carries trigger=prompt_hook" {
+  # The installer-driven auto-consult must be marked prompt_hook so it is audited
+  # but never clears the gate.
+  CAP="${BATS_TEST_TMPDIR}/consult-body.json"
+  kill "$MOCK_PID" 2>/dev/null || true
+  wait "$MOCK_PID" 2>/dev/null || true
+  KB_MOCK_CAPTURE_FILE="$CAP" python3 "${FIXTURE_DIR}/enforce-mock-server.py" "$PORT" &
+  MOCK_PID=$!
+  for _ in $(seq 1 30); do
+    if curl --silent --max-time 0.2 "http://127.0.0.1:${PORT}/api/v1/compliance" >/dev/null 2>&1; then break; fi
+    sleep 0.1
+  done
+
+  run bash -c 'echo "{\"session_id\":\"s1\",\"cwd\":\"/tmp/proj\",\"prompt\":\"add a library\"}" | "'"$HOOK"'" user-prompt'
+  [ "$status" -eq 0 ]
+  [ -f "$CAP" ]
+  run python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["trigger"])' "$CAP"
+  [ "$output" = "prompt_hook" ]
+}
+
 @test "pre-tool mode allows (exit 0) when verdict allow" {
   run bash -c 'echo "{\"session_id\":\"allowme\",\"cwd\":\"/tmp/proj\",\"tool_name\":\"Edit\",\"tool_input\":{\"file_path\":\"/tmp/proj/README.md\"}}" | "'"$HOOK"'" pre-tool'
   [ "$status" -eq 0 ]

--- a/tests/test_kb_enforce_matchers.py
+++ b/tests/test_kb_enforce_matchers.py
@@ -1,0 +1,66 @@
+"""Anchored-matcher tests for the kb enforce installer (WP0c).
+
+Un-anchored alternations substring-match unrelated tools (e.g. "Bash" matches
+"BashOutput"). The installed PreToolUse/BeforeTool matchers must be anchored so
+they gate exactly the intended tool names.
+"""
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+HELPER = Path(__file__).resolve().parents[1] / "bin" / "_kb_enforce.py"
+
+
+def _install(agent: str, settings: Path) -> None:
+    r = subprocess.run(
+        [sys.executable, str(HELPER), "install", "--agent", agent,
+         "--settings", str(settings)],
+        capture_output=True, text=True,
+    )
+    assert r.returncode == 0, r.stderr
+
+
+def _pretool_matcher(settings: Path, event: str) -> str:
+    data = json.loads(settings.read_text())
+    blocks = data["hooks"][event]
+    # The managed block is the one whose command references the dispatcher/plugin.
+    for b in blocks:
+        cmds = " ".join(h.get("command", "") for h in b.get("hooks", []))
+        if "kb-enforce-hook" in cmds:
+            return b["matcher"]
+    raise AssertionError(f"no managed block found in {event}")
+
+
+def test_claude_pretool_matcher_is_anchored(tmp_path) -> None:
+    settings = tmp_path / "s.json"
+    settings.write_text("{}")
+    _install("claude-code", settings)
+    m = _pretool_matcher(settings, "PreToolUse")
+    assert m == "^(Edit|Write|MultiEdit|NotebookEdit|Bash)$"
+    # Behavior: gates Bash but NOT BashOutput.
+    assert re.fullmatch(m, "Bash")
+    assert not re.fullmatch(m, "BashOutput")
+
+
+def test_codex_pretool_matcher_is_anchored(tmp_path) -> None:
+    settings = tmp_path / "hooks.json"
+    settings.write_text("{}")
+    _install("codex", settings)
+    m = _pretool_matcher(settings, "PreToolUse")
+    assert m == "^(Edit|Write|MultiEdit|Bash)$"
+    assert re.fullmatch(m, "Bash")
+    assert not re.fullmatch(m, "BashOutput")
+
+
+def test_gemini_beforetool_matcher_is_anchored(tmp_path) -> None:
+    settings = tmp_path / "s.json"
+    settings.write_text("{}")
+    _install("gemini", settings)
+    m = _pretool_matcher(settings, "BeforeTool")
+    assert m == "^(write_file|replace|run_shell_command)$"
+    assert re.fullmatch(m, "replace")
+    assert not re.fullmatch(m, "replace_all")

--- a/tests/test_opencode_gate_contract.py
+++ b/tests/test_opencode_gate_contract.py
@@ -1,0 +1,57 @@
+"""OpenCode gate payload-contract tests (WP0c).
+
+There is no TypeScript/JS test rig wired into this repo's CI (the toolchain is
+Python + bats), so the CI-portable floor here asserts, by inspecting the plugin
+source, that the gate request the plugin sends satisfies the two contract fixes:
+
+1. workspace is resolved to the main git worktree BASENAME (worktree-invariant,
+   matching the key every other surface records consults under), not the raw
+   absolute directory path;
+2. action_diff carries the change content (command/patch/content), so the gate
+   classifier sees a real signal for bash/patch (which carry no file path).
+
+A richer runtime test (importing the plugin under Bun and exercising the fetch
+payload) lives in tests/test_opencode_gate_runtime.py; it is skipped when Bun is
+not installed (the case in CI), so this source-contract test is the guardrail
+that always runs.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+PLUGIN = (
+    Path(__file__).resolve().parents[1] / "bin" / "opencode" / "data-olympus-gate.ts"
+)
+
+
+def _src() -> str:
+    return PLUGIN.read_text()
+
+
+def test_plugin_resolves_workspace_to_basename_not_raw_path() -> None:
+    src = _src()
+    # Uses a basename-yielding resolver and calls it on the worktree/directory.
+    assert "resolveWorkspace" in src
+    assert 'basename(' in src
+    assert "resolveWorkspace(worktree ?? directory)" in src
+    # The gate body sends the resolved `workspace`, not the raw path.
+    assert "worktree list --porcelain" in src or "worktree" in src
+    # Regression guard: the old raw-path body must be gone.
+    assert "workspace: worktree ?? directory" not in src
+
+
+def test_plugin_sends_action_diff_for_bash_and_patch() -> None:
+    src = _src()
+    assert "action_diff" in src
+    # The diff is drawn from the command/patch/content args and capped.
+    assert ".command" in src
+    assert ".patch" in src
+    assert "slice(0, 4000)" in src
+
+
+def test_plugin_deny_message_is_actionable() -> None:
+    src = _src()
+    # Blocked deny must echo workspace + session id + a copy-pasteable call.
+    assert "kb_consult(workspace=" in src
+    assert "source_session=" in src
+    assert "input.sessionID" in src

--- a/tests/test_opencode_gate_runtime.py
+++ b/tests/test_opencode_gate_runtime.py
@@ -1,0 +1,102 @@
+"""OpenCode gate runtime test (WP0c), executed under Bun when available.
+
+Skipped when Bun is not on PATH (the case in CI, whose toolchain is Python +
+bats). Locally it imports the plugin module and asserts:
+
+- resolveWorkspace returns the main-worktree basename from both the main checkout
+  and a linked worktree (worktree-invariant key);
+- tool.execute.before sends workspace=basename and a non-empty action_diff for a
+  bash tool call, and throws an actionable deny on verdict=consult_required.
+
+The plugin's only non-stdlib import is `import type { Plugin, Hooks } from
+"@opencode-ai/plugin"`, which Bun strips at runtime, so the module loads without
+the package installed.
+"""
+from __future__ import annotations
+
+import shutil
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+BUN = shutil.which("bun")
+PLUGIN = (
+    Path(__file__).resolve().parents[1] / "bin" / "opencode" / "data-olympus-gate.ts"
+)
+
+pytestmark = pytest.mark.skipif(
+    BUN is None, reason="bun not installed (CI floor is the source-contract test)"
+)
+
+
+def _git(cwd: Path, *args: str) -> None:
+    subprocess.run(
+        ["git", "-C", str(cwd), *args], check=True, capture_output=True, text=True,
+    )
+
+
+def test_resolve_workspace_is_worktree_invariant(tmp_path) -> None:
+    main = tmp_path / "mainrepo"
+    main.mkdir()
+    _git(main, "init", "-q", "--initial-branch=main")
+    _git(main, "-c", "user.email=t@e.com", "-c", "user.name=t",
+         "commit", "-q", "--allow-empty", "-m", "init")
+    linked = tmp_path / "linked"
+    _git(main, "worktree", "add", "-q", "-b", "wt", str(linked))
+
+    script = tmp_path / "run.ts"
+    script.write_text(textwrap.dedent(f"""
+        import {{ resolveWorkspace }} from {str(PLUGIN)!r}
+        console.log(resolveWorkspace({str(main)!r}))
+        console.log(resolveWorkspace({str(linked)!r}))
+    """))
+    r = subprocess.run([BUN, "run", str(script)], capture_output=True, text=True)
+    assert r.returncode == 0, r.stderr
+    lines = r.stdout.strip().splitlines()
+    assert lines == ["mainrepo", "mainrepo"], r.stdout
+
+
+def test_tool_execute_before_sends_basename_and_action_diff(tmp_path) -> None:
+    main = tmp_path / "mainrepo"
+    main.mkdir()
+    _git(main, "init", "-q", "--initial-branch=main")
+    _git(main, "-c", "user.email=t@e.com", "-c", "user.name=t",
+         "commit", "-q", "--allow-empty", "-m", "init")
+
+    # Drive the plugin's tool.execute.before with a stubbed global fetch that
+    # captures the request body and returns verdict=consult_required, asserting the
+    # deny throws with an actionable message.
+    script = tmp_path / "run.ts"
+    script.write_text(textwrap.dedent(f"""
+        import {{ DataOlympusGate }} from {str(PLUGIN)!r}
+        let captured: any = null
+        // @ts-ignore - stub global fetch
+        globalThis.fetch = async (_url: string, opts: any) => {{
+            captured = JSON.parse(opts.body)
+            return {{ ok: true, json: async () => ({{ verdict: "consult_required" }}) }} as any
+        }}
+        const wt = {str(main)!r}
+        const hooks = await DataOlympusGate({{ directory: wt, worktree: wt }} as any)
+        let threw = ""
+        try {{
+            await hooks["tool.execute.before"](
+                {{ tool: "bash", sessionID: "sess-1" }} as any,
+                {{ args: {{ command: "pip install requests" }} }} as any,
+            )
+        }} catch (e: any) {{ threw = e.message }}
+        console.log(JSON.stringify({{
+            workspace: captured.workspace,
+            action_diff: captured.action_diff,
+            threw,
+        }}))
+    """))
+    r = subprocess.run([BUN, "run", str(script)], capture_output=True, text=True)
+    assert r.returncode == 0, r.stderr
+    import json
+    out = json.loads(r.stdout.strip().splitlines()[-1])
+    assert out["workspace"] == "mainrepo"
+    assert out["action_diff"] == "pip install requests"
+    assert "kb_consult(workspace='mainrepo'" in out["threw"]
+    assert "source_session='sess-1'" in out["threw"]

--- a/tests/test_server_enforce_tools.py
+++ b/tests/test_server_enforce_tools.py
@@ -17,3 +17,20 @@ def test_enforce_tools_registered(tmp_kb, tmp_index_path) -> None:
     # coroutine that returns FunctionTool objects exposing `.name`; we use that.
     names = {t.name for t in asyncio.run(app.list_tools())}
     assert {"kb_consult", "kb_gate_check", "kb_compliance"} <= names
+
+
+def test_kb_consult_tool_exposes_optional_trigger(tmp_kb, tmp_index_path) -> None:
+    """The MCP kb_consult tool mirrors the REST /consult contract: an optional
+    trigger parameter defaulting to explicit, so MCP callers (and future MCP-based
+    installers) can mark prompt_hook auto-consults. It must be OPTIONAL so
+    existing agent callers that omit it keep working (and count as explicit)."""
+    app = build_app(
+        kb_main_path=tmp_kb, kb_index_path=tmp_index_path,
+        sync_interval_sec=60, staleness_degraded_sec=600, bootstrap_now=True,
+    )
+    tools = {t.name: t for t in asyncio.run(app.list_tools())}
+    schema = tools["kb_consult"].parameters
+    props = schema.get("properties", {})
+    assert "trigger" in props
+    assert "trigger" not in schema.get("required", [])
+    assert props["trigger"].get("default") == "explicit"


### PR DESCRIPTION
## Summary

WP0c of the 0.3.0 program (issue #73): enforcement gate integrity quick wins. The
gate previously meant "an HTTP call to `/consult` happened recently in this
session" rather than "the agent consulted the governing rules". This PR changes
the gate's meaning to require an **explicit** consultation, makes the deny message
actionable, and fixes the OpenCode gate so its workspace key and bash gating
actually work.

## Design rationale: the `trigger` field

The naive fix (require non-empty `rule_ids`) deadlocks: an intent with legitimately
zero governing rules could never clear the gate. Instead, every consult now carries
a `trigger`:

- **`explicit`** (default): a deliberate `kb_consult` call. Old clients that omit
  the field are treated as explicit (a bare consult is always a real agent action).
  Only a fresh explicit consult clears the gate.
- **`prompt_hook`**: the installer auto-consults fired on every user turn
  (Claude/Codex `UserPromptSubmit`, Gemini `BeforeAgent`). Recorded for
  audit/compliance and still injects governing rules, but never clears the gate.

The ledger tracks the last explicit consult (`explicit_at`) separately from the
last consult of any kind (`consulted_at`), so a per-turn prompt-hook consult never
downgrades a still-fresh explicit consult on the same `(session, workspace)`. A
non-governed explicit consult still records a fresh `explicit_at`, so there is no
deadlock: the agent can always clear the gate by calling `kb_consult` and retrying.

## Changes

- **Policy core** (`enforce_policy.py`): `LedgerEntry.explicit_at`; `record(trigger=)`
  with no-downgrade semantics; `is_fresh(require_explicit=True)` (the gate default).
- **`tools_enforce.py`**: `kb_consult_fn(trigger=)`; gate check requires a fresh
  explicit consult; blocked `reason` is a copy-pasteable `kb_consult(...)` call.
- **`models.py`**: `GateCheckResponse` gains `session_id` + `workspace` echo fields.
- **`rest_api.py`**: `/consult` parses optional `trigger` (default explicit).
- **`bin/kb-enforce-hook`**: deny message includes session id + workspace +
  instruction; `user-prompt` mode marks its consult `trigger=prompt_hook`; null
  `session_id` renders empty (not literal `"None"`); tight pre-tool timeouts
  (`--max-time 2 --connect-timeout 1`); single base64-framed payload parse.
- **`bin/_kb_enforce.py`**: anchored tool matchers (`^(...)$`) so `Bash` !=
  `BashOutput`; `doctor` verifies the live marker/version, the dispatcher
  exists+executable, and warns+fails on a worktree-resolved dispatcher.
- **`bin/opencode/data-olympus-gate.ts`**: workspace resolved to the main-worktree
  basename (matching the key every surface records under, not the raw abs path);
  `action_diff` carries command/patch/content so bash/patch are actually classified;
  actionable deny message.
- **`docs/enforcement.md`**: documents the explicit-consult policy honestly;
  corrects the false "Codex does NOT gate Bash" claim (it does).

## Test evidence

- `python -m pytest -q`: all pass (1 pre-existing skip: `sentence_transformers` not
  installed, unrelated).
- `bats -r tests`: 66 pass, 0 fail.
- `ruff check .`: clean. `mypy src`: clean. `python scripts/check_changelog.py`: ok.
- New tests: `test_enforce_gate_policy.py` (explicit clears / prompt_hook does not /
  non-governed explicit clears / TTL expiry / no-downgrade / backward-compat /
  deny-message content), `test_enforce_ledger_trigger.py`, `test_kb_enforce_matchers.py`
  (anchored matchers), `test_kb_enforce_doctor.py` (doctor hardening),
  `test_opencode_gate_contract.py` (CI-portable payload contract) +
  `test_opencode_gate_runtime.py` (Bun runtime test, skipped when Bun absent — the
  case in CI). New bats cases: actionable deny content, null-session-id, and
  `trigger=prompt_hook` in the user-prompt consult body.

bats runs locally (brew bats 1.13.0); CI runs it too (`bats -r tests`).

## Peer review (codex)

`codex exec --sandbox read-only` reviewed `git diff origin/release/0.3.0...HEAD`.

**Verdict: no Blockers.** Codex explicitly confirmed: no deadlock path (non-governed
explicit consult still clears), prompt-hook consults cannot clear the gate and the
installers mark them correctly, the deny message carries session id + workspace +
actionable instruction, the OpenCode workspace key matches the basename convention
and bash gating receives a real diff, backward compatibility for old clients and
old persisted ledger rows holds, and docs/enforcement.md tells the truth.

Two **Concerns**, both addressed in a follow-up commit before this PR:

1. The MCP `kb_consult` tool did not expose the optional `trigger` parameter the
   REST route accepts, so the contract was only partially mirrored. Fixed: the tool
   now takes `trigger: str = "explicit"` and passes it through; a tool-schema test
   asserts the parameter is optional with the explicit default.
2. The per-agent tier table in `docs/enforcement.md` still omitted `Bash` for
   Claude Code and Codex while the caveats said Bash is gated. Fixed: the table
   rows now list Bash, matching the installed matchers.

Note: codex attempted a reciprocal Claude-CLI pass from inside its read-only
sandbox, which failed with a sandbox EPERM (cannot mkdir under ~/.claude); its own
review stands as the companion review for this PR.

Refs #73
