### PR TITLE
feat(format): specify applies_when, demonstrate lifecycle in example bundle, CI doc-consistency guard

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,3 +36,12 @@ jobs:
         run: |
           mapfile -t changed < <(git diff --name-only "origin/$BASE_REF"...HEAD)
           python3 scripts/check_changelog.py "${changed[@]}"
+  doc-consistency-guard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: astral-sh/setup-uv@v7
+      - run: uv venv --python 3.13
+      - run: uv pip install -e '.[dev]'
+      - name: Check SPEC.md / docs/adoption.md enums match format/validate.py
+        run: uv run python3 scripts/check_doc_consistency.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,41 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Specified `applies_when` in SPEC.md (WP4c, 0.3.0). `applies_when` is the
+  highest-weight indexed field in `Index.search` (tied with `title`, ahead of
+  `description` and body) and one of the three discriminating columns for the
+  `abstain` signal gate, but was previously implemented and used in the
+  benchmark story without ever being documented. SPEC.md section 4.2 now lists
+  it as a recommended field with authoring guidance (short verb phrases in an
+  agent's own vocabulary) and a worked example; `docs/adoption.md` gained a
+  matching authoring section. Documented honestly: unlike `tags`, a malformed
+  `applies_when` produces no `kb lint` warning today.
+- Upgraded `example-bundle/` to demonstrate the format's remaining
+  differentiators (WP4c, 0.3.0): a real supersession pair
+  (`STD-U-003`/`STD-U-004`, `status: superseded`/`supersedes`/`superseded_by`),
+  a `memory` document and a `reference` document (the two concept types the
+  bundle previously lacked), and `applies_when` on the standards most likely to
+  be hit mid-task. `example-bundle/index.md` and the new directory `index.md`
+  files were updated to match; `uv run data-olympus lint example-bundle`
+  remains zero-error.
+- Quickstart lifecycle-aware retrieval demo (WP4c, 0.3.0). `docs/quickstart.md`
+  gained a verified section showing default search (soft status rerank: the
+  active `STD-U-004` outranks the superseded `STD-U-003` it replaced, both
+  still returned) versus `in_force=true` (hard filter: `STD-U-003` excluded
+  from the result set entirely), against the upgraded example bundle.
+- CI doc-consistency guard (WP4c, 0.3.0): `scripts/check_doc_consistency.py`,
+  wired as a new `doc-consistency-guard` CI job. Fails when the `type`/`status`
+  enum lists restated in SPEC.md or `docs/adoption.md` drift from
+  `data_olympus.format.validate`'s canonical `TYPES`/`STATUSES`, or when
+  SPEC.md's reserved-filename list drifts from `validate.RESERVED`. Checks
+  every restatement of an enum in a file (SPEC.md states `type`/`status` twice;
+  both are now checked, not just the first), tolerant of reordering, rewrapped
+  lines, and an Oxford "or".
+- Cheap OKF minimal-field structural check (`tests/test_okf_minimal_fields.py`,
+  WP4c, 0.3.0): asserts every example-bundle concept doc has non-empty
+  `id`/`type` and the bundle-root `index.md` declares `okf_version`. This is a
+  structural floor, not a conformance test; the module docstring states
+  exactly what it does and does not prove.
 - Deployable `in_force` and `abstain` modes on `kb_search` (issue #68, epic #75).
   `kb_search` (MCP tool and `GET /api/v1/search`) gains two parameters:
   - `in_force: bool` HARD-filters results to the in-force status class
@@ -99,6 +134,23 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   checkouts no longer accumulate one-per-session forever. GC also deletes the
   session's `kb-session/<safe_id>` branch, so a returning session can create its
   worktree again instead of hitting a fatal "branch already exists" error.
+
+### Documentation
+
+- Reworded OKF-compatibility claims for honesty (WP4c, 0.3.0). `README.md`,
+  `SPEC.md`, `WHY.md`, and `docs/comparison.md` asserted "OKF-compatible" /
+  "any OKF consumer can read a data-olympus bundle unchanged" / "every
+  data-olympus bundle is a valid OKF bundle" with zero executable backing: no
+  test runs a real OKF reference consumer/producer against a data-olympus
+  bundle. The strongest claims are now worded as design intent ("designed to
+  be readable by OKF consumers") backed by the shared structure that does
+  exist by construction (directory layout, frontmatter conventions, reserved
+  filenames, link model), with formal conformance testing tracked in
+  [issue #82](https://github.com/knaisoma/data-olympus/issues/82). A cheap,
+  non-behavioral structural floor (non-empty `id`/`type` on every example-bundle
+  concept doc, `okf_version` on the bundle-root index) was added as
+  `tests/test_okf_minimal_fields.py`; its docstring is explicit that this
+  proves frontmatter shape, not that any OKF tool can read the bundle.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,13 +85,13 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   still returned) versus `in_force=true` (hard filter: `STD-U-003` excluded
   from the result set entirely), against the upgraded example bundle.
 - CI doc-consistency guard (WP4c, 0.3.0): `scripts/check_doc_consistency.py`,
-  wired as a new `doc-consistency-guard` CI job. Fails when the `type`/`status`
-  enum lists restated in SPEC.md or `docs/adoption.md` drift from
-  `data_olympus.format.validate`'s canonical `TYPES`/`STATUSES`, or when
-  SPEC.md's reserved-filename list drifts from `validate.RESERVED`. Checks
-  every restatement of an enum in a file (SPEC.md states `type`/`status` twice;
-  both are now checked, not just the first), tolerant of reordering, rewrapped
-  lines, and an Oxford "or".
+  wired as a new `doc-consistency-guard` CI job. Fails when the
+  `type`/`status`/`tier` enum lists restated in SPEC.md or `docs/adoption.md`
+  drift from `data_olympus.format.validate`'s canonical
+  `TYPES`/`STATUSES`/`TIERS`, or when SPEC.md's reserved-filename list drifts
+  from `validate.RESERVED`. Checks every restatement of an enum in a file
+  (SPEC.md states `type`/`status` twice; both are now checked, not just the
+  first), tolerant of reordering, rewrapped lines, and an Oxford "or".
 - Cheap OKF minimal-field structural check (`tests/test_okf_minimal_fields.py`,
   WP4c, 0.3.0): asserts every example-bundle concept doc has non-empty
   `id`/`type` and the bundle-root `index.md` declares `okf_version`. This is a

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ problem we kept hitting with coding agents, what data-olympus does differently, 
 it relates to Google's Open Knowledge Format, and where our benchmarks say it is
 strong and where it is not. The rest of this README is the technical reference.
 
-data-olympus is a governance-grade knowledge-base format and server for agent workforces. It is an OKF-compatible profile (a conformant extension of the [Open Knowledge Format](https://github.com/GoogleCloudPlatform/knowledge-catalog/tree/main/okf)) with governance extensions (stable `id`, controlled `type`/`status`/`tier` fields, `supersedes` chains) plus a single-writer MCP server and a CLI. The result is a git-native, version-controlled document graph of engineering standards, architectural decisions, and project knowledge that agents and humans can read, search, and extend without any proprietary service.
+data-olympus is a governance-grade knowledge-base format and server for agent workforces. It is designed to be readable by [Open Knowledge Format](https://github.com/GoogleCloudPlatform/knowledge-catalog/tree/main/okf) (OKF) consumers: it inherits OKF's directory structure, frontmatter conventions, reserved filenames, and link model, then layers governance extensions on top (stable `id`, controlled `type`/`status`/`tier` fields, `supersedes` chains) plus a single-writer MCP server and a CLI. Formal conformance testing against the OKF reference tooling is not yet in place (tracked in [issue #82](https://github.com/knaisoma/data-olympus/issues/82)). The result is a git-native, version-controlled document graph of engineering standards, architectural decisions, and project knowledge that agents and humans can read, search, and extend without any proprietary service.
 
 It governs *decisions*, not code. When an agent is about to make a choice (a library, a pattern, a migration), data-olympus surfaces the established standard or decision that should govern that choice. It is deliberately **not** a code-search, reference-finding, or "where is X used" tool: LSP, grep, and Sourcegraph already do that well. The retrieval task it targets is coding-intent to governing-rule, and it helps where current model interaction during vibe-coding is weakest: keeping the model aligned to patterns the team has already established as correct.
 
@@ -18,7 +18,7 @@ It governs *decisions*, not code. When an agent is about to make a choice (a lib
 - **Agent and human readable.** Plain markdown with YAML frontmatter. No SDK required to read or author a document.
 - **Governed multi-agent writes.** The single-writer MCP pipeline (advisory locks, per-session worktrees, durable push queue) prevents concurrent write races without requiring distributed locking infrastructure.
 - **Queryable by status, tier, and type.** Filter by `status: accepted`, `tier: T1`, or `type: decision` without post-processing. The `supersedes` chain makes it possible to trace decision history across the graph.
-- **OKF-compatible.** Any OKF consumer can read a data-olympus bundle. Any OKF-produced bundle can be governed by data-olympus tools.
+- **Designed to be OKF-readable.** Built on OKF's directory structure, frontmatter conventions, reserved filenames, and link model; formal conformance testing against OKF reference tooling is tracked in [issue #82](https://github.com/knaisoma/data-olympus/issues/82), not yet implemented.
 
 ## Quickstart
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -10,7 +10,7 @@
 
 Knowledge that lives in plain markdown with YAML frontmatter is version-controllable, portable, and readable by both humans and automated agents without any special runtime. A git repository becomes the primary audit trail: every change is a commit, rollback is `git revert`, and the full history ships with the bundle.
 
-This specification is an **OKF-compatible profile**: any consumer built for Google's Open Knowledge Format can read a data-olympus bundle unchanged, because we inherit OKF's directory structure, frontmatter conventions, reserved filenames, and link model. On top of that baseline we layer **governance extensions**: a stable `id` field decoupled from path, a controlled type vocabulary, explicit `status` and `tier` fields, ADR chain links, and a single-writer MCP server that enforces propose/review/commit safety across multiple concurrent agents.
+This specification is **designed to be readable by consumers of Google's Open Knowledge Format (OKF)**: it inherits OKF's directory structure, frontmatter conventions, reserved filenames, and link model. Formal conformance testing against the OKF reference tooling is not yet in place ([issue #82](https://github.com/knaisoma/data-olympus/issues/82) tracks it); the claim today rests on shared structure by construction, not on an executable check. On top of that baseline we layer **governance extensions**: a stable `id` field decoupled from path, a controlled type vocabulary, explicit `status` and `tier` fields, ADR chain links, and a single-writer MCP server that enforces propose/review/commit safety across multiple concurrent agents.
 
 The result is a format that is portable and human-readable at rest (plain files, no database required) while supporting structured queries, multi-agent write safety, and progressive disclosure when served through the data-olympus MCP.
 
@@ -60,7 +60,7 @@ The bundle may be organized into subdirectories of any depth. Subdirectory names
 
 ### 4.1 Base layer (inherited from OKF)
 
-The following conventions are inherited from OKF for interoperability. Any OKF consumer can read a data-olympus bundle because these are shared.
+The following conventions are inherited from OKF for interoperability. They are designed so an OKF consumer can read a data-olympus bundle; this is not yet backed by an executable conformance test against OKF reference tooling (see section 11 and [issue #82](https://github.com/knaisoma/data-olympus/issues/82)).
 
 - Documents are UTF-8 encoded markdown files.
 - Structured metadata is expressed as a YAML frontmatter block at the top of the file, opened and closed by a bare `---` line.
@@ -87,8 +87,44 @@ The following fields are added by this profile. OKF consumers silently ignore un
 - `description`: one or two sentences summarizing the concept; used in generated index files and search results.
 - `tags`: a YAML list of lowercase strings for faceted search.
 - `timestamp`: ISO 8601 date or datetime of last meaningful content change.
+- `applies_when`: a YAML list of short trigger phrases describing the coding intents this document governs (see below). Recommended for `standard` and `decision` documents in particular, since these are the concepts an agent needs to retrieve mid-task.
 
-`tags` should always be a list; a scalar value is a warning.
+`tags` should always be a list; a scalar value is a warning. `applies_when` is parsed the same way (a non-list value is silently treated as empty, matching `tags`' parsing), but unlike `tags`, `kb lint` does not currently emit a warning when `applies_when` is missing or malformed — it is recommended by this spec but not yet schema-checked. See section 9 for the exact set of fields `kb lint` checks.
+
+#### `applies_when`: authoring guidance
+
+`applies_when` is the single highest-weight indexed field in the reference implementation's full-text search: it is matched (and boosted) alongside `title`, ahead of `description` and body text. It exists to close the gap between how an agent phrases a task mid-flow and how a document's title or prose describes itself. A standard titled "Secrets Handling" is not what an agent types when it is about to write a `.env` file; `applies_when` lets the document declare the vocabulary an agent would actually use.
+
+`applies_when` also feeds the reference implementation's abstention gate (`kb_search`'s `abstain` mode): a query is required to match at least one of `title`, `tags`, or `applies_when` before retrieval proceeds over the full document; `description` and body prose are deliberately excluded from that gate because their common words would let an out-of-scope query pass. A document with no `applies_when` (and generic tags) is harder for the gate to recognize as relevant to a real coding intent.
+
+Guidance for authoring good `applies_when` values:
+
+- Use short verb phrases, not keywords or full sentences: `"writing a database migration"`, not `"database"` or `"Guidance for writing a safe database migration script."`.
+- Phrase each entry as the coding intent an agent is mid-task on, in the agent's own vocabulary, not the document's internal terminology.
+- Prefer several narrow phrases over one broad one. A standard governing secrets handling benefits more from `"reading a .env file"`, `"committing a credential"`, and `"logging a request body"` than from a single `"security"` entry.
+- Keep the list short (a handful of phrases); this is a retrieval aid, not an exhaustive index of every section in the document.
+
+Worked example:
+
+```yaml
+---
+id: STD-U-601
+type: standard
+status: active
+tier: T1
+title: Secrets Handling
+description: Universal rules for handling credentials, API keys, and other secrets.
+applies_when:
+  - "reading a .env file"
+  - "committing a credential or API key"
+  - "logging a request or response body"
+  - "writing a script that calls a secrets manager"
+tags: [security, secrets, credentials]
+timestamp: "2026-06-24"
+---
+```
+
+An agent mid-task on "I need to log this API response for debugging" shares no vocabulary with the document's title ("Secrets Handling") but matches `"logging a request or response body"` directly.
 
 **Optional decision-chain fields** (not checked by `kb lint`; documented convention only):
 
@@ -117,6 +153,9 @@ tags:
   - standards
 timestamp: "2026-05-15"
 owner: platform-team
+applies_when:
+  - "writing a new document or README"
+  - "drafting a commit message or PR description"
 ---
 
 ## Purpose
@@ -211,9 +250,9 @@ These three are mirrored as the `kb_consult`, `kb_gate_check`, and `kb_complianc
 
 1. Every `.md` file in the bundle that is not a reserved filename (`index.md`, `log.md`, `template.md`) contains a parseable YAML frontmatter block (a valid YAML mapping between opening and closing `---` delimiters at the top of the file).
 2. Every such non-reserved concept document contains all four required fields (`id`, `type`, `status`, `tier`) with values from their respective controlled vocabularies:
-   - `type`: one of `decision`, `memory`, `project`, `reference`, `standard`, `workflow`
-   - `status`: one of `draft`, `active`, `deprecated`, `superseded`, `proposed`, `accepted`, `rejected`
-   - `tier`: one of `T1`, `T2`, `T3`, `T4`, `meta`
+   - `type`: one of `decision`, `memory`, `project`, `reference`, `standard`, `workflow`.
+   - `status`: one of `draft`, `active`, `deprecated`, `superseded`, `proposed`, `accepted`, `rejected`.
+   - `tier`: one of `T1`, `T2`, `T3`, `T4`, `meta`.
 
 **Validation rules for consumers:**
 
@@ -231,7 +270,7 @@ These three are mirrored as the `kb_consult`, `kb_gate_check`, and `kb_complianc
 **`kb lint` severity levels:**
 
 - `error`: missing required field, invalid enum value, or YAML parse failure. Blocks CI.
-- `warning`: missing recommended field (`title`, `description`, `tags`, `timestamp`), or `tags` is not a list. Does not block CI by default. Broken links and missing `supersedes`/`superseded_by`/`owner` are not checked and produce no finding either way (see sections 4.2 and 5).
+- `warning`: missing recommended field (`title`, `description`, `tags`, `timestamp`), or `tags` is not a list. Does not block CI by default. Broken links and missing `supersedes`/`superseded_by`/`owner` are not checked and produce no finding either way (see sections 4.2 and 5). `applies_when` is recommended by this spec but is not yet in `kb lint`'s checked field set: a missing or malformed `applies_when` produces no finding today, even though a non-list value is silently parsed as empty (matching `tags`' parsing, minus the warning).
 
 ---
 
@@ -253,7 +292,7 @@ The `spec_version` field is optional in bundles targeting this `0.1` draft. It b
 
 ## 11. Relationship to other formats
 
-**OKF (Open Knowledge Format).** data-olympus is an OKF-compatible profile. An OKF consumer can read any conformant data-olympus bundle unchanged; our governance extensions (`id`, `status`, `tier`, `supersedes`, `superseded_by`, `owner`, and the write pipeline) are invisible to OKF consumers because they ignore unknown keys. The two formats are complementary: OKF defines the interoperable baseline; data-olympus adds the governance layer needed for multi-agent write safety and ADR chain tracking. The relationship is analogous to how OpenAPI is a profile of JSON Schema.
+**OKF (Open Knowledge Format).** data-olympus is designed to be readable by OKF consumers: our governance extensions (`id`, `status`, `tier`, `supersedes`, `superseded_by`, `owner`, and the write pipeline) are meant to be invisible to OKF consumers because OKF requires tolerating unknown keys. This is a design intent backed by shared structure (directory layout, frontmatter conventions, reserved filenames, link model), not by an executable conformance test against the OKF reference tooling; [issue #82](https://github.com/knaisoma/data-olympus/issues/82) tracks adding one. The two formats are complementary: OKF defines the interoperable baseline; data-olympus adds the governance layer needed for multi-agent write safety and ADR chain tracking. The relationship is analogous to how OpenAPI is a profile of JSON Schema.
 
 **Obsidian and Notion.** Both support markdown files with YAML frontmatter and backlink graphs. data-olympus bundles can be opened in Obsidian as a vault; the frontmatter is visible in properties panels and the body renders normally. The difference is governance: Obsidian and Notion have no concept of propose/pending/resolve write pipelines, controlled-vocabulary enforcement, or tier-based access control. data-olympus complements these tools rather than replacing them: a team may author in Obsidian and commit conformant bundles to git for the MCP server to serve.
 

--- a/WHY.md
+++ b/WHY.md
@@ -124,14 +124,20 @@ experience, because it was close to what we had independently landed on: the sam
 instinct to keep engineering decisions as plain markdown in git and serve them to
 agents. That convergence is what made the decision to open up easy. Rather than
 keep maintaining a private format that happened to resemble OKF, or build
-something positioned against it, we made data-olympus a conformant, OKF-compatible
-profile and put our governance work on top of the standard instead of beside it.
-If OKF becomes a common way to structure knowledge bases, and we think it is a
-sensible one, we would rather build on it than around it.
+something positioned against it, we made data-olympus a profile designed to be
+readable by OKF consumers and put our governance work on top of the standard
+instead of beside it. If OKF becomes a common way to structure knowledge bases,
+and we think it is a sensible one, we would rather build on it than around it.
 
-In practice that compatibility means every data-olympus bundle is a valid OKF
-bundle that any OKF consumer can read, while a bundle produced by the OKF tooling
-can be imported and, once it carries our governance fields, governed by our tools.
+In practice that design intent means a data-olympus bundle inherits OKF's
+directory structure, frontmatter conventions, reserved filenames, and link
+model, so an OKF consumer that tolerates unknown keys (as the OKF spec
+requires) should be able to read it. We have not yet run a real OKF reference
+consumer against a data-olympus bundle to confirm that end to end, or the
+reverse (importing an OKF-tooling-produced bundle and confirming it governs
+cleanly); that executable check is tracked in
+[issue #82](https://github.com/knaisoma/data-olympus/issues/82), not shipped
+today.
 
 The natural question is then why use data-olympus rather than OKF directly. OKF
 defines a deliberately minimal required set (an `id`, a `type`, a `spec_version`)

--- a/WHY.md
+++ b/WHY.md
@@ -92,8 +92,10 @@ prompt file.
 `status`, and decisions that replace older ones are linked through a `supersedes`
 chain. That sounds like bookkeeping until you watch a plain keyword search hand an
 agent a rule you retired six months ago because the old document happens to match
-the words in the query. Because data-olympus understands which rule is current, it
-can keep the superseded one out of the answer.
+the words in the query. Because data-olympus understands which rule is current, a
+default search downranks the superseded document below the one that replaced it
+(it is still returned, useful when tracing history), and a caller that asks for
+only in-force guidance can exclude it from the result set entirely.
 
 **It is queryable in the ways governance actually needs.** You can filter by
 `status`, by `tier`, or by `type` without any post-processing, and ask things like

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -42,9 +42,32 @@ Including these fields improves search quality and the generated index:
 - `description`: one-sentence summary.
 - `tags`: list of keywords.
 - `timestamp`: ISO 8601 date the document was last meaningfully updated.
+- `applies_when`: list of trigger phrases describing the coding intents this
+  document governs (see below).
 
 See `SPEC.md` for the full schema, cross-linking conventions, and tier
 definitions.
+
+### Authoring `applies_when`
+
+`applies_when` is a list of short verb phrases in an agent's own vocabulary,
+not the document's internal terminology: `"reading a .env file"`, not
+`"security"`. It matters because it is the highest-weight field in the
+reference search index, tied with `title`, ahead of `description` and body
+text: a standard titled "Secrets Handling" is retrieved when an agent is
+mid-task on "logging a request body" only because that phrase is listed in
+`applies_when`, not because the title or body happen to share vocabulary
+with the query.
+
+```yaml
+applies_when:
+  - "reading a .env file"
+  - "committing a credential or API key"
+  - "logging a request or response body"
+```
+
+Add it to every `standard` and `decision` document you expect an agent to hit
+mid-task, phrased as that moment, not as a topic label.
 
 ### Reserved files
 

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -2,7 +2,7 @@
 
 ## What data-olympus is
 
-data-olympus is a governance-grade knowledge-base **format** (an OKF-compatible profile with governance extensions) plus a single-writer MCP server and a CLI. The format adds a controlled vocabulary on top of the Open Knowledge Format's minimal `type` field: a stable `id`, required `status` and `tier` fields, a `supersedes`/`superseded_by` chain for decisions, and a normative cross-linking convention. The result is a git-native, human and agent readable document graph that can be served directly to an agent workforce.
+data-olympus is a governance-grade knowledge-base **format** (a profile designed to be readable by Open Knowledge Format consumers, with governance extensions layered on top) plus a single-writer MCP server and a CLI. The format adds a controlled vocabulary on top of the Open Knowledge Format's minimal `type` field: a stable `id`, required `status` and `tier` fields, a `supersedes`/`superseded_by` chain for decisions, and a normative cross-linking convention. The result is a git-native, human and agent readable document graph that can be served directly to an agent workforce.
 
 The system is optimized for one specific job: a small team of agents (and humans) curating engineering standards, architectural decisions, and project knowledge as version-controlled markdown. It is not a general data catalog, not a vector store, and not a wiki platform. It is also deliberately not a code-search, reference-finding, or "where is X used" tool (LSP, grep, and Sourcegraph own that, and it does not compete with them). The retrieval task it targets is **coding-intent to governing-rule**: surfacing the established standard or decision that should govern a choice the model is about to make. Understanding that scope is the clearest lens for reading the comparisons below.
 
@@ -12,7 +12,7 @@ The system is optimized for one specific job: a small team of agents (and humans
 
 | Tool / category | Portability / lock-in | Human + agent readable (no SDK) | Governance and multi-agent write-safety | Structured queryability | Concurrency model | Taxonomy | Hosting model | Interop |
 |---|---|---|---|---|---|---|---|---|
-| **data-olympus** | git-native / none | yes, plain markdown | single-writer MCP pipeline | FTS + filter by status/tier/type | single-writer, advisory locks | controlled vocabulary (type, status, tier) | self-hosted, streamable HTTP | OKF-compatible |
+| **data-olympus** | git-native / none | yes, plain markdown | single-writer MCP pipeline | FTS + filter by status/tier/type | single-writer, advisory locks | controlled vocabulary (type, status, tier) | self-hosted, streamable HTTP | designed to be OKF-readable (conformance test not yet built, [issue #82](https://github.com/knaisoma/data-olympus/issues/82)) |
 | Google OKF | git-native / none | yes | FTS only, no write governance | FTS only | none specified | minimal (type only) | any | OKF native |
 | Enterprise data catalogs (Dataplex, Unity Catalog, Collibra, DataHub, Amundsen) | vendor / high | partial (UI-centric) | strong (RBAC, lineage) | deep (column-level, lineage graphs) | multi-writer | rich, auto-generated | SaaS / self-hosted | APIs, connectors |
 | Markdown KB tools (Obsidian, Notion, MkDocs, Backstage TechDocs) | varies / medium | yes | none | FTS or plugin-based | multi-writer | user-defined | SaaS / local | plugin ecosystem |
@@ -109,7 +109,7 @@ The honest summary: curated `applies_when` triggers are the right primary mechan
 
 ### Google Open Knowledge Format (OKF)
 
-The Open Knowledge Format is the parent specification. data-olympus is an OKF-compatible profile: every data-olympus bundle is a valid OKF bundle, and any OKF consumer can read it.
+The Open Knowledge Format is the parent specification. data-olympus is designed to be readable by OKF consumers: it inherits OKF's directory structure, frontmatter conventions, reserved filenames, and link model. That claim is not yet backed by an executable conformance test against OKF reference tooling ([issue #82](https://github.com/knaisoma/data-olympus/issues/82) tracks adding one); today it rests on shared structure by construction.
 
 **Where data-olympus is better (and why):** OKF defines a minimal required set (`id`, `type`, `spec_version`) with no governance fields. data-olympus adds `status`, `tier`, a `supersedes` chain, and controlled vocabularies for each field, making it possible to query "show me all accepted T1 standards" or "what superseded this decision" without post-processing. data-olympus also ships a validated write pipeline (proposed edits, pending queue, advisory locks, commit-and-push) and an MCP server; OKF specifies no serving or write model.
 
@@ -117,7 +117,7 @@ The Open Knowledge Format is the parent specification. data-olympus is an OKF-co
 
 **Where that is a deliberate decision:** data-olympus targets curated, reviewed knowledge where accuracy and governance matter more than coverage. Auto-ingestion without review is a deliberate non-goal for the v0.1 scope.
 
-**Where they are complementary:** Because data-olympus is an OKF-compatible profile, bundles produced by the OKF producer can be imported and governed by data-olympus tools. Conversely, data-olympus bundles can be consumed by any OKF-aware tool without conversion.
+**Where they are complementary:** Because data-olympus is designed to share OKF's baseline structure, bundles produced by the OKF producer should be importable and governable by data-olympus tools, and data-olympus bundles should be consumable by an OKF-aware tool without conversion. Neither direction has an automated test yet ([issue #82](https://github.com/knaisoma/data-olympus/issues/82)).
 
 ---
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -48,7 +48,40 @@ curl -fsS "http://localhost:8080/api/v1/search?q=writing"
 curl -fsS http://localhost:8080/api/v1/outline
 ```
 
-## 4. Query with the kb CLI
+## 4. Lifecycle-aware retrieval: in-force vs superseded
+
+The example bundle ships a real supersession pair in
+`universal/foundation/`: `STD-U-003` (`status: superseded`,
+`superseded_by: STD-U-004`) and `STD-U-004` (`status: active`,
+`supersedes: STD-U-003`), the standard that replaced it. This section shows
+the two ways `kb_search` treats that pair differently.
+
+**Default search** applies a soft status-aware rerank: an `active` document is
+promoted ahead of the `superseded` document it replaced, but the superseded
+document is still returned (useful when an agent or human is tracing decision
+history).
+
+```bash
+curl -fsS "http://localhost:8080/api/v1/search?q=commit%20format&limit=5"
+```
+
+The top two hits are `STD-U-004` (`status: active`) ranked ahead of
+`STD-U-003` (`status: superseded`) — both present, active first.
+
+**`in_force=true`** is a hard filter, not a rerank: it excludes every
+not-currently-governing status (`superseded`, `deprecated`, `draft`,
+`proposed`, `rejected`) from the result set entirely, before ranking.
+
+```bash
+curl -fsS "http://localhost:8080/api/v1/search?q=commit%20format&limit=5&in_force=true"
+```
+
+`STD-U-003` does not appear in the response at all: an agent that only wants
+guidance currently in force (for example, before writing a commit message)
+gets a result set that can never surface retired governance, rather than
+relying on the rerank to have pushed it down far enough.
+
+## 5. Query with the kb CLI
 
 ```bash
 KB_ENDPOINT=http://localhost:8080 ./bin/kb health -o plain
@@ -63,7 +96,7 @@ export KB_ENDPOINT=http://localhost:8080
 ./bin/kb search writing
 ```
 
-## 5. Docker path
+## 6. Docker path
 
 Build and start with Docker Compose:
 
@@ -84,7 +117,7 @@ docker compose -f deploy/docker/compose.yaml run \
 The bundle at `/path/to/my-kb` must be a git repository (run `git init` inside
 it first).
 
-## 6. Use your own bundle
+## 7. Use your own bundle
 
 Point the server at any git-initialized directory following the
 `example-bundle/` layout:

--- a/example-bundle/index.md
+++ b/example-bundle/index.md
@@ -5,9 +5,10 @@ okf_version: "0.1"
 # Acme Knowledge Bundle
 
 An example data-olympus bundle demonstrating the full tier hierarchy (T1-T4 and
-meta), several supported concept types (`standard`, `decision`, `workflow`,
-`project`), and cross-links between concepts. It does not yet include
-`memory` or `reference` type documents, or a `superseded` document.
+meta), all six supported concept types (`standard`, `decision`, `workflow`,
+`project`, `memory`, `reference`), a live supersession pair (`status:
+superseded` / `supersedes` / `superseded_by`), `applies_when` retrieval
+triggers, and cross-links between concepts.
 
 See [log.md](log.md) for the change history of this bundle.
 
@@ -15,6 +16,8 @@ See [log.md](log.md) for the change history of this bundle.
 
 - [STD-U-001 Writing Style](universal/foundation/STD-U-001-writing-style.md) - base writing style
 - [STD-U-002 Code Review](universal/foundation/STD-U-002-code-review.md) - mandatory review steps
+- [STD-U-003 Commit Message Format (v1)](universal/foundation/STD-U-003-commit-message-format.md) - **superseded** by STD-U-004
+- [STD-U-004 Commit Message Format](universal/foundation/STD-U-004-commit-message-format.md) - Conventional-Commits-style convention; supersedes STD-U-003
 - [STD-U-601 Secrets Handling](universal/security/STD-U-601-secrets.md) - credential safety rules
 
 # Stack Standards (T2)
@@ -29,6 +32,14 @@ See [log.md](log.md) for the change history of this bundle.
 # Workflows (meta)
 
 - [WF-001 Knowledge Base Review Flow](workflows/WF-001-review-flow.md) - propose, review, commit
+
+# Memory
+
+- [NestJS module naming collision](memory/accepted/2026-06-20-nestjs-module-naming-collision.md) - a recorded incident, not a standard
+
+# Reference
+
+- [Acme App API endpoint reference](reference/rest-api-endpoints.md) - current-state lookup table, not a governing rule
 
 # Projects
 

--- a/example-bundle/log.md
+++ b/example-bundle/log.md
@@ -4,6 +4,33 @@ Changes are listed newest-first, grouped by date.
 
 ---
 
+## 2026-07-03 (0.3.0: lifecycle and applies_when demonstration)
+
+Added the remaining concept types and lifecycle mechanics referenced in
+SPEC.md but not previously demonstrated in this bundle: a real supersession
+pair, a `memory` document, a `reference` document, and `applies_when`
+retrieval-trigger metadata on the standards most likely to be hit mid-task.
+
+New files:
+
+- `universal/foundation/STD-U-003-commit-message-format.md` (T1 standard,
+  `status: superseded`, `superseded_by: STD-U-004`)
+- `universal/foundation/STD-U-004-commit-message-format.md` (T1 standard,
+  `status: active`, `supersedes: STD-U-003`)
+- `memory/accepted/2026-06-20-nestjs-module-naming-collision.md` (memory)
+- `reference/rest-api-endpoints.md` (reference)
+- `memory/index.md`, `memory/accepted/index.md`, `reference/index.md`
+
+Changed:
+
+- Added `applies_when` to `STD-U-001` and `STD-U-601` (existing standards)
+  and to the new `STD-U-004`.
+- Updated the root `index.md` to list the new sections and to state
+  accurately which concept types and lifecycle features the bundle now
+  demonstrates.
+
+---
+
 ## 2026-06-24 (P3 expansion)
 
 Added richer multi-tier content to the example bundle to demonstrate cross-links,

--- a/example-bundle/memory/accepted/2026-06-20-nestjs-module-naming-collision.md
+++ b/example-bundle/memory/accepted/2026-06-20-nestjs-module-naming-collision.md
@@ -1,0 +1,36 @@
+---
+id: MEM-2026-06-20-nestjs-module-naming-collision
+type: memory
+status: active
+tier: meta
+title: NestJS module naming collision with the shared `users` package
+description: A recorded incident where a new `users` feature module collided with an existing shared package of the same name, and the resolution the team settled on.
+tags: [nestjs, memory, incident]
+timestamp: "2026-06-20"
+applies_when:
+  - "adding a new NestJS feature module named users"
+  - "naming a module that might collide with a shared package"
+---
+# What happened
+
+While adding a `users` feature module to the Acme App API component (see
+[COMP-acme-app-api](/projects/acme-app/components/api/README.md)), an engineer
+named the module directory `src/users/`, which collided with an existing
+internal shared package also named `users` published to the private npm
+registry. The collision was caught in CI when the bundler resolved the wrong
+`users` import.
+
+# Resolution
+
+Feature modules that would collide with an existing shared package name are
+suffixed with `-module` (e.g. `src/users-module/`) rather than renamed to
+something unrelated, so the directory name still reads clearly next to
+[STD-BN-001](/tech-stacks/backend-nestjs/STD-BN-001-module-structure.md)'s
+naming conventions.
+
+# Why this is recorded as memory, not a standard
+
+This is a one-off naming collision specific to Acme's current package set, not
+a general rule every NestJS project needs. If the same collision recurs across
+multiple projects, promote this into an amendment to STD-BN-001 instead of
+leaving it as a memory entry.

--- a/example-bundle/memory/accepted/index.md
+++ b/example-bundle/memory/accepted/index.md
@@ -1,0 +1,4 @@
+# accepted
+
+# Concepts
+* [NestJS module naming collision with the shared `users` package](2026-06-20-nestjs-module-naming-collision.md) - A recorded incident and the naming convention the team settled on to avoid it recurring.

--- a/example-bundle/memory/index.md
+++ b/example-bundle/memory/index.md
@@ -1,0 +1,8 @@
+# memory
+
+Recorded incidents and observations that inform future work but are not
+themselves standards. See [accepted/](accepted/) for entries a human has
+reviewed and accepted into the bundle.
+
+# Subdirectories
+* [accepted/](accepted/)

--- a/example-bundle/reference/index.md
+++ b/example-bundle/reference/index.md
@@ -1,0 +1,7 @@
+# reference
+
+Lookup documents describing current state (what exists), as distinct from
+standards (what should be true) or decisions (why a choice was made).
+
+# Concepts
+* [Acme App API endpoint reference](rest-api-endpoints.md) - Enumerates the REST endpoints exposed by the Acme App API component.

--- a/example-bundle/reference/rest-api-endpoints.md
+++ b/example-bundle/reference/rest-api-endpoints.md
@@ -1,0 +1,34 @@
+---
+id: REF-acme-app-rest-endpoints
+type: reference
+status: active
+tier: meta
+title: Acme App API endpoint reference
+description: Enumerates the REST endpoints exposed by the Acme App API component, for lookup rather than governance.
+tags: [reference, api, acme-app]
+timestamp: "2026-06-24"
+---
+# Acme App API endpoints
+
+This is a lookup reference, not a standard: it describes what the API
+currently exposes, not a rule the API must follow. See
+[STD-BN-001](/tech-stacks/backend-nestjs/STD-BN-001-module-structure.md) for
+the module conventions the implementation follows, and
+[COMP-acme-app-api](/projects/acme-app/components/api/README.md) for
+component-level context.
+
+| Method | Path                | Module   | Notes                          |
+|--------|---------------------|----------|--------------------------------|
+| GET    | `/health`           | health   | Liveness probe, no auth        |
+| POST   | `/auth/login`       | auth     | Returns a session token        |
+| POST   | `/auth/logout`      | auth     | Invalidates the session token  |
+| GET    | `/users/:id`        | users    | Requires an authenticated user |
+| PATCH  | `/users/:id`        | users    | Requires the user themself     |
+
+# Why this is a `reference` document, not a `standard`
+
+A `reference` document describes current state for lookup (what exists
+today); a `standard` prescribes a rule that governs future work. This table
+will drift out of date as the API changes, which is acceptable for a
+reference doc in a way it would not be for a standard: nothing in this file
+asserts what SHOULD be true, only what currently IS.

--- a/example-bundle/universal/foundation/STD-U-001-writing-style.md
+++ b/example-bundle/universal/foundation/STD-U-001-writing-style.md
@@ -7,6 +7,9 @@ title: Writing Style
 description: How Acme writes clear, agent-readable documentation.
 tags: [foundation, writing]
 timestamp: 2026-06-24
+applies_when:
+  - "writing a new document or README"
+  - "drafting a docstring or code comment"
 ---
 # Rule
 Write in plain language. Prefer structure (headings, lists, tables) over prose.

--- a/example-bundle/universal/foundation/STD-U-003-commit-message-format.md
+++ b/example-bundle/universal/foundation/STD-U-003-commit-message-format.md
@@ -1,0 +1,31 @@
+---
+id: STD-U-003
+type: standard
+status: superseded
+tier: T1
+title: Commit Message Format (v1)
+description: Original commit message convention for Acme repositories. Replaced by STD-U-004, which adds a required scope segment.
+tags: [git, commits, superseded]
+timestamp: "2026-05-10"
+superseded_by: STD-U-004
+---
+# Rule
+
+Commit messages use a free-text subject line under 72 characters, optionally
+followed by a blank line and a longer body.
+
+```
+Fix the login redirect loop
+```
+
+# Why
+
+This was Acme's first attempt at a commit message convention. It did not
+distinguish feature work from fixes or chores, which made it hard to
+generate changelogs automatically.
+
+# Status
+
+Superseded by [STD-U-004](STD-U-004-commit-message-format.md), which requires
+a Conventional-Commits-style `type(scope): subject` header so tooling can
+categorize commits without parsing prose.

--- a/example-bundle/universal/foundation/STD-U-004-commit-message-format.md
+++ b/example-bundle/universal/foundation/STD-U-004-commit-message-format.md
@@ -1,0 +1,42 @@
+---
+id: STD-U-004
+type: standard
+status: active
+tier: T1
+title: Commit Message Format
+description: Conventional-Commits-style commit message convention for Acme repositories, replacing the free-text convention in STD-U-003.
+tags: [git, commits]
+timestamp: "2026-06-24"
+supersedes: STD-U-003
+applies_when:
+  - "writing a commit message"
+  - "opening a pull request"
+---
+# Rule
+
+Commit messages use a Conventional Commits header:
+
+```
+type(scope): subject
+```
+
+- `type` is one of `feat`, `fix`, `chore`, `docs`, `refactor`, `test`.
+- `scope` is the affected module or component (required, unlike the retired
+  STD-U-003 convention).
+- `subject` is an imperative, present-tense description under 72 characters.
+
+```
+fix(auth): stop redirect loop on expired session
+```
+
+# Why
+
+A required `scope` segment lets tooling (changelog generators, release notes)
+group commits by area without parsing prose. This replaces
+[STD-U-003](STD-U-003-commit-message-format.md), which allowed a free-text
+subject with no required structure.
+
+# Migration
+
+Existing history written under STD-U-003 is not rewritten. The new format
+applies to all commits from 2026-06-24 onward.

--- a/example-bundle/universal/foundation/index.md
+++ b/example-bundle/universal/foundation/index.md
@@ -3,3 +3,5 @@
 # Concepts
 * [Writing Style](STD-U-001-writing-style.md) - How Acme writes clear, agent-readable documentation.
 * [Code Review Standard](STD-U-002-code-review.md) - Rules for conducting and recording code reviews at Acme so that quality gates are consistent and auditable.
+* [Commit Message Format (v1)](STD-U-003-commit-message-format.md) - **Superseded** by STD-U-004. Original free-text commit message convention.
+* [Commit Message Format](STD-U-004-commit-message-format.md) - Conventional-Commits-style commit message convention; supersedes STD-U-003.

--- a/example-bundle/universal/security/STD-U-601-secrets.md
+++ b/example-bundle/universal/security/STD-U-601-secrets.md
@@ -7,6 +7,11 @@ title: Secrets Handling
 description: Universal rules for handling credentials, API keys, and other secrets across all Acme projects.
 tags: [security, secrets, credentials]
 timestamp: 2026-06-24
+applies_when:
+  - "reading a .env file"
+  - "committing a credential or API key"
+  - "logging a request or response body"
+  - "writing a script that calls a secrets manager"
 ---
 # Purpose
 

--- a/scripts/check_doc_consistency.py
+++ b/scripts/check_doc_consistency.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+"""CI guard: docs must not drift from the canonical schema in code.
+
+SPEC.md and docs/adoption.md restate, in prose, the controlled-vocabulary
+enums and reserved-filename list that ``data_olympus.format.validate`` defines
+in code (``TYPES``, ``STATUSES``, ``RESERVED``). Those two sources of truth
+have no structural link — nothing stops the code from adding a new ``status``
+value while the docs still list the old set. This script parses each prose
+restatement out of the docs, and fails when its value set no longer matches
+the canonical one imported directly from the package.
+
+What this checks:
+
+1. Every `` `type`: ... `` / `` `status`: ... `` enum restatement in SPEC.md
+   and docs/adoption.md against ``data_olympus.format.validate.TYPES`` /
+   ``STATUSES``.
+2. The reserved-filename list stated in SPEC.md against
+   ``data_olympus.format.validate.RESERVED``.
+
+What this deliberately does NOT check: `tier`, `applies_when`, or any other
+field's documentation; whether the prose reads well; whether a doc's example
+frontmatter blocks are internally consistent. Extend ``_CHECKS`` below if a
+future field's enum should also be guarded.
+
+Expected doc format (what the parser looks for)
+------------------------------------------------
+
+An enum restatement is a Markdown sentence fragment of the form::
+
+    `type`: <anything> `value-one`, `value-two`, ... `value-n`.
+
+i.e. a backtick-quoted field name, a colon, then a comma-separated (optionally
+`` `` and ``, `` or `` alternating, and possibly wrapped across lines) list of
+backtick-quoted values, terminated by a sentence-ending period (a "." followed
+by whitespace or end-of-string, so a period inside a backtick-quoted filename
+like `` `index.md` `` does not end the scan early). The parser is tolerant of:
+
+- Line wraps in the middle of the value list (common in prose paragraphs).
+- An "or" before the last item (`` `x`, `y`, or `z`. ``).
+- Leading qualifier text between the colon and the first backtick-quoted
+  value (e.g. "one of", "controlled vocabulary:", "lifecycle state:").
+- A period inside a backtick-quoted value itself (e.g. a reserved filename).
+
+It is NOT tolerant of a value list that spans multiple sentences, or values
+that aren't backtick-quoted. If SPEC.md's prose changes shape enough to break
+the regex, this script should fail loudly (a `ParseError`) rather than
+silently report zero values as "in sync" — an empty extracted set is treated
+as a parse failure, not a pass.
+
+The reserved-filename restatement is matched the same way, anchored on the
+sentence "Reserved filenames." (SPEC.md section 3) and pulls every
+backtick-quoted `*.md` token from that sentence.
+
+Invocation
+----------
+
+    python scripts/check_doc_consistency.py [--root PATH]
+
+Exit code 0 when every check is in sync, 1 when any drift or parse failure is
+found (all failures are collected and printed before exiting, not just the
+first).
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+
+class ParseError(ValueError):
+    """A doc's prose no longer matches the shape this script expects."""
+
+
+# --- extraction -------------------------------------------------------------
+
+_BACKTICK_VALUE = re.compile(r"`([^`]+)`")
+
+# A sentence-ending period: followed by whitespace or end-of-string, NOT by
+# another non-space character. This distinguishes the "." that ends a
+# sentence from the "." inside a backtick-quoted filename like `index.md`
+# (where the period is immediately followed by a lowercase letter, not
+# whitespace), so the non-greedy scan below doesn't stop mid-filename.
+_SENTENCE_END = re.compile(r"\.(?=\s|$)")
+
+
+def _span_to_sentence_end(text: str, start: int) -> str:
+    """Return text[start:end] where end is the next sentence-ending period.
+
+    Raises ParseError if no sentence-ending period is found after ``start``.
+    """
+    m = _SENTENCE_END.search(text, start)
+    if m is None:
+        raise ParseError("no sentence-ending '.' found after the field marker")
+    return text[start:m.start()]
+
+
+def _extract_enum_occurrences(text: str, *, field: str) -> list[tuple[int, set[str]]]:
+    """Extract every backtick-quoted value list following ``\\`field\\`:`` in text.
+
+    A doc may restate a field's enum in more than one place (SPEC.md restates
+    `type`/`status` in both section 4.2 and the section 9 conformance summary);
+    checking only the first occurrence would silently miss drift in the
+    second. Returns one ``(line_number, values)`` entry per occurrence of the
+    `` `field`: `` marker, matching from the marker to the next
+    sentence-ending period (across newlines; prose line-wraps a long enum
+    list). Raises ParseError if the marker never appears, or if any single
+    occurrence has no backtick-quoted values following it (an empty result is
+    a parse failure, not an empty-but-valid enum: every field this script
+    checks has a non-empty canonical set).
+    """
+    marker = re.escape(f"`{field}`:")
+    occurrences = list(re.finditer(marker, text))
+    if not occurrences:
+        raise ParseError(f"no '`{field}`:' marker found")
+    results: list[tuple[int, set[str]]] = []
+    for m in occurrences:
+        line_no = text.count("\n", 0, m.start()) + 1
+        span = _span_to_sentence_end(text, m.end())
+        values = set(_BACKTICK_VALUE.findall(span))
+        if not values:
+            raise ParseError(
+                f"'`{field}`:' at line {line_no} found but no backtick-quoted "
+                "values followed it"
+            )
+        results.append((line_no, values))
+    return results
+
+
+def _extract_reserved(text: str) -> tuple[int, set[str]]:
+    """Extract the reserved-filename list from SPEC.md's "Reserved filenames." sentence.
+
+    Returns ``(line_number, values)``. Only the first occurrence is checked:
+    SPEC.md states the reserved-filename list normatively once (section 3);
+    other mentions elsewhere in the file are parenthetical cross-references,
+    not restatements of the canonical list.
+    """
+    m = re.search(r"Reserved filenames\.", text)
+    if m is None:
+        raise ParseError("no 'Reserved filenames.' sentence found")
+    line_no = text.count("\n", 0, m.start()) + 1
+    span = _span_to_sentence_end(text, m.end())
+    values = set(_BACKTICK_VALUE.findall(span))
+    if not values:
+        raise ParseError("'Reserved filenames.' found but no backtick-quoted values followed it")
+    return line_no, values
+
+
+# --- checks ------------------------------------------------------------------
+
+
+def _diff_message(
+    *, source: str, field: str, line_no: int, extracted: set[str], canonical: set[str]
+) -> str | None:
+    """Return a human-readable drift message, or None if extracted == canonical."""
+    if extracted == canonical:
+        return None
+    missing = canonical - extracted  # in code, not in doc
+    extra = extracted - canonical  # in doc, not in code
+    parts = [f"{source}:{line_no}: '{field}' enum drifted from data_olympus.format.validate"]
+    if missing:
+        parts.append(f"  missing from doc (in code): {sorted(missing)}")
+    if extra:
+        parts.append(f"  stale in doc (not in code): {sorted(extra)}")
+    return "\n".join(parts)
+
+
+def check_doc_consistency(root: Path) -> list[str]:
+    """Return a list of drift/parse-error messages; empty means everything is in sync."""
+    # Imported here (not at module scope) so a bad --root or missing package
+    # produces a clear error from main(), not an import-time traceback.
+    from data_olympus.format.validate import RESERVED, STATUSES, TYPES
+
+    errors: list[str] = []
+
+    spec_path = root / "SPEC.md"
+    adoption_path = root / "docs" / "adoption.md"
+
+    for label, path, field, canonical in (
+        ("SPEC.md", spec_path, "type", TYPES),
+        ("SPEC.md", spec_path, "status", STATUSES),
+        ("docs/adoption.md", adoption_path, "type", TYPES),
+        ("docs/adoption.md", adoption_path, "status", STATUSES),
+    ):
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            errors.append(f"{label}: could not read {path}: {exc}")
+            continue
+        try:
+            occurrences = _extract_enum_occurrences(text, field=field)
+        except ParseError as exc:
+            errors.append(f"{label}: {exc}")
+            continue
+        for line_no, extracted in occurrences:
+            msg = _diff_message(
+                source=label, field=field, line_no=line_no,
+                extracted=extracted, canonical=set(canonical),
+            )
+            if msg:
+                errors.append(msg)
+
+    # Reserved filenames: SPEC.md only (docs/adoption.md phrases this as a
+    # parenthetical, not the anchored "Reserved filenames." sentence).
+    try:
+        spec_text = spec_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        errors.append(f"SPEC.md: could not read {spec_path}: {exc}")
+    else:
+        try:
+            reserved_line_no, extracted_reserved = _extract_reserved(spec_text)
+        except ParseError as exc:
+            errors.append(f"SPEC.md: {exc}")
+        else:
+            msg = _diff_message(
+                source="SPEC.md",
+                field="RESERVED",
+                line_no=reserved_line_no,
+                extracted=extracted_reserved,
+                canonical=set(RESERVED),
+            )
+            if msg:
+                errors.append(msg)
+
+    return errors
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=Path(__file__).resolve().parent.parent,
+        help="repo root containing SPEC.md and docs/adoption.md (default: repo root)",
+    )
+    args = parser.parse_args(argv)
+
+    errors = check_doc_consistency(args.root)
+    if errors:
+        print("doc consistency guard: FAILED", file=sys.stderr)
+        for err in errors:
+            print(f"  - {err}", file=sys.stderr)
+        return 1
+    print("doc consistency guard: ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/check_doc_consistency.py
+++ b/scripts/check_doc_consistency.py
@@ -3,24 +3,24 @@
 
 SPEC.md and docs/adoption.md restate, in prose, the controlled-vocabulary
 enums and reserved-filename list that ``data_olympus.format.validate`` defines
-in code (``TYPES``, ``STATUSES``, ``RESERVED``). Those two sources of truth
-have no structural link — nothing stops the code from adding a new ``status``
-value while the docs still list the old set. This script parses each prose
-restatement out of the docs, and fails when its value set no longer matches
-the canonical one imported directly from the package.
+in code (``TYPES``, ``STATUSES``, ``TIERS``, ``RESERVED``). Those two sources
+of truth have no structural link — nothing stops the code from adding a new
+``status`` value while the docs still list the old set. This script parses
+each prose restatement out of the docs, and fails when its value set no
+longer matches the canonical one imported directly from the package.
 
 What this checks:
 
-1. Every `` `type`: ... `` / `` `status`: ... `` enum restatement in SPEC.md
-   and docs/adoption.md against ``data_olympus.format.validate.TYPES`` /
-   ``STATUSES``.
+1. Every `` `type`: ... ``, `` `status`: ... ``, or `` `tier`: ... `` enum
+   restatement in SPEC.md and docs/adoption.md against
+   ``data_olympus.format.validate.TYPES`` / ``STATUSES`` / ``TIERS``.
 2. The reserved-filename list stated in SPEC.md against
    ``data_olympus.format.validate.RESERVED``.
 
-What this deliberately does NOT check: `tier`, `applies_when`, or any other
-field's documentation; whether the prose reads well; whether a doc's example
-frontmatter blocks are internally consistent. Extend ``_CHECKS`` below if a
-future field's enum should also be guarded.
+What this deliberately does NOT check: `applies_when` (not an enum) or any
+other field's documentation; whether the prose reads well; whether a doc's
+example frontmatter blocks are internally consistent. Extend the tuple in
+``check_doc_consistency`` if a future field's enum should also be guarded.
 
 Expected doc format (what the parser looks for)
 ------------------------------------------------
@@ -169,7 +169,7 @@ def check_doc_consistency(root: Path) -> list[str]:
     """Return a list of drift/parse-error messages; empty means everything is in sync."""
     # Imported here (not at module scope) so a bad --root or missing package
     # produces a clear error from main(), not an import-time traceback.
-    from data_olympus.format.validate import RESERVED, STATUSES, TYPES
+    from data_olympus.format.validate import RESERVED, STATUSES, TIERS, TYPES
 
     errors: list[str] = []
 
@@ -179,8 +179,10 @@ def check_doc_consistency(root: Path) -> list[str]:
     for label, path, field, canonical in (
         ("SPEC.md", spec_path, "type", TYPES),
         ("SPEC.md", spec_path, "status", STATUSES),
+        ("SPEC.md", spec_path, "tier", TIERS),
         ("docs/adoption.md", adoption_path, "type", TYPES),
         ("docs/adoption.md", adoption_path, "status", STATUSES),
+        ("docs/adoption.md", adoption_path, "tier", TIERS),
     ):
         try:
             text = path.read_text(encoding="utf-8")

--- a/tests/test_check_doc_consistency.py
+++ b/tests/test_check_doc_consistency.py
@@ -129,13 +129,24 @@ def test_diff_message_reports_missing_and_extra() -> None:
 # --- check_doc_consistency (end-to-end against a scratch root) --------------
 
 
-def _write_bundle(tmp_path: Path, *, spec_type_line: str, adoption_type_line: str) -> Path:
+_IN_SYNC_TIER_LINE = "`tier`: one of `T1`, `T2`, `T3`, `T4`, `meta`."
+
+
+def _write_bundle(
+    tmp_path: Path,
+    *,
+    spec_type_line: str,
+    adoption_type_line: str,
+    spec_tier_line: str = _IN_SYNC_TIER_LINE,
+    adoption_tier_line: str = _IN_SYNC_TIER_LINE,
+) -> Path:
     (tmp_path / "docs").mkdir()
     (tmp_path / "SPEC.md").write_text(
         "## 4.2 Governance extensions\n\n"
         f"- {spec_type_line}\n"
         "- `status`: lifecycle state: `draft`, `active`, `deprecated`, `superseded`, "
-        "`proposed`, `accepted`, `rejected`. More prose.\n\n"
+        "`proposed`, `accepted`, `rejected`. More prose.\n"
+        f"- {spec_tier_line}\n\n"
         "**Reserved filenames.** The filenames `index.md`, `log.md`, and "
         "`template.md` are reserved in every directory. More prose.\n",
         encoding="utf-8",
@@ -143,7 +154,8 @@ def _write_bundle(tmp_path: Path, *, spec_type_line: str, adoption_type_line: st
     (tmp_path / "docs" / "adoption.md").write_text(
         f"- {adoption_type_line}\n"
         "- `status`: one of `draft`, `active`, `deprecated`, `superseded`,\n"
-        "  `proposed`, `accepted`, `rejected`.\n",
+        "  `proposed`, `accepted`, `rejected`.\n"
+        f"- {adoption_tier_line}\n",
         encoding="utf-8",
     )
     return tmp_path
@@ -201,6 +213,24 @@ def test_check_doc_consistency_detects_drift_in_adoption_doc(tmp_path: Path) -> 
     assert len(errors) == 1
     assert "docs/adoption.md" in errors[0]
     assert "'memory'" in errors[0]
+
+
+def test_check_doc_consistency_detects_tier_drift_in_spec(tmp_path: Path) -> None:
+    _write_bundle(
+        tmp_path,
+        spec_type_line=_IN_SYNC_TYPE_LINE,
+        adoption_type_line=(
+            "`type`: one of `standard`, `decision`, `workflow`, `project`, "
+            "`memory`, `reference`."
+        ),
+        # Drops 'meta' from the tier enum restatement.
+        spec_tier_line="`tier`: one of `T1`, `T2`, `T3`, `T4`.",
+    )
+    errors = check_doc_consistency(tmp_path)
+    assert len(errors) == 1
+    assert "SPEC.md" in errors[0]
+    assert "'tier'" in errors[0]
+    assert "'meta'" in errors[0]
 
 
 def test_check_doc_consistency_detects_reserved_drift(tmp_path: Path) -> None:

--- a/tests/test_check_doc_consistency.py
+++ b/tests/test_check_doc_consistency.py
@@ -1,0 +1,246 @@
+"""Tests for the doc-consistency CI guard (scripts/check_doc_consistency.py).
+
+Covers both the pure extraction/diff logic (no filesystem) and an
+end-to-end pass/fail run against a scratch root with real SPEC.md /
+docs/adoption.md text, so a regression in the sentence-boundary regex or the
+diffing logic is caught even if the two never disagree in practice.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scripts.check_doc_consistency import (
+    ParseError,
+    _diff_message,
+    _extract_enum_occurrences,
+    _extract_reserved,
+    check_doc_consistency,
+)
+
+# --- _extract_enum_occurrences -----------------------------------------------
+
+
+def test_extract_enum_single_line() -> None:
+    text = "- `type`: one of `standard`, `decision`, `workflow`.\nMore prose."
+    occurrences = _extract_enum_occurrences(text, field="type")
+    assert len(occurrences) == 1
+    line_no, values = occurrences[0]
+    assert line_no == 1
+    assert values == {"standard", "decision", "workflow"}
+
+
+def test_extract_enum_wraps_across_lines() -> None:
+    text = (
+        "- `type`: one of `standard`, `decision`, `workflow`, `project`,\n"
+        "  `memory`, `reference`.\n"
+    )
+    occurrences = _extract_enum_occurrences(text, field="type")
+    assert len(occurrences) == 1
+    _, values = occurrences[0]
+    assert values == {"standard", "decision", "workflow", "project", "memory", "reference"}
+
+
+def test_extract_enum_tolerates_oxford_or() -> None:
+    text = "`status`: one of `draft`, `active`, or `deprecated`.\n"
+    _, values = _extract_enum_occurrences(text, field="status")[0]
+    assert values == {"draft", "active", "deprecated"}
+
+
+def test_extract_enum_does_not_stop_at_period_inside_backticks() -> None:
+    # A period embedded in a backtick-quoted value (e.g. a filename) must not
+    # be mistaken for the sentence-ending period.
+    text = "`type`: one of `index.md`, `standard`. Trailing prose.\n"
+    _, values = _extract_enum_occurrences(text, field="type")[0]
+    assert values == {"index.md", "standard"}
+
+
+def test_extract_enum_finds_multiple_occurrences() -> None:
+    text = (
+        "- `type`: controlled vocabulary: `standard`, `decision`.\n"
+        "...\n"
+        "   - `type`: one of `standard`, `decision`\n"
+    )
+    # Second occurrence has no terminating period at all before EOF; give it
+    # one so both occurrences parse (mirrors the real SPEC.md fix).
+    text = text.rstrip("\n") + ".\n"
+    occurrences = _extract_enum_occurrences(text, field="type")
+    assert len(occurrences) == 2
+    assert occurrences[0][1] == {"standard", "decision"}
+    assert occurrences[1][1] == {"standard", "decision"}
+
+
+def test_extract_enum_raises_when_marker_absent() -> None:
+    with pytest.raises(ParseError, match="no '`type`:' marker found"):
+        _extract_enum_occurrences("nothing relevant here", field="type")
+
+
+def test_extract_enum_raises_when_no_values_follow() -> None:
+    with pytest.raises(ParseError, match="no backtick-quoted values followed"):
+        _extract_enum_occurrences("`type`: nothing quoted here.\n", field="type")
+
+
+def test_extract_enum_raises_when_no_sentence_end() -> None:
+    with pytest.raises(ParseError, match="no sentence-ending"):
+        _extract_enum_occurrences("`type`: one of `standard`, `decision`", field="type")
+
+
+# --- _extract_reserved --------------------------------------------------------
+
+
+def test_extract_reserved() -> None:
+    text = (
+        "**Reserved filenames.** The filenames `index.md`, `log.md`, and "
+        "`template.md` are reserved in every directory. More prose.\n"
+    )
+    line_no, values = _extract_reserved(text)
+    assert line_no == 1
+    assert values == {"index.md", "log.md", "template.md"}
+
+
+def test_extract_reserved_raises_when_sentence_absent() -> None:
+    with pytest.raises(ParseError, match="no 'Reserved filenames.' sentence found"):
+        _extract_reserved("no mention of reserved anything here.\n")
+
+
+# --- _diff_message -------------------------------------------------------------
+
+
+def test_diff_message_none_when_in_sync() -> None:
+    msg = _diff_message(
+        source="SPEC.md", field="type", line_no=1,
+        extracted={"a", "b"}, canonical={"a", "b"},
+    )
+    assert msg is None
+
+
+def test_diff_message_reports_missing_and_extra() -> None:
+    msg = _diff_message(
+        source="SPEC.md", field="type", line_no=42,
+        extracted={"a", "c"}, canonical={"a", "b"},
+    )
+    assert msg is not None
+    assert "SPEC.md:42" in msg
+    assert "'b'" in msg  # missing from doc
+    assert "'c'" in msg  # stale in doc
+
+
+# --- check_doc_consistency (end-to-end against a scratch root) --------------
+
+
+def _write_bundle(tmp_path: Path, *, spec_type_line: str, adoption_type_line: str) -> Path:
+    (tmp_path / "docs").mkdir()
+    (tmp_path / "SPEC.md").write_text(
+        "## 4.2 Governance extensions\n\n"
+        f"- {spec_type_line}\n"
+        "- `status`: lifecycle state: `draft`, `active`, `deprecated`, `superseded`, "
+        "`proposed`, `accepted`, `rejected`. More prose.\n\n"
+        "**Reserved filenames.** The filenames `index.md`, `log.md`, and "
+        "`template.md` are reserved in every directory. More prose.\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "docs" / "adoption.md").write_text(
+        f"- {adoption_type_line}\n"
+        "- `status`: one of `draft`, `active`, `deprecated`, `superseded`,\n"
+        "  `proposed`, `accepted`, `rejected`.\n",
+        encoding="utf-8",
+    )
+    return tmp_path
+
+
+_IN_SYNC_TYPE_LINE = (
+    "`type`: controlled vocabulary: `standard`, `decision`, `workflow`, "
+    "`project`, `memory`, `reference`. Unknown values are an error."
+)
+
+
+def test_check_doc_consistency_passes_when_in_sync(tmp_path: Path) -> None:
+    _write_bundle(
+        tmp_path,
+        spec_type_line=_IN_SYNC_TYPE_LINE,
+        adoption_type_line=(
+            "`type`: one of `standard`, `decision`, `workflow`, `project`, "
+            "`memory`, `reference`."
+        ),
+    )
+    assert check_doc_consistency(tmp_path) == []
+
+
+def test_check_doc_consistency_detects_drift_in_spec(tmp_path: Path) -> None:
+    _write_bundle(
+        tmp_path,
+        # Drops 'reference', adds a stale 'obsolete-type'.
+        spec_type_line=(
+            "`type`: controlled vocabulary: `standard`, `decision`, `workflow`, "
+            "`project`, `memory`, `obsolete-type`. Unknown values are an error."
+        ),
+        adoption_type_line=(
+            "`type`: one of `standard`, `decision`, `workflow`, `project`, "
+            "`memory`, `reference`."
+        ),
+    )
+    errors = check_doc_consistency(tmp_path)
+    assert len(errors) == 1
+    assert "SPEC.md" in errors[0]
+    assert "'reference'" in errors[0]
+    assert "'obsolete-type'" in errors[0]
+
+
+def test_check_doc_consistency_detects_drift_in_adoption_doc(tmp_path: Path) -> None:
+    _write_bundle(
+        tmp_path,
+        spec_type_line=_IN_SYNC_TYPE_LINE,
+        # adoption.md forgot to add 'memory' when it was introduced.
+        adoption_type_line=(
+            "`type`: one of `standard`, `decision`, `workflow`, `project`, "
+            "`reference`."
+        ),
+    )
+    errors = check_doc_consistency(tmp_path)
+    assert len(errors) == 1
+    assert "docs/adoption.md" in errors[0]
+    assert "'memory'" in errors[0]
+
+
+def test_check_doc_consistency_detects_reserved_drift(tmp_path: Path) -> None:
+    _write_bundle(tmp_path, spec_type_line=_IN_SYNC_TYPE_LINE, adoption_type_line=(
+        "`type`: one of `standard`, `decision`, `workflow`, `project`, "
+        "`memory`, `reference`."
+    ))
+    spec_path = tmp_path / "SPEC.md"
+    text = spec_path.read_text(encoding="utf-8")
+    # Drop template.md from the reserved-filename sentence.
+    text = text.replace(
+        "The filenames `index.md`, `log.md`, and `template.md` are reserved",
+        "The filenames `index.md`, `log.md` are reserved",
+    )
+    spec_path.write_text(text, encoding="utf-8")
+
+    errors = check_doc_consistency(tmp_path)
+    assert len(errors) == 1
+    assert "RESERVED" in errors[0]
+    assert "'template.md'" in errors[0]
+
+
+def test_check_doc_consistency_reports_parse_error_without_crashing(tmp_path: Path) -> None:
+    (tmp_path / "docs").mkdir()
+    (tmp_path / "SPEC.md").write_text("nothing relevant in this file.\n", encoding="utf-8")
+    (tmp_path / "docs" / "adoption.md").write_text("also nothing relevant.\n", encoding="utf-8")
+
+    errors = check_doc_consistency(tmp_path)
+    # Every check should fail to parse (both files, both fields, plus
+    # reserved), but the function must return messages, not raise.
+    assert len(errors) >= 4
+    assert all("no '" in e or "marker found" in e or "sentence found" in e for e in errors)
+
+
+def test_check_doc_consistency_real_repo_docs_are_in_sync() -> None:
+    """The actual SPEC.md / docs/adoption.md in this repo must pass today.
+
+    This is the guard's own dogfood check: if this test fails, either the
+    real docs have drifted (fix the docs) or the parser broke on real
+    formatting (fix the parser) — either way CI should have caught it.
+    """
+    repo_root = Path(__file__).resolve().parent.parent
+    assert check_doc_consistency(repo_root) == []

--- a/tests/test_okf_minimal_fields.py
+++ b/tests/test_okf_minimal_fields.py
@@ -1,0 +1,61 @@
+"""Structural assertion of OKF's minimal required fields on example-bundle.
+
+Context (see WHY.md "How this relates to OKF" and the tracking issue linked
+from README.md / SPEC.md section 11): data-olympus claims to be an
+OKF-compatible profile, but has no executable conformance suite against the
+real OKF reference tooling. That is a genuine gap and this test does not
+close it.
+
+What this test DOES prove: every concept document in example-bundle carries
+non-empty `id` and `type` values (OKF's per-document minimal fields), and the
+bundle-root index.md declares an `okf_version`, both structurally, by reading
+the actual frontmatter rather than trusting documentation prose.
+
+What this test does NOT prove:
+- That an OKF reference consumer can actually parse and accept this bundle.
+- That `type` values used here are within whatever vocabulary (if any) the
+  real OKF spec expects at the wire level (data-olympus's `type` vocabulary is
+  its own controlled extension; OKF is documented as leaving `type` open).
+- Anything about OKF's `spec_version` field specifically: data-olympus splits
+  this into two bundle-root fields (`spec_version` for this format,
+  `okf_version` for the OKF target), a data-olympus-specific convention, not
+  a directly-checked OKF field.
+- Round-trip fidelity, link resolution, or any behavioral conformance.
+
+This is a cheap structural floor, not a conformance test. See the tracking
+issue for the real conformance check against OKF reference tooling.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from data_olympus.format import discover_bundle_files
+from data_olympus.format.frontmatter import parse_frontmatter
+
+_BUNDLE_ROOT = Path(__file__).resolve().parent.parent / "example-bundle"
+
+
+def test_every_concept_doc_has_nonempty_id_and_type() -> None:
+    files = discover_bundle_files(_BUNDLE_ROOT)
+    assert files, "example-bundle must have concept files to make this assertion meaningful"
+    missing: list[str] = []
+    for path in files:
+        fm, _body = parse_frontmatter(path.read_text(encoding="utf-8"))
+        doc_id = fm.get("id")
+        doc_type = fm.get("type")
+        if not (isinstance(doc_id, str) and doc_id.strip()):
+            missing.append(f"{path.relative_to(_BUNDLE_ROOT)}: missing/empty id")
+        if not (isinstance(doc_type, str) and doc_type.strip()):
+            missing.append(f"{path.relative_to(_BUNDLE_ROOT)}: missing/empty type")
+    assert not missing, "\n".join(missing)
+
+
+def test_bundle_root_index_declares_okf_version() -> None:
+    root_index = _BUNDLE_ROOT / "index.md"
+    fm, _body = parse_frontmatter(root_index.read_text(encoding="utf-8"))
+    okf_version = fm.get("okf_version")
+    assert isinstance(okf_version, str) and okf_version.strip(), (
+        "example-bundle/index.md must declare a non-empty okf_version "
+        "(the OKF spec version this bundle targets) for the OKF-compatibility "
+        "claim to have even a structural floor"
+    )


### PR DESCRIPTION
## Summary

WP4c of the 0.3.0 release program: make the format's differentiators specified, demonstrated, and CI-guarded. Builds on PR #76 (spec truthfulness) and PR #80 (`in_force`/`abstain` search modes); does not revert either.

- **Specify `applies_when`** in SPEC.md as a recommended frontmatter field (list of trigger phrases), matching what the code actually does: it is the highest-weight indexed field in `Index.search` (tied with `title`, ahead of `description`/body), and one of the three discriminating columns for the `abstain` signal gate (`search_gate.SIGNAL_COLUMNS`). Documented honestly — unlike `tags`, a malformed `applies_when` produces no `kb lint` warning today. `docs/adoption.md` gained a matching authoring section.
- **Upgraded `example-bundle/`** to demonstrate the remaining differentiators: a real supersession pair (`STD-U-003` `status: superseded`/`superseded_by: STD-U-004`, replaced by `STD-U-004` `status: active`/`supersedes: STD-U-003`), a `memory` document and a `reference` document (the two concept types the bundle previously lacked), and `applies_when` on three standards. All `index.md` files updated; bundle lints zero-error (13 docs).
- **Quickstart lifecycle demo**: `docs/quickstart.md` gained a verified section showing default search (soft status rerank — the active `STD-U-004` outranks the superseded `STD-U-003` it replaced, both still returned) vs `in_force=true` (hard filter — `STD-U-003` excluded from the result set entirely), run against the actual local server and the upgraded bundle.
- **CI doc-consistency guard**: `scripts/check_doc_consistency.py`, wired as a new `doc-consistency-guard` CI job. Fails when the `type`/`status`/`tier` enums restated in SPEC.md or `docs/adoption.md` drift from `format/validate.py`'s canonical `TYPES`/`STATUSES`/`TIERS`, or when SPEC.md's reserved-filename list drifts from `validate.RESERVED`. Checks every restatement (SPEC.md states `type`/`status` twice; both are checked). Tolerant of reordering, rewrapped lines, and an Oxford "or"; brittle-to-format-drift verified against a scratch fixture, not just the real docs.
- **OKF claim honesty**: README.md, SPEC.md, WHY.md, and `docs/comparison.md` claimed "OKF-compatible" / "any OKF consumer can read a data-olympus bundle unchanged" with zero executable backing. Reworded the strongest claims to "designed to be readable by OKF consumers" (backed by real shared structure — directory layout, frontmatter conventions, reserved filenames, link model), filed [issue #82](https://github.com/knaisoma/data-olympus/issues/82) to track a real conformance check against OKF reference tooling, and added a cheap **structural** (not behavioral) floor: `tests/test_okf_minimal_fields.py` asserts every example-bundle doc has non-empty `id`/`type` and the bundle-root index declares `okf_version`. The module docstring states exactly what this does and does not prove.

## Test evidence

```
$ uv run ruff check .
All checks passed!

$ uv run mypy src
Success: no issues found in 50 source files

$ uv run pytest -q
...
SKIPPED [1] tests/test_bench_methods.py:69: could not import 'sentence_transformers' (pre-existing, unrelated)
(all other tests pass)

$ bats -r tests
66 passed, 0 failed

$ uv run data-olympus lint example-bundle
0 errors across 0 files (13 linted)

$ uv run python3 scripts/check_doc_consistency.py
doc consistency guard: ok

$ python3 scripts/check_changelog.py <staged files>
changelog guard: ok
```

Quickstart demo commands verified against a real locally-running server (`scripts/run-local.sh` flow) on the upgraded bundle:

```
$ curl -fsS "http://localhost:8080/api/v1/search?q=commit%20format&limit=5"
# top 2 hits: STD-U-004 (active) then STD-U-003 (superseded) — both present

$ curl -fsS "http://localhost:8080/api/v1/search?q=commit%20format&limit=5&in_force=true"
# STD-U-003 absent entirely
```

## Peer review (codex)

Ran `codex exec --sandbox read-only` against `origin/release/0.3.0...HEAD`. Verdict: **no Blockers**, two Concerns, both fixed in the follow-up commit:

- Concern: `check_doc_consistency.py` didn't check the `tier` enum even though it's a required controlled vocabulary in code and docs → fixed, `TIERS` now checked in both SPEC.md and docs/adoption.md, with a regression test.
- Concern: WHY.md's lifecycle paragraph read as if default search always excludes a superseded document, when it actually only downranks it (superseded doc still returned); `in_force=true` is the hard exclude → reworded to state both behaviors precisely, matching the quickstart demo.

Codex independently verified (its own commands, not trusted from me): `applies_when` doc/code match, example-bundle lints clean, `check_doc_consistency.py` runs clean, quickstart REST params (`q`/`limit`/`in_force`) are real, and the OKF rewording is "materially honest."

## New issue

[#82](https://github.com/knaisoma/data-olympus/issues/82): Add executable OKF conformance check against reference tooling.

## Test plan

- [x] CHANGELOG.md updated; `check_changelog.py` passes
- [x] Full test suite (pytest + bats) green
- [x] `ruff check .` and `mypy src` clean
- [x] `data-olympus lint example-bundle` zero-error
- [x] New `doc-consistency-guard` CI job passes locally
- [x] Quickstart demo commands verified against a live local server
- [x] Codex peer review completed, Concerns addressed