### PR TITLE
fix(onboarding): partial-state bootstrap, double-bootstrap guard, atomic pending bundles, safe remote-url injection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -251,10 +251,12 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   - **`partial` is no longer a dead end.** `kb_bootstrap_project` accepted only
     `absent` and rejected `partial` with `rejected_already_onboarded`, contradicting
     the playbook that told the agent to bootstrap on `absent` OR `partial`. It now
-    proceeds on `partial`, narrowing the request to only the `missing_files` the
-    status reports so an already-committed file is never overwritten; if nothing
-    supplied fills a gap it rejects truthfully rather than committing an empty
-    change. The playbook text now matches this behaviour.
+    proceeds on `partial`, narrowing the request to only the exact
+    `missing_files` paths under this workspace/component so an already-committed
+    file is never overwritten and a basename collision cannot smuggle in a write
+    to a different project or component; if nothing supplied fills a gap it
+    rejects truthfully rather than committing an empty change. The playbook text
+    now matches this behaviour.
   - **Double-bootstrap race closed.** A committed bootstrap is invisible to the
     index until it is pushed and re-pulled, so a second call in that convergence
     window passed the `absent` re-check and double-committed. A short-lived,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -246,6 +246,35 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
     `Index.malformed_frontmatter_count` and the `malformed_frontmatter` field in
     `health()`. (Wiring this count into the `/health` degraded signal is a
     tracked follow-up.)
+- Onboarding pipeline (`tools_onboarding.py`, issue WP3b). Four coherence and
+  atomicity fixes, each with regression tests:
+  - **`partial` is no longer a dead end.** `kb_bootstrap_project` accepted only
+    `absent` and rejected `partial` with `rejected_already_onboarded`, contradicting
+    the playbook that told the agent to bootstrap on `absent` OR `partial`. It now
+    proceeds on `partial`, narrowing the request to only the `missing_files` the
+    status reports so an already-committed file is never overwritten; if nothing
+    supplied fills a gap it rejects truthfully rather than committing an empty
+    change. The playbook text now matches this behaviour.
+  - **Double-bootstrap race closed.** A committed bootstrap is invisible to the
+    index until it is pushed and re-pulled, so a second call in that convergence
+    window passed the `absent` re-check and double-committed. A short-lived,
+    self-expiring in-flight marker (`onboarding_inflight.py`) is now claimed on the
+    committed path and rejects a concurrent bootstrap for the same
+    workspace/component as `rejected_already_in_progress`. The playbook now
+    instructs waiting for `kb_onboarding_status` to report `onboarded` before
+    running `kb_cleanup_plan`.
+  - **Pending bundle is now atomic.** In the low-confidence path a `PathLockBusyError`
+    was silently swallowed per file, so a partially-enqueued bundle returned
+    `pending_confirmation` with only the subset that fit. Lock-busy is now treated
+    like queue-full: the whole bundle rolls back (zero orphan pending entries or
+    held locks) and rejects as `rejected_path_locked`. Every entry of a bundle is
+    stamped with a shared `bundle_id` in its metadata (the seam for a future
+    bundle-aware resolve UX).
+  - **Safe remote-URL injection confirmed.** The `git_remote_url` front-matter
+    injection parses and re-serializes YAML with `yaml.safe_dump` (a newline-laden
+    URL cannot forge keys) and its presence check is key-aware, so a URL mentioned
+    only in the body no longer false-positives and suppresses injection. Regression
+    tests lock both behaviours in.
 - OpenCode gate (`data-olympus-gate.ts`): resolves the workspace to the main git
   worktree **basename** (matching the key every other surface records consults
   under) instead of the raw absolute path, which could never match; and passes

--- a/src/data_olympus/onboarding_inflight.py
+++ b/src/data_olympus/onboarding_inflight.py
@@ -1,0 +1,104 @@
+"""Server-side in-flight guard for onboarding bootstrap (item 2).
+
+A committed bootstrap is only reflected in the index after the push queue
+drains and the next pull rebuilds it. During that convergence window
+``kb_onboarding_status`` still reports ``absent`` for the just-bootstrapped
+workspace, so a second ``kb_bootstrap_project`` call (a retry, a concurrent
+agent, a double-click) passes the ``state == absent`` re-check and double-commits.
+
+This module records a short-lived, workspace+component-keyed marker on disk the
+moment a bootstrap is admitted. A second bootstrap for the same key inside the
+window is rejected as ``already_in_progress``. The marker is a plain file with an
+embedded expiry so a crashed process cannot wedge a workspace forever: a claim
+whose recorded expiry is in the past is treated as free and reclaimed.
+
+The store lives on the same durable state volume as the pending queue, so it
+survives a normal restart (the convergence window is the same order of
+magnitude as a restart) yet self-heals via the TTL.
+"""
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import json
+import os
+import time
+
+_DEFAULT_TTL_SECONDS = 900.0  # convergence window: commit -> push -> pull -> reindex
+
+
+def _marker_filename(workspace: str, component: str | None) -> str:
+    key = f"{workspace}\x00{component or ''}"
+    return hashlib.sha256(key.encode("utf-8")).hexdigest() + ".inflight"
+
+
+class BootstrapInFlight:
+    """Filesystem-backed set of workspaces with a bootstrap in the convergence
+    window. Claims are atomic (O_CREAT|O_EXCL) and self-expiring."""
+
+    def __init__(self, root: str, *, ttl_seconds: float = _DEFAULT_TTL_SECONDS) -> None:
+        self._root = root
+        self._ttl = ttl_seconds
+        # The marker directory is created lazily on first claim, not here, so
+        # merely constructing the guard never touches the filesystem. This keeps
+        # the guard cheap on the reject-before-side-effect paths and avoids an
+        # eager mkdir against a not-yet-provisioned (or, in tests, read-only)
+        # state volume.
+
+    def _path(self, workspace: str, component: str | None) -> str:
+        return os.path.join(self._root, _marker_filename(workspace, component))
+
+    def _is_expired(self, path: str) -> bool:
+        """True if the marker at ``path`` is missing or past its recorded expiry."""
+        try:
+            with open(path) as f:
+                data = json.load(f)
+        except (FileNotFoundError, ValueError, json.JSONDecodeError):
+            # Missing, or an unreadable/half-written marker: treat as free so a
+            # corrupt file cannot wedge a workspace.
+            return True
+        expires_at = data.get("expires_at")
+        if not isinstance(expires_at, (int, float)):
+            return True
+        return time.time() >= expires_at
+
+    def claim(self, workspace: str, component: str | None) -> bool:
+        """Atomically claim the bootstrap slot for (workspace, component).
+
+        Returns True if this caller now holds the slot (proceed with bootstrap),
+        False if another live claim already holds it (reject as in-progress).
+        A claim whose recorded expiry has passed is reclaimed transparently.
+        """
+        os.makedirs(self._root, exist_ok=True)
+        path = self._path(workspace, component)
+        now = time.time()
+        payload = json.dumps({
+            "workspace": workspace,
+            "component": component,
+            "claimed_at": now,
+            "expires_at": now + self._ttl,
+        })
+        try:
+            fd = os.open(path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+        except FileExistsError:
+            # A marker exists. If it has expired, reclaim it; a still-live claim
+            # means a bootstrap for this key is genuinely in flight.
+            if not self._is_expired(path):
+                return False
+            # Reclaim: overwrite the stale marker in place. os.O_TRUNC is safe
+            # here because we only reach this branch for an expired claim.
+            try:
+                fd = os.open(path, os.O_CREAT | os.O_TRUNC | os.O_WRONLY, 0o600)
+            except OSError:
+                return False
+        with os.fdopen(fd, "w") as f:
+            f.write(payload)
+        return True
+
+    def release(self, workspace: str, component: str | None) -> None:
+        """Drop the in-flight marker (best effort). Called on the failure paths
+        where a claim was taken but the bootstrap never actually committed, so a
+        retry is not blocked for the full TTL."""
+        path = self._path(workspace, component)
+        with contextlib.suppress(FileNotFoundError):
+            os.unlink(path)

--- a/src/data_olympus/onboarding_inflight.py
+++ b/src/data_olympus/onboarding_inflight.py
@@ -71,29 +71,41 @@ class BootstrapInFlight:
         """
         os.makedirs(self._root, exist_ok=True)
         path = self._path(workspace, component)
-        now = time.time()
-        payload = json.dumps({
-            "workspace": workspace,
-            "component": component,
-            "claimed_at": now,
-            "expires_at": now + self._ttl,
-        })
-        try:
-            fd = os.open(path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
-        except FileExistsError:
-            # A marker exists. If it has expired, reclaim it; a still-live claim
-            # means a bootstrap for this key is genuinely in flight.
-            if not self._is_expired(path):
-                return False
-            # Reclaim: overwrite the stale marker in place. os.O_TRUNC is safe
-            # here because we only reach this branch for an expired claim.
+
+        def _payload() -> str:
+            now = time.time()
+            return json.dumps({
+                "workspace": workspace,
+                "component": component,
+                "claimed_at": now,
+                "expires_at": now + self._ttl,
+            })
+
+        # Reclaim of an expired marker must stay a single-winner operation: an
+        # in-place O_TRUNC overwrite lets two callers that both observe the stale
+        # marker both "succeed", reopening the double-bootstrap race the guard
+        # exists to close (codex Concern). Instead, unlink the expired marker and
+        # re-race the exclusive create; only one O_CREAT|O_EXCL can win. Bounded
+        # retry so a pathological churn cannot spin forever.
+        for _ in range(3):
             try:
-                fd = os.open(path, os.O_CREAT | os.O_TRUNC | os.O_WRONLY, 0o600)
-            except OSError:
-                return False
-        with os.fdopen(fd, "w") as f:
-            f.write(payload)
-        return True
+                fd = os.open(path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+            except FileExistsError:
+                # A marker exists. A still-live claim means a bootstrap for this
+                # key is genuinely in flight; reject.
+                if not self._is_expired(path):
+                    return False
+                # Expired: drop it and retry the exclusive create. If another
+                # caller unlinked/recreated it first, the next iteration sees a
+                # fresh live marker and returns False.
+                with contextlib.suppress(FileNotFoundError):
+                    os.unlink(path)
+                continue
+            with os.fdopen(fd, "w") as f:
+                f.write(_payload())
+            return True
+        # Lost every reclaim race within the bound: treat as in-progress.
+        return False
 
     def release(self, workspace: str, component: str | None) -> None:
         """Drop the in-flight marker (best effort). Called on the failure paths

--- a/src/data_olympus/onboarding_inflight.py
+++ b/src/data_olympus/onboarding_inflight.py
@@ -81,31 +81,52 @@ class BootstrapInFlight:
                 "expires_at": now + self._ttl,
             })
 
