### PR TITLE
fix(cli): treat template.md as reserved in index generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,14 +53,16 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   printing the correct way to serve your own bundle (direct
   `data-olympus-mcp` invocation with `KB_MAIN_PATH`, per `docs/quickstart.md`
   section 6) instead. The no-argument default demo flow is unchanged.
-- `data-olympus index` no longer treats `template.md` as a concept document.
-  Its reserved-filename set previously omitted `template.md`, unlike
+- `data-olympus index` and `data-olympus visualize` no longer treat
+  `template.md` as a concept document. Both modules maintained their own
+  `{"index.md", "log.md"}` reserved-filename set, drifted from
   `format/validate.py`'s `RESERVED` (used by lint and validation), so a
   directory containing only a `template.md` was wrongly treated as holding
-  concept docs: an `index.md` was generated for it and `template.md` was
-  listed as a concept entry. Index generation now imports the same
-  `RESERVED` set as the rest of the format tooling, so `index.md`, `log.md`,
-  and `template.md` are consistently reserved everywhere.
+  concept docs: `index` generated an `index.md` for it and listed
+  `template.md` as a concept entry, and `visualize` counted it as a graph
+  node. Both now import the same `RESERVED` set as the rest of the format
+  tooling, so `index.md`, `log.md`, and `template.md` are consistently
+  reserved everywhere.
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,14 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   printing the correct way to serve your own bundle (direct
   `data-olympus-mcp` invocation with `KB_MAIN_PATH`, per `docs/quickstart.md`
   section 6) instead. The no-argument default demo flow is unchanged.
+- `data-olympus index` no longer treats `template.md` as a concept document.
+  Its reserved-filename set previously omitted `template.md`, unlike
+  `format/validate.py`'s `RESERVED` (used by lint and validation), so a
+  directory containing only a `template.md` was wrongly treated as holding
+  concept docs: an `index.md` was generated for it and `template.md` was
+  listed as a concept entry. Index generation now imports the same
+  `RESERVED` set as the rest of the format tooling, so `index.md`, `log.md`,
+  and `template.md` are consistently reserved everywhere.
 
 ### Documentation
 

--- a/src/data_olympus/cli/indexgen.py
+++ b/src/data_olympus/cli/indexgen.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 from pathlib import Path
 
 from data_olympus.format import Document
+from data_olympus.format.validate import RESERVED as _RESERVED
 
-_RESERVED = {"index.md", "log.md"}
 _SKIP = {".git", "__pycache__", ".venv", ".pytest_cache", ".ruff_cache", "node_modules"}
 
 

--- a/src/data_olympus/viewer/generator.py
+++ b/src/data_olympus/viewer/generator.py
@@ -18,8 +18,8 @@ from pathlib import Path
 from typing import Any
 
 from data_olympus.format import Document
+from data_olympus.format.validate import RESERVED as _RESERVED
 
-_RESERVED = {"index.md", "log.md"}
 _SKIP = frozenset({".git", "__pycache__", ".venv", ".pytest_cache", ".ruff_cache", "node_modules"})
 _LINK_RE = re.compile(r"\]\((/?[^)\s#]+\.md)(?:#[^)]*)?\)")
 _FENCE_RE = re.compile(r"```.*?```", re.DOTALL)

--- a/tests/test_cli_index.py
+++ b/tests/test_cli_index.py
@@ -41,3 +41,27 @@ def test_index_lists_subdirectories(tmp_path):
     main(["index", str(tmp_path)])
     root_idx = (tmp_path / "index.md").read_text(encoding="utf-8")
     assert "[sub/](sub/)" in root_idx or "(sub/)" in root_idx
