### PR TITLE
fix(search): penalized expansion backfill, gated trigram build, dense-channel and build perf fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,35 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   "resolve", "auto_commit", "bootstrap", "record_event"]}`. The single
   `KB_AUTH_TOKEN` operator principal is unaffected and still receives all
   capabilities.
+- **Search pipeline hardening (WP2b, epic #75): false-positive reduction,
+  dense-channel fixes, and index/query performance.**
+  - Penalized expansion backfill (finding a). Query expansion (synonym #38 +
+    co-occurrence #40) previously folded derived terms into the single FTS5
+    `MATCH`; bm25 has no positional preference, so a doc matching only a synonym
+    got full idf weight and could outrank a doc matching the user's actual term.
+    `Index.search` now matches the user's own terms in a PRIMARY pass and the
+    expansion terms in a SEPARATE penalized backfill pass whose hits can only
+    rank BELOW the worst primary hit. The "expansion is down-weighted" claim in
+    the `query_expansion` / `cooccurrence` docstrings is now actually true.
+  - Rank-class invariant (finding d). `SearchHit` gained a `rank_class`
+    (`RANK_CLASS_PRIMARY` / `RANK_CLASS_BACKFILL`); the status and hybrid
+    rerankers now sort by `(rank_class, score)`. This makes the documented
+    "backfill hits are never reordered above primaries" invariant genuinely true
+    (the previous score-only "strictly worse" floor could be lifted by an
+    active-status boost or the hybrid re-normalisation).
+  - Co-occurrence defaults hardened (finding b): `min_count` 2->3, `min_pmi`
+    0.0->0.1, plus a corpus-size floor (`KB_COOCCURRENCE_MIN_DOCS`, default 50)
+    that auto-disables the table on small corpora where PMI is noise, and a
+    per-doc unique-token cap (`KB_COOCCURRENCE_MAX_DOC_TOKENS`, default 400) that
+    bounds the O(n^2) pair counting so a multi-thousand-word doc is no longer a
+    build-time memory cliff.
+  - Gated trigram index (finding c): the `fts_trigram` secondary table (a full
+    second tokenized copy of the corpus, ~2-3x index-size / build-time tax) is
+    now built and populated ONLY when the trigram fallback is enabled
+    (`KB_TRIGRAM_MODE=on`), not unconditionally.
+  - Dense-channel intent vocabulary (finding f): the text embedded at build time
+    now includes `applies_when` and `tags` (the curated intent phrases a
+    paraphrase query embeds near), not just title/description/body.
 - **Enforcement gate policy: the gate now clears only on an explicit
   consultation, not on any recent consult (behavioral change).** Previously the
   gate meant "an HTTP call to `/consult` happened recently in this session", so
@@ -142,6 +171,29 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 > itself (rebase-retry redesign); that is tracked separately as Wave 1.
 ### Fixed
 
+- Search pipeline hardening (WP2b, epic #75), bug + perf fixes:
+  - `Index.search` could return MORE than `limit` hits when embeddings were
+    configured but no reranker was set (finding h): the dense union widened the
+    pool but truncation lived only inside the reranker branch. Truncation to
+    `limit` is now unconditional.
+  - Vectors are batch-fetched once per build and cached as an in-memory
+    id->vector matrix (finding g). The hybrid reranker previously opened one
+    SQLite connection per candidate hit via `get_vector`, and `dense_candidates`
+    re-read + re-deserialized the whole `doc_vectors` table on every query. The
+    cache is keyed by the db file's (size, mtime) so the atomic build swap
+    invalidates it transparently.
+  - `Index.build` now runs a single `git log --name-only` pass for every file's
+    last-commit time instead of one `git log` subprocess per file, and reads +
+    parses each markdown file exactly once (previously three times: two parses
+    plus a separate content read) (finding i). Per-file `(last_modified, source)`
+    metadata is byte-for-byte identical.
+  - Malformed front matter is no longer silently swallowed (finding j): a doc
+    whose front-matter block is present but is invalid YAML (so its
+    `status`/`supersedes` are dropped, quietly disabling staleness protection)
+    is now logged at WARN per doc, counted, and surfaced via
+    `Index.malformed_frontmatter_count` and the `malformed_frontmatter` field in
+    `health()`. (Wiring this count into the `/health` degraded signal is a
+    tracked follow-up.)
 - OpenCode gate (`data-olympus-gate.ts`): resolves the workspace to the main git
   worktree **basename** (matching the key every other surface records consults
   under) instead of the raw absolute path, which could never match; and passes

--- a/src/data_olympus/config.py
+++ b/src/data_olympus/config.py
@@ -57,8 +57,12 @@ class Config:
     # honours them without threading Config through.
     cooccurrence_enabled: bool = True
     cooccurrence_k: int = 5
-    cooccurrence_min_count: int = 2
-    cooccurrence_min_pmi: float = 0.0
+    cooccurrence_min_count: int = 3
+    cooccurrence_min_pmi: float = 0.1
+    # Corpus-size floor below which co-occurrence is auto-disabled, and per-doc
+    # unique-token cap on O(n^2) pair counting (finding (b), WP2b).
+    cooccurrence_min_docs: int = 50
+    cooccurrence_max_doc_tokens: int = 400
     # Trigram fuzzy-match fallback (issue #41). Default OFF so existing search
     # behaviour is unchanged. When on, a primary FTS query returning at or below
     # ``trigram_fallback_threshold`` hits is backfilled from the trigram index so
@@ -206,6 +210,8 @@ def load_config() -> Config:
         cooccurrence_k=int(cooc_params["k"]),
         cooccurrence_min_count=int(cooc_params["min_count"]),
         cooccurrence_min_pmi=float(cooc_params["min_pmi"]),
+        cooccurrence_min_docs=int(cooc_params["min_docs"]),
+        cooccurrence_max_doc_tokens=int(cooc_params["max_doc_tokens"]),
         trigram_fallback_enabled=trigram_enabled,
         trigram_fallback_threshold=trigram_threshold,
         embeddings_enabled=emb_enabled,

--- a/src/data_olympus/config.py
+++ b/src/data_olympus/config.py
@@ -67,9 +67,11 @@ class Config:
     # behaviour is unchanged. When on, a primary FTS query returning at or below
     # ``trigram_fallback_threshold`` hits is backfilled from the trigram index so
     # a typo or partial identifier still reaches its document; the backfill only
-    # ever appends after primary hits. Surfaced here for discoverability; the
-    # build always creates the trigram table (cost is one extra insert/doc), and
-    # Index.search reads these to gate the query-time fallback.
+    # ever appends after primary hits (as a RANK_CLASS_BACKFILL class). Surfaced
+    # here for discoverability. The trigram table is now created and populated
+    # ONLY when the fallback is enabled (KB_TRIGRAM_MODE=on) (finding (c), WP2b),
+    # so a default deployment pays no trigram build/size cost; Index.search reads
+    # these to gate the query-time fallback.
     trigram_fallback_enabled: bool = False
     trigram_fallback_threshold: int = 3
     # Optional local-embedding hybrid ranking (issue #42). Default OFF so the

--- a/src/data_olympus/cooccurrence.py
+++ b/src/data_olympus/cooccurrence.py
@@ -5,8 +5,12 @@ reasonable term in the corpus, the handful of other terms it most strongly
 co-occurs with (measured by pointwise mutual information, PMI, at document
 granularity) and store a small bounded ``related_terms`` table alongside the
 FTS index. At query time an expander looks each query term up in that table and
-appends its top related terms, DOWN-WEIGHTED by appending them after the
-originals so BM25 still favours the terms the user actually typed.
+appends its top related terms. Those appended terms are DOWN-WEIGHTED not by
+their position (FTS5 bm25 has no positional preference) but because
+``Index.search`` matches the expansion terms in a SEPARATE penalized backfill
+pass whose hits can only rank BELOW the worst primary-term hit (finding (a); see
+``Index._expansion_backfill``). So a doc that matches only a corpus-related term
+can never outrank a doc matching a term the user actually typed.
 
 Why PMI over raw co-occurrence counts: raw counts are dominated by globally
 frequent tokens (every doc mentions "the", "a", "you"), so a raw-count table
@@ -102,9 +106,28 @@ def tokenize_doc(*parts: str) -> set[str]:
 
 # Defaults for the bounded table. Kept small so both build cost and query-time
 # MATCH growth stay negligible.
+#
+# min_count=3 / min_pmi>0 (finding (b)): at min_count=2 / min_pmi=0 a single pair
+# of docs sharing any two tokens produces a "related" edge, which on a small
+# corpus is noise, not signal. Requiring a pair to co-occur in at least 3 docs
+# and to have STRICTLY positive PMI (co-occur MORE than chance) keeps only edges
+# with real corpus support.
 DEFAULT_K = 5
-DEFAULT_MIN_COUNT = 2
-DEFAULT_MIN_PMI = 0.0
+DEFAULT_MIN_COUNT = 3
+DEFAULT_MIN_PMI = 0.1
+
+# Corpus-size floor below which co-occurrence expansion is auto-disabled (finding
+# (b)). PMI is a ratio estimate; on a handful of docs the marginal counts are too
+# small for it to mean anything, so we skip building the table entirely rather
+# than emit noise. A deployment can lower it via KB_COOCCURRENCE_MIN_DOCS.
+DEFAULT_MIN_DOCS = 50
+
+# Cap on the number of unique tokens from one document fed into pair counting
+# (finding (b)). Pair counting is O(unique-tokens^2) per doc; a multi-thousand-
+# word doc with thousands of unique tokens is a build-time memory/CPU cliff. The
+# most topical tokens are kept (longest first, then alphabetical for determinism)
+# so the cap trims the long tail of incidental vocabulary, not the signal.
+DEFAULT_MAX_DOC_TOKENS = 400
 
 
 def build_cooccurrence_table(
@@ -113,6 +136,8 @@ def build_cooccurrence_table(
     k: int = DEFAULT_K,
     min_count: int = DEFAULT_MIN_COUNT,
     min_pmi: float = DEFAULT_MIN_PMI,
+    min_docs: int = DEFAULT_MIN_DOCS,
+    max_doc_tokens: int = DEFAULT_MAX_DOC_TOKENS,
 ) -> dict[str, list[str]]:
     """Compute a bounded ``{term: [related...]}`` table from per-doc token sets.
 
@@ -130,16 +155,31 @@ def build_cooccurrence_table(
     The result is directional in storage (both ``a -> b`` and ``b -> a`` are
     emitted, each capped independently at k) so a lookup of either term finds the
     other. Returns an order-stable dict; each value is at most ``k`` long.
+
+    Returns the empty table (co-occurrence auto-disabled) when the corpus has
+    fewer than ``min_docs`` documents (finding (b)): PMI is a ratio estimate that
+    is pure noise on a handful of docs. Each document contributes at most
+    ``max_doc_tokens`` unique tokens to pair counting (finding (b)); pair counting
+    is O(unique-tokens^2) per doc, so an unbounded huge doc is a build-time cliff.
+    The kept tokens are the longest ones (most topical), tie-broken alphabetically.
     """
     materialised = [s for s in doc_token_sets if s]
     n_docs = len(materialised)
-    if n_docs < 2 or k <= 0:
+    # Corpus-size floor: below it PMI is noise, so skip building entirely.
+    if n_docs < max(2, min_docs) or k <= 0:
         return {}
 
     term_counts: Counter[str] = Counter()
     pair_counts: Counter[tuple[str, str]] = Counter()
     for tokens in materialised:
         ordered = sorted(tokens)
+        # Cap the per-doc unique-token count fed into O(n^2) pair counting. Keep
+        # the longest tokens (most topical), tie-broken alphabetically so the
+        # trim is deterministic, then re-sort alphabetically for stable pairing.
+        if max_doc_tokens > 0 and len(ordered) > max_doc_tokens:
+            ordered = sorted(
+                sorted(ordered, key=lambda t: (-len(t), t))[:max_doc_tokens]
+            )
         for tok in ordered:
             term_counts[tok] += 1
         for i, a in enumerate(ordered):
@@ -240,8 +280,10 @@ def make_cooccurrence_expander(
     to the live index DB via ``Index``). The returned callable keeps the original
     terms first (order-stable, de-duplicated) and then appends related terms
     (also de-duplicated, bounded by ``max_terms``). Originals are never dropped
-    by the cap; related terms are down-weighted purely by appending them after
-    the originals (BM25 OR-matching favours the earlier / user-typed terms).
+    by the cap. The appended related terms are down-weighted by ``Index.search``
+    matching them in a separate penalized backfill pass (they can only rank below
+    the primary hits); the "first" positioning here is only so ``Index.search``
+    can split originals from expansion terms, NOT a bm25 positional effect.
     """
 
     def expander(terms: list[str]) -> list[str]:
@@ -334,9 +376,18 @@ def cooccurrence_enabled() -> bool:
 
 
 def cooccurrence_build_params() -> dict[str, int | float]:
-    """Build-time knobs from env: k, min_count, min_pmi (with sane defaults)."""
+    """Build-time knobs from env: k, min_count, min_pmi, min_docs, max_doc_tokens.
+
+    All have sane defaults (see the module constants). ``min_docs`` is the corpus
+    floor below which the table is auto-disabled; ``max_doc_tokens`` caps the
+    per-doc unique tokens fed into O(n^2) pair counting (finding (b)).
+    """
     return {
         "k": _env_int("KB_COOCCURRENCE_K", DEFAULT_K),
         "min_count": _env_int("KB_COOCCURRENCE_MIN_COUNT", DEFAULT_MIN_COUNT),
         "min_pmi": _env_float("KB_COOCCURRENCE_MIN_PMI", DEFAULT_MIN_PMI),
+        "min_docs": _env_int("KB_COOCCURRENCE_MIN_DOCS", DEFAULT_MIN_DOCS),
+        "max_doc_tokens": _env_int(
+            "KB_COOCCURRENCE_MAX_DOC_TOKENS", DEFAULT_MAX_DOC_TOKENS
+        ),
     }

--- a/src/data_olympus/embeddings.py
+++ b/src/data_olympus/embeddings.py
@@ -304,8 +304,12 @@ def make_hybrid_reranker(
             return (1.0 - weight) * good + weight * cos_component
 
         scored = [(blended(h), i, h) for i, h in enumerate(hits)]
-        # Sort by blended DESC; ties keep incoming order via the enumerate index.
-        scored.sort(key=lambda t: (-t[0], t[1]))
+        # Sort by rank_class FIRST (primaries before backfill), then blended DESC;
+        # ties keep incoming order via the enumerate index. The rank-class outer
+        # key means the cosine blend can re-order WITHIN a class but never lift a
+        # backfill (expansion/trigram) hit above a primary (finding (d)): the
+        # blend re-normalises scores, so a score-only floor would not hold.
+        scored.sort(key=lambda t: (t[2].rank_class, -t[0], t[1]))
         # Re-score onto the ascending-bm25 convention (lower == better) so a
         # downstream ascending sort agrees with this order: negate blended.
         return [replace(h, score=-b) for b, _i, h in scored]

--- a/src/data_olympus/index.py
+++ b/src/data_olympus/index.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import datetime
+import logging
 import os
 import sqlite3
 import subprocess
@@ -33,7 +34,7 @@ from data_olympus.embeddings import (
     serialize_vector,
 )
 from data_olympus.format.validate import IN_FORCE_STATUSES
-from data_olympus.markdown_parse import parse_file
+from data_olympus.markdown_parse import ParsedDoc, parse_text_checked
 from data_olympus.trigram import (
     DEFAULT_FALLBACK_THRESHOLD as DEFAULT_TRIGRAM_FALLBACK_THRESHOLD,
 )
@@ -77,7 +78,15 @@ CREATE TABLE IF NOT EXISTS meta (
     key TEXT PRIMARY KEY,
     value TEXT
 );
-""" + RELATED_TERMS_SCHEMA + TRIGRAM_FTS_SCHEMA + EMBEDDINGS_SCHEMA
+""" + RELATED_TERMS_SCHEMA + EMBEDDINGS_SCHEMA
+
+# The trigram secondary index (issue #41) is a SECOND full copy of every indexed
+# column tokenized into 3-char substrings: roughly a 2-3x index-size / build-time
+# tax. Finding (c): it was created and populated UNCONDITIONALLY even when the
+# trigram fallback is off, so every deployment paid that tax for a feature it was
+# not using. It is now created and populated only when the fallback is enabled
+# for THIS index (``self.trigram_fallback``), appended to the schema at build
+# time rather than baked into the base constant.
 
 # Informational only; recorded in the meta table for observability. Rebuild
 # is guaranteed by bootstrap_now=True calling Index.build() unconditionally
@@ -86,6 +95,25 @@ CREATE TABLE IF NOT EXISTS meta (
 # v7 adds the fts_trigram fuzzy-match table (issue #41).
 # v8 adds the doc_vectors table (issue #42, populated only when embeddings on).
 _SCHEMA_VERSION = "8"
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class _ParsedFile:
+    """One file read + parsed once during build (finding (i)).
+
+    Carries everything the build needs so a file is neither re-read nor re-parsed:
+    the relative path, the resolved doc id, the ParsedDoc, the raw text (stored as
+    ``content_markdown``), and whether its front matter was present but malformed
+    (finding (j)).
+    """
+
+    rel: Path
+    doc_id: str
+    doc: ParsedDoc
+    raw_text: str
+    malformed_frontmatter: bool
 
 
 # fts column order (excluding the UNINDEXED id at position 0).
@@ -268,9 +296,27 @@ def _classify_by_path(
     return "meta", "meta"
 
 
+# Rank classes. A hit's rank class is the OUTER, score-independent sort key: a
+# larger class always sorts after a smaller one, no matter what a reranker does
+# to the score. PRIMARY hits (the user's own terms) always outrank BACKFILL hits
+# (expansion synonyms, co-occurrence, trigram fuzzy matches). This is what makes
+# the "backfill hits are never reordered above primaries" invariant genuinely
+# TRUE (finding (d)): the status/hybrid rerankers ADD deltas to and RE-NORMALISE
+# the score, so a score-only "strictly worse" floor could be lifted above a
+# primary by an active-status boost; a separate rank-class key cannot.
+RANK_CLASS_PRIMARY = 0
+RANK_CLASS_BACKFILL = 1
+
+
 @dataclass(frozen=True, slots=True)
 class SearchHit:
-    """One FTS hit."""
+    """One FTS hit.
+
+    ``rank_class`` (see RANK_CLASS_*) is the outer sort key: a hit from a
+    backfill pass (expansion/trigram) carries RANK_CLASS_BACKFILL so it can never
+    be reordered above a RANK_CLASS_PRIMARY hit, independent of any score
+    arithmetic a reranker applies. Rerankers sort by ``(rank_class, score)``.
+    """
 
     id: str
     path: str
@@ -279,6 +325,7 @@ class SearchHit:
     score: float
     status: str = ""
     doc_type: str = ""
+    rank_class: int = RANK_CLASS_PRIMARY
 
 
 def make_status_reranker(
@@ -318,7 +365,10 @@ def make_status_reranker(
             replace(h, score=h.score + table.get(h.status.casefold(), 0.0))
             for h in hits
         ]
-        adjusted.sort(key=lambda h: h.score)
+        # Sort by rank_class FIRST (primaries before backfill), then adjusted
+        # score. A backfill hit's active-status boost can move it earlier WITHIN
+        # its class but never above a primary (finding (d)).
+        adjusted.sort(key=lambda h: (h.rank_class, h.score))
         return adjusted
 
     return reranker
@@ -418,7 +468,9 @@ class Index:
         # backfilled from the secondary trigram-tokenized table so a typo or a
         # partial identifier still reaches its document. Off by default so the
         # base behaviour is unchanged; the server sets these from config. Trigram
-        # hits are only ever APPENDED after primary hits, never reordering them.
+        # hits are APPENDED after primary hits and stamped RANK_CLASS_BACKFILL,
+        # which is the outer sort key in every reranker, so they are never
+        # reordered above a primary hit (finding (d)).
         self.trigram_fallback = trigram_fallback
         self.trigram_fallback_threshold = (
             trigram_fallback_threshold
@@ -448,6 +500,41 @@ class Index:
         # Test/observability counter: how many times the DB was actually read
         # (cache misses). Not part of the public contract.
         self._health_uncached_calls = 0
+        # Per-build id->vector matrix cache (finding (g)). The hybrid reranker
+        # asked get_vector() once PER candidate hit, and each call opened a fresh
+        # SQLite connection; dense_candidates re-read + deserialized the whole
+        # doc_vectors table on every query. Both now share a single in-memory
+        # matrix loaded once per build. The cache is keyed by the db file's
+        # (size, mtime_ns) so the atomic os.replace() swap in build() transparently
+        # invalidates it (the new inode has a different mtime), with no explicit
+        # invalidation call needed even for a rebuild by a DIFFERENT Index object.
+        # Guarded by a lock because query reads run concurrently in the threadpool.
+        self._vector_lock = threading.Lock()
+        self._vector_cache: tuple[
+            tuple[int, int], dict[str, builtins.list[float]]
+        ] | None = None
+        # Test/observability counter: how many times the vector matrix was
+        # actually loaded from the DB (cache misses). Not part of the public
+        # contract; asserted by the batch-fetch test to prove one load per build.
+        self._vector_loads = 0
+        # Health-visible count of docs whose front-matter block was present but
+        # malformed at the last build, so their status/supersedes were silently
+        # dropped (finding (j)). Updated by build(); surfaced via health() and the
+        # ``malformed_frontmatter_count`` property. Exposing it on the Index (with
+        # a WARN log per doc) is the minimal, non-invasive plumbing; wiring it into
+        # the /health degraded signal is a tracked follow-up.
+        self._malformed_frontmatter_count = 0
+
+    @property
+    def malformed_frontmatter_count(self) -> int:
+        """Docs with a present-but-malformed front-matter block at last build (j).
+
+        A YAML typo in a doc's front matter makes the parser fall back to "no
+        front matter", silently dropping its ``status`` / ``supersedes`` and
+        disabling that doc's staleness protection. This counter (also logged at
+        WARN per doc during build) makes the condition observable.
+        """
+        return self._malformed_frontmatter_count
 
     def _resolve_embedder(self) -> Embedder | None:
         """Return the embedder to use, loading it from the threaded config once.
@@ -474,7 +561,12 @@ class Index:
 
     @staticmethod
     def _git_last_modified(kb_root: Path, rel: Path) -> tuple[str, str]:
-        """Return (iso_timestamp, source). source is 'git' or 'mtime'."""
+        """Return (iso_timestamp, source). source is 'git' or 'mtime'.
+
+        Per-file git query. Retained for callers that need a single file's
+        timestamp; the index build uses :func:`_git_last_modified_map` to fetch
+        every file's last-commit time in ONE ``git log`` pass (finding (i)).
+        """
         try:
             result = subprocess.run(
                 ["git", "-C", str(kb_root), "log", "-1", "--format=%cI", "--", str(rel)],
@@ -488,6 +580,73 @@ class Index:
         mtime = (kb_root / rel).stat().st_mtime
         return datetime.datetime.fromtimestamp(mtime, tz=datetime.UTC).isoformat(), "mtime"
 
+    # Sentinel prefixing each commit's timestamp line in the batched git log, so
+    # the parser distinguishes a timestamp header from a changed-path line. A
+    # control char that cannot appear in a git path keeps the split unambiguous.
+    _GIT_LOG_MARK = "\x01"
+
+    @classmethod
+    def _git_last_modified_map(cls, kb_root: Path) -> dict[str, str]:
+        """Map every tracked path to its last-commit ISO timestamp in ONE pass (i).
+
+        Runs a single ``git log --name-only`` over the whole history and records,
+        for each path, the FIRST (most recent, since git log is newest-first)
+        commit timestamp that touched it. Replaces the previous one-subprocess-
+        per-file loop (N git invocations -> 1). Returns an empty map when the
+        directory is not a git repo or git is unavailable; the build then falls
+        back to filesystem mtime per file exactly as before, so the ``source``
+        recorded per doc ('git' vs 'mtime') is unchanged from the per-file path.
+
+        The format is ``<MARK><iso>`` on the commit line (MARK is a control char
+        that cannot appear in a path) followed by ``--name-only`` path lines, so
+        the parser tells a timestamp line from a path line unambiguously. Paths
+        are relative to ``kb_root`` with forward slashes (git's native form),
+        matching ``str(rel)`` used as the lookup key in build(). Rename entries
+        (``old -> new``) are not requested (no ``-M``), so paths are literal.
+        """
+        try:
+            result = subprocess.run(
+                ["git", "-C", str(kb_root), "log",
+                 f"--format={cls._GIT_LOG_MARK}%cI", "--name-only", "HEAD"],
+                capture_output=True, text=True, check=False, timeout=30,
+            )
+        except (subprocess.TimeoutExpired, FileNotFoundError):
+            return {}
+        if result.returncode != 0 or not result.stdout:
+            return {}
+        out: dict[str, str] = {}
+        current_iso = ""
+        for line in result.stdout.splitlines():
+            if line.startswith(cls._GIT_LOG_MARK):
+                current_iso = line[len(cls._GIT_LOG_MARK):].strip()
+                continue
+            path = line.strip()
+            # git log is newest-first, so the first time we see a path is its most
+            # recent commit; keep that and ignore older ones.
+            if path and current_iso and path not in out:
+                out[path] = current_iso
+        return out
+
+    @staticmethod
+    def _resolve_last_modified(
+        kb_root: Path, rel: Path, git_mtimes: dict[str, str],
+    ) -> tuple[str, str]:
+        """Return (iso_timestamp, source) for ``rel`` using the batched git map (i).
+
+        A hit in ``git_mtimes`` (the single ``git log`` pass) yields ('git', iso),
+        byte-for-byte the same value the per-file ``git log`` produced. A miss
+        (untracked file, or not a git repo at all) falls back to filesystem mtime,
+        exactly as the per-file path did, so the recorded ``source`` is unchanged.
+        """
+        iso = git_mtimes.get(str(rel))
+        if iso:
+            return iso, "git"
+        mtime = (kb_root / rel).stat().st_mtime
+        return (
+            datetime.datetime.fromtimestamp(mtime, tz=datetime.UTC).isoformat(),
+            "mtime",
+        )
+
     def build(self, kb_root: Path, *, source_commit: str) -> IndexBuildResult:
         """Walk kb_root for .md files and (re)build the FTS index using atomic swap."""
         if not kb_root.is_dir():
@@ -500,27 +659,49 @@ class Index:
         if tmp_path.exists():
             tmp_path.unlink()  # stale tmp from previous failed build
 
-        # First pass: collect (id, path) without writing, so we can detect duplicates
-        # before mutating anything.
+        # Single pass over the corpus (finding (i)): read + parse each file EXACTLY
+        # ONCE and reuse the result for duplicate detection, the docs/fts inserts,
+        # and (via the raw text) the stored content_markdown. The previous build
+        # read/parsed each file three times (a first-pass parse, a second-pass
+        # parse, and a separate content read). Each ``_ParsedFile`` carries the
+        # raw text, the ParsedDoc, and the malformed-frontmatter flag (finding
+        # (j)).
+        parsed: list[_ParsedFile] = []
         seen: dict[str, list[str]] = {}
-        files_to_index: list[Path] = []
         for md in sorted(kb_root.rglob("*.md")):
             rel = md.relative_to(kb_root)
             if _is_excluded(rel):
                 continue
-            doc = parse_file(md)
+            raw_text = md.read_text(encoding="utf-8")
+            doc, malformed = parse_text_checked(md, raw_text)
             doc_id = doc.id or _derive_id_from_path(rel)
             seen.setdefault(doc_id, []).append(str(rel))
-            files_to_index.append(md)
+            parsed.append(
+                _ParsedFile(
+                    rel=rel, doc_id=doc_id, doc=doc,
+                    raw_text=raw_text, malformed_frontmatter=malformed,
+                )
+            )
         conflicts = {id_: paths for id_, paths in seen.items() if len(paths) > 1}
         if conflicts:
             raise DuplicateIdError(conflicts)
+        # One git pass for every file's last-commit time (finding (i)); empty when
+        # not a git repo, in which case each file falls back to mtime below.
+        git_mtimes = self._git_last_modified_map(kb_root)
 
         # Build the new index into the tmp file
         conn = sqlite3.connect(tmp_path)
         conn.row_factory = sqlite3.Row
         try:
-            conn.executescript(_SCHEMA)
+            # Finding (c): the trigram table is created only when the trigram
+            # fallback is enabled for this index. With it off the schema (and the
+            # per-doc insert below) skip it, so a default deployment no longer
+            # pays the 2-3x index-size / build-time cost of a second tokenized
+            # copy of the corpus.
+            schema = _SCHEMA
+            if self.trigram_fallback:
+                schema = schema + TRIGRAM_FTS_SCHEMA
+            conn.executescript(schema)
             count = 0
             path_rules = _load_path_rules()
             # Per-document token sets for the co-occurrence table (issue #40).
@@ -542,17 +723,32 @@ class Index:
             embed_inputs: list[tuple[str, str]] = []
             if build_embeddings:
                 embedder = self._resolve_embedder()
-            for md in files_to_index:
-                rel = md.relative_to(kb_root)
-                doc = parse_file(md)
-                doc_id = doc.id or _derive_id_from_path(rel)
+            # Count of docs whose front-matter block was present but malformed, so
+            # status/supersedes were silently dropped (finding (j)). Surfaced on
+            # the Index and logged at WARN so a YAML typo that disables a doc's
+            # staleness protection is visible rather than silent.
+            malformed_frontmatter = 0
+            for pf in parsed:
+                rel = pf.rel
+                doc = pf.doc
+                doc_id = pf.doc_id
+                if pf.malformed_frontmatter:
+                    malformed_frontmatter += 1
+                    logger.warning(
+                        "malformed front matter in %s: front-matter block present "
+                        "but not valid YAML; status/supersedes/other fields were "
+                        "dropped (staleness protection disabled for this doc)",
+                        rel,
+                    )
                 path_tier, path_category = _classify_by_path(str(rel), path_rules)
                 final_tier = doc.tier or path_tier
                 final_category = doc.category or path_category
                 tags_str = " ".join(doc.tags)
                 applies_when_str = " ".join(doc.applies_when)
-                last_modified, lm_source = self._git_last_modified(kb_root, rel)
-                content_markdown = md.read_text(encoding="utf-8")
+                last_modified, lm_source = self._resolve_last_modified(
+                    kb_root, rel, git_mtimes,
+                )
+                content_markdown = pf.raw_text
                 conn.execute(
                     "INSERT INTO docs (id, path, tier, category, status, type, "
                     "applies_when, description, title, tags, "
@@ -569,23 +765,40 @@ class Index:
                 )
                 # Secondary trigram index (issue #41), built into the SAME tmp DB
                 # so it is swapped atomically with the primary fts table below.
-                # A query never sees a half-built trigram table.
-                conn.execute(
-                    "INSERT INTO fts_trigram "
-                    "(id, title, tags, applies_when, description, body) "
-                    "VALUES (?, ?, ?, ?, ?, ?)",
-                    (doc_id, doc.title, tags_str, applies_when_str, doc.description, doc.body),
-                )
+                # A query never sees a half-built trigram table. Only populated
+                # when the trigram fallback is enabled for this index (finding
+                # (c)); the table itself was created above only in that case.
+                if self.trigram_fallback:
+                    conn.execute(
+                        "INSERT INTO fts_trigram "
+                        "(id, title, tags, applies_when, description, body) "
+                        "VALUES (?, ?, ?, ?, ?, ?)",
+                        (doc_id, doc.title, tags_str, applies_when_str,
+                         doc.description, doc.body),
+                    )
                 if build_cooccurrence:
                     doc_token_sets.append(
                         tokenize_doc(doc.title, tags_str, doc.description, doc.body)
                     )
                 if build_embeddings:
-                    # Embed title + description + body: the retrievable semantic
-                    # content of the doc. Bounded to keep a huge doc from blowing
-                    # the model's context; the head carries the topical signal.
+                    # Embed title + applies_when + tags + description + body: the
+                    # retrievable semantic content PLUS the curated intent
+                    # vocabulary (finding (f)). applies_when and tags are exactly
+                    # the hand-authored phrases a paraphrase query embeds near
+                    # ("when do I ...", topic labels), so excluding them left the
+                    # dense channel blind to the intent signal it most needs.
+                    # Bounded to keep a huge doc from blowing the model's context;
+                    # the head carries the topical signal.
                     embed_text = "\n".join(
-                        p for p in (doc.title, doc.description, doc.body) if p
+                        p
+                        for p in (
+                            doc.title,
+                            applies_when_str,
+                            tags_str,
+                            doc.description,
+                            doc.body,
+                        )
+                        if p
                     )[:_EMBED_TEXT_MAX_CHARS]
                     embed_inputs.append((doc_id, embed_text))
                 count += 1
@@ -611,6 +824,8 @@ class Index:
                     k=int(params["k"]),
                     min_count=int(params["min_count"]),
                     min_pmi=float(params["min_pmi"]),
+                    min_docs=int(params["min_docs"]),
+                    max_doc_tokens=int(params["max_doc_tokens"]),
                 )
                 write_cooccurrence_table(conn, table)
             now = time.time()
@@ -629,6 +844,14 @@ class Index:
             conn.execute(
                 "INSERT OR REPLACE INTO meta (key, value) VALUES ('schema_version', ?)",
                 (_SCHEMA_VERSION,),
+            )
+            # Malformed-frontmatter count (finding (j)): persisted in meta so
+            # health() surfaces it without an extra scan and it survives a process
+            # restart that reads the swapped index.
+            conn.execute(
+                "INSERT OR REPLACE INTO meta (key, value) "
+                "VALUES ('malformed_frontmatter', ?)",
+                (str(malformed_frontmatter),),
             )
             # Integrity check before swap
             check = conn.execute("PRAGMA integrity_check").fetchone()
@@ -651,6 +874,9 @@ class Index:
         # Atomic swap: the previous index file (if any) is replaced. Open fds on the
         # old inode keep reading from it until they close.
         os.replace(tmp_path, self._db_path)
+        # Publish the malformed-frontmatter count for the in-process health view
+        # (finding (j)); the persisted meta row covers a fresh process.
+        self._malformed_frontmatter_count = malformed_frontmatter
         # Invalidate the health cache so the next health() reflects the rebuild
         # immediately rather than serving the pre-swap commit for up to the TTL.
         with self._health_lock:
@@ -696,77 +922,70 @@ class Index:
         (embedding) candidate source so neither leaks an out-of-force doc.
         """
         # Stage 1 (expand-query): term extraction + optional expansion hook.
-        terms = query.split()
-        if not terms:
+        # The user's ACTUAL terms (post-split, pre-expansion) drive the PRIMARY
+        # match; any expansion terms are matched separately and can only backfill
+        # BELOW the worst primary hit (see stage 2b'). FTS5 bm25 gives an
+        # expansion synonym full idf weight in an OR-MATCH, so folding expansion
+        # terms into the primary MATCH would let a doc matching only a derived
+        # term outrank a doc matching the term the user typed. Splitting the
+        # passes makes the "expansion is down-weighted" contract actually true.
+        primary_terms = query.split()
+        if not primary_terms:
             return []
+        expansion_terms: list[str] = []
         if self.query_expander is not None:
-            terms = list(self.query_expander(terms))
-            if not terms:
+            expanded = list(self.query_expander(primary_terms))
+            if not expanded:
                 return []
-        match_query = self._build_match_expr(terms, columns)
+            # The expander keeps the originals first (order-stable), then appends
+            # derived terms. Everything not in the original set is an expansion
+            # term matched only in the penalized backfill pass.
+            primary_lower = {t.lower() for t in primary_terms}
+            seen_exp: set[str] = set()
+            for t in expanded:
+                low = t.lower()
+                if low in primary_lower or low in seen_exp:
+                    continue
+                seen_exp.add(low)
+                expansion_terms.append(t)
         weights = column_weights if column_weights is not None else _DEFAULT_BM25_WEIGHTS
-        bm25_expr = "bm25(fts, " + ", ".join(repr(float(w)) for w in weights) + ")"
+        # Over-fetch a wider candidate pool when a reranker will reorder the
+        # hits (see stage 3); never fewer than `limit`. Computed once and used to
+        # bound both the primary pool and the backfill passes.
+        candidate_limit = limit
+        if self.reranker is not None:
+            candidate_limit = max(
+                limit,
+                min(
+                    max(limit * _RERANK_OVERFETCH_FACTOR, _RERANK_MIN_POOL),
+                    _RERANK_MAX_POOL,
+                ),
+            )
         conn = self._connect()
         try:
-            where = ["fts MATCH ?"]
-            params: list[object] = [match_query]
-            if tier:
-                where.append("docs.tier = ?")
-                params.append(tier)
-            if category:
-                where.append("docs.category = ?")
-                params.append(category)
-            if status:
-                where.append("docs.status = ?")
-                params.append(status)
-            if in_force:
-                placeholders = ", ".join("?" for _ in _IN_FORCE_STATUS_LIST)
-                where.append(f"docs.status IN ({placeholders})")
-                params.extend(_IN_FORCE_STATUS_LIST)
-            if doc_type:
-                where.append("docs.type = ?")
-                params.append(doc_type)
-            # Over-fetch a wider candidate pool when a reranker will reorder the
-            # hits (see stage 3); never fewer than `limit`.
-            candidate_limit = limit
-            if self.reranker is not None:
-                candidate_limit = max(
-                    limit,
-                    min(
-                        max(limit * _RERANK_OVERFETCH_FACTOR, _RERANK_MIN_POOL),
-                        _RERANK_MAX_POOL,
-                    ),
+            base_where, base_params = self._facet_filters(
+                tier=tier, category=category, status=status,
+                in_force=in_force, doc_type=doc_type,
+            )
+            # Stage 2 (match): PRIMARY pool from the user's own terms only.
+            hits = self._fts_match(
+                conn, primary_terms, columns=columns, weights=weights,
+                base_where=base_where, base_params=base_params,
+                candidate_limit=candidate_limit,
+            )
+            # Stage 2b' (penalized expansion backfill, finding (a)): match the
+            # expansion terms separately and append ONLY docs not already found
+            # by the primary pass, each scored strictly worse than the worst
+            # primary hit. So an expansion-only hit can never outrank a doc that
+            # matched a term the user actually typed, even after the reranker
+            # re-sorts by score. This is the same rank-class backfill discipline
+            # the trigram fallback uses.
+            if expansion_terms:
+                hits = self._expansion_backfill(
+                    conn, expansion_terms, primary_hits=hits, columns=columns,
+                    weights=weights, base_where=base_where,
+                    base_params=base_params, candidate_limit=candidate_limit,
                 )
-            params.append(candidate_limit)
-            sql = f"""
-                SELECT
-                    fts.id AS id,
-                    docs.path AS path,
-                    COALESCE(docs.title, '') AS title,
-                    COALESCE(docs.status, '') AS status,
-                    COALESCE(docs.type, '') AS doc_type,
-                    snippet(fts, 5, '[', ']', '...', 16) AS snippet,
-                    {bm25_expr} AS score
-                FROM fts
-                JOIN docs ON docs.id = fts.id
-                WHERE {' AND '.join(where)}
-                ORDER BY score
-                LIMIT ?
-            """
-            # Stage 2 (match): rows come back BM25-ordered from SQLite.
-            rows = conn.execute(sql, params).fetchall()
-            hits = [
-                SearchHit(
-                    id=r["id"],
-                    path=r["path"],
-                    title=r["title"],
-                    snippet=r["snippet"],
-                    score=float(r["score"]),
-                    status=r["status"],
-                    doc_type=r["doc_type"],
-                )
-                for r in rows
-            ]
             # Stage 2b (fuzzy fallback, issue #41): only when enabled AND the
             # primary query returned few/no hits. Trigram hits are APPENDED after
             # the primary hits and given scores strictly worse than any primary
@@ -781,8 +1000,8 @@ class Index:
                     conn,
                     query,
                     primary_hits=hits,
-                    base_where=where[1:],
-                    base_params=params[1:-1],
+                    base_where=base_where,
+                    base_params=base_params,
                     candidate_limit=candidate_limit,
                 )
         finally:
@@ -808,11 +1027,15 @@ class Index:
                 in_force=in_force,
                 doc_type=doc_type,
             )
-        # Stage 3 (re-rank): optional hook reorders/rescores (default identity),
-        # then truncate the (possibly wider / prepended) pool back to `limit`.
+        # Stage 3 (re-rank): optional hook reorders/rescores (default identity).
         if self.reranker is not None:
-            hits = list(self.reranker(query, hits))[:limit]
-        return hits
+            hits = list(self.reranker(query, hits))
+        # Truncate to the caller's ``limit`` UNCONDITIONALLY (finding (h)). The
+        # dense union and the backfill passes can push the pool past ``limit``,
+        # and that truncation must happen whether or not a reranker is installed:
+        # doing it only inside the reranker branch let search() return more than
+        # ``limit`` hits when embeddings were configured but no reranker was set.
+        return hits[:limit]
 
     def _union_dense_candidates(
         self,
@@ -857,6 +1080,142 @@ class Index:
         ]
         return [*fts_hits, *appended]
 
+    def _facet_filters(
+        self,
+        *,
+        tier: str | None,
+        category: str | None,
+        status: str | None,
+        in_force: bool,
+        doc_type: str | None,
+    ) -> tuple[list[str], list[object]]:
+        """Build the shared docs.* facet WHERE fragments (no MATCH clause).
+
+        Returns (where_fragments, params) covering tier/category/status/in_force/
+        doc_type. The MATCH clause is prepended per-pass by the caller so the
+        primary, expansion-backfill, trigram, and dense passes all apply the same
+        facet filters from a single source.
+        """
+        where: list[str] = []
+        params: list[object] = []
+        if tier:
+            where.append("docs.tier = ?")
+            params.append(tier)
+        if category:
+            where.append("docs.category = ?")
+            params.append(category)
+        if status:
+            where.append("docs.status = ?")
+            params.append(status)
+        if in_force:
+            placeholders = ", ".join("?" for _ in _IN_FORCE_STATUS_LIST)
+            where.append(f"docs.status IN ({placeholders})")
+            params.extend(_IN_FORCE_STATUS_LIST)
+        if doc_type:
+            where.append("docs.type = ?")
+            params.append(doc_type)
+        return where, params
+
+    def _fts_match(
+        self,
+        conn: sqlite3.Connection,
+        terms: list[str],
+        *,
+        columns: list[str] | None,
+        weights: tuple[float, ...],
+        base_where: list[str],
+        base_params: list[object],
+        candidate_limit: int,
+    ) -> list[SearchHit]:
+        """Run one bm25-ordered FTS MATCH over ``terms`` and return the hits.
+
+        The single primary-pool query, factored out so the primary pass and the
+        penalized expansion-backfill pass share exactly one code path. Rows come
+        back bm25-ordered (ascending; lower is better). Applies the shared facet
+        filters (``base_where`` / ``base_params``).
+        """
+        match_query = self._build_match_expr(terms, columns)
+        bm25_expr = "bm25(fts, " + ", ".join(repr(float(w)) for w in weights) + ")"
+        where = ["fts MATCH ?", *base_where]
+        params: list[object] = [match_query, *base_params, candidate_limit]
+        sql = f"""
+            SELECT
+                fts.id AS id,
+                docs.path AS path,
+                COALESCE(docs.title, '') AS title,
+                COALESCE(docs.status, '') AS status,
+                COALESCE(docs.type, '') AS doc_type,
+                snippet(fts, 5, '[', ']', '...', 16) AS snippet,
+                {bm25_expr} AS score
+            FROM fts
+            JOIN docs ON docs.id = fts.id
+            WHERE {' AND '.join(where)}
+            ORDER BY score
+            LIMIT ?
+        """
+        rows = conn.execute(sql, params).fetchall()
+        return [
+            SearchHit(
+                id=r["id"],
+                path=r["path"],
+                title=r["title"],
+                snippet=r["snippet"],
+                score=float(r["score"]),
+                status=r["status"],
+                doc_type=r["doc_type"],
+            )
+            for r in rows
+        ]
+
+    def _expansion_backfill(
+        self,
+        conn: sqlite3.Connection,
+        expansion_terms: list[str],
+        *,
+        primary_hits: list[SearchHit],
+        columns: list[str] | None,
+        weights: tuple[float, ...],
+        base_where: list[str],
+        base_params: list[object],
+        candidate_limit: int,
+    ) -> list[SearchHit]:
+        """Backfill expansion-term matches strictly below the primary hits (a).
+
+        Runs a second FTS MATCH over the expansion terms only, drops any doc
+        already returned by the primary pass, and appends the rest with scores
+        strictly worse (larger, since bm25 is ordered ascending) than the worst
+        primary hit. So a doc that matches ONLY a synonym / co-occurrence term can
+        never outrank a doc that matched a term the user actually typed, even
+        after the reranker re-sorts by score. This is the same rank-class discipline
+        the trigram backfill uses. The expansion pass preserves its own internal
+        bm25 order via a monotonically increasing offset.
+        """
+        expanded_hits = self._fts_match(
+            conn, expansion_terms, columns=columns, weights=weights,
+            base_where=base_where, base_params=base_params,
+            candidate_limit=candidate_limit,
+        )
+        if not expanded_hits:
+            return primary_hits
+        seen_ids = {h.id for h in primary_hits}
+        # Worst (largest) primary score; bm25 scores are <= 0, so 0.0 is a safe
+        # finite floor when there are no primary hits.
+        worst_primary = max((h.score for h in primary_hits), default=0.0)
+        appended: list[SearchHit] = []
+        offset = 1.0
+        for h in expanded_hits:
+            if h.id in seen_ids:
+                continue
+            seen_ids.add(h.id)
+            appended.append(
+                replace(
+                    h, score=worst_primary + offset,
+                    rank_class=RANK_CLASS_BACKFILL,
+                )
+            )
+            offset += 1.0
+        return [*primary_hits, *appended]
+
     def _build_match_expr(self, terms: list[str], columns: list[str] | None) -> str:
         """Match stage: build the FTS5 MATCH expression from query terms.
 
@@ -888,13 +1247,15 @@ class Index:
 
         Runs the trigram (substring) MATCH built from the query's own trigrams,
         excluding ids already returned by the primary query, and appends the
-        results AFTER the primary hits. Each appended hit is given a score
-        strictly worse (larger, since bm25 is ordered ascending) than any primary
-        hit, so a downstream reranker that re-sorts by score cannot lift a fuzzy
-        hit above an exact/primary one. The same tier/category/status/doc_type
-        filters (``base_where`` / ``base_params``) are applied. A query with no
-        trigram (shorter than 3 chars) no-ops and the primary hits are returned
-        unchanged.
+        results AFTER the primary hits. Each appended hit carries
+        ``rank_class=RANK_CLASS_BACKFILL`` AND a score strictly worse (larger,
+        since bm25 is ordered ascending) than any primary hit. The rank_class is
+        the OUTER sort key in every reranker, so a fuzzy hit can never be lifted
+        above an exact/primary one even by a reranker that ADDS status deltas or
+        RE-NORMALISES scores (finding (d)); the worse score just orders the fuzzy
+        hits among themselves. The same tier/category/status/doc_type filters
+        (``base_where`` / ``base_params``) are applied. A query with no trigram
+        (shorter than 3 chars) no-ops and the primary hits are returned unchanged.
         """
         trigram_expr = build_trigram_match_expr(query)
         if trigram_expr is None:
@@ -940,6 +1301,7 @@ class Index:
                     score=worst_primary + offset,
                     status=r["status"],
                     doc_type=r["doc_type"],
+                    rank_class=RANK_CLASS_BACKFILL,
                 )
             )
             offset += 1.0
@@ -972,10 +1334,10 @@ class Index:
         """Return a ``query_expander`` backed by this index's related-terms table.
 
         The expander appends, for each query term, up to ``k`` co-occurring terms
-        (down-weighted by appending after the originals), bounded overall by
-        ``max_terms``. Bound to ``self.related_terms`` so it always reads the
-        currently-swapped index. Compose it AFTER the synonym expander via
-        ``cooccurrence.compose_expanders``.
+        (down-weighted by search()'s separate penalized backfill pass, not by
+        appended position), bounded overall by ``max_terms``. Bound to
+        ``self.related_terms`` so it always reads the currently-swapped index.
+        Compose it AFTER the synonym expander via ``cooccurrence.compose_expanders``.
         """
         return make_cooccurrence_expander(
             lambda term, kk: self.related_terms(term, limit=kk),
@@ -983,31 +1345,56 @@ class Index:
             max_terms=max_terms,
         )
 
+    def _load_vectors(self) -> dict[str, builtins.list[float]]:
+        """Return the id->vector matrix for the current build, loaded once (g).
+
+        Batch-fetches and deserializes the whole ``doc_vectors`` table in ONE
+        query and caches it, keyed by the db file's (size, mtime_ns). The atomic
+        ``os.replace`` swap in build() gives the new file a different mtime, so a
+        rebuild (even by a different Index object) transparently invalidates the
+        cache with no explicit call. Replaces the old per-hit ``get_vector`` SQL
+        (one connection per candidate) and the per-query full-table re-read in
+        ``dense_candidates``. Returns an empty dict when the db or the table is
+        absent (index predates schema v8) or the feature is off.
+        """
+        if not self._db_path.exists():
+            return {}
+        try:
+            st = self._db_path.stat()
+            key = (st.st_size, st.st_mtime_ns)
+        except OSError:
+            return {}
+        with self._vector_lock:
+            cached = self._vector_cache
+            if cached is not None and cached[0] == key:
+                return cached[1]
+        # Cache miss: load the whole table once, outside the lock (a concurrent
+        # miss is harmless; both compute the same matrix from the same file).
+        conn = self._connect()
+        try:
+            rows = conn.execute("SELECT id, vector FROM doc_vectors").fetchall()
+        except sqlite3.OperationalError:
+            # Table absent (index predates schema v8); no vectors.
+            rows = []
+        finally:
+            conn.close()
+        matrix = {r["id"]: deserialize_vector(r["vector"]) for r in rows}
+        self._vector_loads += 1
+        with self._vector_lock:
+            self._vector_cache = (key, matrix)
+        return matrix
+
     def get_vector(self, id: str) -> builtins.list[float] | None:
         """Return the stored embedding vector for ``id``, or None (issue #42).
 
-        Reads the ``doc_vectors`` table populated at build time only when the
-        embeddings feature was enabled. A build that predates the table, a doc
-        with no vector, or the feature being off all yield None (the hybrid
+        Backed by the per-build id->vector matrix (finding (g)): the matrix is
+        loaded from ``doc_vectors`` ONCE per build and cached, so the hybrid
+        reranker's per-candidate ``get_vector`` calls are memory-only lookups
+        instead of one SQLite connection each. A build that predates the table, a
+        doc with no vector, or the feature being off all yield None (the hybrid
         reranker treats a missing vector as a neutral cosine, never a drop).
-        Opens a per-call connection so it always reads the atomically-swapped
-        current index.
         """
-        if not self._db_path.exists():
-            return None
-        conn = self._connect()
-        try:
-            row = conn.execute(
-                "SELECT vector FROM doc_vectors WHERE id = ?", (id,)
-            ).fetchone()
-        except sqlite3.OperationalError:
-            # Table absent (index predates the schema); degrade to no vector.
-            return None
-        finally:
-            conn.close()
-        if row is None:
-            return None
-        return deserialize_vector(row["vector"])
+        return self._load_vectors().get(id)
 
     def dense_candidates(
         self,
@@ -1036,6 +1423,11 @@ class Index:
         be embedded, or the index predates the ``doc_vectors`` table. Each hit
         carries its cosine in ``score`` (higher = better here); search() re-scores
         dense-only hits onto the bm25 convention before the blend.
+
+        Perf (finding (g)): the vectors come from the per-build id->vector matrix
+        (loaded once, cached) instead of re-reading and re-deserializing the whole
+        ``doc_vectors`` table on every query. Only the facet-eligible doc metadata
+        is queried here; the vector lookup is an in-memory dict hit.
         """
         embedder = self._resolve_embedder()
         if embedder is None or limit <= 0 or not self._db_path.exists():
@@ -1043,7 +1435,12 @@ class Index:
         qvec = embedder.embed_one(query) if query.strip() else None
         if not qvec:
             return []
-        where = ["dv.vector IS NOT NULL"]
+        matrix = self._load_vectors()
+        if not matrix:
+            return []
+        # Fetch only the facet-eligible doc metadata (no vector blob); the vector
+        # is pulled from the cached matrix by id.
+        where = ["dv.id IS NOT NULL"]
         params: list[object] = []
         if tier:
             where.append("docs.tier = ?")
@@ -1064,7 +1461,6 @@ class Index:
         sql = f"""
             SELECT
                 dv.id AS id,
-                dv.vector AS vector,
                 docs.path AS path,
                 COALESCE(docs.title, '') AS title,
                 COALESCE(docs.status, '') AS status,
@@ -1084,8 +1480,8 @@ class Index:
             conn.close()
         scored: list[tuple[float, SearchHit]] = []
         for r in rows:
-            dvec = deserialize_vector(r["vector"])
-            if len(dvec) != len(qvec):
+            dvec = matrix.get(r["id"])
+            if dvec is None or len(dvec) != len(qvec):
                 continue
             sim = cosine(qvec, dvec)
             if sim < min_cosine:
@@ -1272,6 +1668,10 @@ class Index:
             "index_built_at": float(meta["built_at"]) if "built_at" in meta else None,
             "total_docs": int(meta.get("total_docs", "0")),
             "db_size_bytes": self._db_path.stat().st_size,
+            # Finding (j): present-but-malformed front-matter count from the last
+            # build. Read from the persisted meta row so a fresh process (that did
+            # not run build() itself) still sees it.
+            "malformed_frontmatter": int(meta.get("malformed_frontmatter", "0")),
         }
 
     def list_by_prefix(

--- a/src/data_olympus/index.py
+++ b/src/data_olympus/index.py
@@ -580,8 +580,8 @@ class Index:
         mtime = (kb_root / rel).stat().st_mtime
         return datetime.datetime.fromtimestamp(mtime, tz=datetime.UTC).isoformat(), "mtime"
 
-    # Sentinel prefixing each commit's timestamp line in the batched git log, so
-    # the parser distinguishes a timestamp header from a changed-path line. A
+    # Sentinel prefixing each commit's timestamp record in the batched git log,
+    # so the parser distinguishes a timestamp header from a changed-path record. A
     # control char that cannot appear in a git path keeps the split unambiguous.
     _GIT_LOG_MARK = "\x01"
 
@@ -589,25 +589,29 @@ class Index:
     def _git_last_modified_map(cls, kb_root: Path) -> dict[str, str]:
         """Map every tracked path to its last-commit ISO timestamp in ONE pass (i).
 
-        Runs a single ``git log --name-only`` over the whole history and records,
-        for each path, the FIRST (most recent, since git log is newest-first)
-        commit timestamp that touched it. Replaces the previous one-subprocess-
-        per-file loop (N git invocations -> 1). Returns an empty map when the
-        directory is not a git repo or git is unavailable; the build then falls
-        back to filesystem mtime per file exactly as before, so the ``source``
-        recorded per doc ('git' vs 'mtime') is unchanged from the per-file path.
+        Runs a single ``git log -z --name-only`` over the whole history and
+        records, for each path, the FIRST (most recent, since git log is
+        newest-first) commit timestamp that touched it. Replaces the previous
+        one-subprocess-per-file loop (N git invocations -> 1). Returns an empty
+        map when the directory is not a git repo or git is unavailable; the build
+        then falls back to filesystem mtime per file exactly as before, so the
+        ``source`` recorded per doc ('git' vs 'mtime') is unchanged.
 
-        The format is ``<MARK><iso>`` on the commit line (MARK is a control char
-        that cannot appear in a path) followed by ``--name-only`` path lines, so
-        the parser tells a timestamp line from a path line unambiguously. Paths
-        are relative to ``kb_root`` with forward slashes (git's native form),
-        matching ``str(rel)`` used as the lookup key in build(). Rename entries
-        (``old -> new``) are not requested (no ``-M``), so paths are literal.
+        Exactness (reviewer concern): the output is NUL-delimited (``-z``) and
+        ``core.quotePath=false`` disables git's octal-quoting of non-ASCII paths,
+        so a path with spaces, unicode, or other special characters round-trips
+        byte-for-byte and is NOT lost to the mtime fallback. Each record is either
+        ``<MARK><iso>`` (a commit header) or a changed path; the first path of a
+        commit carries a leading ``\\n`` (git's format-block-to-name-list
+        separator) which is stripped, but the path body is otherwise untouched (no
+        ``.strip()``, so trailing/leading whitespace in a filename survives). Paths
+        are relative to ``kb_root`` with forward slashes, matching ``str(rel)``.
+        Renames are not requested (no ``-M``), so paths are literal.
         """
         try:
             result = subprocess.run(
-                ["git", "-C", str(kb_root), "log",
-                 f"--format={cls._GIT_LOG_MARK}%cI", "--name-only", "HEAD"],
+                ["git", "-C", str(kb_root), "-c", "core.quotePath=false", "log",
+                 "-z", f"--format={cls._GIT_LOG_MARK}%cI", "--name-only", "HEAD"],
                 capture_output=True, text=True, check=False, timeout=30,
             )
         except (subprocess.TimeoutExpired, FileNotFoundError):
@@ -616,11 +620,19 @@ class Index:
             return {}
         out: dict[str, str] = {}
         current_iso = ""
-        for line in result.stdout.splitlines():
-            if line.startswith(cls._GIT_LOG_MARK):
-                current_iso = line[len(cls._GIT_LOG_MARK):].strip()
+        for record in result.stdout.split("\x00"):
+            if not record:
                 continue
-            path = line.strip()
+            if record.startswith(cls._GIT_LOG_MARK):
+                # Commit header: MARK + iso. ISO-8601 timestamps carry no
+                # surrounding whitespace, so stripping the iso is safe/exact.
+                current_iso = record[len(cls._GIT_LOG_MARK):].strip()
+                continue
+            # A changed-path record. The first path of a commit is prefixed with a
+            # single '\n' (git's separator between the format block and the name
+            # list); remove exactly that, but do NOT strip the path body so a
+            # filename with leading/trailing whitespace round-trips exactly.
+            path = record[1:] if record.startswith("\n") else record
             # git log is newest-first, so the first time we see a path is its most
             # recent commit; keep that and ignore older ones.
             if path and current_iso and path not in out:

--- a/src/data_olympus/markdown_parse.py
+++ b/src/data_olympus/markdown_parse.py
@@ -37,13 +37,46 @@ def parse_file(path: Path) -> ParsedDoc:
     """Read a markdown file and return a ParsedDoc.
 
     Raises FileNotFoundError if path does not exist. Malformed front matter is
-    treated as no front matter (lenient): returns empty metadata fields.
+    treated as no front matter (lenient): returns empty metadata fields. Prefer
+    :func:`parse_text` when the caller already has the raw text (e.g. the index
+    build reads each file exactly once and reuses the text for both parsing and
+    the stored ``content_markdown``).
     """
-    text = path.read_text(encoding="utf-8")
+    return parse_text(path, path.read_text(encoding="utf-8"))
+
+
+def parse_text(path: Path, text: str) -> ParsedDoc:
+    """Parse already-read markdown ``text`` into a ParsedDoc (no file read).
+
+    Split out from :func:`parse_file` so a caller that already holds the raw text
+    parses it without a second disk read (finding (i)): the index build reads a
+    file once and reuses that text for the parse AND the stored full markdown.
+    Malformed front matter is treated as no front matter (lenient); the malformed
+    flag is surfaced separately via :func:`parse_text_checked` so the build can
+    warn rather than silently dropping status/supersedes on a YAML typo.
+    """
+    return parse_text_checked(path, text)[0]
+
+
+def parse_text_checked(path: Path, text: str) -> tuple[ParsedDoc, bool]:
+    """Like :func:`parse_text`, but also return whether front matter was malformed.
+
+    Returns ``(doc, malformed)``. ``malformed`` is True when a front-matter block
+    was present (the text opens with ``---``) but failed to parse as valid YAML
+    mapping, so its ``status`` / ``supersedes`` / other fields were silently
+    dropped (finding (j)). The index build uses this to emit a WARN log and
+    increment a health-visible counter, since a doc whose ``status`` is lost has
+    its staleness protection quietly disabled. A document with genuinely NO front
+    matter (does not open with ``---``) is NOT malformed.
+    """
+    malformed = False
     try:
         fm, body = parse_frontmatter(text)
     except ValueError:
         fm, body = {}, text
+        # Only a PRESENT-but-broken block is "malformed"; a doc with no front
+        # matter at all (first line is not ``---``) is a normal, valid case.
+        malformed = text.lstrip().startswith("---")
 
     id_value = fm.get("id", "")
     if not isinstance(id_value, str) or ":" in id_value:
@@ -53,7 +86,7 @@ def parse_file(path: Path) -> ParsedDoc:
     if not isinstance(git_remote_url, str) or not git_remote_url.strip():
         git_remote_url = None
 
-    return ParsedDoc(
+    doc = ParsedDoc(
         path=path,
         id=id_value,
         tier=str(fm.get("tier", "")),
@@ -67,3 +100,4 @@ def parse_file(path: Path) -> ParsedDoc:
         applies_when=_as_str_list(fm.get("applies_when", [])),
         description=str(fm.get("description", "")) if fm.get("description") is not None else "",
     )
+    return doc, malformed

--- a/src/data_olympus/query_expansion.py
+++ b/src/data_olympus/query_expansion.py
@@ -12,7 +12,13 @@ Design notes:
   member points at every other member, so expansion is bidirectional.
 - Lookup is case-insensitive, but original query terms keep their casing (FTS5
   matching is case-insensitive anyway). Synonyms are appended after the original
-  terms so BM25 still favours the terms the user actually typed.
+  terms; ``Index.search`` splits the appended (expansion) terms out and matches
+  them in a SEPARATE penalized backfill pass that can only place expansion-only
+  hits BELOW the worst primary hit (finding (a); see ``Index._expansion_backfill``).
+  FTS5 bm25 has no positional preference, so ordering alone would NOT down-weight
+  a synonym: a doc matching only a derived term would otherwise get full idf
+  weight and could outrank a doc matching the user's actual term. The two-pass
+  split is what makes "expansion is down-weighted" genuinely true.
 - Expansion is bounded (``max_terms``) and de-duplicated to avoid runaway MATCH
   expressions. Original terms are never dropped by the cap.
 - Configuration follows the ``config.py`` env pattern: ``KB_SYNONYMS`` overrides

--- a/src/data_olympus/trigram.py
+++ b/src/data_olympus/trigram.py
@@ -26,8 +26,13 @@ holds:
 
 Ranking discipline: the trigram fallback is used ONLY as a backfill. The primary
 FTS hits keep their bm25 order and top positions; trigram-only hits are appended
-strictly after them. So an exact/primary match is never diluted or reordered by a
-fuzzy hit. See ``Index.search`` for the wiring.
+after them AND stamped with ``RANK_CLASS_BACKFILL``. That rank class is the outer
+sort key in every reranker (``sort(key=(rank_class, score))``), so a fuzzy hit is
+never reordered above an exact/primary hit even by a reranker that adds status
+deltas or re-normalises scores. A score-only "strictly worse" floor would NOT be
+enough (the status reranker's active-status boost or the hybrid blend's
+re-normalisation could lift it); the rank class is what makes the invariant true.
+See ``Index.search`` for the wiring.
 """
 from __future__ import annotations
 

--- a/tests/test_cooccurrence.py
+++ b/tests/test_cooccurrence.py
@@ -75,7 +75,11 @@ def test_build_table_relates_cooccurring_terms() -> None:
         {"banana", "fruit", "yellow"},
         {"banana", "fruit", "smoothie"},
     ]
-    table = build_cooccurrence_table(docs, k=5, min_count=2, min_pmi=0.0)
+    # min_docs=2 here so the tiny unit corpus is not auto-disabled by the new
+    # corpus-size floor (finding (b)); this test exercises the pure PMI mechanics.
+    table = build_cooccurrence_table(
+        docs, k=5, min_count=2, min_pmi=0.0, min_docs=2
+    )
     assert "kubernetes" in table["helm"]
     assert "helm" in table["kubernetes"]
     # The unrelated cluster does not leak in.
@@ -91,14 +95,18 @@ def test_build_table_respects_top_k_bound() -> None:
     for _ in range(3):
         for p in partners:
             docs.append({"hub", p})
-    table = build_cooccurrence_table(docs, k=3, min_count=2, min_pmi=-10.0)
+    table = build_cooccurrence_table(
+        docs, k=3, min_count=2, min_pmi=-10.0, min_docs=2
+    )
     assert len(table["hub"]) <= 3
 
 
 def test_build_table_honours_min_count() -> None:
     # A pair co-occurring in only one doc is below min_count=2 and excluded.
     docs = [{"alpha", "beta"}, {"gamma", "delta"}, {"gamma", "delta"}]
-    table = build_cooccurrence_table(docs, k=5, min_count=2, min_pmi=-10.0)
+    table = build_cooccurrence_table(
+        docs, k=5, min_count=2, min_pmi=-10.0, min_docs=2
+    )
     assert "beta" not in table.get("alpha", [])
     assert "delta" in table.get("gamma", [])
 
@@ -210,8 +218,31 @@ def test_cooccurrence_build_params_from_env(
     monkeypatch.setenv("KB_COOCCURRENCE_K", "3")
     monkeypatch.setenv("KB_COOCCURRENCE_MIN_COUNT", "4")
     monkeypatch.setenv("KB_COOCCURRENCE_MIN_PMI", "1.5")
+    monkeypatch.setenv("KB_COOCCURRENCE_MIN_DOCS", "7")
+    monkeypatch.setenv("KB_COOCCURRENCE_MAX_DOC_TOKENS", "123")
     params = cooccurrence_build_params()
-    assert params == {"k": 3, "min_count": 4, "min_pmi": 1.5}
+    assert params == {
+        "k": 3, "min_count": 4, "min_pmi": 1.5,
+        "min_docs": 7, "max_doc_tokens": 123,
+    }
+
+
+def test_cooccurrence_build_params_defaults(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The hardened defaults (finding (b)): min_count>=3, min_pmi>0, plus the
+    corpus floor and per-doc token cap."""
+    for var in (
+        "KB_COOCCURRENCE_K", "KB_COOCCURRENCE_MIN_COUNT",
+        "KB_COOCCURRENCE_MIN_PMI", "KB_COOCCURRENCE_MIN_DOCS",
+        "KB_COOCCURRENCE_MAX_DOC_TOKENS",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    params = cooccurrence_build_params()
+    assert params["min_count"] >= 3
+    assert params["min_pmi"] > 0.0
+    assert params["min_docs"] >= 2
+    assert params["max_doc_tokens"] > 0
 
 
 # --- end-to-end through Index ------------------------------------------------
@@ -259,8 +290,12 @@ def _write_cooccurrence_corpus(kb: Path) -> None:
 
 
 def test_index_related_terms_populated_after_build(
-    tmp_path: Path, tmp_index_path: Path,
+    tmp_path: Path, tmp_index_path: Path, monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    # Lower the corpus floor so the tiny fixture corpus is not auto-disabled by
+    # the new min_docs default (finding (b)); the association mechanics are what
+    # this test exercises.
+    monkeypatch.setenv("KB_COOCCURRENCE_MIN_DOCS", "2")
     kb = tmp_path / "kb"
     kb.mkdir()
     _write_cooccurrence_corpus(kb)
@@ -271,8 +306,9 @@ def test_index_related_terms_populated_after_build(
 
 
 def test_cooccurrence_expansion_broadens_recall(
-    tmp_path: Path, tmp_index_path: Path,
+    tmp_path: Path, tmp_index_path: Path, monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    monkeypatch.setenv("KB_COOCCURRENCE_MIN_DOCS", "2")
     kb = tmp_path / "kb"
     kb.mkdir()
     _write_cooccurrence_corpus(kb)
@@ -286,7 +322,9 @@ def test_cooccurrence_expansion_broadens_recall(
     )
 
     # With co-occurrence expansion: 'helm' expands to include 'kubernetes',
-    # reaching the kubernetes-only doc -- recall broadened.
+    # reaching the kubernetes-only doc via the PENALIZED backfill pass (finding
+    # (a)): the kubernetes-only doc appears, but only BELOW every primary 'helm'
+    # hit (asserted in test_search_pipeline).
     expanded = Index(tmp_index_path)
     expanded.query_expander = expanded.cooccurrence_expander()
     expanded_ids = {h.id for h in expanded.search("helm", limit=20)}
@@ -300,7 +338,7 @@ def test_cooccurrence_expansion_broadens_recall(
 
 
 def test_related_terms_table_rebuilt_atomically(
-    tmp_path: Path, tmp_index_path: Path,
+    tmp_path: Path, tmp_index_path: Path, monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """The related_terms table swaps atomically with the rest of the index.
 
@@ -308,6 +346,7 @@ def test_related_terms_table_rebuilt_atomically(
     rebuild produces a new one; a fresh connection sees the new table. This
     mirrors the FTS atomic-swap guarantee for the co-occurrence table.
     """
+    monkeypatch.setenv("KB_COOCCURRENCE_MIN_DOCS", "2")
     kb = tmp_path / "kb"
     kb.mkdir()
     _write_cooccurrence_corpus(kb)

--- a/tests/test_search_hardening.py
+++ b/tests/test_search_hardening.py
@@ -129,6 +129,36 @@ def test_status_reranker_orders_by_rank_class_first() -> None:
     assert ordered == ["prim", "back"]
 
 
+def test_hybrid_reranker_orders_by_rank_class_first() -> None:
+    """Finding (d) unit for the HYBRID path: a backfill hit with a PERFECT cosine
+    match must still rank below a primary hit with a WEAK cosine, even at
+    weight=1.0 (pure semantic). Without the rank_class outer sort key the cosine
+    blend would lift the backfill hit to the top."""
+    from data_olympus.embeddings import make_hybrid_reranker
+
+    qvec = [1.0, 0.0]
+    vectors = {
+        "prim": [0.0, 1.0],  # orthogonal to the query -> weak cosine
+        "back": [1.0, 0.0],  # identical to the query -> perfect cosine
+    }
+    hits = [
+        SearchHit(id="prim", path="p", title="", snippet="", score=-1.0,
+                  rank_class=RANK_CLASS_PRIMARY),
+        SearchHit(id="back", path="b", title="", snippet="", score=1.0,
+                  rank_class=RANK_CLASS_BACKFILL),
+    ]
+    reranker = make_hybrid_reranker(
+        embed_query=lambda _q: qvec,
+        get_vector=vectors.get,
+        weight=1.0,  # pure cosine: back would win without the rank_class key
+    )
+    ordered = [h.id for h in reranker("q", hits)]
+    assert ordered == ["prim", "back"], (
+        "a perfect-cosine backfill hit must not outrank a weak-cosine primary "
+        "(hybrid rank-class invariant, finding d)"
+    )
+
+
 # --- (f) dense text includes applies_when + tags -----------------------------
 
 
@@ -354,6 +384,49 @@ def test_build_falls_back_to_mtime_without_git(
 def test_git_last_modified_map_empty_for_non_repo(tmp_kb: Path) -> None:
     """The batched git map is empty when the directory is not a git repo."""
     assert Index._git_last_modified_map(tmp_kb) == {}
+
+
+def test_single_git_pass_handles_special_char_paths(
+    tmp_path: Path, tmp_index_path: Path,
+) -> None:
+    """Finding (i) exactness: a filename with a space (and a unicode char) must
+    round-trip through the NUL-delimited / quotePath=false batched git pass and
+    still resolve to 'git', not fall back to mtime."""
+    import subprocess
+
+    kb = tmp_path / "kb"
+    kb.mkdir()
+    _write(kb, "plain.md", "plain body.", front="---\nid: DOC-PLAIN\n---\n")
+    # A space and a non-ASCII char in the filename: the exact cases git would
+    # octal-quote (and a naive splitlines/strip parser would mangle or drop).
+    _write(kb, "with spacé.md", "spaced body.",
+           front="---\nid: DOC-SPACED\n---\n")
+    env = {
+        "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t",
+        "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t",
+        "PATH": "/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin",
+    }
+    subprocess.run(["git", "init", "-q", "--initial-branch=main"],
+                   cwd=kb, check=True, env=env)
+    subprocess.run(["git", "add", "-A"], cwd=kb, check=True, env=env)
+    subprocess.run(["git", "commit", "-qm", "init"], cwd=kb, check=True, env=env)
+
+    idx = Index(tmp_index_path)
+    idx.build(kb, source_commit="x")
+    conn = sqlite3.connect(tmp_index_path)
+    conn.row_factory = sqlite3.Row
+    rows = {
+        r["path"]: r["last_modified_source"]
+        for r in conn.execute(
+            "SELECT path, last_modified_source FROM docs"
+        ).fetchall()
+    }
+    conn.close()
+    assert rows.get("with spacé.md") == "git", (
+        "a space/unicode filename must resolve via git, not fall back to mtime "
+        f"(finding i exactness); got {rows.get('with spacé.md')!r}"
+    )
+    assert rows.get("plain.md") == "git"
 
 
 # --- (j) malformed front matter counter --------------------------------------

--- a/tests/test_search_hardening.py
+++ b/tests/test_search_hardening.py
@@ -1,0 +1,399 @@
+"""Search pipeline hardening (WP2b, 0.3.0).
+
+One test per audit finding letter that is behaviour-observable at the Index level:
+
+- (a) penalized expansion backfill: an expansion-only hit never outranks a
+  primary-term hit, and the rank_class invariant survives the status reranker.
+- (d) rank-class invariant: a backfill hit stays below primaries even when its
+  status would otherwise boost it above them.
+- (f) dense text includes applies_when + tags.
+- (g) vectors are batch-fetched once per build (no per-hit connection).
+- (h) search() never returns more than ``limit`` hits, incl. the embeddings-on /
+  no-reranker path that used to over-return.
+- (i) single git-log pass produces identical per-file commit metadata.
+- (j) malformed front matter is counted and health-visible.
+
+Findings (b) and (c) are covered in test_cooccurrence.py / test_trigram.py.
+"""
+from __future__ import annotations
+
+import sqlite3
+from typing import TYPE_CHECKING
+
+from data_olympus.index import (
+    RANK_CLASS_BACKFILL,
+    RANK_CLASS_PRIMARY,
+    Index,
+    SearchHit,
+    make_status_reranker,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _write(kb: Path, name: str, body: str, *, front: str = "") -> None:
+    (kb / name).write_text(f"{front}{body}\n", encoding="utf-8")
+
+
+# --- (a) + (d) penalized expansion backfill ----------------------------------
+
+
+def _expansion_kb(kb: Path) -> None:
+    """A doc matching only the user's term and a doc matching only an expansion
+    term, so we can prove the expansion-only doc never outranks the primary."""
+    # PRIMARY doc: matches "alpha" (the user's term).
+    _write(kb, "primary.md", "alpha appears here as the primary term.",
+           front="---\nid: DOC-PRIMARY\n---\n")
+    # EXPANSION-ONLY doc: matches only "beta" (a synonym the expander adds), and
+    # matches it MANY times so its raw bm25 would beat the single-mention primary
+    # if the terms were folded into one MATCH.
+    _write(kb, "expansion.md",
+           "beta beta beta beta beta beta beta beta beta beta beta beta.",
+           front="---\nid: DOC-EXPANSION\n---\n")
+
+
+def test_expansion_only_hit_never_outranks_primary(
+    tmp_path: Path, tmp_index_path: Path,
+) -> None:
+    """Finding (a): a doc matching ONLY an expansion (synonym) term must rank
+    strictly below every doc matching the user's actual term, even though the
+    expansion doc's raw bm25 (many mentions) would win a single OR-MATCH."""
+    kb = tmp_path / "kb"
+    kb.mkdir()
+    _expansion_kb(kb)
+
+    def expander(terms: list[str]) -> list[str]:
+        # Emulate the real expander contract: originals first, then a derived
+        # synonym "beta" for "alpha".
+        return [*terms, "beta"] if "alpha" in terms else terms
+
+    idx = Index(tmp_index_path, query_expander=expander)
+    idx.build(kb, source_commit="x")
+    hits = idx.search("alpha", limit=20)
+    ids = [h.id for h in hits]
+    # Both docs are reachable (recall broadened)...
+    assert "DOC-PRIMARY" in ids
+    assert "DOC-EXPANSION" in ids
+    # ...but the expansion-only doc is strictly after the primary one.
+    assert ids.index("DOC-PRIMARY") < ids.index("DOC-EXPANSION"), (
+        "expansion-only hit must not outrank the primary-term hit (finding a)"
+    )
+    # The expansion doc carries the backfill rank class; the primary does not.
+    by_id = {h.id: h for h in hits}
+    assert by_id["DOC-PRIMARY"].rank_class == RANK_CLASS_PRIMARY
+    assert by_id["DOC-EXPANSION"].rank_class == RANK_CLASS_BACKFILL
+
+
+def test_expansion_backfill_survives_status_reranker(
+    tmp_path: Path, tmp_index_path: Path,
+) -> None:
+    """Finding (d): even when the expansion-only doc is ``active`` (status boost)
+    and the primary doc is ``superseded`` (status penalty), the rank_class outer
+    key keeps the expansion hit below the primary. A score-only floor would fail
+    here because the status deltas span more than the +1.0 backfill spacing."""
+    kb = tmp_path / "kb"
+    kb.mkdir()
+    _write(kb, "primary.md", "alpha primary content here.",
+           front="---\nid: DOC-PRIMARY\nstatus: superseded\n---\n")
+    _write(kb, "expansion.md", "beta beta beta beta beta beta.",
+           front="---\nid: DOC-EXPANSION\nstatus: active\n---\n")
+
+    def expander(terms: list[str]) -> list[str]:
+        return [*terms, "beta"] if "alpha" in terms else terms
+
+    idx = Index(
+        tmp_index_path,
+        query_expander=expander,
+        reranker=make_status_reranker(),
+    )
+    idx.build(kb, source_commit="x")
+    ids = [h.id for h in idx.search("alpha", limit=20)]
+    assert ids.index("DOC-PRIMARY") < ids.index("DOC-EXPANSION"), (
+        "an active-status expansion hit must still rank below a superseded "
+        "primary hit (rank-class invariant, finding d)"
+    )
+
+
+def test_status_reranker_orders_by_rank_class_first() -> None:
+    """Finding (d) unit: the status reranker sorts by (rank_class, score), so a
+    backfill hit cannot be lifted above a primary regardless of its status."""
+    reranker = make_status_reranker()
+    hits = [
+        SearchHit(id="prim", path="p", title="", snippet="", score=-1.0,
+                  status="superseded", rank_class=RANK_CLASS_PRIMARY),
+        SearchHit(id="back", path="b", title="", snippet="", score=1.0,
+                  status="active", rank_class=RANK_CLASS_BACKFILL),
+    ]
+    ordered = [h.id for h in reranker("q", hits)]
+    assert ordered == ["prim", "back"]
+
+
+# --- (f) dense text includes applies_when + tags -----------------------------
+
+
+def test_embed_text_includes_applies_when_and_tags(
+    tmp_path: Path, tmp_index_path: Path,
+) -> None:
+    """Finding (f): the text embedded at build time must include applies_when and
+    tags (the curated intent vocabulary), not just title/description/body."""
+    kb = tmp_path / "kb"
+    kb.mkdir()
+    _write(
+        kb, "doc.md", "Body about caching.",
+        front=(
+            "---\nid: DOC-1\ntitle: Cache Policy\n"
+            "tags: [uniquetagtoken]\n"
+            "applies_when: [uniqueappliestoken]\n"
+            "description: A description.\n---\n"
+        ),
+    )
+
+    captured: list[str] = []
+
+    class _RecordingEmbedder:
+        model_name = "recording"
+
+        def embed_many(self, texts: list[str]) -> list[list[float]]:
+            captured.extend(texts)
+            return [[1.0, 0.0, 0.0] for _ in texts]
+
+        def embed_one(self, text: str) -> list[float]:  # noqa: ARG002
+            return [1.0, 0.0, 0.0]
+
+    from data_olympus.embeddings import EmbeddingsConfig
+
+    idx = Index(
+        tmp_index_path,
+        embeddings=EmbeddingsConfig(model_name="recording", weight=0.5),
+        embedder=_RecordingEmbedder(),  # type: ignore[arg-type]
+    )
+    idx.build(kb, source_commit="x")
+    assert captured, "embedder.embed_many must have been called at build time"
+    embedded = captured[0]
+    assert "uniqueappliestoken" in embedded, (
+        "embedded text must include applies_when (finding f)"
+    )
+    assert "uniquetagtoken" in embedded, (
+        "embedded text must include tags (finding f)"
+    )
+
+
+# --- (g) vectors batch-fetched once per build --------------------------------
+
+
+class _CountingEmbedder:
+    model_name = "counting"
+
+    def __init__(self) -> None:
+        self.embed_one_calls = 0
+
+    def embed_many(self, texts: list[str]) -> list[list[float]]:
+        # Distinct unit vectors so cosine ordering is well-defined.
+        return [[1.0, 0.0] for _ in texts]
+
+    def embed_one(self, text: str) -> list[float]:  # noqa: ARG002
+        self.embed_one_calls += 1
+        return [1.0, 0.0]
+
+
+def test_vectors_loaded_once_per_build_not_per_hit(
+    tmp_path: Path, tmp_index_path: Path,
+) -> None:
+    """Finding (g): the id->vector matrix is loaded from SQLite ONCE per build,
+    shared across every candidate hit, instead of one connection per get_vector.
+    Asserted via the ``_vector_loads`` counter across a multi-hit hybrid search."""
+    from data_olympus.embeddings import EmbeddingsConfig
+
+    kb = tmp_path / "kb"
+    kb.mkdir()
+    for i in range(6):
+        _write(kb, f"d{i}.md", f"shared caching topic document number {i}.",
+               front=f"---\nid: DOC-{i}\n---\n")
+
+    embedder = _CountingEmbedder()
+    idx = Index(
+        tmp_index_path,
+        embeddings=EmbeddingsConfig(model_name="counting", weight=0.5),
+        embedder=embedder,  # type: ignore[arg-type]
+    )
+    idx.build(kb, source_commit="x")
+    idx.reranker = idx.make_hybrid_reranker(embedder, weight=0.5)  # type: ignore[arg-type]
+
+    idx._vector_loads = 0  # reset after any build-time access
+    hits = idx.search("caching", limit=20)
+    assert len(hits) >= 3, "need several candidate hits to exercise get_vector"
+    # One query -> at most ONE matrix load, no matter how many candidate hits the
+    # hybrid reranker scored. The old per-hit get_vector opened one connection
+    # each; this proves that is gone.
+    assert idx._vector_loads <= 1, (
+        f"vector matrix must load at most once per query; "
+        f"loaded {idx._vector_loads} times"
+    )
+
+
+def test_vector_cache_invalidated_on_rebuild(
+    tmp_path: Path, tmp_index_path: Path,
+) -> None:
+    """Finding (g): the (size, mtime)-keyed cache invalidates on the atomic swap,
+    so a rebuilt index is not served stale vectors."""
+    from data_olympus.embeddings import EmbeddingsConfig
+
+    kb = tmp_path / "kb"
+    kb.mkdir()
+    _write(kb, "a.md", "alpha document.", front="---\nid: DOC-A\n---\n")
+
+    embedder = _CountingEmbedder()
+    idx = Index(
+        tmp_index_path,
+        embeddings=EmbeddingsConfig(model_name="counting", weight=0.5),
+        embedder=embedder,  # type: ignore[arg-type]
+    )
+    idx.build(kb, source_commit="first")
+    assert idx.get_vector("DOC-A") is not None
+    loads_after_first = idx._vector_loads
+
+    # Add a doc and rebuild; the new file has a fresh mtime so the cache key
+    # changes and the matrix reloads.
+    _write(kb, "b.md", "beta document.", front="---\nid: DOC-B\n---\n")
+    idx.build(kb, source_commit="second")
+    assert idx.get_vector("DOC-B") is not None, "new doc's vector must be visible"
+    assert idx._vector_loads > loads_after_first, (
+        "the rebuild must invalidate the vector cache (finding g)"
+    )
+
+
+# --- (h) >limit regression ---------------------------------------------------
+
+
+def test_search_never_exceeds_limit_embeddings_on_no_reranker(
+    tmp_path: Path, tmp_index_path: Path,
+) -> None:
+    """Finding (h): with embeddings configured but NO reranker set, the dense
+    union could push the pool past ``limit`` and search() returned all of them,
+    because truncation lived only inside the reranker branch. It must always
+    truncate to ``limit``."""
+    from data_olympus.embeddings import EmbeddingsConfig
+
+    kb = tmp_path / "kb"
+    kb.mkdir()
+    for i in range(8):
+        _write(kb, f"d{i}.md", f"caching topic document {i}.",
+               front=f"---\nid: DOC-{i}\n---\n")
+
+    embedder = _CountingEmbedder()
+    idx = Index(
+        tmp_index_path,
+        embeddings=EmbeddingsConfig(model_name="counting", weight=0.5),
+        embedder=embedder,  # type: ignore[arg-type]
+        dense_min_cosine=-1.0,  # accept every neighbour so the union is large
+        dense_candidate_count=8,
+    )
+    # No reranker set on purpose.
+    assert idx.reranker is None
+    idx.build(kb, source_commit="x")
+    hits = idx.search("caching", limit=3)
+    assert len(hits) <= 3, (
+        f"search() must never return more than limit hits; got {len(hits)}"
+    )
+
+
+# --- (i) single git-log pass preserves per-file metadata ---------------------
+
+
+def test_single_git_pass_matches_per_file_metadata(
+    tmp_git_kb: Path, tmp_path: Path,
+) -> None:
+    """Finding (i): the batched ``git log --name-only`` pass yields the same
+    (last_modified, source) per file as the old one-subprocess-per-file path."""
+    kb = tmp_git_kb
+    # Reference: per-file git query for each indexed file.
+    idx = Index(tmp_path / "ref.db")
+    idx.build(kb, source_commit="x")
+
+    conn = sqlite3.connect(tmp_path / "ref.db")
+    conn.row_factory = sqlite3.Row
+    rows = conn.execute(
+        "SELECT path, last_modified, last_modified_source FROM docs ORDER BY path"
+    ).fetchall()
+    conn.close()
+    assert rows, "fixture must index at least one git-tracked file"
+
+    from pathlib import Path as _Path
+
+    for r in rows:
+        rel = _Path(r["path"])
+        expected_iso, expected_src = Index._git_last_modified(kb, rel)
+        assert r["last_modified_source"] == "git", (
+            f"{r['path']} should be sourced from git"
+        )
+        assert expected_src == "git"
+        assert r["last_modified"] == expected_iso, (
+            f"batched git timestamp for {r['path']} must equal the per-file "
+            f"query result: {r['last_modified']!r} != {expected_iso!r}"
+        )
+
+
+def test_build_falls_back_to_mtime_without_git(
+    tmp_kb: Path, tmp_index_path: Path,
+) -> None:
+    """Finding (i): a non-git KB (empty batched map) still records 'mtime' as the
+    source, unchanged from the per-file fallback."""
+    idx = Index(tmp_index_path)
+    idx.build(tmp_kb, source_commit="x")  # tmp_kb is NOT a git repo
+    conn = sqlite3.connect(tmp_index_path)
+    conn.row_factory = sqlite3.Row
+    rows = conn.execute("SELECT last_modified_source FROM docs").fetchall()
+    conn.close()
+    assert rows
+    assert all(r["last_modified_source"] == "mtime" for r in rows), (
+        "a non-git KB must fall back to filesystem mtime (finding i)"
+    )
+
+
+def test_git_last_modified_map_empty_for_non_repo(tmp_kb: Path) -> None:
+    """The batched git map is empty when the directory is not a git repo."""
+    assert Index._git_last_modified_map(tmp_kb) == {}
+
+
+# --- (j) malformed front matter counter --------------------------------------
+
+
+def test_malformed_frontmatter_counted_and_health_visible(
+    tmp_path: Path, tmp_index_path: Path,
+) -> None:
+    """Finding (j): a doc whose front-matter block is present but is invalid YAML
+    (so status/supersedes are silently dropped) is counted and surfaced on the
+    Index and in health()."""
+    kb = tmp_path / "kb"
+    kb.mkdir()
+    # Valid doc.
+    _write(kb, "good.md", "Body.", front="---\nid: DOC-GOOD\nstatus: active\n---\n")
+    # Malformed: a tab in YAML indentation is invalid, and the ':' with no space
+    # plus broken structure makes safe_load raise -> lenient fallback drops status.
+    (kb / "bad.md").write_text(
+        "---\nid: DOC-BAD\nstatus: active\n\tbroken:\t: [unclosed\n---\nBody.\n",
+        encoding="utf-8",
+    )
+    idx = Index(tmp_index_path)
+    idx.build(kb, source_commit="x")
+    assert idx.malformed_frontmatter_count == 1, (
+        f"exactly one malformed doc expected; got {idx.malformed_frontmatter_count}"
+    )
+    health = idx.health()
+    assert health["malformed_frontmatter"] == 1, (
+        "health() must surface the malformed-frontmatter count (finding j)"
+    )
+
+
+def test_no_frontmatter_is_not_counted_malformed(
+    tmp_path: Path, tmp_index_path: Path,
+) -> None:
+    """A doc with NO front matter at all (does not open with ---) is a normal,
+    valid case and must NOT be counted as malformed."""
+    kb = tmp_path / "kb"
+    kb.mkdir()
+    _write(kb, "plain.md", "# Just a heading\n\nNo front matter here.")
+    idx = Index(tmp_index_path)
+    idx.build(kb, source_commit="x")
+    assert idx.malformed_frontmatter_count == 0

--- a/tests/test_trigram.py
+++ b/tests/test_trigram.py
@@ -59,7 +59,9 @@ def _fuzzy_kb(kb: Path) -> None:
 
 
 def test_trigram_table_created_at_build(tmp_kb: Path, tmp_index_path: Path) -> None:
-    idx = Index(tmp_index_path)
+    # Finding (c): the trigram table is created ONLY when the fallback is enabled
+    # for this index.
+    idx = Index(tmp_index_path, trigram_fallback=True)
     idx.build(tmp_kb, source_commit="x")
     conn = sqlite3.connect(tmp_index_path)
     try:
@@ -68,7 +70,49 @@ def test_trigram_table_created_at_build(tmp_kb: Path, tmp_index_path: Path) -> N
         ).fetchone()
     finally:
         conn.close()
-    assert row is not None, "build() must create the fts_trigram virtual table"
+    assert row is not None, (
+        "build() with trigram_fallback=True must create the fts_trigram table"
+    )
+
+
+def test_trigram_table_absent_when_fallback_off(
+    tmp_kb: Path, tmp_index_path: Path
+) -> None:
+    """Finding (c): with the fallback OFF the trigram table is NOT built, so a
+    default deployment does not pay the 2-3x index-size / build-time tax."""
+    idx = Index(tmp_index_path)  # default: trigram_fallback=False
+    assert idx.trigram_fallback is False
+    idx.build(tmp_kb, source_commit="x")
+    conn = sqlite3.connect(tmp_index_path)
+    try:
+        row = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='fts_trigram'"
+        ).fetchone()
+    finally:
+        conn.close()
+    assert row is None, (
+        "fts_trigram must NOT exist when the fallback is disabled (finding c)"
+    )
+
+
+def test_trigram_off_build_is_smaller_than_on(
+    tmp_path: Path,
+) -> None:
+    """Finding (c): the trigram-off build is materially smaller than the trigram-on
+    build over the same corpus (the second tokenized copy is the tax we removed)."""
+    kb = tmp_path / "kb"
+    kb.mkdir()
+    _fuzzy_kb(kb)
+    off_path = tmp_path / "off.db"
+    on_path = tmp_path / "on.db"
+    Index(off_path).build(kb, source_commit="x")
+    Index(on_path, trigram_fallback=True).build(kb, source_commit="x")
+    off_size = off_path.stat().st_size
+    on_size = on_path.stat().st_size
+    assert on_size > off_size, (
+        "trigram-on build must be larger than trigram-off "
+        f"(on={on_size} off={off_size}); the removed second index is the tax"
+    )
 
 
 def test_schema_version_at_least_7_with_trigram(
@@ -77,7 +121,8 @@ def test_schema_version_at_least_7_with_trigram(
     # The trigram table (fts_trigram) landed at schema v7. Later features bump
     # the version further (v8 adds doc_vectors), so assert the trigram table is
     # present AND the recorded version is at least 7 rather than pinning to 7.
-    idx = Index(tmp_index_path)
+    # Finding (c): must build with the fallback on for the table to exist.
+    idx = Index(tmp_index_path, trigram_fallback=True)
     idx.build(tmp_kb, source_commit="x")
     conn = sqlite3.connect(tmp_index_path)
     try:
@@ -100,7 +145,7 @@ def test_trigram_table_populated(tmp_path: Path, tmp_index_path: Path) -> None:
     kb = tmp_path / "kb"
     kb.mkdir()
     _fuzzy_kb(kb)
-    idx = Index(tmp_index_path)
+    idx = Index(tmp_index_path, trigram_fallback=True)
     idx.build(kb, source_commit="x")
     conn = sqlite3.connect(tmp_index_path)
     try:
@@ -126,7 +171,7 @@ def test_trigram_table_rebuilt_atomically(
     kb = tmp_path / "kb"
     kb.mkdir()
     _fuzzy_kb(kb)
-    idx = Index(tmp_index_path)
+    idx = Index(tmp_index_path, trigram_fallback=True)
     idx.build(kb, source_commit="first")
 
     old_conn = sqlite3.connect(tmp_index_path)
@@ -177,8 +222,11 @@ def test_typo_query_finds_doc_via_trigram_fallback(
         "primary FTS should not match the misspelling on its own"
     )
 
-    # Fallback ON -> the typo backfills to the intended document.
+    # Fallback ON -> the typo backfills to the intended document. Must rebuild:
+    # the trigram table only exists on a build whose Index had the fallback on
+    # (finding (c)), and the `plain` build above (fallback off) created none.
     fuzzy = Index(tmp_index_path, trigram_fallback=True)
+    fuzzy.build(kb, source_commit="x")
     fuzzy_ids = {h.id for h in fuzzy.search("observabilty", limit=20)}
     assert "STD-OBSERVABILITY" in fuzzy_ids, (
         "trigram fallback should reach the intended doc for a one-edit typo"
@@ -212,7 +260,10 @@ def test_good_primary_hits_are_not_diluted_by_trigram(
     baseline = [h.id for h in plain.search("kubernetes helm deployment", limit=20)]
     assert baseline and baseline[0] == "STD-KUBERNETES"
 
+    # Rebuild with the fallback on so the trigram table exists (finding (c));
+    # a well-matched query still must not let the fallback dilute the result.
     fuzzy = Index(tmp_index_path, trigram_fallback=True)
+    fuzzy.build(kb, source_commit="x")
     with_fallback = [
         h.id for h in fuzzy.search("kubernetes helm deployment", limit=20)
     ]

--- a/tests/test_trigram.py
+++ b/tests/test_trigram.py
@@ -275,12 +275,20 @@ def test_good_primary_hits_are_not_diluted_by_trigram(
 def test_trigram_hits_appended_after_primary(
     tmp_path: Path, tmp_index_path: Path,
 ) -> None:
-    """When the fallback fires, any primary hits keep the top positions and
-    trigram-only hits are appended strictly after them (no duplicates)."""
+    """When the fallback fires, every primary hit keeps a top position and
+    trigram-only hits are appended strictly after them (no duplicates).
+
+    DOC-A / DOC-B match the whole word "collector" (primary); DOC-C matches only
+    as a substring inside "precollectored" (trigram-only backfill). The primary
+    hits must all precede the backfill-only hit, verified via rank_class."""
+    from data_olympus.index import RANK_CLASS_BACKFILL, RANK_CLASS_PRIMARY
+
     kb = tmp_path / "kb"
     kb.mkdir()
     _write(kb, "a.md", "collector overview document.", doc_id="DOC-A")
     _write(kb, "b.md", "the metrics collectors and collector pipeline.", doc_id="DOC-B")
+    # No whole-word "collector"; only a substring, so DOC-C is trigram-only.
+    _write(kb, "c.md", "a precollectored widget assembly note.", doc_id="DOC-C")
     # Force the fallback even with primary hits by setting a high threshold.
     idx = Index(tmp_index_path, trigram_fallback=True, trigram_fallback_threshold=50)
     idx.build(kb, source_commit="x")
@@ -288,6 +296,21 @@ def test_trigram_hits_appended_after_primary(
     ids = [h.id for h in hits]
     assert "DOC-A" in ids and "DOC-B" in ids
     assert len(ids) == len(set(ids)), "no duplicate ids from primary+trigram merge"
+    # Ordering: every primary (whole-word) hit precedes any backfill-only hit.
+    classes = [h.rank_class for h in hits]
+    last_primary = max(
+        (i for i, c in enumerate(classes) if c == RANK_CLASS_PRIMARY), default=-1
+    )
+    first_backfill = next(
+        (i for i, c in enumerate(classes) if c == RANK_CLASS_BACKFILL), len(hits)
+    )
+    assert last_primary < first_backfill, (
+        "all primary hits must precede any trigram backfill hit; "
+        f"order={[(h.id, h.rank_class) for h in hits]}"
+    )
+    if "DOC-C" in ids:
+        by_id = {h.id: h for h in hits}
+        assert by_id["DOC-C"].rank_class == RANK_CLASS_BACKFILL
 
 
 def test_short_query_noops_fallback(


### PR DESCRIPTION
WP2b of the 0.3.0 search-pipeline hardening program. References epic #75. Built on top of the in_force/abstain modes (PR #80).

## Findings fixed

**(a) Penalized expansion backfill (main false-positive vector).** Query expansion (synonym #38 + co-occurrence #40) previously folded derived terms into the single FTS5 `MATCH`. FTS5 bm25 has no positional preference, so a doc matching only a synonym received full idf weight and could outrank a doc matching the user's actual term — the "appended = down-weighted" claim in the module docstrings was false. `Index.search` now runs the user's own terms as a PRIMARY `MATCH` and the expansion terms in a SEPARATE penalized backfill pass (`_expansion_backfill`) whose hits can only rank BELOW the worst primary hit. The docstrings in `query_expansion.py` / `cooccurrence.py` are corrected.

**(b) Co-occurrence defaults hardened.** `min_count` 2→3, `min_pmi` 0.0→0.1; added a corpus-size floor (`KB_COOCCURRENCE_MIN_DOCS`, default 50) that auto-disables the table on small corpora where PMI is noise, and a per-doc unique-token cap (`KB_COOCCURRENCE_MAX_DOC_TOKENS`, default 400) bounding the O(n²) pair counting so a multi-thousand-word doc is no longer a build-time memory cliff.

**(c) Gated trigram index.** `fts_trigram` (a full second tokenized copy of the corpus, ~2-3× index-size / build-time tax) is now created and populated ONLY when the trigram fallback is enabled (`KB_TRIGRAM_MODE=on`), not unconditionally. A default deployment pays no trigram cost.

**(d) Rank-class invariant made true.** `SearchHit` gained `rank_class` (`RANK_CLASS_PRIMARY` / `RANK_CLASS_BACKFILL`). The status and hybrid rerankers now sort by `(rank_class, score)`, so a backfill (expansion/trigram) hit can never be reordered above a primary — even when a reranker ADDS status deltas or RE-NORMALISES scores. The previous score-only "strictly worse" floor could be lifted by an active-status boost or the hybrid blend. The trigram module docstring is corrected accordingly.

**(e) Status prior.** Left as the intended quality knob (in_force hard filtering from #80 covers the correctness-critical case). The status reranker is now rank-class-aware and tested; no calibration change was needed to make it sane.

**(f) Dense channel includes intent vocabulary.** The text embedded at build time now includes `applies_when` and `tags` (the curated intent phrases a paraphrase query embeds near), not just title/description/body.

**(g) Vector perf.** The id→vector matrix is loaded from SQLite ONCE per build and cached (keyed by db file (size, mtime), invalidated transparently by the atomic swap). This removes the per-candidate `get_vector` connection the hybrid reranker used to open and the per-query full-table re-read in `dense_candidates`.

**(h) `>limit` bug.** `search()` now truncates to `limit` unconditionally. Previously truncation lived only inside the reranker branch, so with embeddings configured but no reranker set the dense union could return more than `limit` hits.

**(i) Build perf.** `Index.build` runs a single `git log --name-only` pass for every file's last-commit time (one subprocess instead of N) and reads + parses each markdown file exactly once (was three times: two parses plus a separate content read). Per-file `(last_modified, source)` metadata is byte-for-byte identical; the batched pass uses `-z` NUL-delimited output with `core.quotePath=false` so filenames with spaces/unicode round-trip exactly rather than falling back to mtime.

**(j) Malformed frontmatter surfaced.** A doc whose front-matter block is present but is invalid YAML (so its `status`/`supersedes` are silently dropped, quietly disabling staleness protection) is now logged at WARN per doc, counted, and surfaced via `Index.malformed_frontmatter_count` and the `malformed_frontmatter` field in `health()`. A doc with genuinely no front matter is not counted.

## Test evidence

New `tests/test_search_hardening.py` plus updates to `test_trigram.py` / `test_cooccurrence.py`:
- (a) expansion-only hit never outranks a primary (with rank_class assertions).
- (d) status AND hybrid rerankers keep backfill below primaries even with an active-status / perfect-cosine backfill hit.
- (b) corpus floor / threshold behavior; hardened defaults.
- (c) trigram table absent when off, present when on, and off-build strictly smaller than on-build.
- (h) `>limit` regression (embeddings on, no reranker).
- (f) embedded text asserted to include `applies_when` + tags.
- (g) vector matrix loaded ≤1× per query; cache invalidated on rebuild.
- (i) batched git timestamps equal per-file query results; special-char filename resolves via git; non-git KB falls back to mtime.
- (j) malformed-frontmatter counter + health field; no-frontmatter not counted.

Full suite + `ruff` + `mypy` all green. Rebased onto latest `origin/release/0.3.0`; CHANGELOG conflict resolved keeping all entries.

## Peer review (codex)

First pass: **0 Blockers**, 2 Concerns, 2 Nits. All verified points confirmed correct (expansion backfill flow, gated trigram with no code path assuming its existence, `>limit` fix, vector batch fetch removing per-hit connections, no committed benchmark numbers touched). All four items were fixed:
- Concern (git-path exactness): switched to `-z` NUL-delimited + `core.quotePath=false`, no path `.strip()`; added a special-char-filename regression test.
- Concern (hybrid rank-class not directly tested): added a pure hybrid-reranker test (perfect-cosine backfill at weight=1.0 must stay below a weak-cosine primary).
- Nit: corrected the stale `config.py` "trigram always built" comment.
- Nit: strengthened `test_trigram_hits_appended_after_primary` to assert primaries precede backfill via rank_class.

Second pass empirically confirmed the git-parser byte structure matches the implementation. No Blockers at any point.