-        # Reclaim of an expired marker must stay a single-winner operation: an
-        # in-place O_TRUNC overwrite lets two callers that both observe the stale
-        # marker both "succeed", reopening the double-bootstrap race the guard
-        # exists to close (codex Concern). Instead, unlink the expired marker and
-        # re-race the exclusive create; only one O_CREAT|O_EXCL can win. Bounded
-        # retry so a pathological churn cannot spin forever.
-        for _ in range(3):
-            try:
-                fd = os.open(path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
-            except FileExistsError:
-                # A marker exists. A still-live claim means a bootstrap for this
-                # key is genuinely in flight; reject.
-                if not self._is_expired(path):
-                    return False
-                # Expired: drop it and retry the exclusive create. If another
-                # caller unlinked/recreated it first, the next iteration sees a
-                # fresh live marker and returns False.
-                with contextlib.suppress(FileNotFoundError):
-                    os.unlink(path)
-                continue
+        # Fast path: create the marker exclusively. If it does not yet exist, this
+        # single O_CREAT|O_EXCL is the whole claim and is inherently single-winner.
+        try:
+            fd = os.open(path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+        except FileExistsError:
+            pass
+        else:
             with os.fdopen(fd, "w") as f:
                 f.write(_payload())
             return True
-        # Lost every reclaim race within the bound: treat as in-progress.
-        return False
+
+        # A marker exists. A still-live claim means a bootstrap for this key is
+        # genuinely in flight; reject without touching it.
+        if not self._is_expired(path):
+            return False
+
+        # The marker is expired and must be reclaimed. Reclaim must be a
+        # single-winner operation, otherwise two callers that both observe the
+        # stale marker could each unlink+recreate and both return True, reopening
+        # the double-bootstrap race the guard exists to close (codex Concern). A
+        # blind unlink is itself racy: a slow contender could delete the fresh
+        # marker a fast contender just wrote. So we gate the whole reclaim critical
+        # section behind an exclusive reclaim-lock: only the caller that creates
+        # the lock re-checks expiry, unlinks the stale marker, writes a fresh one,
+        # and drops the lock. Contenders that cannot take the lock reject.
+        reclaim_lock = path + ".reclaim"
+        try:
+            lock_fd = os.open(reclaim_lock, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+        except FileExistsError:
+            # Another caller is already reclaiming this slot; treat as in-progress.
+            return False
+        try:
+            os.close(lock_fd)
+            # Re-check under the lock: a winner may have already reclaimed and
+            # written a fresh, live marker between our expiry check and the lock.
+            if not self._is_expired(path):
+                return False
+            with contextlib.suppress(FileNotFoundError):
+                os.unlink(path)
+            fd = os.open(path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+            with os.fdopen(fd, "w") as f:
+                f.write(_payload())
+            return True
+        finally:
+            with contextlib.suppress(FileNotFoundError):
+                os.unlink(reclaim_lock)
 
     def release(self, workspace: str, component: str | None) -> None:
         """Drop the in-flight marker (best effort). Called on the failure paths

--- a/src/data_olympus/onboarding_playbook.py
+++ b/src/data_olympus/onboarding_playbook.py
@@ -15,12 +15,21 @@ Ask only what imported files do not answer. Map answers to canonical files:
 """
 
 _CLEANUP = """\
-After bootstrap, call kb_cleanup_plan with the local doc files. Present the plan
-per file (default to the recommended action). For imported_duplicate items, apply
-the supplied thin-pointer text to the project repo with your own edit tool and
-leave the changes staged for the human to commit. Show partial_overlap items for
-manual review; leave unique files untouched. The server never edits the project
-repo.
+Before cleanup, wait for the bootstrap to converge. A committed bootstrap is not
+visible to the index until it is pushed and re-pulled, so poll kb_onboarding_status
+until it reports 'onboarded' (or watch kb_health advance past the bootstrap commit)
+BEFORE calling kb_cleanup_plan. Running cleanup against a not-yet-converged index
+classifies the just-bootstrapped files as unique and produces a wrong plan.
+
+Then call kb_cleanup_plan with the local doc files. Present the plan per file
+(default to the recommended action). For imported_duplicate items, apply the
+supplied thin-pointer text to the project repo with your own edit tool and leave
+the changes staged for the human to commit. Show partial_overlap items for manual
+review; leave unique files untouched. The server never edits the project repo.
+
+Do not re-run kb_bootstrap_project while a prior bootstrap for the same workspace
+is still converging: the server holds a short-lived in-flight guard and rejects a
+second call with rejected_already_in_progress until the window elapses.
 """
 
 _DISPATCH = """\
@@ -38,11 +47,15 @@ _PROJECT = """\
 # Onboarding project: {workspace}
 
 1. Confirm kb_onboarding_status(workspace={workspace!r}) is 'absent' or 'partial'.
+   'absent' bootstraps every canonical file; 'partial' completes an existing
+   project by committing ONLY the missing_files the status reports (an already
+   present file is never overwritten). If it is already 'onboarded', stop.
 2. Inventory local docs (README.md, AGENTS.md, CLAUDE.md, .rules/, docs/).
 {interview}
 3. Assemble imported files + interview answers and call kb_bootstrap_project
    (workspace={workspace!r}, workspace_remote_url={workspace_remote_url!r}). One
-   atomic commit on high confidence, else one pending bundle.
+   atomic commit on high confidence, else one pending bundle. On 'partial' you
+   may supply the full set; the server narrows it to the missing files.
 {cleanup}
 """
 
@@ -52,7 +65,9 @@ _COMPONENT = """\
 1. Read the parent project's AGENTS.md first (kb_get projects-{workspace}-AGENTS)
    to inherit its conventions and lessons; only ask for component-specific deltas.
 2. Confirm kb_onboarding_status(workspace={workspace!r}, component={component!r})
-   is 'absent' or 'partial'.
+   is 'absent' or 'partial'. 'partial' completes the component by committing ONLY
+   the missing_files reported; existing files are never overwritten. Stop if it is
+   already 'onboarded'.
 {interview}
 3. Call kb_bootstrap_project(workspace={workspace!r}, component={component!r},
    component_remote_url={component_remote_url!r}).

--- a/src/data_olympus/tools_onboarding.py
+++ b/src/data_olympus/tools_onboarding.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import contextlib
 import math
+import os
 from typing import TYPE_CHECKING
 
 from data_olympus.models import (
@@ -13,15 +14,30 @@ from data_olympus.models import (
     RenameCandidateModel,
 )
 from data_olympus.onboarding import compute_status
+from data_olympus.onboarding_inflight import BootstrapInFlight
 
 if TYPE_CHECKING:
     from data_olympus.audit_log import AuditLog
     from data_olympus.auth import PathBlocklist
     from data_olympus.index import Index
+    from data_olympus.onboarding import OnboardingStatus
     from data_olympus.pending import PendingQueue
     from data_olympus.push_queue import PushQueue
     from data_olympus.rate_limit import SlidingWindowLimiter
     from data_olympus.worktrees import WorktreeRegistry
+
+
+def _pending_root(pending: PendingQueue) -> str:
+    """Best-effort read of the pending queue's on-disk root.
+
+    SEAM: PendingQueue has no public root accessor (module owned by a concurrent
+    Wave-1 package). We read the private ._root; if that ever disappears we fall
+    back to KB_PENDING_ROOT (the same env config.py reads) so the in-flight guard
+    still lands on the state volume rather than crashing."""
+    root = getattr(pending, "_root", None)
+    if isinstance(root, str):
+        return root
+    return os.getenv("KB_PENDING_ROOT", "/state/pending")
 
 
 def kb_onboarding_status_fn(
@@ -78,23 +94,137 @@ def kb_bootstrap_project_fn(
     can_auto_commit: bool = True,
     max_postimage_bytes: int = 0,
     max_files: int = 0,
+    in_flight: BootstrapInFlight | None = None,
 ) -> BootstrapResponse:
-    """Bootstrap a new workspace/component. Only callable when status=absent.
+    """Bootstrap a new workspace/component. Callable when status is ``absent`` or
+    ``partial``.
+
+    On ``absent`` all supplied files are written. On ``partial`` (some but not all
+    canonical files present) the request is narrowed to only the ``missing_files``
+    the status reports, so an in-progress onboarding can be completed without ever
+    overwriting a file already committed (item 1).
 
     Atomic outcome: ONE commit (high-conf) or ONE pending bundle (low-conf).
+
+    A committed bootstrap is not visible to ``compute_status`` until the push
+    queue drains and the index is rebuilt. To stop a second bootstrap
+    double-committing during that convergence window, an in-flight marker is
+    claimed once the request is admitted and held across a committed outcome
+    (item 2); the marker self-expires so a crash cannot wedge the workspace.
     """
-    # Server-side re-check that status is absent.
+    # Server-side re-check that status is absent OR partial. `partial` is a valid
+    # entry point: it means the workspace exists in the KB but is missing some
+    # canonical file(s), and this bootstrap completes it (item 1).
     s = compute_status(
         workspace=workspace, component=component,
         workspace_remote_url=workspace_remote_url,
         component_remote_url=component_remote_url,
         idx=idx,
     )
-    if s.state != "absent":
+    if s.state not in ("absent", "partial"):
         return BootstrapResponse(
             status="rejected_already_onboarded",
             rejected_paths=[],
         )
+
+    # Lazily materialize the in-flight guard on the same durable state volume as
+    # the pending queue, unless the caller injected one (tests). Both entry points
+    # (MCP tool, REST route) run in one process and share one PendingQueue, so a
+    # filesystem marker beside the pending root is a process-wide guard without
+    # threading a new argument through the off-limits server.py / rest_api.py
+    # wiring. SEAM: PendingQueue exposes no public root accessor yet, so we read
+    # its ._root. A one-line public `root` property on the Wave-1-owned pending
+    # module would let us drop this; flagged in the PR body.
+    if in_flight is None:
+        in_flight = BootstrapInFlight(
+            os.path.join(os.path.dirname(_pending_root(pending)), "bootstrap-inflight"),
+        )
+    # Claim the slot for this workspace/component. A live claim (a bootstrap
+    # already in the convergence window) rejects this one as in-progress and
+    # closes the double-bootstrap race the absent-recheck cannot (item 2).
+    if not in_flight.claim(workspace, component):
+        return BootstrapResponse(
+            status="rejected_already_in_progress",
+            rejected_paths=[f["target_path"] for f in files],
+        )
+    # From here on, any outcome that did NOT commit must release the claim so a
+    # legitimate retry is not blocked for the full TTL. Only a committed outcome
+    # holds the claim across the convergence window.
+    resp = _bootstrap_admitted(
+        status_obj=s,
+        workspace=workspace, component=component,
+        workspace_remote_url=workspace_remote_url,
+        component_remote_url=component_remote_url,
+        files=files, source_session=source_session,
+        agent_identity=agent_identity, confidence=confidence,
+        confidence_threshold=confidence_threshold,
+        worktrees=worktrees, push_queue=push_queue, pending=pending,
+        rate_limiter=rate_limiter, blocklist=blocklist,
+        remote_addr=remote_addr, can_auto_commit=can_auto_commit,
+        max_postimage_bytes=max_postimage_bytes, max_files=max_files,
+    )
+    if resp.status != "committed":
+        in_flight.release(workspace, component)
+    return resp
+
+
+def _bootstrap_admitted(
+    *,
+    status_obj: OnboardingStatus,
+    workspace: str,
+    component: str | None,
+    workspace_remote_url: str | None,
+    component_remote_url: str | None,
+    files: list[dict[str, str]],
+    source_session: str,
+    agent_identity: str,
+    confidence: float,
+    confidence_threshold: float,
+    worktrees: WorktreeRegistry,
+    push_queue: PushQueue,
+    pending: PendingQueue,
+    rate_limiter: SlidingWindowLimiter,
+    blocklist: PathBlocklist,
+    remote_addr: str,
+    can_auto_commit: bool,
+    max_postimage_bytes: int,
+    max_files: int,
+) -> BootstrapResponse:
+    """Body of a bootstrap that passed the state re-check and won the in-flight
+    claim. Split out so the outer function owns the claim/release lifecycle and
+    this body owns validation, injection, and the commit/pending outcome.
+
+    On ``partial`` state, ``files`` is narrowed to only those whose canonical
+    basename is one of ``status_obj.missing_files`` so an existing committed file
+    is never overwritten (item 1)."""
+    from data_olympus.auth import (
+        is_writable_path,
+        normalize_target_path,
+        safe_join_under_root,
+    )
+    from data_olympus.index import _classify_by_path
+
+    # Partial state: keep only the files that fill a reported gap. A file that
+    # targets an already-present canonical name is dropped rather than overwriting
+    # the committed copy. missing_files holds bare canonical filenames
+    # (e.g. "AGENTS.md"); match on the canonical basename.
+    if status_obj.state == "partial":
+        missing = set(status_obj.missing_files)
+        kept: list[dict[str, str]] = []
+        for f in files:
+            canonical = normalize_target_path(f["target_path"])
+            basename = canonical.rsplit("/", 1)[-1] if canonical else ""
+            if basename in missing:
+                kept.append(f)
+        if not kept:
+            # Every supplied file targets an already-present path (or none maps to
+            # a gap): nothing to do. Report the completed state truthfully rather
+            # than committing an empty change.
+            return BootstrapResponse(
+                status="rejected_already_onboarded",
+                rejected_paths=[f["target_path"] for f in files],
+            )
+        files = kept
 
     # Aggregate file-count cap: one request must not enqueue/write an unbounded
     # number of (individually capped) files. Aggregate byte size is bounded by the
@@ -112,8 +242,6 @@ def kb_bootstrap_project_fn(
     # operate on the same value that passed validation (item 4). Without this a
     # backslash path like ``decisions\\x.md`` validated as ``decisions/x.md`` yet
     # committed a literal root-level backslash file outside every indexed prefix.
-    from data_olympus.auth import is_writable_path, normalize_target_path
-    from data_olympus.index import _classify_by_path
     rejected: list[str] = []
     canonical_files: list[dict[str, str]] = []
     for f in files:
@@ -158,11 +286,15 @@ def kb_bootstrap_project_fn(
 
     if confidence < confidence_threshold or not can_auto_commit:
         # Low confidence (or caller not authorized to auto-commit): enqueue ALL
-        # files as a single pending bundle.
-        # For onboarding v1, we enqueue them one-by-one (the pending queue
-        # supports per-file entries; resolving "all" is the operator's choice).
-        # Future: native bundle support in PendingQueue.
+        # files as a single pending bundle. The pending queue stores per-file
+        # entries; every entry of one bootstrap shares a `bundle_id` in its meta
+        # so the operator (and a future bundle-aware resolve UX) can treat them as
+        # a unit. Bundle-aware resolve itself is out of scope here; the id is the
+        # seam (item 3).
+        import uuid
+
         from data_olympus.pending import PathLockBusyError, PendingQueueFullError
+        bundle_id = uuid.uuid4().hex
         # Atomicity: a bootstrap is one bundle. Reject up front if the whole
         # bundle would not fit, so we never leave a partial set of pending entries.
         if pending.would_exceed(len(files)):
@@ -170,7 +302,16 @@ def kb_bootstrap_project_fn(
                 status="rejected_pending_queue_full",
                 rejected_paths=[f["target_path"] for f in files],
             )
-        pending_ids = []
+        pending_ids: list[str] = []
+
+        def _rollback() -> None:
+            # Roll back every entry this bundle already enqueued so a failed
+            # bootstrap leaves zero orphan pending entries or held path locks
+            # (reject() releases the lock and removes the entry).
+            for pid in pending_ids:
+                with contextlib.suppress(Exception):
+                    pending.reject(pid)
+
         for f in files:
             try:
                 pid = pending.enqueue(
@@ -182,18 +323,26 @@ def kb_bootstrap_project_fn(
                           "source_session": source_session,
                           "confidence": confidence,
                           "bootstrap": True,
+                          "bundle_id": bundle_id,
                           "workspace": workspace,
                           "component": component},
                 )
                 pending_ids.append(pid)
             except PathLockBusyError:
-                pass  # already pending; skip
+                # A path in this bundle is already locked by another pending
+                # entry, so the bundle cannot be enqueued whole. Treat this like
+                # the queue-full race: roll the whole bundle back and reject it,
+                # rather than silently returning only the subset that fit (item 3).
+                # Partial enqueue is not a valid onboarding outcome.
+                _rollback()
+                return BootstrapResponse(
+                    status="rejected_path_locked",
+                    rejected_paths=[f["target_path"] for f in files],
+                )
             except PendingQueueFullError:
                 # Lost a capacity race after the pre-check: roll back this bundle's
                 # enqueued entries so the bootstrap stays all-or-nothing.
-                for pid in pending_ids:
-                    with contextlib.suppress(Exception):
-                        pending.reject(pid)
+                _rollback()
                 return BootstrapResponse(
                     status="rejected_pending_queue_full",
                     rejected_paths=[f["target_path"] for f in files],
@@ -201,15 +350,16 @@ def kb_bootstrap_project_fn(
         return BootstrapResponse(
             status="pending_confirmation",
             pending_id=pending_ids[0] if pending_ids else None,
-            operator_prompt=f"Bootstrap of {workspace} pending; run `kb pending` to see entries.",
+            operator_prompt=(
+                f"Bootstrap of {workspace} pending ({len(pending_ids)} files, "
+                f"bundle {bundle_id}); run `kb pending` to see entries."
+            ),
         )
 
     # High confidence: one atomic commit with all files.
-    import os
     import subprocess
 
     from data_olympus.audit_trailers import build_commit_message
-    from data_olympus.auth import safe_join_under_root
     wt = worktrees.get_or_create(source_session=source_session, agent_identity=agent_identity)
     for f in files:
         # Shared symlink-escape containment guard (see safe_join_under_root).

--- a/src/data_olympus/tools_onboarding.py
+++ b/src/data_olympus/tools_onboarding.py
@@ -149,23 +149,31 @@ def kb_bootstrap_project_fn(
         )
     # From here on, any outcome that did NOT commit must release the claim so a
     # legitimate retry is not blocked for the full TTL. Only a committed outcome
-    # holds the claim across the convergence window.
-    resp = _bootstrap_admitted(
-        status_obj=s,
-        workspace=workspace, component=component,
-        workspace_remote_url=workspace_remote_url,
-        component_remote_url=component_remote_url,
-        files=files, source_session=source_session,
-        agent_identity=agent_identity, confidence=confidence,
-        confidence_threshold=confidence_threshold,
-        worktrees=worktrees, push_queue=push_queue, pending=pending,
-        rate_limiter=rate_limiter, blocklist=blocklist,
-        remote_addr=remote_addr, can_auto_commit=can_auto_commit,
-        max_postimage_bytes=max_postimage_bytes, max_files=max_files,
-    )
-    if resp.status != "committed":
-        in_flight.release(workspace, component)
-    return resp
+    # holds the claim across the convergence window. A pre-commit exception (git
+    # write / commit / push-queue enqueue failure) must also release, otherwise a
+    # crash mid-bootstrap would wedge the workspace as `already_in_progress` until
+    # the TTL even though nothing committed (codex Concern). The try/finally guards
+    # both the raised and the returned non-committed paths.
+    committed = False
+    try:
+        resp = _bootstrap_admitted(
+            status_obj=s,
+            workspace=workspace, component=component,
+            workspace_remote_url=workspace_remote_url,
+            component_remote_url=component_remote_url,
+            files=files, source_session=source_session,
+            agent_identity=agent_identity, confidence=confidence,
+            confidence_threshold=confidence_threshold,
+            worktrees=worktrees, push_queue=push_queue, pending=pending,
+            rate_limiter=rate_limiter, blocklist=blocklist,
+            remote_addr=remote_addr, can_auto_commit=can_auto_commit,
+            max_postimage_bytes=max_postimage_bytes, max_files=max_files,
+        )
+        committed = resp.status == "committed"
+        return resp
+    finally:
+        if not committed:
+            in_flight.release(workspace, component)
 
 
 def _bootstrap_admitted(
@@ -204,22 +212,30 @@ def _bootstrap_admitted(
     )
     from data_olympus.index import _classify_by_path
 
-    # Partial state: keep only the files that fill a reported gap. A file that
-    # targets an already-present canonical name is dropped rather than overwriting
-    # the committed copy. missing_files holds bare canonical filenames
-    # (e.g. "AGENTS.md"); match on the canonical basename.
+    # Partial state: keep only the files that fill a reported gap for THIS exact
+    # workspace/component. Match on the full canonical path, not the basename: a
+    # basename-only check ("AGENTS.md" in missing) would also admit
+    # `projects/other/AGENTS.md` or `projects/{ws}/components/{c}/AGENTS.md`,
+    # letting the onboarding endpoint overwrite a file in a different project or
+    # component (codex Blocker). missing_files holds bare canonical filenames; the
+    # allowed set is exactly those filenames under this workspace/component root.
     if status_obj.state == "partial":
-        missing = set(status_obj.missing_files)
+        base = (
+            f"projects/{workspace}/components/{component}/"
+            if component
+            else f"projects/{workspace}/"
+        )
+        allowed = {base + name for name in status_obj.missing_files}
         kept: list[dict[str, str]] = []
         for f in files:
             canonical = normalize_target_path(f["target_path"])
-            basename = canonical.rsplit("/", 1)[-1] if canonical else ""
-            if basename in missing:
+            if canonical in allowed:
                 kept.append(f)
         if not kept:
-            # Every supplied file targets an already-present path (or none maps to
-            # a gap): nothing to do. Report the completed state truthfully rather
-            # than committing an empty change.
+            # No supplied file fills a gap for this exact target (every file is
+            # already present, or targets a different project/component): nothing
+            # to do here. Report the completed state truthfully rather than
+            # committing an empty change or writing outside the intended gap.
             return BootstrapResponse(
                 status="rejected_already_onboarded",
                 rejected_paths=[f["target_path"] for f in files],

--- a/tests/test_tools_onboarding.py
+++ b/tests/test_tools_onboarding.py
@@ -274,6 +274,33 @@ def test_partial_bootstrap_nothing_missing_is_rejected(tmp_path) -> None:
     assert pending.size() == 0
 
 
+def test_partial_bootstrap_rejects_foreign_project_path(tmp_path) -> None:
+    """A partial bootstrap for workspace 'p' must not admit a file whose basename
+    matches a missing file but whose path belongs to a DIFFERENT project. The
+    filter is exact-path, not basename (codex Blocker)."""
+    idx = _partial_idx(["projects/p/README.md"])  # p is missing AGENTS.md
+    files = [
+        # Basename AGENTS.md matches the gap, but the path targets another project.
+        {"target_path": "projects/other/AGENTS.md", "postimage": "evil\n"},
+    ]
+    resp, pending = _bootstrap_low_conf(idx, files, tmp_path)
+    # Nothing fills the gap for THIS workspace -> rejected, nothing enqueued.
+    assert resp.status == "rejected_already_onboarded"
+    assert pending.size() == 0
+
+
+def test_partial_bootstrap_rejects_component_path_for_project_gap(tmp_path) -> None:
+    """A project-level (T3) partial gap must not be filled by a component-level
+    (T4) path that happens to share the basename (codex Blocker)."""
+    idx = _partial_idx(["projects/p/README.md"])  # project p missing AGENTS.md
+    files = [
+        {"target_path": "projects/p/components/c/AGENTS.md", "postimage": "x\n"},
+    ]
+    resp, pending = _bootstrap_low_conf(idx, files, tmp_path)
+    assert resp.status == "rejected_already_onboarded"
+    assert pending.size() == 0
+
+
 def test_absent_bootstrap_unchanged_writes_all_files(tmp_path) -> None:
     """Regression: the absent flow still enqueues every supplied file (item 1 did
     not narrow the absent path)."""
@@ -375,6 +402,50 @@ def test_expired_inflight_marker_allows_reclaim(tmp_path) -> None:
     assert guard.claim("p", None) is True
     # ttl -1 means the marker is already expired; a second claim reclaims it.
     assert guard.claim("p", None) is True
+
+
+def test_exception_before_commit_releases_claim(tmp_path) -> None:
+    """A pre-commit exception (e.g. worktree/git failure) must release the
+    in-flight claim so a legitimate retry is not blocked for the full TTL
+    (codex Concern)."""
+    from data_olympus.auth import PathBlocklist
+    from data_olympus.onboarding_inflight import BootstrapInFlight
+    from data_olympus.pending import PendingQueue
+    from data_olympus.rate_limit import SlidingWindowLimiter
+    idx = MagicMock()
+    idx.list_by_prefix.return_value = []  # absent
+    idx.list_with_remote_url.return_value = []
+    guard = BootstrapInFlight(str(tmp_path / "inflight"))
+    boom = MagicMock()
+    boom.get_or_create.side_effect = RuntimeError("git blew up")
+    with pytest.raises(RuntimeError):
+        kb_bootstrap_project_fn(
+            idx=idx, workspace="p", component=None,
+            workspace_remote_url=None, component_remote_url=None,
+            files=[{"target_path": "projects/p/README.md", "postimage": "r\n"}],
+            source_session="s", agent_identity="claude",
+            confidence=0.95, confidence_threshold=0.85,  # high -> commit path
+            worktrees=boom, push_queue=MagicMock(),
+            pending=PendingQueue(pending_root=str(tmp_path / "p")),
+            rate_limiter=SlidingWindowLimiter(max_per_hour=100),
+            blocklist=PathBlocklist(tier_blocks=[], path_blocks=[]),
+            in_flight=guard,
+        )
+    # The claim was released by the finally block; the slot is free for a retry.
+    assert guard.claim("p", None) is True
+
+
+def test_expired_marker_reclaim_is_single_winner(tmp_path) -> None:
+    """When a marker has expired, only one caller may reclaim it; a concurrent
+    reclaim of the same expired slot must not both succeed (codex Concern)."""
+    from data_olympus.onboarding_inflight import BootstrapInFlight
+    # ttl 0: the marker written by the first claim is immediately expired.
+    guard = BootstrapInFlight(str(tmp_path / "inflight"), ttl_seconds=0.0)
+    assert guard.claim("p", None) is True  # writes an already-expired marker
+    # A long-TTL guard on the SAME dir reclaims once and then locks out.
+    live = BootstrapInFlight(str(tmp_path / "inflight"), ttl_seconds=900.0)
+    assert live.claim("p", None) is True   # reclaims the expired slot
+    assert live.claim("p", None) is False  # now live -> second caller rejected
 
 
 def test_non_committed_bootstrap_releases_claim(tmp_path) -> None:

--- a/tests/test_tools_onboarding.py
+++ b/tests/test_tools_onboarding.py
@@ -1,12 +1,45 @@
 """Tests for kb_onboarding_status_fn + kb_bootstrap_project_fn."""
 from __future__ import annotations
 
+import subprocess
+from pathlib import Path
 from unittest.mock import MagicMock
+
+import pytest
 
 from data_olympus.tools_onboarding import (
     kb_bootstrap_project_fn,  # noqa: F401  used in later tasks; ensure import works
     kb_onboarding_status_fn,
 )
+
+
+def _partial_idx(present_paths: list[str]) -> MagicMock:
+    """An idx mock whose T3 workspace already contains ``present_paths`` (so a
+    canonical file that is NOT present makes compute_status report 'partial')."""
+    idx = MagicMock()
+    idx.list_by_prefix.return_value = [{"path": p} for p in present_paths]
+    idx.list_with_remote_url.return_value = []
+    return idx
+
+
+@pytest.fixture
+def real_worktrees(tmp_path, monkeypatch):
+    """A WorktreeRegistry over a real temp git repo, for exercising the
+    high-confidence commit path end to end."""
+    from data_olympus.git_ops import GitOps
+    from data_olympus.worktrees import WorktreeRegistry
+    monkeypatch.setenv("GIT_AUTHOR_NAME", "t")
+    monkeypatch.setenv("GIT_AUTHOR_EMAIL", "t@e.com")
+    monkeypatch.setenv("GIT_COMMITTER_NAME", "t")
+    monkeypatch.setenv("GIT_COMMITTER_EMAIL", "t@e.com")
+    repo = tmp_path / "kb"
+    repo.mkdir()
+    subprocess.run(["git", "init", "--initial-branch=main"], cwd=repo, check=True)
+    (repo / "seed.md").write_text("seed\n")
+    subprocess.run(["git", "-C", str(repo), "add", "-A"], check=True)
+    subprocess.run(["git", "-C", str(repo), "commit", "-m", "init"], check=True)
+    git = GitOps(Path(repo))
+    return WorktreeRegistry(git=git, worktree_root=str(tmp_path / "wts"))
 
 
 def test_kb_onboarding_status_returns_absent_for_new_workspace() -> None:
@@ -20,9 +53,10 @@ def test_kb_onboarding_status_returns_absent_for_new_workspace() -> None:
     assert resp.state == "absent"
 
 
-def test_bootstrap_rejects_too_many_files() -> None:
+def test_bootstrap_rejects_too_many_files(tmp_path) -> None:
     """An aggregate file-count cap stops one request enqueuing/writing an
     unbounded number of (individually capped) files."""
+    from data_olympus.onboarding_inflight import BootstrapInFlight
     idx = MagicMock()
     idx.list_by_prefix.return_value = []  # workspace absent
     idx.list_with_remote_url.return_value = []
@@ -35,6 +69,7 @@ def test_bootstrap_rejects_too_many_files() -> None:
         worktrees=MagicMock(), push_queue=MagicMock(), pending=MagicMock(),
         rate_limiter=MagicMock(), blocklist=MagicMock(),
         max_files=2,
+        in_flight=BootstrapInFlight(str(tmp_path / "inflight")),
     )
     assert resp.status == "rejected_too_many_files"
 
@@ -43,6 +78,7 @@ def test_low_conf_bootstrap_is_atomic_when_queue_would_overflow(tmp_path) -> Non
     """A low-confidence bootstrap that would overflow the pending queue is rejected
     up front, leaving no partial pending entries."""
     from data_olympus.auth import PathBlocklist
+    from data_olympus.onboarding_inflight import BootstrapInFlight
     from data_olympus.pending import PendingQueue
     from data_olympus.rate_limit import SlidingWindowLimiter
     idx = MagicMock()
@@ -58,6 +94,7 @@ def test_low_conf_bootstrap_is_atomic_when_queue_would_overflow(tmp_path) -> Non
         worktrees=MagicMock(), push_queue=MagicMock(), pending=pending,
         rate_limiter=SlidingWindowLimiter(max_per_hour=100),
         blocklist=PathBlocklist(tier_blocks=[], path_blocks=[]),
+        in_flight=BootstrapInFlight(str(tmp_path / "inflight")),
     )
     assert resp.status == "rejected_pending_queue_full"
     assert pending.size() == 0  # atomic: nothing was enqueued
@@ -67,6 +104,7 @@ def test_bootstrap_canonicalizes_backslash_path(tmp_path) -> None:
     """item 4: a backslash path in a bootstrap file is stored canonical in the
     pending entry, never as a literal root-level backslash filename."""
     from data_olympus.auth import PathBlocklist
+    from data_olympus.onboarding_inflight import BootstrapInFlight
     from data_olympus.pending import PendingQueue
     from data_olympus.rate_limit import SlidingWindowLimiter
     idx = MagicMock()
@@ -82,6 +120,7 @@ def test_bootstrap_canonicalizes_backslash_path(tmp_path) -> None:
         worktrees=MagicMock(), push_queue=MagicMock(), pending=pending,
         rate_limiter=SlidingWindowLimiter(max_per_hour=100),
         blocklist=PathBlocklist(tier_blocks=[], path_blocks=[]),
+        in_flight=BootstrapInFlight(str(tmp_path / "inflight")),
     )
     assert resp.status == "pending_confirmation"
     entry = pending.get(resp.pending_id)
@@ -91,6 +130,7 @@ def test_bootstrap_canonicalizes_backslash_path(tmp_path) -> None:
 
 def test_bootstrap_rejects_control_char_path(tmp_path) -> None:
     from data_olympus.auth import PathBlocklist
+    from data_olympus.onboarding_inflight import BootstrapInFlight
     from data_olympus.pending import PendingQueue
     from data_olympus.rate_limit import SlidingWindowLimiter
     idx = MagicMock()
@@ -106,6 +146,7 @@ def test_bootstrap_rejects_control_char_path(tmp_path) -> None:
         pending=PendingQueue(pending_root=str(tmp_path / "p")),
         rate_limiter=SlidingWindowLimiter(max_per_hour=100),
         blocklist=PathBlocklist(tier_blocks=[], path_blocks=[]),
+        in_flight=BootstrapInFlight(str(tmp_path / "inflight")),
     )
     assert resp.status == "rejected_path_not_indexable_or_blocked"
 
@@ -146,6 +187,7 @@ def test_bootstrap_cap_counts_injected_postimage(tmp_path) -> None:
     idx = MagicMock()
     idx.list_by_prefix.return_value = []
     idx.list_with_remote_url.return_value = []
+    from data_olympus.onboarding_inflight import BootstrapInFlight
     long_url = "https://example.com/" + "a" * 500 + ".git"
     files = [{"target_path": "projects/p/README.md",
               "postimage": "---\ntitle: P\n---\n\nhi\n"}]
@@ -159,6 +201,7 @@ def test_bootstrap_cap_counts_injected_postimage(tmp_path) -> None:
         rate_limiter=SlidingWindowLimiter(max_per_hour=100),
         blocklist=PathBlocklist(tier_blocks=[], path_blocks=[]),
         max_postimage_bytes=200,
+        in_flight=BootstrapInFlight(str(tmp_path / "inflight")),
     )
     assert resp.status == "rejected_payload_too_large"
 
@@ -175,3 +218,259 @@ def test_kb_onboarding_status_returns_onboarded() -> None:
         workspace_remote_url=None, component_remote_url=None,
     )
     assert resp.state == "onboarded"
+
+
+# --------------------------------------------------------------------------
+# item 1: partial-state bootstrap fills only missing files, never overwrites.
+# --------------------------------------------------------------------------
+
+def _bootstrap_low_conf(idx, files, tmp_path, **overrides):
+    """Run a low-confidence (pending-path) bootstrap with real queue + guard."""
+    from data_olympus.auth import PathBlocklist
+    from data_olympus.onboarding_inflight import BootstrapInFlight
+    from data_olympus.pending import PendingQueue
+    from data_olympus.rate_limit import SlidingWindowLimiter
+    pending = overrides.pop("pending", None) or PendingQueue(
+        pending_root=str(tmp_path / "p"),
+    )
+    kwargs = dict(
+        idx=idx, workspace="p", component=None,
+        workspace_remote_url=None, component_remote_url=None,
+        files=files, source_session="s", agent_identity="claude",
+        confidence=0.4, confidence_threshold=0.85,  # low -> pending
+        worktrees=MagicMock(), push_queue=MagicMock(), pending=pending,
+        rate_limiter=SlidingWindowLimiter(max_per_hour=100),
+        blocklist=PathBlocklist(tier_blocks=[], path_blocks=[]),
+        in_flight=BootstrapInFlight(str(tmp_path / "inflight")),
+    )
+    kwargs.update(overrides)
+    return kb_bootstrap_project_fn(**kwargs), pending
+
+
+def test_partial_bootstrap_fills_only_missing_files(tmp_path) -> None:
+    """A 'partial' workspace (README present, AGENTS missing) bootstraps ONLY the
+    missing AGENTS.md; a supplied README is dropped, never overwriting the
+    committed copy (item 1)."""
+    idx = _partial_idx(["projects/p/README.md"])  # AGENTS.md missing -> partial
+    files = [
+        {"target_path": "projects/p/README.md", "postimage": "new readme\n"},
+        {"target_path": "projects/p/AGENTS.md", "postimage": "agents\n"},
+    ]
+    resp, pending = _bootstrap_low_conf(idx, files, tmp_path)
+    assert resp.status == "pending_confirmation"
+    enqueued = [e["target_path"] for e in pending.list()]
+    assert enqueued == ["projects/p/AGENTS.md"]  # only the missing file
+    assert "projects/p/README.md" not in enqueued  # existing file untouched
+
+
+def test_partial_bootstrap_nothing_missing_is_rejected(tmp_path) -> None:
+    """If every supplied file targets an already-present canonical path, the
+    partial bootstrap rejects rather than committing an empty change (item 1)."""
+    idx = _partial_idx(["projects/p/README.md"])  # AGENTS.md missing
+    # Caller supplies only README (which is present); nothing fills the gap.
+    files = [{"target_path": "projects/p/README.md", "postimage": "again\n"}]
+    resp, pending = _bootstrap_low_conf(idx, files, tmp_path)
+    assert resp.status == "rejected_already_onboarded"
+    assert pending.size() == 0
+
+
+def test_absent_bootstrap_unchanged_writes_all_files(tmp_path) -> None:
+    """Regression: the absent flow still enqueues every supplied file (item 1 did
+    not narrow the absent path)."""
+    idx = MagicMock()
+    idx.list_by_prefix.return_value = []  # absent
+    idx.list_with_remote_url.return_value = []
+    files = [
+        {"target_path": "projects/p/README.md", "postimage": "r\n"},
+        {"target_path": "projects/p/AGENTS.md", "postimage": "a\n"},
+    ]
+    resp, pending = _bootstrap_low_conf(idx, files, tmp_path)
+    assert resp.status == "pending_confirmation"
+    assert sorted(e["target_path"] for e in pending.list()) == [
+        "projects/p/AGENTS.md", "projects/p/README.md",
+    ]
+
+
+def test_partial_high_conf_commit_does_not_overwrite_existing(
+    tmp_path, real_worktrees,
+) -> None:
+    """High-confidence partial bootstrap commits only the missing file into the
+    worktree; the present file is never written (item 1, commit path)."""
+    from data_olympus.auth import PathBlocklist
+    from data_olympus.onboarding_inflight import BootstrapInFlight
+    from data_olympus.pending import PendingQueue
+    from data_olympus.rate_limit import SlidingWindowLimiter
+    idx = _partial_idx(["projects/p/README.md"])  # AGENTS.md missing
+    files = [
+        {"target_path": "projects/p/README.md", "postimage": "SHOULD NOT LAND\n"},
+        {"target_path": "projects/p/AGENTS.md", "postimage": "agents body\n"},
+    ]
+    push_queue = MagicMock()
+    resp = kb_bootstrap_project_fn(
+        idx=idx, workspace="p", component=None,
+        workspace_remote_url=None, component_remote_url=None,
+        files=files, source_session="sess-partial", agent_identity="claude",
+        confidence=0.95, confidence_threshold=0.85,  # high -> commit
+        worktrees=real_worktrees, push_queue=push_queue,
+        pending=PendingQueue(pending_root=str(tmp_path / "p")),
+        rate_limiter=SlidingWindowLimiter(max_per_hour=100),
+        blocklist=PathBlocklist(tier_blocks=[], path_blocks=[]),
+        in_flight=BootstrapInFlight(str(tmp_path / "inflight")),
+    )
+    assert resp.status == "committed"
+    wt = real_worktrees.get_or_create(
+        source_session="sess-partial", agent_identity="claude",
+    )
+    committed = subprocess.run(
+        ["git", "-C", wt.path, "show", "--name-only", "--format=", "HEAD"],
+        capture_output=True, text=True, check=True,
+    ).stdout.split()
+    assert committed == ["projects/p/AGENTS.md"]  # ONLY the missing file
+    assert not (Path(wt.path) / "projects/p/README.md").exists()
+
+
+# --------------------------------------------------------------------------
+# item 2: double-bootstrap within the convergence window is rejected.
+# --------------------------------------------------------------------------
+
+def test_double_bootstrap_within_window_rejected(tmp_path, real_worktrees) -> None:
+    """After a committed bootstrap, the index still reports absent until it
+    converges; a second bootstrap in that window is rejected as in-progress
+    (item 2)."""
+    from data_olympus.auth import PathBlocklist
+    from data_olympus.onboarding_inflight import BootstrapInFlight
+    from data_olympus.pending import PendingQueue
+    from data_olympus.rate_limit import SlidingWindowLimiter
+    idx = MagicMock()
+    idx.list_by_prefix.return_value = []  # absent, and STAYS absent (no reindex)
+    idx.list_with_remote_url.return_value = []
+    guard = BootstrapInFlight(str(tmp_path / "inflight"))
+
+    def _run():
+        return kb_bootstrap_project_fn(
+            idx=idx, workspace="p", component=None,
+            workspace_remote_url=None, component_remote_url=None,
+            files=[{"target_path": "projects/p/README.md", "postimage": "r\n"}],
+            source_session="sess-dbl", agent_identity="claude",
+            confidence=0.95, confidence_threshold=0.85,
+            worktrees=real_worktrees, push_queue=MagicMock(),
+            pending=PendingQueue(pending_root=str(tmp_path / "p")),
+            rate_limiter=SlidingWindowLimiter(max_per_hour=100),
+            blocklist=PathBlocklist(tier_blocks=[], path_blocks=[]),
+            in_flight=guard,
+        )
+
+    first = _run()
+    assert first.status == "committed"
+    # Index has NOT reindexed yet (still absent); the guard must reject the retry.
+    second = _run()
+    assert second.status == "rejected_already_in_progress"
+
+
+def test_expired_inflight_marker_allows_reclaim(tmp_path) -> None:
+    """A stale in-flight claim (TTL elapsed) is reclaimed, so a crashed bootstrap
+    cannot wedge a workspace forever (item 2)."""
+    from data_olympus.onboarding_inflight import BootstrapInFlight
+    guard = BootstrapInFlight(str(tmp_path / "inflight"), ttl_seconds=-1.0)
+    assert guard.claim("p", None) is True
+    # ttl -1 means the marker is already expired; a second claim reclaims it.
+    assert guard.claim("p", None) is True
+
+
+def test_non_committed_bootstrap_releases_claim(tmp_path) -> None:
+    """A rejected (non-committed) bootstrap must release its claim so a real retry
+    is not blocked for the full TTL (item 2)."""
+    from data_olympus.onboarding_inflight import BootstrapInFlight
+    idx = MagicMock()
+    idx.list_by_prefix.return_value = []
+    idx.list_with_remote_url.return_value = []
+    guard = BootstrapInFlight(str(tmp_path / "inflight"))
+    files = [{"target_path": f"projects/p/f{i}.md", "postimage": "x"} for i in range(3)]
+    # too_many_files -> rejected, no side effect, claim released.
+    resp, _ = _bootstrap_low_conf(idx, files, tmp_path, in_flight=guard, max_files=2)
+    assert resp.status == "rejected_too_many_files"
+    # The slot is free again immediately.
+    assert guard.claim("p", None) is True
+
+
+# --------------------------------------------------------------------------
+# item 3: lock-busy bundle rolls back completely; bundle_id shared.
+# --------------------------------------------------------------------------
+
+def test_lock_busy_bundle_rolls_back_completely(tmp_path) -> None:
+    """If one file in a bundle is already path-locked by a pre-existing pending
+    entry, the whole bundle rolls back: no partial enqueue, no orphan lock, and a
+    whole-bundle rejection (item 3)."""
+    from data_olympus.pending import PendingQueue
+    idx = MagicMock()
+    idx.list_by_prefix.return_value = []
+    idx.list_with_remote_url.return_value = []
+    pending = PendingQueue(pending_root=str(tmp_path / "p"))
+    # Pre-lock the SECOND file so the first enqueues then the second raises busy.
+    pre_id = pending.enqueue(
+        proposal_type="edit", target_path="projects/p/AGENTS.md",
+        postimage="pre\n", base_commit="HEAD", base_blob_sha=None,
+        target_file_hash=None, meta={},
+    )
+    files = [
+        {"target_path": "projects/p/README.md", "postimage": "r\n"},
+        {"target_path": "projects/p/AGENTS.md", "postimage": "a\n"},  # locked
+    ]
+    resp, _ = _bootstrap_low_conf(idx, files, tmp_path, pending=pending)
+    assert resp.status == "rejected_path_locked"
+    assert sorted(resp.rejected_paths) == ["projects/p/AGENTS.md", "projects/p/README.md"]
+    # Only the pre-existing entry survives; the bundle's README enqueue rolled back.
+    remaining = [e["target_path"] for e in pending.list()]
+    assert remaining == ["projects/p/AGENTS.md"]
+    assert pending.get(pre_id)  # untouched
+    assert pending.locks_held() == 1  # only the pre-existing lock
+
+
+def test_bundle_id_shared_across_pending_entries(tmp_path) -> None:
+    """Every pending entry of one bootstrap carries the same bundle_id (item 3)."""
+    from data_olympus.pending import PendingQueue
+    idx = MagicMock()
+    idx.list_by_prefix.return_value = []
+    idx.list_with_remote_url.return_value = []
+    pending = PendingQueue(pending_root=str(tmp_path / "p"))
+    files = [
+        {"target_path": "projects/p/README.md", "postimage": "r\n"},
+        {"target_path": "projects/p/AGENTS.md", "postimage": "a\n"},
+    ]
+    resp, _ = _bootstrap_low_conf(idx, files, tmp_path, pending=pending)
+    assert resp.status == "pending_confirmation"
+    bundle_ids = {
+        pending.get(e["pending_id"])["meta"]["bundle_id"] for e in pending.list()
+    }
+    assert len(bundle_ids) == 1  # one shared id
+    assert next(iter(bundle_ids))  # non-empty
+
+
+# --------------------------------------------------------------------------
+# item 4: remote-url injection is key-aware and newline-safe.
+# --------------------------------------------------------------------------
+
+def test_inject_remote_url_body_mention_is_not_a_false_positive() -> None:
+    """A URL mentioned only in the body must NOT suppress injection into the
+    frontmatter: the presence check is key-aware, not a substring scan (item 4)."""
+    import yaml
+
+    from data_olympus.tools_onboarding import _inject_remote_url
+    url = "https://github.com/org/repo"
+    files = [{"target_path": "projects/p/README.md",
+              "postimage": f"---\ntitle: P\n---\n\nsee {url} for details\n"}]
+    out = _inject_remote_url(files, url, target_filename="README.md")
+    fm = yaml.safe_load(out[0]["postimage"].split("---\n", 2)[1])
+    assert fm["git_remote_url"] == url  # injected despite the body mention
+    assert fm["title"] == "P"
+
+
+def test_inject_remote_url_already_present_key_is_noop() -> None:
+    """If the frontmatter already carries the exact git_remote_url, the file is
+    left byte-identical (key-aware presence check, item 4)."""
+    from data_olympus.tools_onboarding import _inject_remote_url
+    url = "https://github.com/org/repo"
+    postimage = f"---\ngit_remote_url: {url}\ntitle: P\n---\n\nbody\n"
+    files = [{"target_path": "projects/p/README.md", "postimage": postimage}]
+    out = _inject_remote_url(files, url, target_filename="README.md")
+    assert out[0]["postimage"] == postimage

--- a/tests/test_tools_onboarding.py
+++ b/tests/test_tools_onboarding.py
@@ -448,6 +448,35 @@ def test_expired_marker_reclaim_is_single_winner(tmp_path) -> None:
     assert live.claim("p", None) is False  # now live -> second caller rejected
 
 
+def test_concurrent_reclaim_grants_exactly_one_winner(tmp_path) -> None:
+    """Many threads racing to reclaim the SAME expired marker must yield exactly
+    one successful claim; the reclaim critical section is single-winner even under
+    contention (codex Concern)."""
+    import threading
+
+    from data_olympus.onboarding_inflight import BootstrapInFlight
+    # Seed an already-expired marker.
+    BootstrapInFlight(str(tmp_path / "inflight"), ttl_seconds=0.0).claim("p", None)
+
+    results: list[bool] = []
+    lock = threading.Lock()
+    start = threading.Barrier(8)
+
+    def _contend() -> None:
+        guard = BootstrapInFlight(str(tmp_path / "inflight"), ttl_seconds=900.0)
+        start.wait()
+        won = guard.claim("p", None)
+        with lock:
+            results.append(won)
+
+    threads = [threading.Thread(target=_contend) for _ in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    assert sum(results) == 1  # exactly one reclaimer won
+
+
 def test_non_committed_bootstrap_releases_claim(tmp_path) -> None:
     """A rejected (non-committed) bootstrap must release its claim so a real retry
     is not blocked for the full TTL (item 2)."""


### PR DESCRIPTION
## Summary

WP3b of the 0.3.0 release program: onboarding pipeline fixes. Four audit findings addressed in `tools_onboarding.py`, `onboarding_playbook.py`, and a new `onboarding_inflight.py`.

1. **`partial` was a dead end.** The playbook told the agent to bootstrap on `absent` OR `partial`, but the handler rejected anything `!= absent` with `rejected_already_onboarded`. `kb_bootstrap_project` now proceeds on `partial`, narrowing the request to only the **exact canonical `missing_files` paths under the target `projects/{workspace}[/components/{component}]/` root** so an already-committed file is never overwritten and a basename collision can't smuggle a write into a different project/component. When nothing supplied fills a gap it rejects truthfully. Playbook text updated to match.
2. **Read-your-writes / double-bootstrap race.** A committed bootstrap is invisible to the index until it is pushed and re-pulled, so a second call in that window passed the `absent` re-check and double-committed. A short-lived, self-expiring **in-flight marker** (`onboarding_inflight.py`) is claimed once the request is admitted and held only across a committed outcome; a concurrent bootstrap for the same workspace/component is rejected as `rejected_already_in_progress`. The claim is released in a `finally` block so a pre-commit exception (git/push-queue failure) never wedges the workspace. Expired-marker reclaim is single-winner (gated behind an exclusive `.reclaim` lock, verified under thread contention). Playbook now instructs waiting for `kb_onboarding_status` to report `onboarded` before running `kb_cleanup_plan`.
3. **Non-atomic pending bundle.** In the low-confidence path, `PathLockBusyError` was silently swallowed per file, so a partially-enqueued bundle returned `pending_confirmation` with only the subset that fit. Lock-busy is now treated like queue-full: the whole bundle rolls back (zero orphan pending entries or held locks) and rejects as `rejected_path_locked`. Every entry of a bundle is stamped with a shared `bundle_id` in its metadata (the seam for a future bundle-aware resolve UX; that UX itself is out of scope).
4. **`_inject_remote_url` YAML safety.** Confirmed and regression-locked: the injection parses and re-serializes frontmatter with `yaml.safe_dump` (a newline-laden URL cannot forge keys) and its presence check is key-aware, so a URL mentioned only in the body no longer false-positives and suppresses injection.

### Seams / notes for the concurrent Wave-1 package (owns `pending.py`, `server.py`, `rest_api.py`)

- **`PendingQueue` root accessor.** The in-flight guard needs the pending queue's on-disk root to place its marker dir beside it. `PendingQueue` exposes no public accessor, so `tools_onboarding._pending_root()` reads `._root` with a `KB_PENDING_ROOT` env fallback. A one-line public `root` property on `PendingQueue` would let us drop the private read. Not done here to respect the file ownership boundary.
- **New response statuses.** `rejected_already_in_progress` and `rejected_path_locked` fall through `rest_api._propose_status` to the default 400. `409 Conflict` (in-progress) and `423 Locked` would be more precise but require editing the off-limits `rest_api.py`; flagged for the owner.
- **Stale MCP tool docstring.** `server.py:kb_bootstrap_project` still says "Only valid when status=absent." It should say "absent or partial." Left untouched (off-limits `server.py`); flagged for the owner.

## Test evidence

Full suite + ruff + mypy + changelog guard all green (post-rebase onto latest `origin/release/0.3.0`):

- `pytest -q`: all pass (1 unrelated skip: `sentence_transformers` not installed).
- `ruff check .`: All checks passed.
- `mypy src`: Success, no issues in 51 source files.
- `scripts/check_changelog.py`: ok.

New/updated regression tests in `tests/test_tools_onboarding.py`:
- partial bootstrap fills only the exact missing file; a supplied README (already present) is dropped; foreign-project and component-path basename collisions are rejected; absent flow still writes all files.
- high-confidence partial commit lands ONLY the missing file in the worktree; the present file is never written.
- double-bootstrap within the window rejected as `rejected_already_in_progress`; non-committed and pre-commit-exception paths release the claim; expired-marker reclaim is single-winner (including an 8-thread contention test asserting exactly one winner, run 25x with no flake).
- lock-busy bundle rolls back completely (no partial enqueue, only the pre-existing lock survives) and returns a whole-bundle rejection; `bundle_id` shared across a bundle's entries.
- remote-URL injection: body-mention is not a false positive; already-present key is a no-op; newline URL cannot forge keys.

## Peer review (codex)

Two-round codex review (CLI, `--sandbox read-only`).

Round 1 raised 1 Blocker + 2 Concerns, all fixed:
- **Blocker** (partial filter matched by basename, allowing cross-project/component overwrite) → now matches exact canonical paths under the target root.
- **Concern** (claim not released on pre-commit exception) → released in a `finally` block.
- **Concern** (expired-marker reclaim not single-winner: in-place `O_TRUNC`) → reworked to unlink + `O_CREAT|O_EXCL` re-race.

Round 2 confirmed the Blocker and exception-release fixes correct, and raised one further **Concern**: the unlink+recreate reclaim still had a TOCTOU window (a slow contender's blind unlink could delete a fresh winner's marker). Fixed by gating the entire reclaim critical section behind an exclusive `.reclaim` lock (re-checks expiry under the lock; contenders reject). Added an 8-thread contention test proving exactly one winner. Verdict on the other items: partial overwrite safety, lock-busy rollback, `bundle_id` consistency, YAML injection, and playbook text all confirmed correct.