+
+
+def test_index_ignores_directory_with_only_template_md(tmp_path):
+    """A directory holding only template.md has no concept docs and must not
+    get an index.md written for it (template.md is reserved, like index.md
+    and log.md; see format/validate.py RESERVED)."""
+    _write(tmp_path / "empty_bundle/template.md", "---\nid: TEMPLATE\n---\nplaceholder\n")
+    main(["index", str(tmp_path)])
+    assert not (tmp_path / "empty_bundle" / "index.md").exists()
+
+
+def test_index_excludes_template_md_from_concept_list(tmp_path):
+    """template.md living alongside real concept docs must not be listed as
+    a concept entry in the generated index.md."""
+    _write(
+        tmp_path / "tables/orders.md",
+        "---\nid: T1\ntype: standard\nstatus: active\ntier: T1\n"
+        "title: Orders\ndescription: One row per order.\n---\nbody\n",
+    )
+    _write(tmp_path / "tables/template.md", "---\nid: TEMPLATE\n---\nplaceholder\n")
+    main(["index", str(tmp_path)])
+    idx = (tmp_path / "tables" / "index.md").read_text(encoding="utf-8")
+    assert "[Orders](orders.md)" in idx
+    assert "template.md" not in idx

--- a/tests/test_viewer_generator_reserved.py
+++ b/tests/test_viewer_generator_reserved.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+
+from data_olympus.viewer.generator import generate_visualization
+
+
+def _write(p: Path, text: str) -> None:
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(text, encoding="utf-8")
+
+
+def test_visualization_excludes_template_md_from_node_count(tmp_path):
+    """template.md is reserved (format/validate.py RESERVED) like index.md and
+    log.md, so it must not be counted as a concept node in the generated
+    visualization graph."""
+    _write(
+        tmp_path / "a.md",
+        "---\nid: A\ntype: standard\nstatus: active\ntier: T1\n"
+        "title: A\ndescription: doc a.\n---\nbody\n",
+    )
+    _write(tmp_path / "template.md", "---\nid: TEMPLATE\n---\nplaceholder\n")
+    out = tmp_path / "viz.html"
+    stats = generate_visualization(tmp_path, out)
+    assert stats["nodes"] == 1


### PR DESCRIPTION
## Summary

- `indexgen.py` maintained its own `_RESERVED = {"index.md", "log.md"}` set, drifted from `format/validate.py`'s `RESERVED` frozenset (`index.md`, `log.md`, `template.md`), which is what `format/lint.py` uses and what `SPEC.md` sections 3/9 and `docs/adoption.md` document. A directory containing only `template.md` was therefore treated as holding concept docs: `data-olympus index` generated an `index.md` for it and listed `template.md` as a concept entry.
- Codex peer review of the indexgen fix flagged the same drifted copy in `src/data_olympus/viewer/generator.py` (`data-olympus visualize`), so that module is fixed the same way in a second commit.
- Both modules now import `RESERVED` from `format.validate` instead of maintaining a second, drifting local copy.

## Test plan

- [x] `uv run pytest -q` — all tests pass (877 passed, 1 skipped for an optional `sentence_transformers` dep, pre-existing)
- [x] `uv run ruff check .` — all checks passed
- [x] New regression tests added and manually verified to fail against the pre-fix code, pass against the fix:
  - `tests/test_cli_index.py::test_index_ignores_directory_with_only_template_md`
  - `tests/test_cli_index.py::test_index_excludes_template_md_from_concept_list`
  - `tests/test_viewer_generator_reserved.py::test_visualization_excludes_template_md_from_node_count`
- [x] `CHANGELOG.md` updated under `[Unreleased]` / `### Fixed`

## Peer review (codex)

Ran `codex exec --sandbox read-only` against `origin/release/0.3.0...HEAD` after the indexgen-only commit. Verdict: no Blocker in the indexgen path; raised a Concern that `viewer/generator.py` had the identical drifted reserved-set copy, meaning `data-olympus visualize` would still mis-treat `template.md`, and that the changelog's "consistently reserved everywhere" claim was not yet true. Addressed by fixing `viewer/generator.py` the same way and adding a regression test, then updating the changelog wording to cover both commands. Codex could not execute pytest itself (no writable temp dir in its sandbox) but confirmed via static check that the imported `RESERVED` set resolves to `['index.md', 'log.md', 'template.md']` and that `index.md`/`log.md` filtering is unchanged (old local set is a subset of the new one, used in the same filters).