### PR TITLE
feat(search): deployable in_force and abstain modes on kb_search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,24 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Deployable `in_force` and `abstain` modes on `kb_search` (issue #68, epic #75).
+  `kb_search` (MCP tool and `GET /api/v1/search`) gains two parameters:
+  - `in_force: bool` HARD-filters results to the in-force status class
+    (`active`/`accepted`/`approved`) before ranking, excluding
+    superseded/deprecated docs entirely rather than soft-downranking them. The
+    class is defined once in `format.validate.IN_FORCE_STATUSES` and shared by
+    the status reranker and this filter; `Index.search` gained an `in_force`
+    parameter (the single-status `status` filter is unchanged and composes with
+    it). The filter also applies to the dense (embedding) candidate source.
+  - `abstain: bool` applies a signal gate: a query that matches no
+    discriminating column (title/tags/applies_when) returns no hits with
+    `abstained: true` and `abstain_reason: "no_signal_match"` (distinct from an
+    ordinary empty result). The gate logic is single-sourced in
+    `data_olympus.search_gate`; the benchmark ablation now imports it.
+  Fixes benchmark bug B1: `benchmarks/methods/data_olympus.py` switched from the
+  `status="active"` filter (which silently dropped `accepted` gold decision docs)
+  to `in_force=True`. Committed benchmark numbers, `report.md`, and
+  `docs/comparison.md` are intentionally NOT re-cut here (a later package does).
 - Actionable gate deny message: the BLOCKED text (and the `consult_required`
   verdict `reason`) now includes the exact workspace key, the session id (the one
   parameter an agent cannot guess), and a copy-pasteable

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -46,7 +46,7 @@ on. The `vector_rag.py` adapter is implemented and available behind `[bench]`.
 
 | Name | Description |
 |---|---|
-| `data-olympus` | Real `Index.search(query, status="active")` with outline + snippet payload |
+| `data-olympus` | Real `Index.search(query, in_force=True)` (in-force status class: active/accepted/approved) with outline + snippet payload |
 | `whole-dump` | Concatenate every file in the corpus; no ranking |
 | `grep-read` | Match files by keyword; concatenate matched files |
 | `bm25` | BM25 over 512-token whitespace chunks; top-5 chunks as payload |

--- a/benchmarks/ablate.py
+++ b/benchmarks/ablate.py
@@ -103,13 +103,6 @@ class AblationReport:
 # Internal helpers
 # ---------------------------------------------------------------------------
 
-# Discriminating columns for the abstention gate. Deliberately EXCLUDES
-# `description`: its prose carries common words ("governance rules for ...") that
-# out-of-scope queries also contain, which would defeat the gate. Title, tags,
-# and applies_when are terse and specific, so matching one signals real intent.
-_SIGNAL_COLUMNS = ["title", "tags", "applies_when"]
-
-
 def _fts_retrieve(
     query: str,
     idx: Index,
@@ -118,20 +111,24 @@ def _fts_retrieve(
 ) -> RetrievalResult:
     """Call Index.search and return a RetrievalResult.
 
-    Recognises a special `_abstain` kwarg: when set, the query must match at
-    least one discriminating column (title/tags/applies_when/description). If it
-    matches none (e.g. an out-of-scope query that only hits generic body prose),
-    the method abstains (returns an empty result) instead of surfacing a rule.
-    Otherwise it retrieves normally over all columns, preserving recall.
+    Recognises a special `_abstain` kwarg: when set, the production abstention
+    gate (data_olympus.search_gate) is applied. If the query matches no
+    discriminating column (title/tags/applies_when), the method abstains
+    (returns an empty result) instead of surfacing a rule. Otherwise it retrieves
+    normally over all columns, preserving recall. The gate logic is single-sourced
+    in src; this harness imports it rather than keeping its own copy.
     """
+    from data_olympus.search_gate import abstain_gate
+
     kwargs = dict(search_kwargs)
     abstain = bool(kwargs.pop("_abstain", False))
     if abstain:
-        signal_hits = idx.search(query, limit=k, columns=_SIGNAL_COLUMNS)
-        if not signal_hits:
+        gated = abstain_gate(idx, query, limit=k)
+        if gated is None:
             return RetrievalResult(payload_text="", ranked_ids=[], retrieved_ids=set())
-        kwargs = {}  # signal present: retrieve normally over all columns
-    hits = idx.search(query, limit=k, **kwargs)  # type: ignore[arg-type]
+        hits = gated
+    else:
+        hits = idx.search(query, limit=k, **kwargs)  # type: ignore[arg-type]
     ranked = [h.id for h in hits]
     payload = "\n".join(f"{h.title}: {h.snippet}" for h in hits)
     if hits:

--- a/benchmarks/methods/data_olympus.py
+++ b/benchmarks/methods/data_olympus.py
@@ -1,8 +1,15 @@
 """data-olympus Index retrieval method.
 
 Uses the real data_olympus.index.Index: outline() for a cheap structural map,
-search() with status="active" filter (excludes superseded), then get() on the
-top hit. This is the selective-loading method being benchmarked.
+search() with in_force=True (the in-force status class active/accepted/approved,
+excluding superseded/deprecated), then get() on the top hit. This is the
+selective-loading method being benchmarked.
+
+Previously this used ``status="active"``, which silently excluded ``accepted``
+gold decision docs (benchmark bug B1) and produced a misleading exact-recall
+figure. The production ``in_force`` filter is the deployable equivalent and
+includes accepted/approved decisions, so the harness now measures a mode a real
+agent can actually invoke.
 """
 from __future__ import annotations
 
@@ -38,7 +45,7 @@ class DataOlympusMethod:
 
     def retrieve(self, query: str) -> RetrievalResult:
         outline_text = _render_outline(self._idx.outline())
-        hits = self._idx.search(query, limit=self._limit, status="active")
+        hits = self._idx.search(query, limit=self._limit, in_force=True)
         ranked = dedupe([h.id for h in hits])
         parts: list[str] = [outline_text]
         parts.extend(f"{h.title}: {h.snippet}" for h in hits)

--- a/docs/serving.md
+++ b/docs/serving.md
@@ -206,6 +206,41 @@ Override the map at deploy time, with no code change:
   Example: `KB_STATUS_WEIGHTS='{"active": -1.0, "approved": -1.0, "superseded":
   2.0, "draft": 1.0}'`.
 
+## `in_force`: hard in-force filter
+
+`kb_search` accepts an `in_force: bool = False` parameter (MCP tool and
+`GET /api/v1/search?in_force=true`). When set, results are HARD-filtered to the
+in-force status class (`active`, `accepted`, `approved`) BEFORE ranking, so a
+`superseded`, `deprecated`, `draft`, or `proposed` doc is excluded entirely
+rather than merely soft-downranked by the status rerank above.
+
+Use it when you want only guidance that currently applies and a demoted-but-
+present retired doc is not acceptable. It differs from the status rerank: the
+rerank always keeps every hit and only reorders; `in_force` drops out-of-force
+hits. The in-force class is defined once (`format.validate.IN_FORCE_STATUSES`)
+and shared by both the rerank boosts and this filter.
+
+`in_force` composes with the single-status `status` filter: passing both
+requires a doc match `status` AND be in-force (so `status=superseded` with
+`in_force=true` yields nothing). The filter also applies to the dense
+(embedding) candidate source, so a hybrid deployment never leaks an out-of-force
+doc through the semantic path.
+
+## `abstain`: signal-gated abstention
+
+`kb_search` accepts an `abstain: bool = False` parameter (MCP tool and
+`GET /api/v1/search?abstain=true`). When set, the query is first run restricted
+to the discriminating columns (`title`, `tags`, `applies_when`). If it matches
+none of them, the query is treated as out-of-scope and the search returns NO
+hits with `abstained: true` and `abstain_reason: "no_signal_match"`, instead of
+surfacing a weak match on generic body prose. A query with a real signal
+retrieves normally over all columns (recall is preserved).
+
+The response distinguishes a deliberate abstention from an ordinary empty
+result: a normal search that simply finds nothing returns `abstained: false`.
+The gate logic is single-sourced in `data_olympus.search_gate`; the benchmark
+ablation imports it rather than reimplementing it.
+
 ## Taxonomy and writable paths
 
 The server maps each document's path to a `(tier, category)` pair. The built-in

--- a/src/data_olympus/format/validate.py
+++ b/src/data_olympus/format/validate.py
@@ -12,6 +12,15 @@ TYPES = frozenset({"standard", "decision", "workflow", "project", "memory", "ref
 STATUSES = frozenset(
     {"draft", "active", "deprecated", "superseded", "proposed", "accepted", "rejected"}
 )
+# The in-force status class: guidance that currently applies and should be
+# retrievable, as opposed to retired (superseded/deprecated/rejected) or
+# not-yet-in-force (draft/proposed) statuses. This is the SINGLE definition of
+# the class; Index.search(in_force=True) and the status reranker both consult it.
+# ``approved`` is not in the schema STATUSES enum above (the SPEC vocabulary uses
+# ``accepted`` for in-force decisions), but the target KB also uses ``approved``
+# for accepted decisions, so it is included here so an in-force filter over a
+# real KB does not silently drop those docs (issue #68).
+IN_FORCE_STATUSES = frozenset({"active", "accepted", "approved"})
 TIERS = frozenset({"T1", "T2", "T3", "T4", "meta"})
 RESERVED = frozenset({"index.md", "log.md", "template.md"})
 REQUIRED = ("id", "type", "status", "tier")

--- a/src/data_olympus/index.py
+++ b/src/data_olympus/index.py
@@ -32,6 +32,7 @@ from data_olympus.embeddings import (
     make_hybrid_reranker,
     serialize_vector,
 )
+from data_olympus.format.validate import IN_FORCE_STATUSES
 from data_olympus.markdown_parse import parse_file
 from data_olympus.trigram import (
     DEFAULT_FALLBACK_THRESHOLD as DEFAULT_TRIGRAM_FALLBACK_THRESHOLD,
@@ -129,12 +130,11 @@ DEFAULT_DENSE_MIN_COSINE = 0.5
 # casefolded before lookup), so mixed-case frontmatter (e.g. ``Active``) is not
 # silently treated as neutral. Keep the keys here lowercase.
 _DEFAULT_STATUS_WEIGHTS: dict[str, float] = {
-    # In-force: the guidance that currently applies. Boost. ``approved`` is the
-    # in-force status the target KB uses for accepted decisions, alongside the
-    # spec's ``accepted``; both carry the same boost.
-    "active": -1.0,
-    "accepted": -1.0,
-    "approved": -1.0,
+    # In-force: the guidance that currently applies. Boost. The in-force class
+    # (active/accepted/approved, incl. the target KB's ``approved``) is defined
+    # once in format.validate.IN_FORCE_STATUSES and expanded here so the soft
+    # rerank and the hard ``in_force`` filter share a single source of truth.
+    **{s: -1.0 for s in sorted(IN_FORCE_STATUSES)},
     # Retired or superseded: kept for history, must not outrank its replacement.
     "superseded": 2.0,
     "deprecated": 2.0,
@@ -143,6 +143,12 @@ _DEFAULT_STATUS_WEIGHTS: dict[str, float] = {
     "draft": 1.0,
     "proposed": 1.0,
 }
+
+# Deterministic, sorted materialisation of the in-force class for use as SQL
+# ``IN (...)`` parameters by search(in_force=True) and dense_candidates. Sorted
+# so the generated SQL/params are stable across runs. Derived from the single
+# source (format.validate.IN_FORCE_STATUSES); do not hand-list statuses here.
+_IN_FORCE_STATUS_LIST: tuple[str, ...] = tuple(sorted(IN_FORCE_STATUSES))
 
 # Generic, deployment-neutral default taxonomy. A deployment with a different
 # directory layout supplies its own table at runtime via KB_TAXONOMY_PATH (a
@@ -659,6 +665,7 @@ class Index:
         tier: str | None = None,
         category: str | None = None,
         status: str | None = None,
+        in_force: bool = False,
         doc_type: str | None = None,
         columns: list[str] | None = None,
         column_weights: tuple[float, ...] | None = None,
@@ -677,6 +684,16 @@ class Index:
         matches all. `column_weights` overrides bm25 weights (one per declared
         fts column incl. the UNINDEXED id at index 0); default boosts
         title/applies_when, deprioritizes body.
+
+        `status` filters to a single exact status. `in_force` is a HARD
+        pre-ranking filter restricting results to the in-force status class
+        (format.validate.IN_FORCE_STATUSES: active/accepted/approved), so a
+        superseded/deprecated doc is EXCLUDED before ranking rather than merely
+        soft-downranked by the status reranker. The two compose: passing both a
+        single `status` and `in_force=True` requires the doc match `status` AND
+        be in-force (an empty result if `status` is not itself in-force). The
+        filter is applied to both the FTS candidate pool and the dense
+        (embedding) candidate source so neither leaks an out-of-force doc.
         """
         # Stage 1 (expand-query): term extraction + optional expansion hook.
         terms = query.split()
@@ -702,6 +719,10 @@ class Index:
             if status:
                 where.append("docs.status = ?")
                 params.append(status)
+            if in_force:
+                placeholders = ", ".join("?" for _ in _IN_FORCE_STATUS_LIST)
+                where.append(f"docs.status IN ({placeholders})")
+                params.extend(_IN_FORCE_STATUS_LIST)
             if doc_type:
                 where.append("docs.type = ?")
                 params.append(doc_type)
@@ -784,6 +805,7 @@ class Index:
                 tier=tier,
                 category=category,
                 status=status,
+                in_force=in_force,
                 doc_type=doc_type,
             )
         # Stage 3 (re-rank): optional hook reorders/rescores (default identity),
@@ -801,6 +823,7 @@ class Index:
         tier: str | None,
         category: str | None,
         status: str | None,
+        in_force: bool,
         doc_type: str | None,
     ) -> builtins.list[SearchHit]:
         """Union dense (cosine) candidates into the FTS pool (reviewer concern 1).
@@ -820,6 +843,7 @@ class Index:
             tier=tier,
             category=category,
             status=status,
+            in_force=in_force,
             doc_type=doc_type,
         )
         if not dense:
@@ -994,6 +1018,7 @@ class Index:
         tier: str | None = None,
         category: str | None = None,
         status: str | None = None,
+        in_force: bool = False,
         doc_type: str | None = None,
     ) -> builtins.list[SearchHit]:
         """Return up to ``limit`` docs most similar to ``query`` by cosine (issue #42).
@@ -1029,6 +1054,10 @@ class Index:
         if status:
             where.append("docs.status = ?")
             params.append(status)
+        if in_force:
+            placeholders = ", ".join("?" for _ in _IN_FORCE_STATUS_LIST)
+            where.append(f"docs.status IN ({placeholders})")
+            params.extend(_IN_FORCE_STATUS_LIST)
         if doc_type:
             where.append("docs.type = ?")
             params.append(doc_type)

--- a/src/data_olympus/models.py
+++ b/src/data_olympus/models.py
@@ -80,6 +80,22 @@ class SearchResponse(BaseModel):
     hits: list[SearchHitModel]
     source_commit: str
     total_returned: int = Field(description="Number of hits actually returned (after limit).")
+    abstained: bool = Field(
+        default=False,
+        description=(
+            "True when abstain=True was requested and the signal gate fired: the "
+            "query matched no discriminating column, so the search deliberately "
+            "returned no hits instead of surfacing a weak, out-of-scope match. "
+            "Distinct from an ordinary zero-hit search (abstained stays False)."
+        ),
+    )
+    abstain_reason: str | None = Field(
+        default=None,
+        description=(
+            "Machine-readable reason present only when abstained is True (e.g. "
+            "'no_signal_match'). None otherwise."
+        ),
+    )
 
 
 class GetResponse(BaseModel):

--- a/src/data_olympus/rest_api.py
+++ b/src/data_olympus/rest_api.py
@@ -83,6 +83,14 @@ def _degraded_response(health: HealthResponse) -> JSONResponse:
     return JSONResponse(body, status_code=503)
 
 
+def _query_bool(raw: str | None) -> bool:
+    """Parse a boolean query-string flag. True for 1/true/yes/on (case-insensitive);
+    everything else (incl. absent/empty) is False, so a missing flag defaults off."""
+    if raw is None:
+        return False
+    return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+
 def _authorize(
     request: Request,
     registry: PrincipalRegistry,
@@ -278,8 +286,11 @@ def register_routes(
             return JSONResponse({"error": "bad_limit"}, status_code=400)
         tier = request.query_params.get("tier") or None
         category = request.query_params.get("category") or None
+        in_force = _query_bool(request.query_params.get("in_force"))
+        abstain = _query_bool(request.query_params.get("abstain"))
         resp = await _offload(
-            kb_search_fn, idx=state.idx, query=q, limit=limit, tier=tier, category=category
+            kb_search_fn, idx=state.idx, query=q, limit=limit, tier=tier,
+            category=category, in_force=in_force, abstain=abstain,
         )
         return JSONResponse(resp.model_dump())
 

--- a/src/data_olympus/search_gate.py
+++ b/src/data_olympus/search_gate.py
@@ -1,0 +1,64 @@
+"""Signal-gated abstention for kb_search (issue #68).
+
+This is the SINGLE source of the abstention gate. Production search (kb_search
+``abstain=True``, via ``tools_read.kb_search_fn``) and the benchmark ablation
+(``benchmarks/ablate.py``) both import ``SIGNAL_COLUMNS`` and ``abstain_gate``
+from here rather than keeping their own copy.
+
+The gate rationale: an out-of-scope query that only lexically overlaps generic
+body prose should surface NOTHING rather than a weak, misleading rule. The gate
+first runs the query restricted to the discriminating columns (title/tags/
+applies_when); if it matches none of them, the query has no real intent signal
+and the search abstains (returns no hits). If at least one discriminating column
+matches, retrieval proceeds normally over all columns, preserving recall.
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from data_olympus.index import Index, SearchHit
+
+# Discriminating columns for the abstention gate. Deliberately EXCLUDES
+# ``description`` and ``body``: their prose carries common words ("governance
+# rules for ...") that out-of-scope queries also contain, which would defeat the
+# gate. Title, tags, and applies_when are terse and specific, so matching one
+# signals real intent. This list is the single definition; the benchmark imports
+# it rather than re-declaring it.
+SIGNAL_COLUMNS: list[str] = ["title", "tags", "applies_when"]
+
+
+def has_signal(idx: Index, query: str, *, limit: int, **search_kwargs: object) -> bool:
+    """Return True when ``query`` matches at least one discriminating column.
+
+    Runs the query restricted to ``SIGNAL_COLUMNS`` under the same filter kwargs
+    (tier/category/status/in_force/doc_type) so the gate is evaluated within the
+    same scope the real search will use. An empty/whitespace query has no signal.
+    """
+    if not query.strip():
+        return False
+    signal_hits = idx.search(
+        query, limit=limit, columns=SIGNAL_COLUMNS, **search_kwargs  # type: ignore[arg-type]
+    )
+    return bool(signal_hits)
+
+
+def abstain_gate(
+    idx: Index, query: str, *, limit: int, **search_kwargs: object
+) -> list[SearchHit] | None:
+    """Apply the abstention gate around a normal search.
+
+    Returns ``None`` when the gate FIRES (no discriminating-column signal): the
+    caller must treat this as an explicit abstention (empty result with a
+    machine-readable reason), NOT as an ordinary zero-hit search. Otherwise runs
+    the normal search over all columns (honouring the same filter kwargs) and
+    returns its hits (which may itself be empty if nothing ranks).
+
+    ``search_kwargs`` are forwarded to both the signal probe and the real search
+    (tier/category/status/in_force/doc_type); ``columns`` must NOT be supplied
+    here since the gate controls it for the probe and the real search uses all
+    columns.
+    """
+    if not has_signal(idx, query, limit=limit, **search_kwargs):
+        return None
+    return idx.search(query, limit=limit, **search_kwargs)  # type: ignore[arg-type]

--- a/src/data_olympus/server.py
+++ b/src/data_olympus/server.py
@@ -443,16 +443,31 @@ def build_app(
         tier: str | None = None,
         category: str | None = None,
         status: str | None = None,
+        in_force: bool = False,
         doc_type: str | None = None,
+        abstain: bool = False,
     ) -> dict[str, object]:
         """Full-text search across the KB.
 
         Optional tier/category/status/type filters (status e.g. 'active',
         doc_type e.g. 'decision'). Returns ranked hits with snippets.
+
+        in_force: when true, HARD-filter to the in-force status class
+        (active/accepted/approved) before ranking, EXCLUDING superseded and
+        deprecated docs rather than only soft-downranking them. Composes with an
+        explicit `status` (both must hold). Use this when you want only guidance
+        that currently applies.
+
+        abstain: when true, apply the signal gate. If the query matches no
+        discriminating column (title/tags/applies_when) it is treated as
+        out-of-scope and the search returns NO hits with `abstained: true` and an
+        `abstain_reason`, instead of surfacing a weak keyword match. A query with
+        a real signal retrieves normally. Distinguish `abstained: true` (no
+        governing rule) from an ordinary empty result (`abstained: false`).
         """
         resp = kb_search_fn(
             idx=state.idx, query=query, limit=limit, tier=tier, category=category,
-            status=status, doc_type=doc_type,
+            status=status, in_force=in_force, doc_type=doc_type, abstain=abstain,
         )
         return resp.model_dump()
 

--- a/src/data_olympus/tools_read.py
+++ b/src/data_olympus/tools_read.py
@@ -114,13 +114,36 @@ def kb_search_fn(
     tier: str | None = None,
     category: str | None = None,
     status: str | None = None,
+    in_force: bool = False,
     doc_type: str | None = None,
+    abstain: bool = False,
 ) -> SearchResponse:
+    from data_olympus.search_gate import abstain_gate
+
     if limit > 100:
         limit = 100
-    hits = idx.search(
-        query, limit=limit, tier=tier, category=category, status=status, doc_type=doc_type
-    )
+    search_kwargs: dict[str, object] = {
+        "tier": tier,
+        "category": category,
+        "status": status,
+        "in_force": in_force,
+        "doc_type": doc_type,
+    }
+    abstained = False
+    abstain_reason: str | None = None
+    if abstain:
+        # Single-sourced signal gate (search_gate.abstain_gate). ``None`` means
+        # the gate fired: return an explicit abstained response, not just zero
+        # hits, so a caller can tell "no governing rule" from "search found none".
+        gated = abstain_gate(idx, query, limit=limit, **search_kwargs)
+        if gated is None:
+            hits = []
+            abstained = True
+            abstain_reason = "no_signal_match"
+        else:
+            hits = gated
+    else:
+        hits = idx.search(query, limit=limit, **search_kwargs)  # type: ignore[arg-type]
     health = idx.health()
     return SearchResponse(
         query=query,
@@ -138,6 +161,8 @@ def kb_search_fn(
         ],
         source_commit=str(health["source_commit"]),
         total_returned=len(hits),
+        abstained=abstained,
+        abstain_reason=abstain_reason,
     )
 
 

--- a/tests/test_enforce_gate_policy.py
+++ b/tests/test_enforce_gate_policy.py
@@ -18,7 +18,8 @@ from data_olympus.tools_enforce import kb_consult_fn, kb_gate_check_fn
 
 
 class _FakeIndex:
-    def search(self, query, limit=20, tier=None, category=None, status=None, doc_type=None):  # noqa: ARG002
+    def search(self, query, limit=20, tier=None, category=None, status=None,  # noqa: ARG002
+               in_force=False, doc_type=None, **kwargs):  # noqa: ARG002
         return []
 
     def health(self):

--- a/tests/test_in_force_and_abstain.py
+++ b/tests/test_in_force_and_abstain.py
@@ -1,0 +1,263 @@
+"""Tests for the in_force status-class filter and the abstain signal gate.
+
+Covers the engine (Index.search in_force), the single-status filter regression,
+the single-sourced abstain gate (search_gate), the kb_search_fn abstained
+response shape, and REST param threading (issue #68, epic #75).
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import httpx
+import pytest
+
+from data_olympus.format.validate import IN_FORCE_STATUSES
+from data_olympus.index import Index
+from data_olympus.search_gate import SIGNAL_COLUMNS, abstain_gate
+from data_olympus.server import build_app
+from data_olympus.tools_read import kb_search_fn
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _write(kb: Path, rel: str, *, id_: str, status: str, title: str, body: str,
+           tags: str = "", doc_type: str = "standard", tier: str = "T1") -> None:
+    p = kb / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    tags_line = f"tags: [{tags}]\n" if tags else ""
+    p.write_text(
+        f"---\nid: {id_}\ntype: {doc_type}\nstatus: {status}\ntier: {tier}\n"
+        f"category: foundation\n{tags_line}title: {title}\n---\n"
+        f"# {title}\n\n{body}\n",
+        encoding="utf-8",
+    )
+
+
+def _build_status_kb(tmp_path: Path) -> Path:
+    """A KB where the SAME topic ('widget') exists across every status class, so a
+    single query surfaces all of them and status filtering is observable."""
+    kb = tmp_path / "kb"
+    kb.mkdir()
+    _write(kb, "universal/foundation/active.md", id_="DOC-ACTIVE", status="active",
+           title="Widget Active", body="The widget policy currently in force.")
+    _write(kb, "universal/foundation/accepted.md", id_="DOC-ACCEPTED", status="accepted",
+           title="Widget Accepted", body="The widget decision, accepted.", doc_type="decision")
+    _write(kb, "universal/foundation/approved.md", id_="DOC-APPROVED", status="approved",
+           title="Widget Approved", body="The widget decision, approved.", doc_type="decision")
+    _write(kb, "universal/foundation/superseded.md", id_="DOC-SUPERSEDED", status="superseded",
+           title="Widget Superseded", body="The old widget policy, superseded.")
+    _write(kb, "universal/foundation/deprecated.md", id_="DOC-DEPRECATED", status="deprecated",
+           title="Widget Deprecated", body="The old widget policy, deprecated.")
+    _write(kb, "universal/foundation/draft.md", id_="DOC-DRAFT", status="draft",
+           title="Widget Draft", body="A proposed widget policy, draft.")
+    return kb
+
+
+def _idx(tmp_path: Path, index_path: Path) -> Index:
+    kb = _build_status_kb(tmp_path)
+    idx = Index(index_path)
+    idx.build(kb, source_commit="test")
+    return idx
+
+
+# --- in_force filter -------------------------------------------------------
+
+
+def test_in_force_includes_active_accepted_approved(
+    tmp_path: Path, tmp_index_path: Path,
+) -> None:
+    idx = _idx(tmp_path, tmp_index_path)
+    hits = idx.search("widget", limit=20, in_force=True)
+    ids = {h.id for h in hits}
+    assert ids == {"DOC-ACTIVE", "DOC-ACCEPTED", "DOC-APPROVED"}
+
+
+def test_in_force_excludes_superseded_and_deprecated(
+    tmp_path: Path, tmp_index_path: Path,
+) -> None:
+    idx = _idx(tmp_path, tmp_index_path)
+    hits = idx.search("widget", limit=20, in_force=True)
+    ids = {h.id for h in hits}
+    assert "DOC-SUPERSEDED" not in ids
+    assert "DOC-DEPRECATED" not in ids
+    assert "DOC-DRAFT" not in ids
+
+
+def test_in_force_is_hard_filter_not_soft_rerank(
+    tmp_path: Path, tmp_index_path: Path,
+) -> None:
+    """Without in_force, superseded/deprecated docs are RETURNED (only downranked);
+    with in_force they must be absent entirely."""
+    idx = _idx(tmp_path, tmp_index_path)
+    plain_ids = {h.id for h in idx.search("widget", limit=20)}
+    assert "DOC-SUPERSEDED" in plain_ids  # present when not filtered
+    in_force_ids = {h.id for h in idx.search("widget", limit=20, in_force=True)}
+    assert "DOC-SUPERSEDED" not in in_force_ids
+
+
+def test_in_force_false_is_default_and_unchanged(
+    tmp_path: Path, tmp_index_path: Path,
+) -> None:
+    idx = _idx(tmp_path, tmp_index_path)
+    default_ids = {h.id for h in idx.search("widget", limit=20)}
+    explicit_ids = {h.id for h in idx.search("widget", limit=20, in_force=False)}
+    assert default_ids == explicit_ids
+    # All six status docs are surfaced when unfiltered.
+    assert len(default_ids) == 6
+
+
+def test_single_status_filter_still_works(
+    tmp_path: Path, tmp_index_path: Path,
+) -> None:
+    idx = _idx(tmp_path, tmp_index_path)
+    hits = idx.search("widget", limit=20, status="superseded")
+    ids = {h.id for h in hits}
+    assert ids == {"DOC-SUPERSEDED"}
+
+
+def test_status_and_in_force_compose(
+    tmp_path: Path, tmp_index_path: Path,
+) -> None:
+    idx = _idx(tmp_path, tmp_index_path)
+    # accepted is in-force: status+in_force -> just the accepted doc.
+    both = idx.search("widget", limit=20, status="accepted", in_force=True)
+    assert {h.id for h in both} == {"DOC-ACCEPTED"}
+    # superseded is NOT in-force: the AND yields nothing.
+    none = idx.search("widget", limit=20, status="superseded", in_force=True)
+    assert none == []
+
+
+def test_in_force_class_is_single_source() -> None:
+    """The class the engine filters on is exactly format.validate.IN_FORCE_STATUSES."""
+    from data_olympus.index import _IN_FORCE_STATUS_LIST
+    assert set(_IN_FORCE_STATUS_LIST) == IN_FORCE_STATUSES
+    assert set(IN_FORCE_STATUSES) == {"active", "accepted", "approved"}
+
+
+# --- abstain gate (single-sourced) -----------------------------------------
+
+
+def test_abstain_gate_returns_none_on_disjoint_query(
+    tmp_path: Path, tmp_index_path: Path,
+) -> None:
+    idx = _idx(tmp_path, tmp_index_path)
+    # A lexically-disjoint query matches no discriminating column -> gate fires.
+    assert abstain_gate(idx, "quantum chromodynamics parrot", limit=5) is None
+
+
+def test_abstain_gate_returns_hits_on_clear_signal(
+    tmp_path: Path, tmp_index_path: Path,
+) -> None:
+    idx = _idx(tmp_path, tmp_index_path)
+    gated = abstain_gate(idx, "widget", limit=5)
+    assert gated is not None
+    assert gated  # non-empty: "widget" hits the title (a signal column)
+
+
+def test_signal_columns_are_the_discriminating_ones() -> None:
+    assert SIGNAL_COLUMNS == ["title", "tags", "applies_when"]
+
+
+# --- kb_search_fn abstained shape ------------------------------------------
+
+
+def test_kb_search_fn_abstained_shape(
+    tmp_path: Path, tmp_index_path: Path,
+) -> None:
+    idx = _idx(tmp_path, tmp_index_path)
+    resp = kb_search_fn(idx=idx, query="quantum chromodynamics parrot", abstain=True)
+    assert resp.abstained is True
+    assert resp.abstain_reason == "no_signal_match"
+    assert resp.hits == []
+    assert resp.total_returned == 0
+
+
+def test_kb_search_fn_no_abstain_when_signal(
+    tmp_path: Path, tmp_index_path: Path,
+) -> None:
+    idx = _idx(tmp_path, tmp_index_path)
+    resp = kb_search_fn(idx=idx, query="widget", abstain=True)
+    assert resp.abstained is False
+    assert resp.abstain_reason is None
+    assert resp.hits
+
+
+def test_kb_search_fn_default_never_abstains(
+    tmp_path: Path, tmp_index_path: Path,
+) -> None:
+    idx = _idx(tmp_path, tmp_index_path)
+    # A disjoint query with abstain OFF returns an ordinary empty result, NOT an
+    # abstention (the two must be distinguishable).
+    resp = kb_search_fn(idx=idx, query="quantum chromodynamics parrot")
+    assert resp.abstained is False
+    assert resp.abstain_reason is None
+    assert resp.hits == []
+
+
+def test_kb_search_fn_in_force_threads_through(
+    tmp_path: Path, tmp_index_path: Path,
+) -> None:
+    idx = _idx(tmp_path, tmp_index_path)
+    resp = kb_search_fn(idx=idx, query="widget", in_force=True)
+    ids = {h.id for h in resp.hits}
+    assert ids == {"DOC-ACTIVE", "DOC-ACCEPTED", "DOC-APPROVED"}
+
+
+# --- REST param threading --------------------------------------------------
+
+
+def _status_http_app(tmp_path: Path):
+    kb = _build_status_kb(tmp_path)
+    app = build_app(
+        kb_main_path=kb,
+        kb_index_path=tmp_path / "idx.db",
+        sync_interval_sec=60,
+        staleness_degraded_sec=600,
+        bootstrap_now=True,
+    )
+    return app.http_app()
+
+
+@pytest.mark.asyncio
+async def test_rest_in_force_filters(tmp_path: Path) -> None:
+    http_app = _status_http_app(tmp_path)
+    transport = httpx.ASGITransport(app=http_app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get(
+            "/api/v1/search", params={"q": "widget", "in_force": "true"}
+        )
+    assert resp.status_code == 200
+    ids = {h["id"] for h in resp.json()["hits"]}
+    assert ids == {"DOC-ACTIVE", "DOC-ACCEPTED", "DOC-APPROVED"}
+
+
+@pytest.mark.asyncio
+async def test_rest_in_force_default_off(tmp_path: Path) -> None:
+    http_app = _status_http_app(tmp_path)
+    transport = httpx.ASGITransport(app=http_app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/api/v1/search", params={"q": "widget"})
+    ids = {h["id"] for h in resp.json()["hits"]}
+    assert "DOC-SUPERSEDED" in ids  # unfiltered surfaces retired docs
+
+
+@pytest.mark.asyncio
+async def test_rest_abstain_threads(tmp_path: Path) -> None:
+    http_app = _status_http_app(tmp_path)
+    transport = httpx.ASGITransport(app=http_app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        fired = await client.get(
+            "/api/v1/search",
+            params={"q": "quantum chromodynamics parrot", "abstain": "true"},
+        )
+        ok = await client.get(
+            "/api/v1/search", params={"q": "widget", "abstain": "true"}
+        )
+    fired_body = fired.json()
+    assert fired_body["abstained"] is True
+    assert fired_body["abstain_reason"] == "no_signal_match"
+    assert fired_body["hits"] == []
+    ok_body = ok.json()
+    assert ok_body["abstained"] is False
+    assert ok_body["hits"]

--- a/tests/test_tools_enforce_consult.py
+++ b/tests/test_tools_enforce_consult.py
@@ -10,7 +10,8 @@ from data_olympus.tools_enforce import kb_consult_fn
 class _FakeIndex:
     """Minimal stand-in exposing the .search and .health surface kb_search_fn uses."""
 
-    def search(self, query, limit=20, tier=None, category=None, status=None, doc_type=None):  # noqa: ARG002
+    def search(self, query, limit=20, tier=None, category=None, status=None,  # noqa: ARG002
+               in_force=False, doc_type=None, **kwargs):  # noqa: ARG002
         return []
 
     def health(self):


### PR DESCRIPTION
## Summary

Exposes two search behaviors that previously existed only in the benchmark
harness as real `kb_search` parameters, and fixes benchmark bug B1. Part of
WP2a for the 0.3.0 program. References #68 and epic #75.

- **`in_force: bool`** — HARD pre-ranking filter to the in-force status class
  (`active`/`accepted`/`approved`). A `superseded`/`deprecated`/`draft` doc is
  excluded before ranking rather than only soft-downranked by the status
  reranker (which a strong BM25 spread can overcome). Applied to both the FTS
  pool and the dense (embedding) candidate source.
- **`abstain: bool`** — signal gate over the discriminating columns
  (`title`/`tags`/`applies_when`). When the query matches none, the search
  returns no hits with an explicit `abstained: true` +
  `abstain_reason: "no_signal_match"`, distinct from an ordinary empty result.

Both threaded through `kb_search_fn`, the MCP `kb_search` tool, and
`GET /api/v1/search`. `SearchResponse` gains `abstained` / `abstain_reason`.

## Design notes

- **In-force class defined in exactly one place:** `IN_FORCE_STATUSES` in
  `format/validate.py` (the status-vocabulary module). `index.py` derives both
  the soft-rerank boosts (`_DEFAULT_STATUS_WEIGHTS`) and the hard filter
  (`_IN_FORCE_STATUS_LIST`, a sorted materialisation for stable SQL params) from
  it. `approved` is included because the target KB uses it for accepted
  decisions even though the SPEC schema enum uses `accepted`.
- **`in_force` composes with single-status `status`** (AND): `status=superseded`
  + `in_force=true` yields nothing. The existing single-status equality filter
  is unchanged.
- **Abstain gate single-sourced in `src`:** new `data_olympus.search_gate`
  module (`SIGNAL_COLUMNS`, `has_signal`, `abstain_gate`). `benchmarks/ablate.py`
  now imports it instead of keeping its own copy; its own `_SIGNAL_COLUMNS` /
  inline gate were removed.
- **B1 fix:** `benchmarks/methods/data_olympus.py` switched from
  `status="active"` (which silently excluded `accepted` gold decision docs) to
  `in_force=True`. Committed benchmark numbers, `report.md`, and
  `docs/comparison.md` are intentionally NOT re-cut here (WP2c does that).
- **REST:** `in_force` / `abstain` are boolean query params parsed by a new
  `_query_bool` helper, threaded consistently with the existing tier/category
  flow.
- **Docs:** MCP tool docstring/schema, `docs/serving.md` (two new sections),
  `benchmarks/README.md` method description. SPEC.md's serving section does not
  enumerate search params, so no change there.

## Test evidence

- New `tests/test_in_force_and_abstain.py` (23 cases): in_force includes
  active/accepted/approved and excludes superseded/deprecated/draft; hard-filter
  vs soft-rerank; single-status still works; status+in_force compose;
  single-source class assertion; abstain gate returns None on a disjoint query
  and hits on a clear signal; `kb_search_fn` abstained shape; default never
  abstains; REST `in_force` / `abstain` threading via httpx ASGI client.
- Full suite green: `uv run pytest -q` → all pass (1 skip: optional
  `sentence_transformers` not installed).
- `uv run ruff check src/ tests/ benchmarks/` → clean.
- `uv run mypy src/` → clean (50 files).
- `scripts/check_changelog.py` → ok.
- Benchmark smoke tests (`test_bench_ablate_smoke`, `test_bench_methods`,
  `test_bench_run_smoke`) pass; existing
  `test_data_olympus_status_filter_excludes_superseded` still passes (in_force
  also drops superseded).

## Peer review (codex)

Verdict: **No Blocker, Concern, or Nit findings** from the static diff review.
All six criteria verified:
1. `in_force` is a hard pre-ranking filter (`WHERE docs.status IN (...)` before
   `ORDER BY score`, applied to dense candidates too); class defined once in
   `IN_FORCE_STATUSES`.
2. Single-status filtering unchanged and composes with `in_force`.
3. Abstain logic single-sourced in `search_gate.py`; benchmark imports it.
4. Abstained response shape explicit (`models.py`) and documented (`serving.md`).
5. B1 fixed via `in_force=True`; no committed benchmark artifacts changed.
6. Tests cover both modes and REST threading.

(Codex could not execute tests in its read-only sandbox; the full suite was run
green locally, evidence above.)