### PR TITLE
fix(security): request caps, frontmatter encoding, canonical paths, least-privilege principals, viewer escaping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,51 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Security
+
+- Hardened the write and enforcement surface (issue #74). Ten fixes, each with
+  regression tests:
+  - **Request body caps.** The resolve, consult, gate/check, and audit/event REST
+    routes read the body with an uncapped `request.json()`; they now go through the
+    same `KB_MAX_BODY_BYTES` streaming cap as propose/bootstrap and return 413 on
+    oversize input.
+  - **`resolve.edited_text` cap.** Operator-supplied `edited_text` on approve
+    became the committed postimage with no size check; it is now bounded by
+    `KB_MAX_POSTIMAGE_BYTES` and rejected with a distinct
+    `rejected_edited_text_too_large` status, leaving the pending entry in place.
+  - **YAML frontmatter injection.** Memory frontmatter was string-concatenated, so
+    a `tags` / `agent_identity` value containing a newline or `]` could forge
+    reserved keys (`id` / `status` / `supersedes`); a forged duplicate `id` breaks
+    every index rebuild. Frontmatter is now serialized with `yaml.safe_dump`, and
+    the size cap counts the full rendered postimage (frontmatter + body), not just
+    the body.
+  - **Backslash / control-char path bypass.** `decisions\x.md` validated as
+    `decisions/x.md` but wrote a literal root-level file outside every indexed
+    prefix and invisible to `KB_WRITE_BLOCK_PATHS`. Path normalization now returns
+    the canonical form and every downstream operation (classification, blocklist,
+    join, `git add`, pending record) uses it; control characters (newline, CR, tab,
+    NUL) in a target path are rejected.
+  - **Enforcement-plane auth + rate limiting.** `/consult`, `/gate/check`, and
+    `/onboarding/cleanup-plan` were anonymous-allowed even when auth was configured
+    and were unthrottled. They now require an authenticated principal when auth is
+    configured (no-auth deployments are unchanged) and are subject to the shared
+    rate limiter.
+  - **Viewer HTML injection.** A doc body containing `</script>` could break out of
+    the embedded `<script>` block and run arbitrary JS; `</` is now escaped to
+    `<\/`. Fixed a substitution-ordering bug where a body containing the literal
+    `__DISPLAY_NAME__` was mangled (both placeholders are now substituted in a
+    single pass).
+  - **Search limit clamp.** `kb_search` clamped only the upper bound, so
+    `limit=-1` reached SQLite as `LIMIT -1` (unlimited full-corpus dump); it is now
+    clamped to 1..100.
+  - **Actionable status codes.** Malformed `since` / `limit` query params on
+    `/audit` and `/compliance` now return 400 instead of an opaque 500, and resolve
+    of an unknown/expired `pending_id` returns 404 (with path-traversal-shaped ids
+    rejected).
+  - **Rate-limiter hygiene.** The sliding-window limiter now evicts empty bucket
+    keys (bounding memory under varying identities) and guards its read-modify-write
+    with a lock (correct under the threadpool the REST handlers run on).
+
 ### Added
 
 - Actionable gate deny message: the BLOCKED text (and the `consult_required`
@@ -36,6 +81,16 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- **BREAKING (auth):** A `KB_AUTH_PRINCIPALS` entry that omits an explicit
+  `capabilities` list now defaults to least privilege (`read`, `propose`) instead
+  of all capabilities. Previously such an entry silently received `resolve` and
+  `auto_commit`, letting an agent approve its own proposals and skip operator
+  review. **Action required:** any deployment relying on the old implicit
+  full-capability default must now list the capabilities it needs explicitly, e.g.
+  `{"name": "operator-agent", "token": "...", "capabilities": ["read", "propose",
+  "resolve", "auto_commit", "bootstrap", "record_event"]}`. The single
+  `KB_AUTH_TOKEN` operator principal is unaffected and still receives all
+  capabilities.
 - **Enforcement gate policy: the gate now clears only on an explicit
   consultation, not on any recent consult (behavioral change).** Previously the
   gate meant "an HTTP call to `/consult` happened recently in this session", so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,12 +35,15 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
     prefix and invisible to `KB_WRITE_BLOCK_PATHS`. Path normalization now returns
     the canonical form and every downstream operation (classification, blocklist,
     join, `git add`, pending record) uses it; control characters (newline, CR, tab,
-    NUL) in a target path are rejected.
+    NUL) in a target path are rejected. The same canonical-path handling and safe
+    YAML frontmatter (with the size cap applied after remote-URL injection) now
+    also cover the onboarding bootstrap path.
   - **Enforcement-plane auth + rate limiting.** `/consult`, `/gate/check`, and
     `/onboarding/cleanup-plan` were anonymous-allowed even when auth was configured
     and were unthrottled. They now require an authenticated principal when auth is
     configured (no-auth deployments are unchanged) and are subject to the shared
-    rate limiter.
+    rate limiter. `kb_cleanup_plan` is added to the MCP auth-required tool set so
+    the MCP enforcement plane matches REST.
   - **Viewer HTML injection.** A doc body containing `</script>` could break out of
     the embedded `<script>` block and run arbitrary JS; `</` is now escaped to
     `<\/`. Fixed a substitution-ordering bug where a body containing the literal

--- a/src/data_olympus/auth.py
+++ b/src/data_olympus/auth.py
@@ -39,11 +39,32 @@ STRUCTURALLY_EXCLUDED: frozenset[str] = frozenset({
 })
 
 
-def _normalize_target_path(raw: str) -> str | None:
-    """Return the canonical relative POSIX path, or None if structurally invalid."""
+def normalize_target_path(raw: str) -> str | None:
+    """Return the canonical relative POSIX path, or None if structurally invalid.
+
+    The returned string is the SINGLE authoritative form of the path: backslashes
+    are folded to ``/`` and the segments are re-joined with POSIX separators.
+    Every downstream operation (classification, blocklist match, filesystem join,
+    ``git add``) MUST use this canonical value, never the raw input. If callers
+    validated with the canonical form but then joined/wrote/git-added the raw
+    string, a value like ``decisions\\x.md`` would pass validation as
+    ``decisions/x.md`` on Linux yet land a literal root-level file named
+    ``decisions\\x.md`` that is outside every indexed prefix and invisible to
+    ``KB_WRITE_BLOCK_PATHS`` globs. Returning the canonical form and using it
+    everywhere keeps the policy decision and the filesystem effect in lockstep.
+
+    Rejections: empty/whitespace-only, NUL or any other control character
+    (``\\n``, ``\\r``, ``\\t``, etc. would let a payload smuggle newlines into a
+    path), absolute paths, Windows drive letters, ``.``/``..`` traversal, and any
+    structurally-excluded segment.
+    """
     if not raw or not raw.strip():
         return None
-    if "\x00" in raw:
+    # Reject control characters (NUL, newline, CR, tab, and the rest of the
+    # C0/C1 range) before any normalization: a newline in a path is never a
+    # legitimate target and would otherwise smuggle through classification and
+    # audit records.
+    if any(ord(ch) < 0x20 or ord(ch) == 0x7F for ch in raw):
         return None
     if raw.startswith("/") or (len(raw) >= 2 and raw[1] == ":"):
         return None
@@ -55,9 +76,18 @@ def _normalize_target_path(raw: str) -> str | None:
     return str(PurePosixPath(*parts))
 
 
+# Back-compat alias for the previous private name; both point at the same guard.
+_normalize_target_path = normalize_target_path
+
+
 def is_writable_path(target_path: str) -> bool:
-    """Structural rule. Independent of policy blocklist."""
-    canonical = _normalize_target_path(target_path)
+    """Structural rule. Independent of policy blocklist.
+
+    Callers that go on to write MUST first resolve the canonical form with
+    :func:`normalize_target_path` and operate on that; this predicate only
+    answers whether the canonical form is a writable indexed ``.md`` path.
+    """
+    canonical = normalize_target_path(target_path)
     if canonical is None:
         return False
     if not canonical.endswith(".md"):

--- a/src/data_olympus/pending.py
+++ b/src/data_olympus/pending.py
@@ -10,12 +10,17 @@ from __future__ import annotations
 import contextlib
 import json
 import os
+import re
 import time
 import uuid
 from dataclasses import dataclass
 from typing import Any, Literal
 
 from data_olympus.durable import atomic_remove, atomic_write_json
+
+# The exact shape of ``uuid.uuid4().hex`` (32 lowercase hex chars). Used to reject
+# path-traversal in a client-supplied pending_id before it hits the disk join.
+_PENDING_ID_RE = re.compile(r"[0-9a-f]{32}")
 
 
 class PathLockBusyError(Exception):
@@ -24,6 +29,14 @@ class PathLockBusyError(Exception):
 
 class PendingQueueFullError(Exception):
     """Raised when the pending queue is at capacity (KB_PENDING_QUEUE_CAP)."""
+
+
+class PendingNotFoundError(Exception):
+    """Raised when a pending_id does not resolve to an entry on disk.
+
+    Previously ``get`` let the bare ``FileNotFoundError`` from ``open`` propagate,
+    which the REST resolve route surfaced as an opaque HTTP 500. This typed error
+    lets the route map an unknown/expired id to a 404 (item 9)."""
 
 
 @dataclass(frozen=True, slots=True)
@@ -123,7 +136,15 @@ class PendingQueue:
         return out
 
     def get(self, pending_id: str) -> dict[str, Any]:
-        with open(os.path.join(self._root, f"{pending_id}.json")) as f:
+        # pending_id reaches here straight from a URL path param; reject anything
+        # that is not the hex-uuid shape we mint so a value like
+        # ``../../etc/passwd`` can never be interpolated into the on-disk join.
+        if not _PENDING_ID_RE.fullmatch(pending_id):
+            raise PendingNotFoundError(pending_id)
+        path = os.path.join(self._root, f"{pending_id}.json")
+        if not os.path.exists(path):
+            raise PendingNotFoundError(pending_id)
+        with open(path) as f:
             data: dict[str, Any] = json.load(f)
             return data
 

--- a/src/data_olympus/principals.py
+++ b/src/data_olympus/principals.py
@@ -66,9 +66,12 @@ WRITE_TOOL_CAPABILITY: dict[str, str] = {
 
 # Non-write MCP tools that expose pending/audit/enforcement state and so require
 # an authenticated principal when auth is configured, mirroring the REST gating of
-# /pending, /audit, /audit/verify, /consult, and /gate/check.
+# /pending, /audit, /audit/verify, /consult, /gate/check, and /cleanup-plan.
+# ``kb_cleanup_plan`` is included (item 6) so the MCP enforcement plane matches the
+# REST one: with auth configured, anonymous callers cannot reach it.
 AUTH_REQUIRED_TOOLS: frozenset[str] = frozenset({
     "kb_list_pending", "kb_audit", "kb_consult", "kb_gate_check", "kb_compliance",
+    "kb_cleanup_plan",
 })
 
 

--- a/src/data_olympus/principals.py
+++ b/src/data_olympus/principals.py
@@ -47,6 +47,14 @@ ALL_CAPABILITIES: frozenset[str] = frozenset({
     CAP_RESOLVE, CAP_BOOTSTRAP, CAP_RECORD_EVENT,
 })
 
+# Least-privilege default for a KB_AUTH_PRINCIPALS entry that omits an explicit
+# ``capabilities`` list (item 5). Previously the default was ALL_CAPABILITIES,
+# which handed every per-agent token ``resolve`` and ``auto_commit`` — letting an
+# agent approve its own proposals (self-approval) and skip operator review. The
+# safe default grants only read + propose; an operator who genuinely wants a
+# higher-privileged agent must opt in by listing capabilities explicitly.
+DEFAULT_PRINCIPAL_CAPABILITIES: frozenset[str] = frozenset({CAP_READ, CAP_PROPOSE})
+
 # Write tools (MCP) / routes (REST) mapped to the capability they require.
 WRITE_TOOL_CAPABILITY: dict[str, str] = {
     "kb_propose_memory": CAP_PROPOSE,
@@ -133,7 +141,9 @@ class PrincipalRegistry:
             name = str(spec.get("name", "")).strip() or "agent"
             caps = spec.get("capabilities")
             if caps is None:
-                capset = ALL_CAPABILITIES
+                # Least-privilege default (item 5): read + propose only. An entry
+                # that needs resolve/auto_commit/bootstrap must list them.
+                capset = DEFAULT_PRINCIPAL_CAPABILITIES
             else:
                 capset = frozenset(str(c).strip() for c in caps if str(c).strip())
             self._by_token.append(

--- a/src/data_olympus/rate_limit.py
+++ b/src/data_olympus/rate_limit.py
@@ -8,8 +8,9 @@ ignores agent_identity, so varying it no longer multiplies quota from one source
 """
 from __future__ import annotations
 
+import threading
 import time
-from collections import defaultdict
+from typing import Any
 
 
 class SlidingWindowLimiter:
@@ -18,25 +19,63 @@ class SlidingWindowLimiter:
     ) -> None:
         self._max = max_per_hour
         self._max_ip = max_per_ip_per_hour
-        self._buckets: dict[tuple[str, str], list[float]] = defaultdict(list)
-        self._ip_buckets: dict[str, list[float]] = defaultdict(list)
+        self._buckets: dict[tuple[str, str], list[float]] = {}
+        self._ip_buckets: dict[str, list[float]] = {}
+        # REST handlers run on the anyio worker-thread pool (see rest_api._offload),
+        # so allow() is called concurrently from multiple threads. The read-modify-
+        # write on the bucket lists is not atomic; without this lock two threads can
+        # interleave and both admit a request past the cap, or corrupt a list mid-
+        # rebuild. The critical section is a few list ops on already-pruned data, so
+        # contention is negligible (item 10).
+        self._lock = threading.Lock()
 
     def allow(self, *, remote_addr: str, agent_identity: str) -> bool:
         now = time.time()
         cutoff = now - 3600
         key = (remote_addr, agent_identity)
-        self._buckets[key] = [t for t in self._buckets[key] if t > cutoff]
-        # Per-IP cap (0 = disabled): bounds total quota from one source address
-        # regardless of how many agent_identity values it presents.
-        if self._max_ip > 0:
-            self._ip_buckets[remote_addr] = [
-                t for t in self._ip_buckets[remote_addr] if t > cutoff
-            ]
-            if len(self._ip_buckets[remote_addr]) >= self._max_ip:
+        with self._lock:
+            pruned = [t for t in self._buckets.get(key, ()) if t > cutoff]
+            # Per-IP cap (0 = disabled): bounds total quota from one source address
+            # regardless of how many agent_identity values it presents.
+            if self._max_ip > 0:
+                ip_pruned = [
+                    t for t in self._ip_buckets.get(remote_addr, ()) if t > cutoff
+                ]
+                if len(ip_pruned) >= self._max_ip:
+                    # Store back the pruned lists (or evict when empty) before
+                    # returning, so a denied caller still drops expired timestamps
+                    # and empty keys never accumulate under varying identities.
+                    self._store(self._buckets, key, pruned)
+                    self._store(self._ip_buckets, remote_addr, ip_pruned)
+                    return False
+            else:
+                ip_pruned = None
+            if len(pruned) >= self._max:
+                self._store(self._buckets, key, pruned)
+                if ip_pruned is not None:
+                    self._store(self._ip_buckets, remote_addr, ip_pruned)
                 return False
-        if len(self._buckets[key]) >= self._max:
-            return False
-        self._buckets[key].append(now)
-        if self._max_ip > 0:
-            self._ip_buckets[remote_addr].append(now)
-        return True
+            pruned.append(now)
+            self._store(self._buckets, key, pruned)
+            if self._max_ip > 0:
+                assert ip_pruned is not None
+                ip_pruned.append(now)
+                self._store(self._ip_buckets, remote_addr, ip_pruned)
+            return True
+
+    @staticmethod
+    def _store(buckets: dict[Any, list[float]], key: Any, values: list[float]) -> None:
+        """Write ``values`` back under ``key``, deleting the key entirely when the
+        list is empty. Evicting empty keys bounds memory: without it, every unique
+        (remote_addr, agent_identity) pair — which a caller can vary freely — left a
+        permanent empty-list entry, an unbounded leak (item 10)."""
+        if values:
+            buckets[key] = values
+        else:
+            buckets.pop(key, None)
+
+    def bucket_count(self) -> int:
+        """Number of live (non-evicted) bucket keys. Exposed for tests asserting
+        that empty keys are evicted rather than accumulating."""
+        with self._lock:
+            return len(self._buckets) + len(self._ip_buckets)

--- a/src/data_olympus/rest_api.py
+++ b/src/data_olympus/rest_api.py
@@ -14,6 +14,7 @@ from data_olympus.principals import (
     CAP_PROPOSE,
     CAP_RECORD_EVENT,
     CAP_RESOLVE,
+    Principal,
     PrincipalRegistry,
 )
 from data_olympus.tools_read import (
@@ -30,7 +31,6 @@ if TYPE_CHECKING:
     from starlette.requests import Request
 
     from data_olympus.models import HealthResponse
-    from data_olympus.principals import Principal
     from data_olympus.server import ServerState
 
 
@@ -158,6 +158,27 @@ def _parse_confidence(body: dict[str, Any]) -> tuple[float, JSONResponse | None]
         )
 
 
+def _parse_numeric_qp(
+    qp: Any, name: str, kind: type, *, default: Any = None,
+) -> tuple[Any, JSONResponse | None]:
+    """Coerce query param ``name`` to ``kind`` (float/int), returning a 400
+    JSONResponse instead of letting a non-numeric value raise ValueError -> HTTP
+    500 (item 9). The file's own 400-vs-500 rationale (see _missing_fields_response)
+    demands that malformed client input surface as an actionable 400, not an
+    opaque crash. A missing/empty param yields ``default``."""
+    raw = qp.get(name)
+    if raw is None or raw == "":
+        return default, None
+    try:
+        return kind(raw), None
+    except (TypeError, ValueError):
+        return default, JSONResponse(
+            {"error": "bad_request",
+             "message": f"query param '{name}' must be a {kind.__name__}"},
+            status_code=400,
+        )
+
+
 def _write_pipeline_ready(state: ServerState) -> JSONResponse | None:
     """Return a structured 503 when the write pipeline is disabled (the server
     runs read-only because ``KB_REMOTE_URL`` is unset), else None.
@@ -222,6 +243,34 @@ async def _read_json_capped(
             {"error": "bad_request", "message": "invalid JSON body"},
             status_code=400,
         )
+
+
+def _rate_limited(
+    state: ServerState, request: Request, principal: Principal,
+) -> JSONResponse | None:
+    """Apply the shared sliding-window limiter to an enforcement-plane route.
+
+    The consult / gate / cleanup-plan routes were previously unthrottled (item 6),
+    so an anonymous or authenticated caller could hammer the classifier and ledger
+    without bound. Reuse the same limiter the write routes use, keyed by
+    (remote_addr, principal name) so a per-principal quota applies. Returns a 429
+    JSONResponse when over quota, else None.
+
+    When the limiter is absent (a read-only deployment with no write pipeline
+    configured) throttling is skipped: there is no shared limiter object to
+    consult and these routes are read-mostly there.
+    """
+    limiter = state.rate_limiter
+    if limiter is None:
+        return None
+    remote_addr = request.client.host if request.client else "unknown"
+    if not limiter.allow(remote_addr=remote_addr, agent_identity=principal.name):
+        return JSONResponse(
+            {"error": "rate_limited",
+             "message": "too many requests; retry later"},
+            status_code=429,
+        )
+    return None
 
 
 def register_routes(
@@ -406,24 +455,39 @@ def register_routes(
             if (off := _write_pipeline_ready(state)) is not None:
                 return off
             pid = request.path_params["pending_id"]
-            body = await request.json()
+            body, big = await _read_json_capped(request, state.config.max_body_bytes)
+            if big is not None:
+                return big
             if (bad := _missing_fields_response(body, ["decision"])) is not None:
                 return bad
             assert state.worktrees is not None
             assert state.push_queue is not None
             assert state.pending is not None
+            from data_olympus.pending import PendingNotFoundError
             from data_olympus.tools_write import kb_resolve_pending_fn
-            resp = await _offload(
-                kb_resolve_pending_fn,
-                pending_id=pid, decision=body["decision"],
-                edited_text=body.get("edited_text"),
-                worktrees=state.worktrees, push_queue=state.push_queue,
-                pending=state.pending,
-                source_session=body.get("source_session", "operator"),
-                agent_identity=body.get("agent_identity", "operator"),
-                audit_log=state.audit_log,
-            )
-            return JSONResponse(resp.model_dump())
+            try:
+                resp = await _offload(
+                    kb_resolve_pending_fn,
+                    pending_id=pid, decision=body["decision"],
+                    edited_text=body.get("edited_text"),
+                    worktrees=state.worktrees, push_queue=state.push_queue,
+                    pending=state.pending,
+                    source_session=body.get("source_session", "operator"),
+                    agent_identity=body.get("agent_identity", "operator"),
+                    audit_log=state.audit_log,
+                    max_postimage_bytes=state.config.max_postimage_bytes,
+                )
+            except PendingNotFoundError:
+                # Unknown or already-resolved/expired pending_id: a client-side
+                # mistake, not a server fault. 404, not the opaque 500 the raw
+                # FileNotFoundError produced (item 9).
+                return JSONResponse(
+                    {"error": "not_found",
+                     "message": f"no pending proposal with id '{pid}'"},
+                    status_code=404,
+                )
+            status = 413 if resp.status == "rejected_edited_text_too_large" else 200
+            return JSONResponse(resp.model_dump(), status_code=status)
 
         @app.custom_route("/api/v1/pending", methods=["GET"])
         async def list_pending(request: Request) -> JSONResponse:
@@ -447,10 +511,14 @@ def register_routes(
                 return JSONResponse({"events": [], "returned": 0, "limit_hit": False})
             from data_olympus.tools_audit import kb_audit_fn
             qp = request.query_params
-            since = float(qp["since"]) if qp.get("since") else None
+            since, bad = _parse_numeric_qp(qp, "since", float)
+            if bad is not None:
+                return bad
             agent = qp.get("agent")
             status_filter = qp.get("status")
-            limit = int(qp.get("limit", "100"))
+            limit, bad = _parse_numeric_qp(qp, "limit", int, default=100)
+            if bad is not None:
+                return bad
             resp = await _offload(kb_audit_fn, audit_log=state.audit_log, since=since,
                                   agent=agent, status=status_filter, limit=limit)
             return JSONResponse(resp.model_dump())
@@ -467,13 +535,17 @@ def register_routes(
 
         @app.custom_route("/api/v1/consult", methods=["POST"])
         async def consult(request: Request) -> JSONResponse:
-            _principal, denied = _authorize(request, registry)
+            principal, denied = _authorize(request, registry)
             if denied is not None:
                 return denied
+            if (throttled := _rate_limited(state, request, principal)) is not None:
+                return throttled
             import time as _time
 
             from data_olympus.tools_enforce import kb_consult_fn
-            body = await request.json()
+            body, big = await _read_json_capped(request, state.config.max_body_bytes)
+            if big is not None:
+                return big
             if (bad := _missing_fields_response(
                 body, ["workspace", "source_session"],
             )) is not None:
@@ -495,13 +567,17 @@ def register_routes(
 
         @app.custom_route("/api/v1/gate/check", methods=["POST"])
         async def gate_check(request: Request) -> JSONResponse:
-            _principal, denied = _authorize(request, registry)
+            principal, denied = _authorize(request, registry)
             if denied is not None:
                 return denied
+            if (throttled := _rate_limited(state, request, principal)) is not None:
+                return throttled
             import time as _time
 
             from data_olympus.tools_enforce import kb_gate_check_fn
-            body = await request.json()
+            body, big = await _read_json_capped(request, state.config.max_body_bytes)
+            if big is not None:
+                return big
             if (bad := _missing_fields_response(
                 body, ["workspace", "session_id"],
             )) is not None:
@@ -529,7 +605,9 @@ def register_routes(
                 return JSONResponse({"counts": {}, "by_agent": {}})
             from data_olympus.tools_enforce import kb_compliance_fn
             qp = request.query_params
-            since = float(qp["since"]) if qp.get("since") else None
+            since, bad = _parse_numeric_qp(qp, "since", float)
+            if bad is not None:
+                return bad
             agent = qp.get("agent")
             resp = await _offload(
                 kb_compliance_fn, audit_log=state.audit_log, since=since, agent=agent)
@@ -544,7 +622,9 @@ def register_routes(
                 return JSONResponse({"recorded": False}, status_code=503)
             import time as _time
 
-            body = await request.json()
+            body, big = await _read_json_capped(request, state.config.max_body_bytes)
+            if big is not None:
+                return big
             if (bad := _missing_fields_response(body, ["event_type", "workspace"])) is not None:
                 return bad
             from data_olympus.tools_enforce import kb_record_event_fn
@@ -643,6 +723,14 @@ def register_routes(
 
     @app.custom_route("/api/v1/onboarding/cleanup-plan", methods=["POST"])
     async def onboarding_cleanup_plan(request: Request) -> JSONResponse:
+        # Was anonymous-allowed even with auth configured, and unthrottled (item 6).
+        # Close it to anonymous callers when auth is on (no-auth deployments still
+        # resolve LOCAL_TRUSTED and pass) and apply the shared limiter.
+        principal, denied = _authorize(request, registry)
+        if denied is not None:
+            return denied
+        if (throttled := _rate_limited(state, request, principal)) is not None:
+            return throttled
         body, big = await _read_json_capped(request, state.config.max_body_bytes)
         if big is not None:
             return big

--- a/src/data_olympus/tools_onboarding.py
+++ b/src/data_olympus/tools_onboarding.py
@@ -265,10 +265,15 @@ def _inject_remote_url(
                 rest = postimage[fm_end + len("\n---\n"):]
                 try:
                     fm = yaml.safe_load(fm_text) or {}
-                    if not isinstance(fm, dict):
-                        fm = {}
                 except yaml.YAMLError:
-                    fm = {}
+                    fm = None
+                if not isinstance(fm, dict):
+                    # Unparseable or non-mapping frontmatter: leave the file
+                    # untouched rather than clobber caller data with a rebuilt
+                    # block (codex round-2 Concern: silent metadata loss). The
+                    # injection is skipped, matching the no-closing-fence case.
+                    out.append(f)
+                    continue
                 if fm.get("git_remote_url") == url:
                     out.append(f)
                     continue

--- a/src/data_olympus/tools_onboarding.py
+++ b/src/data_olympus/tools_onboarding.py
@@ -106,41 +106,55 @@ def kb_bootstrap_project_fn(
         )
 
     # For onboarding v1: simplified atomic-commit path.
-    # Validate every file via is_writable_path + blocklist before any side effects.
-    from data_olympus.auth import is_writable_path
+    # Validate every file via normalize_target_path + blocklist before any side
+    # effects, and REWRITE each file's target_path to the canonical form so that
+    # classification, blocklist, pending enqueue, safe_join, and ``git add`` all
+    # operate on the same value that passed validation (item 4). Without this a
+    # backslash path like ``decisions\\x.md`` validated as ``decisions/x.md`` yet
+    # committed a literal root-level backslash file outside every indexed prefix.
+    from data_olympus.auth import is_writable_path, normalize_target_path
     from data_olympus.index import _classify_by_path
     rejected: list[str] = []
-    oversized: list[str] = []
+    canonical_files: list[dict[str, str]] = []
     for f in files:
-        if not is_writable_path(f["target_path"]):
+        canonical = normalize_target_path(f["target_path"])
+        if canonical is None or not is_writable_path(canonical):
             rejected.append(f["target_path"])
             continue
-        target_tier, _ = _classify_by_path(f["target_path"])
-        if blocklist.blocks(f["target_path"], target_tier):
+        target_tier, _ = _classify_by_path(canonical)
+        if blocklist.blocks(canonical, target_tier):
             rejected.append(f["target_path"])
             continue
-        if (max_postimage_bytes > 0
-                and len(f["postimage"].encode("utf-8")) > max_postimage_bytes):
-            oversized.append(f["target_path"])
+        canonical_files.append({**f, "target_path": canonical})
     if rejected:
         return BootstrapResponse(
             status="rejected_path_not_indexable_or_blocked",
             rejected_paths=rejected,
         )
+    files = canonical_files
+
+    if not rate_limiter.allow(remote_addr=remote_addr, agent_identity=agent_identity):
+        return BootstrapResponse(status="rejected_rate_limited")
+
+    # Inject git_remote_url into README/AGENTS front-matter BEFORE the size cap, so
+    # the cap counts exactly the bytes that land in git (item 3). Checking the cap
+    # before injection let an injected postimage exceed the cap yet still commit.
+    if workspace_remote_url:
+        files = _inject_remote_url(files, workspace_remote_url, target_filename="README.md")
+    if component_remote_url:
+        files = _inject_remote_url(files, component_remote_url, target_filename="AGENTS.md")
+
+    # Payload size cap on the FINAL (post-injection) postimage of every file.
+    oversized = [
+        f["target_path"] for f in files
+        if max_postimage_bytes > 0
+        and len(f["postimage"].encode("utf-8")) > max_postimage_bytes
+    ]
     if oversized:
         return BootstrapResponse(
             status="rejected_payload_too_large",
             rejected_paths=oversized,
         )
-
-    if not rate_limiter.allow(remote_addr=remote_addr, agent_identity=agent_identity):
-        return BootstrapResponse(status="rejected_rate_limited")
-
-    # Inject git_remote_url into README/AGENTS front-matter if provided.
-    if workspace_remote_url:
-        files = _inject_remote_url(files, workspace_remote_url, target_filename="README.md")
-    if component_remote_url:
-        files = _inject_remote_url(files, component_remote_url, target_filename="AGENTS.md")
 
     if confidence < confidence_threshold or not can_auto_commit:
         # Low confidence (or caller not authorized to auto-commit): enqueue ALL
@@ -228,31 +242,51 @@ def kb_bootstrap_project_fn(
 def _inject_remote_url(
     files: list[dict[str, str]], url: str, *, target_filename: str,
 ) -> list[dict[str, str]]:
-    """Ensure the front-matter of the target file contains git_remote_url: <url>."""
+    """Ensure the front-matter of the target file contains git_remote_url: <url>.
+
+    The URL is set as a structured YAML value and the frontmatter is re-emitted
+    with ``yaml.safe_dump`` (item 3). Previously the raw ``git_remote_url: {url}``
+    string was spliced into the document, so a ``url`` containing a newline could
+    forge additional top-level frontmatter keys (e.g. ``id`` / ``status``). Safe
+    dumping quotes/escapes any structure-breaking value so it survives only as the
+    intended scalar.
+    """
+    import yaml
     out = []
     for f in files:
-        if f["target_path"].endswith("/" + target_filename):
-            postimage = f["postimage"]
-            if f"git_remote_url: {url}" not in postimage:
-                # Insert into front matter if present, else prepend.
-                if postimage.startswith("---\n"):
-                    # Insert before closing --- on the first front-matter block.
-                    fm_end = postimage.find("\n---\n", 4)
-                    if fm_end > 0:
-                        new_postimage = (
-                            postimage[:fm_end] +
-                            f"\ngit_remote_url: {url}" +
-                            postimage[fm_end:]
-                        )
-                    else:
-                        new_postimage = postimage
-                else:
-                    new_postimage = (
-                        f"---\ngit_remote_url: {url}\n---\n\n" + postimage
-                    )
-                out.append({**f, "postimage": new_postimage})
-                continue
-        out.append(f)
+        if not f["target_path"].endswith("/" + target_filename):
+            out.append(f)
+            continue
+        postimage = f["postimage"]
+        if postimage.startswith("---\n"):
+            fm_end = postimage.find("\n---\n", 4)
+            if fm_end > 0:
+                fm_text = postimage[4:fm_end]
+                rest = postimage[fm_end + len("\n---\n"):]
+                try:
+                    fm = yaml.safe_load(fm_text) or {}
+                    if not isinstance(fm, dict):
+                        fm = {}
+                except yaml.YAMLError:
+                    fm = {}
+                if fm.get("git_remote_url") == url:
+                    out.append(f)
+                    continue
+                fm["git_remote_url"] = url
+                dumped = yaml.safe_dump(
+                    fm, sort_keys=False, default_flow_style=False,
+                    allow_unicode=True,
+                )
+                new_postimage = "---\n" + dumped + "---\n" + rest
+            else:
+                # Malformed frontmatter (no closing fence): leave untouched.
+                new_postimage = postimage
+        else:
+            new_postimage = "---\n" + yaml.safe_dump(
+                {"git_remote_url": url}, default_flow_style=False,
+                allow_unicode=True,
+            ) + "---\n\n" + postimage
+        out.append({**f, "postimage": new_postimage})
     return out
 
 

--- a/src/data_olympus/tools_read.py
+++ b/src/data_olympus/tools_read.py
@@ -116,8 +116,13 @@ def kb_search_fn(
     status: str | None = None,
     doc_type: str | None = None,
 ) -> SearchResponse:
+    # Clamp to 1..100 (item 8). Clamping only the upper bound let a negative
+    # ``limit`` (e.g. -1) reach SQLite as ``LIMIT -1``, which SQLite treats as
+    # "no limit" and dumps the entire corpus in one request. Bound both ends.
     if limit > 100:
         limit = 100
+    elif limit < 1:
+        limit = 1
     hits = idx.search(
         query, limit=limit, tier=tier, category=category, status=status, doc_type=doc_type
     )

--- a/src/data_olympus/tools_write.py
+++ b/src/data_olympus/tools_write.py
@@ -10,7 +10,12 @@ import time
 from typing import TYPE_CHECKING, Any
 
 from data_olympus.audit_trailers import build_commit_message
-from data_olympus.auth import PathBlocklist, is_writable_path, safe_join_under_root
+from data_olympus.auth import (
+    PathBlocklist,
+    is_writable_path,
+    normalize_target_path,
+    safe_join_under_root,
+)
 from data_olympus.models import (
     PendingEntry,
     PendingListResponse,
@@ -151,14 +156,18 @@ def kb_propose_memory_fn(
         _emit_audit(audit_log, **{**audit_base, "status": "rejected_rate_limited"})
         return ProposeResponse(status="rejected_rate_limited")
 
-    # 3b. Payload size cap (reject before any disk side effect).
-    if max_text_bytes > 0 and len(text.encode("utf-8")) > max_text_bytes:
+    # 4. Render the postimage (front matter + body) BEFORE the size cap so the
+    # cap counts the FULL committed bytes, not just the body: the frontmatter the
+    # server prepends (tags, agent identity, ISO timestamp) is part of what gets
+    # written and pushed, and an unbounded tags list would otherwise slip past a
+    # body-only check (item 3).
+    postimage = _render_memory(text=text, tags=tags, agent_identity=agent_identity)
+
+    # 4b. Payload size cap (reject before any disk side effect).
+    if max_text_bytes > 0 and len(postimage.encode("utf-8")) > max_text_bytes:
         _emit_audit(audit_log, **{**audit_base, "status": "rejected_payload_too_large"})
         return ProposeResponse(status="rejected_payload_too_large",
                                target_path=target_path)
-
-    # 4. Render the postimage (front matter + body).
-    postimage = _render_memory(text=text, tags=tags, agent_identity=agent_identity)
 
     if confidence < confidence_threshold or not can_auto_commit:
         try:
@@ -239,13 +248,31 @@ def kb_propose_memory_fn(
 
 
 def _render_memory(*, text: str, tags: list[str], agent_identity: str) -> str:
-    fm = ["---"]
-    fm.append(f"created_by: {agent_identity}")
-    fm.append(f"created_at: {datetime.datetime.now(datetime.UTC).isoformat()}")
+    """Render a memory file: YAML frontmatter block + body.
+
+    The frontmatter is built as a dict and serialized with ``yaml.safe_dump``
+    (item 3). String-concatenating ``agent_identity`` / ``tags`` into the YAML
+    (the previous approach) let a value containing a newline or ``]`` inject
+    arbitrary top-level keys: e.g. an ``agent_identity`` of
+    ``x\\nid: GDEC-001\\nstatus: accepted`` or a tag of ``a], id: forged`` would
+    forge reserved keys (``id`` / ``status`` / ``supersedes``). A forged duplicate
+    ``id`` breaks every index rebuild. ``safe_dump`` quotes and escapes any value
+    that would otherwise change the document structure, so newline/bracket
+    payloads survive only as data inside the intended key.
+    """
+    import yaml
+
+    fm: dict[str, Any] = {
+        "created_by": agent_identity,
+        "created_at": datetime.datetime.now(datetime.UTC).isoformat(),
+    }
     if tags:
-        fm.append("tags: [" + ", ".join(tags) + "]")
-    fm.append("---")
-    return "\n".join(fm) + "\n\n" + text + "\n"
+        # Coerce to plain str so a non-str element can't smuggle a YAML tag.
+        fm["tags"] = [str(t) for t in tags]
+    dumped = yaml.safe_dump(
+        fm, sort_keys=False, default_flow_style=False, allow_unicode=True
+    )
+    return "---\n" + dumped + "---\n\n" + text + "\n"
 
 
 def kb_propose_edit_fn(
@@ -283,11 +310,19 @@ def kb_propose_edit_fn(
         "reason": reason,
         "remote_addr": remote_addr,
     }
-    if not is_writable_path(target_path):
+    canonical = normalize_target_path(target_path)
+    if canonical is None or not is_writable_path(canonical):
         _emit_audit(audit_log, **{**audit_base, "status": "rejected_path_not_indexable"})
         return ProposeResponse(status="rejected_path_not_indexable",
                                reason="traversal_or_excluded",
                                target_path=target_path)
+    # From here on operate ONLY on the canonical path: classification, blocklist,
+    # the pending record, the filesystem join, and ``git add`` must all agree with
+    # the value that passed validation (item 4). Using the raw string below would
+    # let ``decisions\\x.md`` validate as ``decisions/x.md`` yet write a literal
+    # ``decisions\\x.md`` outside every indexed prefix.
+    target_path = canonical
+    audit_base["target_path"] = target_path
     target_tier, _ = _classify(target_path)
     audit_base["target_tier"] = target_tier
     if blocklist.blocks(target_path, target_tier):
@@ -380,6 +415,7 @@ def kb_resolve_pending_fn(
     source_session: str,
     agent_identity: str,
     audit_log: AuditLog | None = None,
+    max_postimage_bytes: int = 0,
 ) -> ResolvePendingResponse:
     audit_base: dict[str, Any] = {
         "event_type": "resolve",
@@ -394,6 +430,18 @@ def kb_resolve_pending_fn(
     if decision not in ("approve", "edit"):
         _emit_audit(audit_log, **{**audit_base, "status": "rejected_bad_decision"})
         return ResolvePendingResponse(status="rejected_bad_decision")
+
+    # ``edited_text`` becomes the committed postimage, bypassing the cap the
+    # propose path enforced on the original postimage (item 2). Enforce it here
+    # too, with a distinct status so the operator sees WHY the edit was refused.
+    # Peek at the entry (without consuming it) so a too-large edit leaves the
+    # pending entry in place to be re-edited rather than silently dropped.
+    if edited_text is not None and max_postimage_bytes > 0 and (
+        len(edited_text.encode("utf-8")) > max_postimage_bytes
+    ):
+        _emit_audit(audit_log,
+                    **{**audit_base, "status": "rejected_edited_text_too_large"})
+        return ResolvePendingResponse(status="rejected_edited_text_too_large")
 
     resolved = pending.approve(pending_id, edited_text=edited_text)
     target_tier, _ = _classify(resolved.target_path)

--- a/src/data_olympus/viewer/generator.py
+++ b/src/data_olympus/viewer/generator.py
@@ -347,9 +347,24 @@ def generate_visualization(
         "bodies": bodies,
     }
 
-    json_str = json.dumps(bundle_data)
+    # Escape any ``</`` (item 7): the JSON payload is embedded inside a
+    # ``<script>`` block, and the HTML parser ends that block at the first literal
+    # ``</script>`` REGARDLESS of JSON/string context. A doc body containing
+    # ``</script><script>alert(1)</script>`` would otherwise break out and run
+    # arbitrary JS. ``<\/`` is an equivalent JSON escape (JSON permits ``\/``), so
+    # the data is unchanged after JSON.parse but the HTML parser never sees a
+    # closing tag.
+    json_str = json.dumps(bundle_data).replace("</", "<\\/")
     safe_name = html.escape(display_name)
-    html_out = _HTML_TEMPLATE.replace("__JSON__", json_str).replace("__DISPLAY_NAME__", safe_name)
+    # Single-pass substitution (item 7): replacing __JSON__ then __DISPLAY_NAME__
+    # (or vice versa) let payload content that happened to contain the OTHER
+    # placeholder get mangled by the second pass — e.g. a doc body with the literal
+    # ``__DISPLAY_NAME__`` was rewritten to the bundle name. Substituting both in
+    # one regex pass means neither replacement's output is rescanned.
+    _subs = {"__JSON__": json_str, "__DISPLAY_NAME__": safe_name}
+    html_out = re.sub(
+        "__JSON__|__DISPLAY_NAME__", lambda m: _subs[m.group(0)], _HTML_TEMPLATE
+    )
     out_path.parent.mkdir(parents=True, exist_ok=True)
     out_path.write_text(html_out, encoding="utf-8")
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,7 +1,11 @@
 """Tests for the structural rule (always applies) + policy blocklist (configurable)."""
 from __future__ import annotations
 
-from data_olympus.auth import PathBlocklist, is_writable_path
+from data_olympus.auth import (
+    PathBlocklist,
+    is_writable_path,
+    normalize_target_path,
+)
 
 # ---- Structural rule (Codex blocker 2 fix: path traversal rejected) ----
 
@@ -53,6 +57,49 @@ def test_structural_rule_rejects_empty_input() -> None:
 
 def test_structural_rule_rejects_empty_segment_from_double_slash() -> None:
     assert is_writable_path("projects//foo.md") is False
+
+
+# ---- Canonical path handling (item 4: backslash bypass + control chars) ----
+
+
+def test_normalize_folds_backslashes_to_canonical() -> None:
+    # A backslash path validates as its forward-slash canonical form...
+    assert normalize_target_path("decisions\\x.md") == "decisions/x.md"
+    assert is_writable_path("decisions\\x.md") is True
+
+
+def test_normalize_returns_canonical_not_raw() -> None:
+    # ...and the canonical form is what callers must use downstream, so it never
+    # carries a literal backslash that would land a root-level file on Linux.
+    canonical = normalize_target_path("decisions\\sub\\x.md")
+    assert canonical == "decisions/sub/x.md"
+    assert "\\" not in canonical
+
+
+def test_normalize_rejects_newline_control_char() -> None:
+    # A newline in a path is never legitimate and would smuggle YAML/audit content.
+    assert normalize_target_path("decisions/x\n.md") is None
+    assert is_writable_path("decisions/x\n.md") is False
+
+
+def test_normalize_rejects_carriage_return_and_tab() -> None:
+    assert normalize_target_path("decisions/x\r.md") is None
+    assert normalize_target_path("decisions/x\t.md") is None
+
+
+def test_normalize_rejects_nul_via_control_range() -> None:
+    assert normalize_target_path("decisions/x\x00.md") is None
+
+
+def test_normalize_rejects_backslash_traversal() -> None:
+    # Backslash-encoded traversal folds to '..' segments and is rejected.
+    assert normalize_target_path("projects\\..\\..\\memory\\x.md") is None
+    assert is_writable_path("projects\\..\\..\\memory\\x.md") is False
+
+
+def test_normalize_rejects_backslash_into_excluded_dir() -> None:
+    assert normalize_target_path("tools\\foo.md") is None
+    assert is_writable_path("tools\\foo.md") is False
 
 
 # ---- Policy blocklist (empty by default; configurable) ----

--- a/tests/test_principals.py
+++ b/tests/test_principals.py
@@ -103,6 +103,17 @@ def test_principal_without_token_is_skipped() -> None:
     assert reg.auth_configured is False
 
 
+def test_cleanup_plan_is_auth_required() -> None:
+    """item 6: the MCP enforcement plane must gate kb_cleanup_plan behind auth when
+    configured, matching the REST /onboarding/cleanup-plan gating. The middleware
+    (server.py) consults AUTH_REQUIRED_TOOLS, so membership here is the mechanism."""
+    from data_olympus.principals import AUTH_REQUIRED_TOOLS
+    assert "kb_cleanup_plan" in AUTH_REQUIRED_TOOLS
+    # And the pre-existing enforcement tools stay gated.
+    assert "kb_consult" in AUTH_REQUIRED_TOOLS
+    assert "kb_gate_check" in AUTH_REQUIRED_TOOLS
+
+
 def test_parse_principals_env_tolerates_garbage() -> None:
     assert parse_principals_env("") == []
     assert parse_principals_env("not json") == []

--- a/tests/test_principals.py
+++ b/tests/test_principals.py
@@ -62,6 +62,41 @@ def test_per_agent_principal_capabilities() -> None:
     assert resolver.has(CAP_AUTO_COMMIT)
 
 
+def test_principal_omitting_capabilities_defaults_to_least_privilege() -> None:
+    """item 5: a KB_AUTH_PRINCIPALS entry with no explicit capabilities gets
+    read+propose ONLY, never resolve/auto_commit. Otherwise an agent could
+    approve its own proposals."""
+    from data_olympus.principals import (
+        CAP_BOOTSTRAP,
+        CAP_READ,
+        DEFAULT_PRINCIPAL_CAPABILITIES,
+    )
+    reg = PrincipalRegistry(
+        auth_token=TOKEN,
+        principals=[{"name": "agent", "token": "atok"}],  # no "capabilities" key
+    )
+    p = reg.resolve("Bearer atok")
+    assert p.name == "agent"
+    assert p.capabilities == DEFAULT_PRINCIPAL_CAPABILITIES
+    assert p.has(CAP_READ)
+    assert p.has(CAP_PROPOSE)
+    # The dangerous capabilities must NOT be granted by default.
+    assert not p.has(CAP_RESOLVE)
+    assert not p.has(CAP_AUTO_COMMIT)
+    assert not p.has(CAP_BOOTSTRAP)
+    assert not p.can_auto_commit
+
+
+def test_operator_token_still_gets_all_capabilities() -> None:
+    """The back-compat single KB_AUTH_TOKEN operator keeps full capabilities;
+    the least-privilege default applies only to KB_AUTH_PRINCIPALS entries."""
+    reg = PrincipalRegistry(auth_token=TOKEN)
+    p = reg.resolve(f"Bearer {TOKEN}")
+    assert p.capabilities == ALL_CAPABILITIES
+    assert p.has(CAP_RESOLVE)
+    assert p.can_auto_commit
+
+
 def test_principal_without_token_is_skipped() -> None:
     reg = PrincipalRegistry(principals=[{"name": "x", "capabilities": ["read"]}])
     # No token => no usable principal => auth not configured.

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -67,3 +67,64 @@ def test_window_slides_after_hour(monkeypatch) -> None:
     # Advance 1 hour + 1s.
     fake_time[0] += 3601
     assert rl.allow(remote_addr="10.0.0.1", agent_identity="claude") is True
+
+
+def test_empty_buckets_are_evicted_after_window(monkeypatch) -> None:
+    """item 10: a key whose timestamps all age out must be dropped, not left as a
+    permanent empty-list entry. Otherwise varying (addr, identity) leaks memory."""
+    import data_olympus.rate_limit as rl_mod
+    fake_time = [1000.0]
+    monkeypatch.setattr(rl_mod.time, "time", lambda: fake_time[0])
+    rl = SlidingWindowLimiter(max_per_hour=5)
+    # Touch 100 distinct identities from one IP.
+    for i in range(100):
+        assert rl.allow(remote_addr="10.0.0.1", agent_identity=f"agent-{i}") is True
+    assert rl.bucket_count() == 100
+    # Advance past the window and touch a single new key: the sweep on the next
+    # allow() only prunes the touched key, but the follow-up assertion drives each
+    # stale key to eviction as it is next consulted.
+    fake_time[0] += 3601
+    for i in range(100):
+        # Re-consulting each aged key rebuilds it to empty, then re-adds one ts;
+        # to observe pure eviction, consult without re-adding by exceeding cap.
+        assert rl.allow(remote_addr="10.0.0.1", agent_identity=f"agent-{i}") is True
+    # Each key now holds exactly one fresh timestamp; none leaked as empty.
+    assert rl.bucket_count() == 100
+
+
+def test_denied_request_still_evicts_when_empty(monkeypatch) -> None:
+    """A per-IP-capped denial path must not resurrect an empty key. With the
+    per-IP cap on, a blocked request prunes and stores back; empty stays evicted."""
+    import data_olympus.rate_limit as rl_mod
+    fake_time = [1000.0]
+    monkeypatch.setattr(rl_mod.time, "time", lambda: fake_time[0])
+    rl = SlidingWindowLimiter(max_per_hour=100, max_per_ip_per_hour=1)
+    assert rl.allow(remote_addr="10.0.0.1", agent_identity="a") is True
+    # Second request from same IP is denied by the per-IP cap.
+    assert rl.allow(remote_addr="10.0.0.1", agent_identity="b") is False
+    # 'b' had no prior timestamps and the request was denied -> no empty 'b' key.
+    assert ("10.0.0.1", "b") not in rl._buckets
+
+
+def test_concurrent_allow_never_exceeds_cap() -> None:
+    """item 10: the lock must make concurrent allow() calls honor the cap exactly.
+    Without the lock, interleaved read-modify-write admits more than max_per_hour."""
+    import threading
+
+    rl = SlidingWindowLimiter(max_per_hour=50)
+    granted = []
+    lock = threading.Lock()
+
+    def worker() -> None:
+        ok = rl.allow(remote_addr="10.0.0.1", agent_identity="claude")
+        if ok:
+            with lock:
+                granted.append(1)
+
+    threads = [threading.Thread(target=worker) for _ in range(200)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    # Exactly the cap is admitted, never more.
+    assert sum(granted) == 50

--- a/tests/test_rest_auth.py
+++ b/tests/test_rest_auth.py
@@ -400,3 +400,162 @@ async def test_open_app_write_routes_no_header_not_401(open_app, route, payload)
     assert resp.status_code != 401, (
         f"Expected open (non-401) on {route} without auth_token, got {resp.status_code}"
     )
+
+
+# ---------------------------------------------------------------------------
+# WP0b item 6: enforcement-plane auth (consult / gate / cleanup-plan) closed to
+# anonymous when auth is configured; open when it is not.
+# ---------------------------------------------------------------------------
+
+_ENFORCE_ROUTES = [
+    ("/api/v1/consult", {"workspace": "/w", "source_session": "s"}),
+    ("/api/v1/gate/check", {"workspace": "/w", "session_id": "s"}),
+    ("/api/v1/onboarding/cleanup-plan", {"workspace": "/w", "local_files": []}),
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("route,payload", _ENFORCE_ROUTES)
+async def test_enforcement_routes_require_auth_when_configured(
+    authed_app, route, payload,
+) -> None:
+    transport = httpx.ASGITransport(app=authed_app, raise_app_exceptions=False)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post(route, json=payload)
+    assert resp.status_code == 401, (
+        f"Expected 401 (anonymous) on {route} with auth configured, "
+        f"got {resp.status_code}"
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("route,payload", _ENFORCE_ROUTES)
+async def test_enforcement_routes_open_without_auth(open_app, route, payload) -> None:
+    """No-auth deployments keep the enforcement plane anonymous (unchanged)."""
+    transport = httpx.ASGITransport(app=open_app, raise_app_exceptions=False)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post(route, json=payload)
+    assert resp.status_code != 401, (
+        f"Expected open (non-401) on {route} without auth_token, got {resp.status_code}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# WP0b item 1: request body caps on resolve / consult / gate / audit-event.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def tiny_body_app(tmp_kb, tmp_index_path, tmp_path):
+    """App with a very small body cap so oversize POSTs trip the 413 path."""
+    env = {**os.environ, "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@e.com",
+           "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@e.com"}
+    subprocess.run(["git", "init", "--initial-branch=main"], cwd=tmp_kb, check=True, env=env)
+    subprocess.run(["git", "-C", str(tmp_kb), "add", "-A"], check=True, env=env)
+    subprocess.run(["git", "-C", str(tmp_kb), "commit", "-m", "init"], check=True, env=env)
+    app = build_app(
+        kb_main_path=tmp_kb, kb_index_path=tmp_index_path,
+        sync_interval_sec=60, staleness_degraded_sec=600, bootstrap_now=True,
+        kb_remote_url="dummy",
+        worktree_root=str(tmp_path / "wts"),
+        pending_root=str(tmp_path / "pending"),
+        push_queue_root=str(tmp_path / "pq"),
+        write_block_tiers=[], write_block_paths=[],
+        max_body_bytes=200,
+    )
+    return app.http_app()
+
+
+_CAPPED_BODY_ROUTES = [
+    "/api/v1/resolve/deadbeefdeadbeefdeadbeefdeadbeef",
+    "/api/v1/consult",
+    "/api/v1/gate/check",
+    "/api/v1/audit/event",
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("route", _CAPPED_BODY_ROUTES)
+async def test_oversize_body_returns_413(tiny_body_app, route) -> None:
+    """A body over the cap returns 413 on every previously-uncapped route."""
+    transport = httpx.ASGITransport(app=tiny_body_app, raise_app_exceptions=False)
+    big = {"filler": "x" * 5000, "workspace": "/w", "source_session": "s",
+           "session_id": "s", "decision": "approve", "event_type": "e"}
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post(route, json=big)
+    assert resp.status_code == 413, f"{route} -> {resp.status_code}"
+    assert resp.json()["error"] == "payload_too_large"
+
+
+# ---------------------------------------------------------------------------
+# WP0b item 6: rate limiting on the enforcement plane.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def throttled_app(tmp_kb, tmp_index_path, tmp_path):
+    """No-auth app with a rate limit of 2/hour to exercise the 429 path."""
+    env = {**os.environ, "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@e.com",
+           "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@e.com"}
+    subprocess.run(["git", "init", "--initial-branch=main"], cwd=tmp_kb, check=True, env=env)
+    subprocess.run(["git", "-C", str(tmp_kb), "add", "-A"], check=True, env=env)
+    subprocess.run(["git", "-C", str(tmp_kb), "commit", "-m", "init"], check=True, env=env)
+    app = build_app(
+        kb_main_path=tmp_kb, kb_index_path=tmp_index_path,
+        sync_interval_sec=60, staleness_degraded_sec=600, bootstrap_now=True,
+        kb_remote_url="dummy",
+        worktree_root=str(tmp_path / "wts"),
+        pending_root=str(tmp_path / "pending"),
+        push_queue_root=str(tmp_path / "pq"),
+        write_block_tiers=[], write_block_paths=[],
+        rate_limit_per_hour=2,
+    )
+    return app.http_app()
+
+
+@pytest.mark.asyncio
+async def test_consult_is_rate_limited(throttled_app) -> None:
+    transport = httpx.ASGITransport(app=throttled_app, raise_app_exceptions=False)
+    payload = {"workspace": "/w", "source_session": "s"}
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        r1 = await client.post("/api/v1/consult", json=payload)
+        r2 = await client.post("/api/v1/consult", json=payload)
+        r3 = await client.post("/api/v1/consult", json=payload)
+    assert r1.status_code != 429
+    assert r2.status_code != 429
+    assert r3.status_code == 429
+    assert r3.json()["error"] == "rate_limited"
+
+
+# ---------------------------------------------------------------------------
+# WP0b item 9: 400 on malformed numeric query params; 404 on unknown pending id.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_audit_bad_since_returns_400(open_app) -> None:
+    transport = httpx.ASGITransport(app=open_app, raise_app_exceptions=False)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/api/v1/audit?since=notanumber")
+    assert resp.status_code == 400
+    assert resp.json()["error"] == "bad_request"
+
+
+@pytest.mark.asyncio
+async def test_audit_bad_limit_returns_400(open_app) -> None:
+    transport = httpx.ASGITransport(app=open_app, raise_app_exceptions=False)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/api/v1/audit?limit=abc")
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_resolve_unknown_pending_id_returns_404(open_app) -> None:
+    transport = httpx.ASGITransport(app=open_app, raise_app_exceptions=False)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post(
+            "/api/v1/resolve/deadbeefdeadbeefdeadbeefdeadbeef",
+            json={"decision": "approve"},
+        )
+    assert resp.status_code == 404
+    assert resp.json()["error"] == "not_found"

--- a/tests/test_tools_onboarding.py
+++ b/tests/test_tools_onboarding.py
@@ -63,6 +63,96 @@ def test_low_conf_bootstrap_is_atomic_when_queue_would_overflow(tmp_path) -> Non
     assert pending.size() == 0  # atomic: nothing was enqueued
 
 
+def test_bootstrap_canonicalizes_backslash_path(tmp_path) -> None:
+    """item 4: a backslash path in a bootstrap file is stored canonical in the
+    pending entry, never as a literal root-level backslash filename."""
+    from data_olympus.auth import PathBlocklist
+    from data_olympus.pending import PendingQueue
+    from data_olympus.rate_limit import SlidingWindowLimiter
+    idx = MagicMock()
+    idx.list_by_prefix.return_value = []
+    idx.list_with_remote_url.return_value = []
+    pending = PendingQueue(pending_root=str(tmp_path / "p"))
+    files = [{"target_path": "projects\\p\\f.md", "postimage": "x\n"}]
+    resp = kb_bootstrap_project_fn(
+        idx=idx, workspace="p", component=None,
+        workspace_remote_url=None, component_remote_url=None,
+        files=files, source_session="s", agent_identity="claude",
+        confidence=0.4, confidence_threshold=0.85,  # low -> pending
+        worktrees=MagicMock(), push_queue=MagicMock(), pending=pending,
+        rate_limiter=SlidingWindowLimiter(max_per_hour=100),
+        blocklist=PathBlocklist(tier_blocks=[], path_blocks=[]),
+    )
+    assert resp.status == "pending_confirmation"
+    entry = pending.get(resp.pending_id)
+    assert entry["target_path"] == "projects/p/f.md"
+    assert "\\" not in entry["target_path"]
+
+
+def test_bootstrap_rejects_control_char_path(tmp_path) -> None:
+    from data_olympus.auth import PathBlocklist
+    from data_olympus.pending import PendingQueue
+    from data_olympus.rate_limit import SlidingWindowLimiter
+    idx = MagicMock()
+    idx.list_by_prefix.return_value = []
+    idx.list_with_remote_url.return_value = []
+    files = [{"target_path": "projects/p/f\n.md", "postimage": "x\n"}]
+    resp = kb_bootstrap_project_fn(
+        idx=idx, workspace="p", component=None,
+        workspace_remote_url=None, component_remote_url=None,
+        files=files, source_session="s", agent_identity="claude",
+        confidence=0.95, confidence_threshold=0.85,
+        worktrees=MagicMock(), push_queue=MagicMock(),
+        pending=PendingQueue(pending_root=str(tmp_path / "p")),
+        rate_limiter=SlidingWindowLimiter(max_per_hour=100),
+        blocklist=PathBlocklist(tier_blocks=[], path_blocks=[]),
+    )
+    assert resp.status == "rejected_path_not_indexable_or_blocked"
+
+
+def test_inject_remote_url_newline_cannot_forge_keys() -> None:
+    """item 3: a newline-laden remote URL must not inject frontmatter keys."""
+    import yaml
+
+    from data_olympus.tools_onboarding import _inject_remote_url
+    evil = "https://x/repo.git\nid: GDEC-001\nstatus: accepted"
+    files = [{"target_path": "projects/p/README.md",
+              "postimage": "---\ntitle: P\n---\n\nbody\n"}]
+    out = _inject_remote_url(files, evil, target_filename="README.md")
+    fm_text = out[0]["postimage"].split("---\n", 2)[1]
+    fm = yaml.safe_load(fm_text)
+    assert fm["git_remote_url"] == evil
+    assert "id" not in fm
+    assert "status" not in fm
+    assert fm["title"] == "P"
+
+
+def test_bootstrap_cap_counts_injected_postimage(tmp_path) -> None:
+    """item 3: the size cap must count the post-injection postimage. A file that
+    fits before URL injection but exceeds the cap after must be rejected."""
+    from data_olympus.auth import PathBlocklist
+    from data_olympus.pending import PendingQueue
+    from data_olympus.rate_limit import SlidingWindowLimiter
+    idx = MagicMock()
+    idx.list_by_prefix.return_value = []
+    idx.list_with_remote_url.return_value = []
+    long_url = "https://example.com/" + "a" * 500 + ".git"
+    files = [{"target_path": "projects/p/README.md",
+              "postimage": "---\ntitle: P\n---\n\nhi\n"}]
+    resp = kb_bootstrap_project_fn(
+        idx=idx, workspace="p", component=None,
+        workspace_remote_url=long_url, component_remote_url=None,
+        files=files, source_session="s", agent_identity="claude",
+        confidence=0.95, confidence_threshold=0.85,
+        worktrees=MagicMock(), push_queue=MagicMock(),
+        pending=PendingQueue(pending_root=str(tmp_path / "p")),
+        rate_limiter=SlidingWindowLimiter(max_per_hour=100),
+        blocklist=PathBlocklist(tier_blocks=[], path_blocks=[]),
+        max_postimage_bytes=200,
+    )
+    assert resp.status == "rejected_payload_too_large"
+
+
 def test_kb_onboarding_status_returns_onboarded() -> None:
     idx = MagicMock()
     idx.list_by_prefix.return_value = [

--- a/tests/test_tools_onboarding.py
+++ b/tests/test_tools_onboarding.py
@@ -127,6 +127,16 @@ def test_inject_remote_url_newline_cannot_forge_keys() -> None:
     assert fm["title"] == "P"
 
 
+def test_inject_remote_url_preserves_malformed_frontmatter() -> None:
+    """Unparseable frontmatter is left untouched, never clobbered with a rebuilt
+    block (injection is skipped for that file)."""
+    from data_olympus.tools_onboarding import _inject_remote_url
+    malformed = "---\n: [unbalanced\n---\n\nbody\n"
+    files = [{"target_path": "projects/p/README.md", "postimage": malformed}]
+    out = _inject_remote_url(files, "https://x/r.git", target_filename="README.md")
+    assert out[0]["postimage"] == malformed
+
+
 def test_bootstrap_cap_counts_injected_postimage(tmp_path) -> None:
     """item 3: the size cap must count the post-injection postimage. A file that
     fits before URL injection but exceeds the cap after must be rejected."""

--- a/tests/test_tools_read.py
+++ b/tests/test_tools_read.py
@@ -54,6 +54,45 @@ def test_kb_search_fn_empty_for_unmatched(tmp_kb: Path, tmp_path: Path) -> None:
     assert resp.hits == []
 
 
+def _capture_limit(idx: Index) -> list[int]:
+    """Wrap idx.search to record the limit it is actually called with."""
+    seen: list[int] = []
+    real = idx.search
+
+    def spy(query, *, limit, **kw):  # type: ignore[no-untyped-def]
+        seen.append(limit)
+        return real(query, limit=limit, **kw)
+
+    idx.search = spy  # type: ignore[method-assign]
+    return seen
+
+
+def test_kb_search_fn_clamps_negative_limit(tmp_kb: Path, tmp_path: Path) -> None:
+    """item 8: limit=-1 must NOT reach SQLite as LIMIT -1 (unlimited full-corpus
+    dump). It is clamped to the lower bound of 1."""
+    idx = Index(tmp_path / "idx.db")
+    idx.build(tmp_kb, source_commit="e")
+    seen = _capture_limit(idx)
+    kb_search_fn(idx=idx, query="STD", limit=-1)
+    assert seen == [1]
+
+
+def test_kb_search_fn_clamps_zero_limit(tmp_kb: Path, tmp_path: Path) -> None:
+    idx = Index(tmp_path / "idx.db")
+    idx.build(tmp_kb, source_commit="f")
+    seen = _capture_limit(idx)
+    kb_search_fn(idx=idx, query="STD", limit=0)
+    assert seen == [1]
+
+
+def test_kb_search_fn_clamps_over_max(tmp_kb: Path, tmp_path: Path) -> None:
+    idx = Index(tmp_path / "idx.db")
+    idx.build(tmp_kb, source_commit="g")
+    seen = _capture_limit(idx)
+    kb_search_fn(idx=idx, query="STD", limit=99999)
+    assert seen == [100]
+
+
 def test_kb_search_fn_tier_filter_includes_matches(tmp_kb: Path, tmp_path: Path) -> None:
     """Filtering by tier=T1 includes the STDs in T1."""
     idx = Index(tmp_path / "idx.db")

--- a/tests/test_tools_write.py
+++ b/tests/test_tools_write.py
@@ -310,3 +310,180 @@ def test_kb_resolve_pending_reject_clears(tmp_path) -> None:
     )
     assert resp.status == "rejected"
     assert pen.size() == 0
+
+
+# ---- item 3: YAML frontmatter injection + full-postimage cap ----
+
+
+def test_render_memory_newline_in_agent_identity_cannot_forge_keys() -> None:
+    """A newline-laden agent_identity must not inject top-level YAML keys."""
+    import yaml
+
+    from data_olympus.tools_write import _render_memory
+    payload = "claude\nid: GDEC-001\nstatus: accepted\nsupersedes: GDEC-000"
+    out = _render_memory(text="body", tags=[], agent_identity=payload)
+    fm_text = out.split("---\n", 2)[1]
+    fm = yaml.safe_load(fm_text)
+    # The whole payload survives ONLY as the created_by value; no forged keys.
+    assert fm["created_by"] == payload
+    assert "id" not in fm
+    assert "status" not in fm
+    assert "supersedes" not in fm
+
+
+def test_render_memory_bracket_in_tag_cannot_forge_keys() -> None:
+    """A tag containing '], key: value' must not break out of the list."""
+    import yaml
+
+    from data_olympus.tools_write import _render_memory
+    out = _render_memory(
+        text="body", tags=["a], id: forged", "normal"], agent_identity="claude"
+    )
+    fm_text = out.split("---\n", 2)[1]
+    fm = yaml.safe_load(fm_text)
+    assert "id" not in fm
+    assert fm["tags"] == ["a], id: forged", "normal"]
+
+
+def test_propose_memory_forged_tag_does_not_forge_id(tmp_path, monkeypatch) -> None:
+    """End-to-end: a malicious tag through the propose path is stored inertly."""
+    import yaml
+    _set_git_env(monkeypatch)
+    git, reg, pq, pen, rl, bl = _state(tmp_path)
+    resp = kb_propose_memory_fn(
+        text="body", tags=["x], id: DEC-999"], source_session="s",
+        agent_identity="claude", confidence=0.95, confidence_threshold=0.85,
+        worktrees=reg, push_queue=pq, pending=pen, rate_limiter=rl, blocklist=bl,
+        remote_addr="1.2.3.4",
+    )
+    assert resp.status == "committed"
+    # Read the committed file back out of the worktree and confirm no forged id.
+    wt = reg.get_or_create(source_session="s", agent_identity="claude")
+    import glob
+    written = glob.glob(os.path.join(wt.path, "memory", "inbox", "*.md"))
+    assert written
+    with open(written[0]) as fh:
+        content = fh.read()
+    fm = yaml.safe_load(content.split("---\n", 2)[1])
+    assert "id" not in fm
+
+
+def test_propose_memory_cap_counts_full_rendered_postimage(
+    tmp_path, monkeypatch,
+) -> None:
+    """item 3: the size cap must count the rendered frontmatter+body, not just
+    the body. A large tags list that fits under a body-only check but pushes the
+    full postimage over the cap must be rejected."""
+    _set_git_env(monkeypatch)
+    git, reg, pq, pen, rl, bl = _state(tmp_path)
+    # Body is tiny, but many long tags inflate the rendered frontmatter.
+    big_tags = ["t" * 100 for _ in range(50)]
+    resp = kb_propose_memory_fn(
+        text="hi", tags=big_tags, source_session="s", agent_identity="claude",
+        confidence=0.95, confidence_threshold=0.85, worktrees=reg, push_queue=pq,
+        pending=pen, rate_limiter=rl, blocklist=bl, remote_addr="1.2.3.4",
+        max_text_bytes=200,
+    )
+    assert resp.status == "rejected_payload_too_large"
+    assert pq.size() == 0
+
+
+# ---- item 4: canonical path (backslash bypass) in propose_edit ----
+
+
+def test_propose_edit_rejects_backslash_path(tmp_path) -> None:
+    """A backslash path must not slip through as a root-level literal file."""
+    git, reg, pq, pen, rl, bl = _state(tmp_path)
+    resp = kb_propose_edit_fn(
+        target_path="decisions\\x.md",
+        postimage="body\n", base_commit="HEAD", base_blob_sha=None,
+        target_file_hash=None, reason="", source_session="s",
+        agent_identity="claude", confidence=0.3, confidence_threshold=0.85,
+        worktrees=reg, push_queue=pq, pending=pen, rate_limiter=rl, blocklist=bl,
+        remote_addr="1.2.3.4",
+    )
+    # decisions/ is an indexed prefix, so the canonicalized path is accepted and
+    # parked as pending — but under the CANONICAL forward-slash path.
+    assert resp.status == "pending_confirmation"
+    entry = pen.get(resp.pending_id)
+    assert entry["target_path"] == "decisions/x.md"
+    assert "\\" not in entry["target_path"]
+
+
+def test_propose_edit_rejects_control_char_path(tmp_path) -> None:
+    git, reg, pq, pen, rl, bl = _state(tmp_path)
+    resp = kb_propose_edit_fn(
+        target_path="decisions/x\n.md",
+        postimage="body\n", base_commit="HEAD", base_blob_sha=None,
+        target_file_hash=None, reason="", source_session="s",
+        agent_identity="claude", confidence=0.3, confidence_threshold=0.85,
+        worktrees=reg, push_queue=pq, pending=pen, rate_limiter=rl, blocklist=bl,
+        remote_addr="1.2.3.4",
+    )
+    assert resp.status == "rejected_path_not_indexable"
+
+
+# ---- item 2: resolve edited_text bypasses the postimage cap ----
+
+
+def test_resolve_edited_text_over_cap_is_rejected(tmp_path, monkeypatch) -> None:
+    _set_git_env(monkeypatch)
+    git, reg, pq, pen, rl, bl = _state(tmp_path)
+    m = kb_propose_memory_fn(
+        text="small", tags=[], source_session="s", agent_identity="claude",
+        confidence=0.3, confidence_threshold=0.85, worktrees=reg, push_queue=pq,
+        pending=pen, rate_limiter=rl, blocklist=bl, remote_addr="1.2.3.4",
+    )
+    resp = kb_resolve_pending_fn(
+        pending_id=m.pending_id, decision="approve",
+        edited_text="X" * 5000,
+        worktrees=reg, push_queue=pq, pending=pen,
+        source_session="s", agent_identity="operator",
+        max_postimage_bytes=100,
+    )
+    assert resp.status == "rejected_edited_text_too_large"
+    # The pending entry is left in place (not consumed) so it can be re-edited.
+    assert pen.size() == 1
+    assert pq.size() == 0
+
+
+def test_resolve_edited_text_under_cap_commits(tmp_path, monkeypatch) -> None:
+    _set_git_env(monkeypatch)
+    git, reg, pq, pen, rl, bl = _state(tmp_path)
+    m = kb_propose_memory_fn(
+        text="small", tags=[], source_session="s", agent_identity="claude",
+        confidence=0.3, confidence_threshold=0.85, worktrees=reg, push_queue=pq,
+        pending=pen, rate_limiter=rl, blocklist=bl, remote_addr="1.2.3.4",
+    )
+    resp = kb_resolve_pending_fn(
+        pending_id=m.pending_id, decision="approve",
+        edited_text="edited body\n",
+        worktrees=reg, push_queue=pq, pending=pen,
+        source_session="s", agent_identity="operator",
+        max_postimage_bytes=1_000_000,
+    )
+    assert resp.status == "committed"
+
+
+# ---- item 9: unknown/expired pending_id ----
+
+
+def test_resolve_unknown_pending_id_raises_not_found(tmp_path) -> None:
+    from data_olympus.pending import PendingNotFoundError
+    git, reg, pq, pen, rl, bl = _state(tmp_path)
+    import pytest
+    with pytest.raises(PendingNotFoundError):
+        kb_resolve_pending_fn(
+            pending_id="deadbeefdeadbeefdeadbeefdeadbeef",
+            decision="approve", edited_text=None,
+            worktrees=reg, push_queue=pq, pending=pen,
+            source_session="s", agent_identity="operator",
+        )
+
+
+def test_pending_get_rejects_traversal_id(tmp_path) -> None:
+    from data_olympus.pending import PendingNotFoundError
+    pen = PendingQueue(pending_root=str(tmp_path / "pending"))
+    import pytest
+    with pytest.raises(PendingNotFoundError):
+        pen.get("../../etc/passwd")

--- a/tests/test_viewer_escaping.py
+++ b/tests/test_viewer_escaping.py
@@ -1,0 +1,58 @@
+"""item 7: viewer HTML/JS injection + substitution-ordering regression tests."""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from data_olympus.viewer.generator import generate_visualization
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _write_doc(root: Path, name: str, body: str, title: str = "Doc") -> None:
+    (root / name).write_text(
+        f"---\nid: {name[:-3]}\ntitle: {title}\ntype: concept\n---\n{body}\n",
+        encoding="utf-8",
+    )
+
+
+def test_script_close_tag_in_body_is_escaped(tmp_path: Path) -> None:
+    """A doc body containing </script> must not break out of the <script> block."""
+    root = tmp_path / "bundle"
+    root.mkdir()
+    _write_doc(root, "a.md", "before </script><script>window.__pwned__=1;</script> after")
+    out = tmp_path / "viz.html"
+    generate_visualization(root, out, name="B")
+    html = out.read_text(encoding="utf-8")
+    # The raw closing tag must NOT appear inside the embedded JSON payload.
+    assert "</script><script>window.__pwned__" not in html
+    # It must be present only in its escaped form.
+    assert "<\\/script>" in html
+
+
+def test_display_name_placeholder_in_body_not_mangled(tmp_path: Path) -> None:
+    """A doc body containing the literal __DISPLAY_NAME__ must survive verbatim
+    (single-pass substitution), not get rewritten to the bundle name."""
+    root = tmp_path / "bundle"
+    root.mkdir()
+    _write_doc(root, "a.md", "the literal __DISPLAY_NAME__ token here")
+    out = tmp_path / "viz.html"
+    generate_visualization(root, out, name="MyBundle")
+    html = out.read_text(encoding="utf-8")
+    # The placeholder inside the body's JSON payload is preserved verbatim.
+    assert "the literal __DISPLAY_NAME__ token here" in html
+    # And the real title slot got the bundle name.
+    assert "MyBundle - data-olympus viewer" in html
+
+
+def test_json_placeholder_in_display_name_not_mangled(tmp_path: Path) -> None:
+    """A display name containing __JSON__ must not swallow the payload."""
+    root = tmp_path / "bundle"
+    root.mkdir()
+    _write_doc(root, "a.md", "plain body")
+    out = tmp_path / "viz.html"
+    generate_visualization(root, out, name="__JSON__weird")
+    html = out.read_text(encoding="utf-8")
+    # The title slot keeps the literal name; the payload is still valid.
+    assert "__JSON__weird - data-olympus viewer" in html
+    assert "window.__BUNDLE_DATA__ = {" in html


### PR DESCRIPTION
## Summary

WP0b of the 0.3.0 security hardening program (issue #74). Ten security quick-wins on the write and enforcement surface, each with regression tests. One breaking behavior change (least-privilege principal default) is documented in `CHANGELOG.md`.

Base: `release/0.3.0`.

## Item-by-item checklist

- [x] **1. Unbounded request bodies** — resolve, consult, gate/check, and audit/event REST routes now use the same `_read_json_capped` streaming cap (`KB_MAX_BODY_BYTES`) as propose/bootstrap; oversize input returns 413.
- [x] **2. `resolve.edited_text` bypasses the postimage cap** — `kb_resolve_pending_fn` now enforces `max_postimage_bytes` on `edited_text` with a distinct `rejected_edited_text_too_large` status (413), leaving the pending entry in place. REST route wires the config value through.
- [x] **3. YAML frontmatter injection** — `_render_memory` serializes frontmatter with `yaml.safe_dump`; the size cap now counts the full rendered postimage (frontmatter + body). Same treatment extended to the onboarding bootstrap's remote-URL injection (`_inject_remote_url`), with the cap applied after injection.
- [x] **4. Backslash / control-char path bypass** — `normalize_target_path` returns the canonical form; classification, blocklist, join, `git add`, and the pending record all use it. Control characters (newline, CR, tab, NUL) in a path are rejected. Applied in `kb_propose_edit_fn` and the onboarding bootstrap; a traversal-shaped `pending_id` is rejected before the disk join.
- [x] **5. Principals least-privilege default** — a `KB_AUTH_PRINCIPALS` entry with no explicit `capabilities` now defaults to `{read, propose}` (was all capabilities). **BREAKING** — see CHANGELOG.
- [x] **6. Auth + rate limiting on the enforcement plane** — `/consult`, `/gate/check`, `/onboarding/cleanup-plan` require an authenticated principal when auth is configured (no-auth deployments unchanged) and are subject to the shared rate limiter. `kb_cleanup_plan` added to the MCP `AUTH_REQUIRED_TOOLS` set.
- [x] **7. Viewer HTML injection** — the embedded JSON payload escapes `</` to `<\/`; both template placeholders are substituted in a single pass so a body containing the literal `__DISPLAY_NAME__` is no longer mangled.
- [x] **8. Search limit clamp** — `kb_search_fn` clamps `limit` to 1..100, blocking `limit=-1` (SQLite `LIMIT -1` full-corpus dump).
- [x] **9. 400 not 500** — malformed `since`/`limit` on `/audit` and `/compliance` return 400; resolve of an unknown/expired `pending_id` returns 404.
- [x] **10. Rate limiter hygiene** — `SlidingWindowLimiter` evicts empty bucket keys and guards its read-modify-write with a `threading.Lock`.

### kb-enforce-hook Authorization (item 6 question)

`bin/kb-enforce-hook` **already** sends `Authorization: Bearer $KB_AUTH_TOKEN` on its POSTs (lines 19, 121-122), so the enforcement-plane auth change is compatible with the existing hook — no bin/ change needed.

## Test evidence

- `uv run pytest` (after rebase onto latest `release/0.3.0`, post PRs #76-#79): **900 passed, 1 skipped** (skip is the optional `sentence_transformers` dep).
- `uv run ruff check .`: clean.
- `uv run python scripts/check_changelog.py`: `changelog guard: ok`.
- `uv run data-olympus lint example-bundle`: `0 errors`.

New regression tests: injection payloads (newline/bracket forge attempts), backslash + control-char traversal, cap boundaries (memory full-postimage, resolve edited_text, bootstrap post-injection), 400/404 statuses, limiter eviction + concurrency, viewer `</script>` breakout and placeholder collision, search clamp, least-privilege default, MCP cleanup-plan gating.

## Peer review (codex)

Security-focused review via `codex exec --sandbox read-only`.

**Round 1 — verdict: 4 Blockers.** Items 1, 5, 7, 8, 9, 10 verified complete; REST edited-text cap, main propose-edit canonicalization, and memory frontmatter verified. Blockers:
1. Canonical-path bypass still present in onboarding bootstrap.
2. Onboarding remote-URL frontmatter injection + size-cap-before-injection.
3. MCP `kb_resolve_pending` lacks the edited_text cap (server.py).
4. MCP enforcement plane uneven: `kb_cleanup_plan` not in `AUTH_REQUIRED_TOOLS`; MCP consult/gate/cleanup-plan unthrottled (server.py).

**Resolution:**
- Blockers 1, 2, and the `AUTH_REQUIRED_TOOLS` half of 4 were fixed in this PR (second commit), reusing the same helpers.
- The remaining halves of Blockers 3 and 4 require editing `server.py`, which this work package is explicitly forbidden to touch (owned by the server/enforcement package). They are defense-in-depth gaps for *authenticated* MCP principals only — the REST plane and the operator-facing surface are fully closed. **Flagged for the server.py owner** (see Follow-ups).

**Round 2 — verdict: no new Blockers; all three addressed items confirmed clean.** Codex confirmed: (1) bootstrap canonical-path handling clean, no raw-path use in any enforcement or write sink, size cap after URL injection; (2) newline frontmatter forging fixed via `yaml.safe_dump` with valid frontmatter preserved; (3) `kb_cleanup_plan` in `AUTH_REQUIRED_TOOLS` closes the anonymous-MCP hole via the existing middleware. It also confirmed the two remaining Blockers are genuinely `server.py`-only.

Round 2 raised two **Concerns** (resolved as follows):
- *`_inject_remote_url` clobbered unparseable frontmatter* (silent metadata loss in the round-1 fix): **fixed** in this PR — unparseable/non-mapping frontmatter is now left untouched (injection skipped for that file, matching the pre-existing no-closing-fence behavior).
- *`PathLockBusyError` swallowing breaks bootstrap all-or-none atomicity*: **pre-existing behavior** (the `pass # already pending; skip` predates this diff), functional rather than security, and outside this package's item list. Recorded as a follow-up below.

## Follow-ups for other package owners

1. **server.py:** MCP `kb_resolve_pending` tool (~line 553) should pass `max_postimage_bytes=state.config.max_postimage_bytes` to `kb_resolve_pending_fn` so the MCP resolve path enforces the same edited_text cap as REST. The function already accepts the parameter.
2. **server.py:** MCP `kb_consult` / `kb_gate_check` / `kb_cleanup_plan` tools should apply `state.rate_limiter` like the REST enforcement routes do, keyed by the resolved principal.
3. **onboarding:** low-confidence bootstrap should roll back and reject on `PathLockBusyError` instead of silently skipping the locked file (all-or-none atomicity; pre-existing, flagged by codex round 2).

Refs #74.
