### PR TITLE
feat(cli): data-olympus import for CLAUDE.md/AGENTS.md/cursorrules/ADR/OKF corpora

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 
 - **`data-olympus import` command** to migrate an existing agent-rule corpus into
-  a governed draft bundle (issue #67). Supports five source kinds via `--kind`:
+  a governed draft bundle (issue #67). Supports six source kinds via `--kind`:
   - Flat rule files (`claude-md` / `agents-md` / `gemini-md` / `cursorrules`):
     heuristic splitting into candidate concepts (markdown headings first, then
     blank-line-separated bullet clusters for heading-less files). Each becomes a
@@ -24,12 +24,14 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
     from the first sentence, tags heuristically from content). The original text
     is preserved verbatim as the body.
   - `adr` (adr-tools `doc/adr/NNNN-title.md` directories): maps number+title to
-    `ADR-NNNN`/title, parses the `## Status` section into `status` plus
-    `supersedes` / `superseded_by` references, `type: decision`.
+    `ADR-NNNN`/title, parses the `## Status` section into `supersedes` /
+    `superseded_by` references, preserves the parsed adr-tools status in a
+    non-activating `source_status` field, `type: decision`.
   - `okf` bundles: normalizes alias field names into the profile, fills missing
     required fields with draft-safe defaults, and reports every inference.
-  - Everything lands as `status: draft` (or the ADR-derived status, flagged for
-    review); nothing is committed to git and nothing auto-activates. The command
+  - Everything lands as `status: draft`; nothing is committed to git and nothing
+    auto-activates (imported ADRs keep their original status in `source_status`
+    for the reviewer). Duplicate ids are refused. The command
     writes files into the output dir and prints a human-readable and (with
     `--json`) machine-readable report: files created, sections skipped as too
     short, inferences made, and "needs human review" items. It runs the existing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,33 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **`data-olympus import` command** to migrate an existing agent-rule corpus into
+  a governed draft bundle (issue #67). Supports five source kinds via `--kind`:
+  - Flat rule files (`claude-md` / `agents-md` / `gemini-md` / `cursorrules`):
+    heuristic splitting into candidate concepts (markdown headings first, then
+    blank-line-separated bullet clusters for heading-less files). Each becomes a
+    draft with stamped frontmatter (generated `<prefix>-NNN` id, `type: standard`,
+    `status: draft`, tier/category from flags, title from heading, description
+    from the first sentence, tags heuristically from content). The original text
+    is preserved verbatim as the body.
+  - `adr` (adr-tools `doc/adr/NNNN-title.md` directories): maps number+title to
+    `ADR-NNNN`/title, parses the `## Status` section into `status` plus
+    `supersedes` / `superseded_by` references, `type: decision`.
+  - `okf` bundles: normalizes alias field names into the profile, fills missing
+    required fields with draft-safe defaults, and reports every inference.
+  - Everything lands as `status: draft` (or the ADR-derived status, flagged for
+    review); nothing is committed to git and nothing auto-activates. The command
+    writes files into the output dir and prints a human-readable and (with
+    `--json`) machine-readable report: files created, sections skipped as too
+    short, inferences made, and "needs human review" items. It runs the existing
+    lint machinery over the output (lint-clean on the happy path) and points at
+    `kb_cleanup_plan` for dedup when importing into an existing KB. Re-running
+    into the same output dir is refused unless `--force` is given (no silent
+    duplication or clobber). Type/status/tier vocabularies are single-sourced
+    from `format/validate.py`.
+
 ### Security
 
 - Hardened the write and enforcement surface (issue #74). Ten fixes, each with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,35 +12,6 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-### Added
-
-- **`data-olympus import` command** to migrate an existing agent-rule corpus into
-  a governed draft bundle (issue #67). Supports six source kinds via `--kind`:
-  - Flat rule files (`claude-md` / `agents-md` / `gemini-md` / `cursorrules`):
-    heuristic splitting into candidate concepts (markdown headings first, then
-    blank-line-separated bullet clusters for heading-less files). Each becomes a
-    draft with stamped frontmatter (generated `<prefix>-NNN` id, `type: standard`,
-    `status: draft`, tier/category from flags, title from heading, description
-    from the first sentence, tags heuristically from content). The original text
-    is preserved verbatim as the body.
-  - `adr` (adr-tools `doc/adr/NNNN-title.md` directories): maps number+title to
-    `ADR-NNNN`/title, parses the `## Status` section into `supersedes` /
-    `superseded_by` references, preserves the parsed adr-tools status in a
-    non-activating `source_status` field, `type: decision`.
-  - `okf` bundles: normalizes alias field names into the profile, fills missing
-    required fields with draft-safe defaults, and reports every inference.
-  - Everything lands as `status: draft`; nothing is committed to git and nothing
-    auto-activates (imported ADRs keep their original status in `source_status`
-    for the reviewer). Duplicate ids are refused. The command
-    writes files into the output dir and prints a human-readable and (with
-    `--json`) machine-readable report: files created, sections skipped as too
-    short, inferences made, and "needs human review" items. It runs the existing
-    lint machinery over the output (lint-clean on the happy path) and points at
-    `kb_cleanup_plan` for dedup when importing into an existing KB. Re-running
-    into the same output dir is refused unless `--force` is given (no silent
-    duplication or clobber). Type/status/tier vocabularies are single-sourced
-    from `format/validate.py`.
-
 ### Security
 
 - Hardened the write and enforcement surface (issue #74). Ten fixes, each with
@@ -91,6 +62,32 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **`data-olympus import` command** to migrate an existing agent-rule corpus into
+  a governed draft bundle (issue #67). Supports six source kinds via `--kind`:
+  - Flat rule files (`claude-md` / `agents-md` / `gemini-md` / `cursorrules`):
+    heuristic splitting into candidate concepts (markdown headings first, then
+    blank-line-separated bullet clusters for heading-less files). Each becomes a
+    draft with stamped frontmatter (generated `<prefix>-NNN` id, `type: standard`,
+    `status: draft`, tier/category from flags, title from heading, description
+    from the first sentence, tags heuristically from content). The original text
+    is preserved verbatim as the body.
+  - `adr` (adr-tools `doc/adr/NNNN-title.md` directories): maps number+title to
+    `ADR-NNNN`/title, parses the `## Status` section into `supersedes` /
+    `superseded_by` references, preserves the parsed adr-tools status in a
+    non-activating `source_status` field, `type: decision`.
+  - `okf` bundles: normalizes alias field names into the profile, fills missing
+    required fields with draft-safe defaults, and reports every inference.
+  - Everything lands as `status: draft`; nothing is committed to git and nothing
+    auto-activates (imported ADRs keep their original status in `source_status`
+    for the reviewer). Duplicate ids are refused. The command
+    writes files into the output dir and prints a human-readable and (with
+    `--json`) machine-readable report: files created, sections skipped as too
+    short, inferences made, and "needs human review" items. It runs the existing
+    lint machinery over the output (lint-clean on the happy path) and points at
+    `kb_cleanup_plan` for dedup when importing into an existing KB. Re-running
+    into the same output dir is refused unless `--force` is given (no silent
+    duplication or clobber). Type/status/tier vocabularies are single-sourced
+    from `format/validate.py`.
 - Specified `applies_when` in SPEC.md (WP4c, 0.3.0). `applies_when` is the
   highest-weight indexed field in `Index.search` (tied with `title`, ahead of
   `description` and body) and one of the three discriminating columns for the

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -100,7 +100,75 @@ There is no required directory layout beyond the reserved file names. The
 `tech-stacks/`, `decisions/`, `workflows/`, `projects/`) is a proven pattern
 and is described in `SPEC.md`, but you can adapt it to your context.
 
-## 3. Validate
+## 3. Migrating an existing rule corpus
+
+If you already have agent rules in flat files (`CLAUDE.md`, `AGENTS.md`,
+`GEMINI.md`, `.cursorrules`), adr-tools ADR directories, or an OKF-produced
+bundle, the `import` command migrates them into governed drafts instead of
+requiring you to hand-write frontmatter for each concept:
+
+```bash
+uv run data-olympus import <source> --kind <kind> --tier <tier> [options]
+```
+
+- `<source>`: a flat rule file (for the flat kinds) or a directory (for `adr` /
+  `okf`).
+- `--kind`: one of `claude-md`, `agents-md`, `gemini-md`, `cursorrules`, `adr`,
+  `okf`.
+- `--tier`: the governance tier stamped on every draft (`T1`..`T4`, `meta`, or a
+  bare digit like `3`).
+- `--out <dir>`: output bundle directory (default: `<source>/imported-<kind>` or,
+  for a flat file, a sibling `imported-<kind>/` directory).
+- `--category <cat>`: optional `category` stamped on every draft.
+- `--id-prefix <prefix>`: id prefix for generated ids (default: per-kind, e.g.
+  `CLAUDE`, `AGENTS`, `OKF`; ADR imports always use `ADR-NNNN`).
+- `--force`: overwrite an output directory that was already used as an import
+  target (see re-run behavior below).
+- `--json`: emit the import report as JSON instead of the human-readable form.
+
+### What the importer does
+
+- **Flat rule files** are split into candidate concepts: markdown headings first
+  (each heading starts a section), and for heading-less files, blank-line
+  separated bullet clusters. Each concept becomes a draft with a generated id,
+  `type: standard`, `status: draft`, and a title/description/tags derived from
+  the source. The original text is preserved verbatim as the body; the importer
+  never rewrites your words. Sections too short to be a real concept are skipped
+  and listed in the report.
+- **ADR directories** (`doc/adr/NNNN-title.md`) map the number and title to an
+  `ADR-NNNN` id and title, parse the `## Status` section into `status` plus
+  `supersedes` / `superseded_by` references (`type: decision`), and preserve the
+  ADR body.
+- **OKF bundles** are normalized into the governance profile: alias field names
+  are renamed to the canonical schema keys, missing required fields are filled
+  with draft-safe defaults, and every inference is reported.
+
+### Safety and next steps
+
+- **Everything lands as `status: draft`** (or the ADR-derived status, which is
+  flagged for human review). Nothing auto-activates, and the importer never
+  commits to git: it only writes files into the output directory.
+- The command runs the existing lint machinery over the output; the happy path
+  produces lint-clean drafts. Any finding is included in the report.
+- **Re-run behavior:** the importer refuses to write into an output directory it
+  already used as an import target (or any directory that already holds governed
+  files), so a second run cannot silently duplicate or clobber. Pass `--force` to
+  overwrite, or choose a fresh `--out` directory.
+- **Converging with an existing KB:** the report's next-steps point at the dedup
+  pass (the `kb_cleanup_plan` MCP tool / `POST /api/v1/onboarding/cleanup-plan`),
+  which classifies each draft against your committed KB as
+  `imported_duplicate` / `partial_overlap` / `unique` and proposes thin-pointer
+  replacements for exact duplicates. Run it before activating the drafts so
+  imports converge with the KB instead of duplicating it.
+
+Example: import a `CLAUDE.md` into a new draft bundle and inspect the result:
+
+```bash
+uv run data-olympus import ./CLAUDE.md --kind claude-md --tier T3 --out ./imported
+uv run data-olympus lint ./imported
+```
+
+## 4. Validate
 
 ```bash
 uv run data-olympus lint <your-bundle-dir>
@@ -119,7 +187,7 @@ and reserved-file constraints. Fix any reported errors before proceeding.
 empty or mis-pathed bundle), so a clean pass always means real files were
 checked.
 
-## 4. Generate navigation and graph
+## 5. Generate navigation and graph
 
 ```bash
 uv run data-olympus index <your-bundle-dir>
@@ -136,7 +204,7 @@ uv run data-olympus visualize <your-bundle-dir> -o <your-bundle-dir>/viz.html --
 This generates an interactive HTML graph of all concepts and their
 cross-links. Open the file in a browser to explore the knowledge graph.
 
-## 5. Serve to agents
+## 6. Serve to agents
 
 ### Local (development)
 
@@ -204,7 +272,7 @@ but does not push, and the write pipeline is disabled. REST write routes
 `{"status": "write_pipeline_disabled"}` rather than crashing. Read routes work
 normally.
 
-## 6. Wire an agent
+## 7. Wire an agent
 
 Register the MCP endpoint with your agent. The server exposes MCP over
 streamable HTTP at `http://<host>:8080/mcp` (or the port you configured).

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -136,24 +136,31 @@ uv run data-olympus import <source> --kind <kind> --tier <tier> [options]
   never rewrites your words. Sections too short to be a real concept are skipped
   and listed in the report.
 - **ADR directories** (`doc/adr/NNNN-title.md`) map the number and title to an
-  `ADR-NNNN` id and title, parse the `## Status` section into `status` plus
-  `supersedes` / `superseded_by` references (`type: decision`), and preserve the
-  ADR body.
+  `ADR-NNNN` id and title, parse the `## Status` section into `supersedes` /
+  `superseded_by` references (`type: decision`), and preserve the ADR body. The
+  parsed adr-tools status (e.g. `Accepted`, `Superseded by ...`) is preserved in
+  a non-activating `source_status` field for the reviewer; the concept itself is
+  imported as `status: draft` so it does not become in-force before review.
 - **OKF bundles** are normalized into the governance profile: alias field names
   are renamed to the canonical schema keys, missing required fields are filled
   with draft-safe defaults, and every inference is reported.
 
 ### Safety and next steps
 
-- **Everything lands as `status: draft`** (or the ADR-derived status, which is
-  flagged for human review). Nothing auto-activates, and the importer never
-  commits to git: it only writes files into the output directory.
+- **Everything lands as `status: draft`.** Nothing auto-activates, and the
+  importer never commits to git: it only writes files into the output directory.
+  Imported ADRs keep their original status in `source_status` for the reviewer.
+- **Duplicate ids are refused.** If two imported concepts (or an imported concept
+  and one already in the output dir) would share an id, the import aborts rather
+  than write a structurally unsafe bundle.
 - The command runs the existing lint machinery over the output; the happy path
   produces lint-clean drafts. Any finding is included in the report.
 - **Re-run behavior:** the importer refuses to write into an output directory it
   already used as an import target (or any directory that already holds governed
   files), so a second run cannot silently duplicate or clobber. Pass `--force` to
-  overwrite, or choose a fresh `--out` directory.
+  re-run: it deletes exactly the files the previous import wrote (ids restart
+  deterministically) and leaves any file you added by hand untouched. Or choose a
+  fresh `--out` directory.
 - **Converging with an existing KB:** the report's next-steps point at the dedup
   pass (the `kb_cleanup_plan` MCP tool / `POST /api/v1/onboarding/cleanup-plan`),
   which classifies each draft against your committed KB as

--- a/src/data_olympus/cli/import_cmd.py
+++ b/src/data_olympus/cli/import_cmd.py
@@ -1,0 +1,115 @@
+"""`data-olympus import`: migrate an existing rule corpus into a draft bundle.
+
+Wires the CLI flags to ``data_olympus.importer.run_import`` and renders the
+import report either human-readably or as JSON (``--json``). Exit codes:
+- 0: import succeeded and the output is lint-clean.
+- 1: import succeeded but the output has lint errors (should not happen on the
+     happy path; surfaces a stamping regression instead of silently passing).
+- 2: bad input or a refused re-run (ImportError_).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import TYPE_CHECKING
+
+from data_olympus.importer import ImportError_, run_import
+
+if TYPE_CHECKING:
+    import argparse
+
+    from data_olympus.importer.model import ImportReport
+
+
+def _render_human(report: ImportReport) -> str:
+    lines: list[str] = []
+    lines.append(f"Imported {report.kind} from {report.source}")
+    lines.append(f"  output: {report.out_dir}")
+    lines.append(f"  created {len(report.created)} draft(s):")
+    for name in report.created:
+        lines.append(f"    + {name}")
+    if report.skipped:
+        lines.append(f"  skipped {len(report.skipped)} section(s) (too short):")
+        for s in report.skipped:
+            lines.append(f"    - {s.heading}: {s.reason}")
+    if report.inferences:
+        lines.append(f"  inferences ({len(report.inferences)}):")
+        for note in report.inferences:
+            lines.append(f"    * {note}")
+    if report.needs_review:
+        lines.append(f"  needs human review ({len(report.needs_review)}):")
+        for note in report.needs_review:
+            lines.append(f"    ! {note}")
+    if report.lint:
+        lines.append(f"  lint findings ({len(report.lint)}):")
+        for f in report.lint:
+            lines.append(f"    [{f.severity}] {f.path}: {f.field}: {f.message}")
+        lines.append(f"  lint clean: {report.lint_clean}")
+    else:
+        lines.append("  lint: clean (no findings)")
+    lines.append("  next steps:")
+    for step in report.next_steps:
+        lines.append(f"    - {step}")
+    return "\n".join(lines)
+
+
+def _cmd_import(args: argparse.Namespace) -> int:
+    try:
+        report = run_import(
+            source=args.source,
+            kind=args.kind,
+            tier=args.tier,
+            out=args.out,
+            category=args.category,
+            id_prefix=args.id_prefix,
+            force=args.force,
+        )
+    except ImportError_ as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    if args.json:
+        print(json.dumps(report.to_dict()))
+    else:
+        print(_render_human(report))
+
+    return 0 if report.lint_clean else 1
+
+
+def add_import_subparser(sub: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
+    """Register the ``import`` subcommand on the CLI's subparser action."""
+    p = sub.add_parser(
+        "import",
+        help="migrate an existing rule corpus (CLAUDE.md/AGENTS.md/.cursorrules/ADR/OKF) "
+        "into a governed draft bundle",
+    )
+    p.add_argument("source", help="path to the source file (flat rule file) or directory (ADR/OKF)")
+    p.add_argument(
+        "--kind",
+        required=True,
+        choices=["claude-md", "agents-md", "gemini-md", "cursorrules", "adr", "okf"],
+        help="source corpus kind",
+    )
+    p.add_argument(
+        "--tier",
+        required=True,
+        help="governance tier for the imported drafts (T1|T2|T3|T4|meta, or a bare digit)",
+    )
+    p.add_argument(
+        "-o", "--out", default=None,
+        help="output bundle directory (default: <source>/imported-<kind>). Refuses to write "
+        "into a dir that already holds governed files unless --force is given.",
+    )
+    p.add_argument("--category", default=None, help="optional category stamped on every draft")
+    p.add_argument(
+        "--id-prefix", default=None,
+        help="id prefix for generated ids (default: per-kind, e.g. CLAUDE/AGENTS/OKF; "
+        "ADR imports always use ADR-NNNN)",
+    )
+    p.add_argument(
+        "--force", action="store_true",
+        help="overwrite an output dir that was already used as an import target",
+    )
+    p.add_argument("--json", action="store_true", help="emit the import report as JSON")
+    p.set_defaults(func=_cmd_import)

--- a/src/data_olympus/cli/main.py
+++ b/src/data_olympus/cli/main.py
@@ -105,6 +105,8 @@ def build_parser() -> argparse.ArgumentParser:
     p_report.add_argument("--emit-events", action="store_true",
                           help="record a gate_bypass audit event per unverified governed change")
     p_report.set_defaults(func=_cmd_report)
+    from data_olympus.cli.import_cmd import add_import_subparser
+    add_import_subparser(sub)
     return parser
 
 

--- a/src/data_olympus/importer/__init__.py
+++ b/src/data_olympus/importer/__init__.py
@@ -1,0 +1,13 @@
+"""Importer: migrate existing agent-rule corpora into a governed draft bundle.
+
+Public API:
+- ``run_import`` — orchestrate an import, returning an ``ImportReport``.
+- ``ImportReport`` / ``DraftDoc`` — result and per-doc models.
+- ``ImportError_`` — raised on bad input or a refused re-run.
+- ``KINDS`` — the supported source kinds.
+"""
+
+from .model import DraftDoc, ImportError_, ImportReport
+from .run import KINDS, run_import
+
+__all__ = ["run_import", "ImportReport", "DraftDoc", "ImportError_", "KINDS"]

--- a/src/data_olympus/importer/adr.py
+++ b/src/data_olympus/importer/adr.py
@@ -1,0 +1,286 @@
+"""Parse an adr-tools directory (doc/adr/NNNN-title.md convention).
+
+Maps each ADR file's leading number + title into an id (``ADR-NNNN``) and title,
+and reads its ``## Status`` section to derive a governance status plus
+``supersedes`` / ``superseded_by`` references where the ADR text records them.
+
+adr-tools status conventions handled:
+- ``Accepted``      -> status: accepted
+- ``Proposed``      -> status: proposed
+- ``Rejected``      -> status: rejected
+- ``Deprecated``    -> status: deprecated
+- ``Superseded by ADR-0005`` / ``Superseded by [ADR-0005](0005-...)`` ->
+      status: superseded, superseded_by: ADR-0005
+- ``Supersedes ADR-0002``                     -> supersedes: ADR-0002
+
+The ADR body is preserved verbatim under stamped frontmatter.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from data_olympus.format.validate import STATUSES
+
+from .stamp import first_sentence, slugify
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+# doc/adr filename convention: 4-digit number, dash, slug.
+_ADR_FILENAME_RE = re.compile(r"^(?P<num>\d{1,5})[-_](?P<slug>.+?)\.md$", re.IGNORECASE)
+# A reference to another ADR anywhere in a status line: ADR-0005, ADR 5, or a
+# bare 4-digit number inside a "superseded by ..." clause.
+_ADR_REF_RE = re.compile(r"ADR[-\s]?0*(\d{1,5})", re.IGNORECASE)
+_BARE_NUM_RE = re.compile(r"\b0*(\d{1,5})\b")
+
+# Map the leading keyword of a status line to a schema status. Only these
+# spellings are recognized; an unrecognized status is reported and the doc lands
+# as draft (never silently mis-stamped).
+_STATUS_KEYWORDS: dict[str, str] = {
+    "accepted": "accepted",
+    "proposed": "proposed",
+    "rejected": "rejected",
+    "deprecated": "deprecated",
+    "superseded": "superseded",
+}
+
+
+def _canonical_adr_id(num: int) -> str:
+    return f"ADR-{num:04d}"
+
+
+@dataclass
+class ParsedADR:
+    path: Path
+    number: int
+    doc_id: str
+    slug: str
+    title: str
+    body: str
+    status: str
+    supersedes: list[str] = field(default_factory=list)
+    superseded_by: str | None = None
+    inferences: list[str] = field(default_factory=list)
+    needs_review: list[str] = field(default_factory=list)
+
+
+# A leading "N. " / "N) " ordinal in an ADR heading (adr-tools writes
+# "# 12. Use X"); we strip it so the title is the decision, not the number.
+_LEADING_ORDINAL_RE = re.compile(r"^\d+\s*[.)]\s+")
+
+
+def _first_title(body: str, fallback: str) -> str:
+    """Return the first ATX-heading text in the body (minus its ordinal), else
+    the fallback slug."""
+    for line in body.splitlines():
+        stripped = line.lstrip()
+        if stripped.startswith("#"):
+            text = stripped.lstrip("#").strip().strip("*_`").strip()
+            text = _LEADING_ORDINAL_RE.sub("", text).strip()
+            if text:
+                return text
+    return fallback
+
+
+def _status_section(body: str) -> str:
+    """Return the text under a ``## Status`` heading (up to the next heading)."""
+    lines = body.splitlines()
+    out: list[str] = []
+    capturing = False
+    for line in lines:
+        stripped = line.lstrip()
+        is_heading = stripped.startswith("#")
+        if is_heading:
+            heading = stripped.lstrip("#").strip().lower()
+            if heading == "status":
+                capturing = True
+                continue
+            if capturing:
+                break  # next heading ends the Status section
+        elif capturing:
+            out.append(line)
+    return "\n".join(out).strip()
+
+
+@dataclass
+class StatusInfo:
+    status: str = "draft"
+    supersedes: list[str] = field(default_factory=list)
+    superseded_by: str | None = None
+    inferences: list[str] = field(default_factory=list)
+    needs_review: list[str] = field(default_factory=list)
+
+
+def _parse_status(status_text: str, *, this_num: int) -> StatusInfo:
+    """Parse an ADR ``## Status`` section into a StatusInfo.
+
+    Each non-empty line of the Status section is examined. A line beginning with
+    a recognized keyword sets the status; a "supersedes"/"superseded by" clause
+    records the referenced ADR ids. Unknown status text yields draft + a review
+    flag so nothing is mis-stamped.
+    """
+    status = "draft"
+    supersedes: list[str] = []
+    superseded_by: str | None = None
+    inferences: list[str] = []
+    needs_review: list[str] = []
+    if not status_text:
+        needs_review.append("no Status section found; defaulted to draft")
+        return StatusInfo(status, supersedes, superseded_by, inferences, needs_review)
+
+    recognized = False
+    for raw in status_text.splitlines():
+        line = raw.strip()
+        if not line:
+            continue
+        low = line.lower()
+        # "supersedes X" (this ADR replaces X) — check before the keyword map so
+        # "Superseded by" (passive) is not confused with "Supersedes" (active).
+        if low.startswith("supersedes") or low.startswith("supercedes"):
+            for ref in _extract_refs(line, exclude=this_num):
+                if ref not in supersedes:
+                    supersedes.append(ref)
+            recognized = True
+            continue
+        first_word = low.split()[0].rstrip(":.")
+        mapped = _STATUS_KEYWORDS.get(first_word)
+        if mapped:
+            status = mapped
+            recognized = True
+            if mapped == "superseded":
+                refs = _extract_refs(line, exclude=this_num)
+                if refs:
+                    superseded_by = refs[0]
+                    if len(refs) > 1:
+                        needs_review.append(
+                            f"Status line names multiple superseding ADRs {refs}; "
+                            f"used {superseded_by}"
+                        )
+                else:
+                    needs_review.append(
+                        "status 'superseded' but no superseding ADR id found in Status section"
+                    )
+            continue
+
+    if not recognized:
+        needs_review.append(
+            f"unrecognized Status text {status_text.splitlines()[0]!r}; defaulted to draft"
+        )
+    if status != "draft":
+        inferences.append(f"status inferred as {status!r} from ADR Status section")
+    if status not in STATUSES:  # pragma: no cover - keywords are all valid
+        needs_review.append(f"derived status {status!r} not in schema; forcing draft")
+        status = "draft"
+    return StatusInfo(status, supersedes, superseded_by, inferences, needs_review)
+
+
+def _extract_refs(line: str, *, exclude: int) -> list[str]:
+    """Extract referenced ADR ids from a status line, excluding self-references."""
+    nums: list[int] = []
+    matched = list(_ADR_REF_RE.finditer(line))
+    if matched:
+        nums = [int(m.group(1)) for m in matched]
+    else:
+        # No explicit ADR- prefix: fall back to bare numbers (adr-tools often
+        # writes just "Superseded by 0007").
+        nums = [int(m.group(1)) for m in _BARE_NUM_RE.finditer(line)]
+    out: list[str] = []
+    for n in nums:
+        if n == exclude:
+            continue
+        ref = _canonical_adr_id(n)
+        if ref not in out:
+            out.append(ref)
+    return out
+
+
+def parse_adr_file(path: Path) -> ParsedADR | None:
+    """Parse a single ADR file. Returns None when the filename does not match
+    the adr-tools ``NNNN-title.md`` convention (the caller reports the skip)."""
+    m = _ADR_FILENAME_RE.match(path.name)
+    if not m:
+        return None
+    number = int(m.group("num"))
+    slug = slugify(m.group("slug"))
+    body = path.read_text(encoding="utf-8")
+    title = _first_title(body, fallback=m.group("slug").replace("-", " ").strip())
+    status_text = _status_section(body)
+    info = _parse_status(status_text, this_num=number)
+    return ParsedADR(
+        path=path,
+        number=number,
+        doc_id=_canonical_adr_id(number),
+        slug=slug,
+        title=title,
+        body=body,
+        status=info.status,
+        supersedes=info.supersedes,
+        superseded_by=info.superseded_by,
+        inferences=info.inferences,
+        needs_review=info.needs_review,
+    )
+
+
+def discover_adr_files(source: Path) -> list[Path]:
+    """Return the ADR markdown files under ``source`` in number order.
+
+    Accepts either an adr directory directly or a repo root containing a
+    ``doc/adr`` or ``docs/adr`` subtree. Only files matching the NNNN-title.md
+    convention are returned; ``index.md`` / ``template.md`` are ignored.
+    """
+    candidates: list[Path]
+    if source.is_dir():
+        roots = [source]
+        for sub in ("doc/adr", "docs/adr"):
+            p = source / sub
+            if p.is_dir():
+                roots.append(p)
+        seen: set[Path] = set()
+        candidates = []
+        for root in roots:
+            for md in sorted(root.glob("*.md")):
+                if md not in seen and _ADR_FILENAME_RE.match(md.name):
+                    seen.add(md)
+                    candidates.append(md)
+    else:
+        candidates = [source] if _ADR_FILENAME_RE.match(source.name) else []
+    candidates.sort(key=lambda p: int(_ADR_FILENAME_RE.match(p.name).group("num")))  # type: ignore[union-attr]
+    return candidates
+
+
+def _section_text(body: str, name: str) -> str:
+    """Return the text under a ``## <name>`` heading (case-insensitive)."""
+    out: list[str] = []
+    capturing = False
+    for line in body.splitlines():
+        stripped = line.lstrip()
+        if stripped.startswith("#"):
+            if capturing:
+                break
+            capturing = stripped.lstrip("#").strip().lower() == name.lower()
+            continue
+        if capturing:
+            out.append(line)
+    return "\n".join(out).strip()
+
+
+def description_for(adr: ParsedADR) -> str:
+    """Return a one-sentence description for the ADR.
+
+    Prefers the Context section's first sentence (the decision's rationale),
+    then the Decision section, then any body prose, then the title. The Date:
+    metadata line adr-tools emits is never used as a description.
+    """
+    for section in ("Context", "Decision"):
+        text = _section_text(adr.body, section)
+        sentence = first_sentence(text)
+        if sentence:
+            return sentence
+    # Fall back to whole-body prose but drop a leading "Date:" line first.
+    body_no_date = "\n".join(
+        ln for ln in adr.body.splitlines() if not ln.strip().lower().startswith("date:")
+    )
+    return first_sentence(body_no_date) or adr.title

--- a/src/data_olympus/importer/flat.py
+++ b/src/data_olympus/importer/flat.py
@@ -65,11 +65,14 @@ def _top_heading_depth(lines: list[str]) -> int:
     Splitting at a single shallow depth keeps nested subsections attached to
     their parent concept instead of over-splitting. The boundary is the
     SHALLOWEST depth that occurs MORE THAN ONCE, so a document with one H1 title
-    over several H2 concepts splits at H2 (the lone H1 becomes preamble/part of
-    the first concept) rather than collapsing into a single giant concept.
-    Falls back to the shallowest depth when no depth repeats (e.g. a flat list
-    of same-level headings, or a single heading). Assumes at least one heading
-    exists (the caller only invokes this when ``has_headings`` is true)."""
+    over several H2 concepts splits at H2 rather than collapsing into a single
+    giant concept. A lone leading H1 is itself a boundary heading (``depth <=
+    boundary`` in ``_split_by_headings``): with enough prose it becomes its own
+    section (usually the document-title concept), otherwise it is dropped as too
+    short. Falls back to the shallowest depth when no depth repeats (e.g. a flat
+    list of same-level headings, or a single heading). Assumes at least one
+    heading exists (the caller only invokes this when ``has_headings`` is
+    true)."""
     depths = [d for d in (_heading_depth(ln) for ln in lines) if d is not None]
     counts: dict[int, int] = {}
     for d in depths:

--- a/src/data_olympus/importer/flat.py
+++ b/src/data_olympus/importer/flat.py
@@ -1,0 +1,131 @@
+"""Heuristic splitting of flat rule files into candidate draft concepts.
+
+Handles CLAUDE.md / AGENTS.md / GEMINI.md / .cursorrules: files that are a wall
+of agent rules with no governance frontmatter. The split strategy:
+
+1. If the file has ATX headings (``#``..``######``), each heading starts a new
+   section; the run of lines up to the next heading of the same-or-shallower
+   depth is that section's body. Preamble before the first heading becomes its
+   own section only when it carries enough prose.
+2. If the file has NO headings, group consecutive non-blank lines into
+   "bullet clusters" separated by blank lines; each cluster becomes a section.
+
+A section shorter than ``MIN_BODY_CHARS`` (excluding its heading) is skipped and
+reported as too-short. The original text of each kept section is preserved
+verbatim as the draft body.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .stamp import heading_text
+
+# A section must carry at least this many body characters (heading excluded) to
+# become a draft. Below this it is almost always a stray line or a section
+# title with no content; we skip and report it rather than emit a stub draft.
+MIN_BODY_CHARS = 40
+
+
+@dataclass
+class Section:
+    """A candidate concept carved out of a flat file."""
+
+    heading: str
+    body: str
+
+    @property
+    def body_len(self) -> int:
+        return len(self.body.strip())
+
+
+def _heading_depth(line: str) -> int | None:
+    stripped = line.lstrip()
+    if not stripped.startswith("#"):
+        return None
+    if heading_text(line) is None:
+        return None
+    depth = len(stripped) - len(stripped.lstrip("#"))
+    return depth if 1 <= depth <= 6 else None
+
+
+def _split_by_headings(text: str) -> list[Section]:
+    """Split on ATX headings. Preamble before the first heading is its own
+    section with a synthetic 'Preamble' heading."""
+    lines = text.splitlines()
+    sections: list[Section] = []
+    current_heading = "Preamble"
+    current_body: list[str] = []
+
+    def flush() -> None:
+        body = "\n".join(current_body).strip("\n")
+        # Keep every section (even short ones) as a candidate; the caller
+        # decides skip-vs-keep so it can report the skip. A section with an
+        # empty body but a real heading is still a candidate (reported short).
+        sections.append(Section(heading=current_heading, body=body))
+
+    started = False
+    for line in lines:
+        depth = _heading_depth(line)
+        if depth is not None:
+            # Flush the accumulated preamble/section before starting a new one.
+            # Only flush a preamble that has real content; a leading heading
+            # with no preamble must not emit an empty 'Preamble' candidate.
+            if started or "".join(current_body).strip():
+                flush()
+            current_heading = heading_text(line) or "Untitled"
+            current_body = []
+            started = True
+        else:
+            current_body.append(line)
+    if started or "".join(current_body).strip():
+        flush()
+    return sections
+
+
+def _split_by_clusters(text: str) -> list[Section]:
+    """Group blank-line-separated clusters for heading-less files.
+
+    Each cluster of consecutive non-blank lines becomes a section whose heading
+    is derived from the cluster's first line (trimmed). This is the fallback for
+    ``.cursorrules`` and any flat file without markdown headings.
+    """
+    sections: list[Section] = []
+    cluster: list[str] = []
+
+    def flush() -> None:
+        if not cluster:
+            return
+        block = "\n".join(cluster).strip("\n")
+        first = cluster[0].strip()
+        # Derive a heading from the first line: strip a leading bullet marker.
+        heading = first.lstrip("-*+ ").strip() or "Rule"
+        # Trim an over-long heading to a sane length for a title.
+        if len(heading) > 80:
+            heading = heading[:79].rstrip() + "…"
+        sections.append(Section(heading=heading, body=block))
+
+    for line in text.splitlines():
+        if line.strip():
+            cluster.append(line)
+        else:
+            flush()
+            cluster = []
+    flush()
+    return sections
+
+
+def has_headings(text: str) -> bool:
+    return any(_heading_depth(line) is not None for line in text.splitlines())
+
+
+def split_flat(text: str) -> list[Section]:
+    """Return the ordered candidate sections for a flat rule file.
+
+    Uses heading-based splitting when the file has any ATX heading, otherwise
+    falls back to bullet-cluster grouping. Returns candidates including
+    too-short ones; the orchestrator filters and reports skips.
+    """
+    if has_headings(text):
+        return _split_by_headings(text)
+    return _split_by_clusters(text)

--- a/src/data_olympus/importer/flat.py
+++ b/src/data_olympus/importer/flat.py
@@ -36,7 +36,17 @@ class Section:
 
     @property
     def body_len(self) -> int:
-        return len(self.body.strip())
+        """Length of the section's PROSE, excluding a leading heading line.
+
+        The boundary heading is kept inside ``body`` so the concept text is
+        complete, but the too-short skip test must measure content, not the
+        heading — otherwise a long heading over an empty body would spuriously
+        clear the threshold."""
+        text = self.body
+        lines = text.splitlines()
+        if lines and _heading_depth(lines[0]) is not None:
+            text = "\n".join(lines[1:])
+        return len(text.strip())
 
 
 def _heading_depth(line: str) -> int | None:
@@ -49,10 +59,34 @@ def _heading_depth(line: str) -> int | None:
     return depth if 1 <= depth <= 6 else None
 
 
+def _top_heading_depth(lines: list[str]) -> int:
+    """Return the heading depth to split at (the section boundary level).
+
+    Splitting at a single shallow depth keeps nested subsections attached to
+    their parent concept instead of over-splitting. The boundary is the
+    SHALLOWEST depth that occurs MORE THAN ONCE, so a document with one H1 title
+    over several H2 concepts splits at H2 (the lone H1 becomes preamble/part of
+    the first concept) rather than collapsing into a single giant concept.
+    Falls back to the shallowest depth when no depth repeats (e.g. a flat list
+    of same-level headings, or a single heading). Assumes at least one heading
+    exists (the caller only invokes this when ``has_headings`` is true)."""
+    depths = [d for d in (_heading_depth(ln) for ln in lines) if d is not None]
+    counts: dict[int, int] = {}
+    for d in depths:
+        counts[d] = counts.get(d, 0) + 1
+    repeated = [d for d, n in counts.items() if n > 1]
+    if repeated:
+        return min(repeated)
+    return min(depths)
+
+
 def _split_by_headings(text: str) -> list[Section]:
-    """Split on ATX headings. Preamble before the first heading is its own
-    section with a synthetic 'Preamble' heading."""
+    """Split at the shallowest heading depth. Deeper (nested) headings stay in
+    their parent section's body, and the boundary heading line itself is kept in
+    the body so no source text is dropped. Preamble before the first boundary
+    heading becomes its own 'Preamble' section when it carries content."""
     lines = text.splitlines()
+    boundary = _top_heading_depth(lines)
     sections: list[Section] = []
     current_heading = "Preamble"
     current_body: list[str] = []
@@ -67,14 +101,16 @@ def _split_by_headings(text: str) -> list[Section]:
     started = False
     for line in lines:
         depth = _heading_depth(line)
-        if depth is not None:
-            # Flush the accumulated preamble/section before starting a new one.
-            # Only flush a preamble that has real content; a leading heading
-            # with no preamble must not emit an empty 'Preamble' candidate.
+        if depth is not None and depth <= boundary:
+            # New top-level section. Flush the accumulated preamble/section
+            # first, but only emit a preamble that has real content so a leading
+            # boundary heading does not produce an empty 'Preamble' candidate.
             if started or "".join(current_body).strip():
                 flush()
             current_heading = heading_text(line) or "Untitled"
-            current_body = []
+            # Keep the heading line in the body so the concept text is complete
+            # and nothing the author wrote is silently dropped.
+            current_body = [line]
             started = True
         else:
             current_body.append(line)

--- a/src/data_olympus/importer/model.py
+++ b/src/data_olympus/importer/model.py
@@ -1,0 +1,106 @@
+"""Data model for the importer: draft documents and the import report.
+
+These are pure data holders. Splitting/stamping logic lives in the per-kind
+modules (``flat``, ``adr``, ``okf``) and the orchestrator (``run``).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class DraftDoc:
+    """A single draft concept ready to be written into the output bundle.
+
+    ``frontmatter`` is an ordered mapping serialized verbatim above the body;
+    ``body`` is the ORIGINAL source text, never rewritten. ``filename`` is the
+    basename the orchestrator writes it under (relative to the output dir).
+    """
+
+    filename: str
+    frontmatter: dict[str, Any]
+    body: str
+    # Free-form notes surfaced in the report's "inferences" list for this doc
+    # (e.g. "type inferred as decision", "title from heading").
+    inferences: list[str] = field(default_factory=list)
+    # True when the doc needs a human to look at it before activation beyond the
+    # blanket draft-status review (e.g. a non-draft ADR status, a dangling
+    # supersedes ref, an OKF doc missing an id we had to synthesize).
+    needs_review: list[str] = field(default_factory=list)
+
+
+@dataclass
+class SkippedSection:
+    """A candidate section that was NOT turned into a draft (too short, empty)."""
+
+    heading: str
+    reason: str
+
+
+@dataclass
+class LintFinding:
+    """A flattened lint finding for the report (path relative to out dir)."""
+
+    path: str
+    severity: str
+    field: str
+    message: str
+
+
+@dataclass
+class ImportReport:
+    """The machine- and human-readable result of an import run.
+
+    ``created`` lists files actually written (relative paths). ``skipped`` lists
+    candidate sections that were too short to become a draft. ``inferences`` and
+    ``needs_review`` aggregate per-doc notes. ``lint`` holds the post-write lint
+    result over the output. ``next_steps`` carries the dedup pointer text.
+    """
+
+    kind: str
+    source: str
+    out_dir: str
+    created: list[str] = field(default_factory=list)
+    skipped: list[SkippedSection] = field(default_factory=list)
+    inferences: list[str] = field(default_factory=list)
+    needs_review: list[str] = field(default_factory=list)
+    lint: list[LintFinding] = field(default_factory=list)
+    next_steps: list[str] = field(default_factory=list)
+
+    @property
+    def lint_clean(self) -> bool:
+        """True when no lint ERROR was produced over the output (warnings ok)."""
+        return not any(f.severity == "error" for f in self.lint)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Machine-readable shape emitted under ``--json``."""
+        return {
+            "kind": self.kind,
+            "source": self.source,
+            "out_dir": self.out_dir,
+            "created": list(self.created),
+            "skipped": [{"heading": s.heading, "reason": s.reason} for s in self.skipped],
+            "inferences": list(self.inferences),
+            "needs_review": list(self.needs_review),
+            "lint": [
+                {
+                    "path": f.path,
+                    "severity": f.severity,
+                    "field": f.field,
+                    "message": f.message,
+                }
+                for f in self.lint
+            ],
+            "lint_clean": self.lint_clean,
+            "next_steps": list(self.next_steps),
+        }
+
+
+class ImportError_(Exception):
+    """Raised on unrecoverable importer input problems (bad source, refuse-on-rerun).
+
+    Named with a trailing underscore to avoid shadowing the builtin ``ImportError``.
+    The CLI catches it and prints the message to stderr with a non-zero exit.
+    """

--- a/src/data_olympus/importer/okf.py
+++ b/src/data_olympus/importer/okf.py
@@ -103,9 +103,14 @@ def normalize_okf_doc(path: Path, *, default_tier: str, category: str | None) ->
         fm["type"] = DEFAULT_TYPE
 
     # status: force to draft on import (never auto-activate). If the source
-    # carried an in-force status, report that we downgraded it.
+    # carried an in-force status, report that we downgraded it. Every case is
+    # recorded (downgrade, out-of-schema, or synthesized default) so the
+    # normalization stays fully auditable and no required field is invented
+    # silently.
     src_status = fm.get("status")
-    if src_status and src_status != DRAFT_STATUS:
+    if not src_status:
+        inferences.append(f"missing status; defaulted to {DRAFT_STATUS!r}")
+    elif src_status != DRAFT_STATUS:
         if src_status in STATUSES:
             inferences.append(f"status {src_status!r} downgraded to {DRAFT_STATUS!r} on import")
         else:

--- a/src/data_olympus/importer/okf.py
+++ b/src/data_olympus/importer/okf.py
@@ -1,0 +1,187 @@
+"""Normalize OKF-ish bundles into the data-olympus governance profile.
+
+OKF docs already carry frontmatter with an id/type. This module:
+- reads each ``.md`` file's existing frontmatter,
+- maps common alias field names into the canonical schema fields,
+- fills REQUIRED fields that are missing with draft-safe defaults, reporting
+  every inference so nothing is invented silently,
+- validates enum values against the schema vocab, downgrading an out-of-vocab
+  status/type/tier to a safe default with a "needs review" note.
+
+Field VALUES are never rewritten beyond the documented normalizations; the body
+is preserved verbatim.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+from data_olympus.format.frontmatter import parse_frontmatter
+from data_olympus.format.validate import STATUSES, TIERS, TYPES
+
+from .stamp import DEFAULT_TYPE, DRAFT_STATUS, first_sentence
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+# Alias -> canonical frontmatter key. Only unambiguous renames; we never guess a
+# value, only relocate a field the author already wrote under a different name.
+_ALIASES: dict[str, str] = {
+    "identifier": "id",
+    "uid": "id",
+    "kind": "type",
+    "doctype": "type",
+    "state": "status",
+    "level": "tier",
+    "name": "title",
+    "summary": "description",
+    "keywords": "tags",
+    "date": "timestamp",
+    "updated": "timestamp",
+}
+
+# Recommended fields we backfill from the body when absent (title/description),
+# reporting the inference. tags/timestamp get generic defaults.
+
+
+@dataclass
+class NormalizedOKF:
+    path: Path
+    frontmatter: dict[str, Any]
+    body: str
+    inferences: list[str] = field(default_factory=list)
+    needs_review: list[str] = field(default_factory=list)
+
+
+def _apply_aliases(fm: dict[str, Any]) -> tuple[dict[str, Any], list[str]]:
+    """Rename alias keys to canonical keys. Reports each rename. A canonical key
+    already present wins over its alias (the alias is dropped and reported)."""
+    out: dict[str, Any] = {}
+    inferences: list[str] = []
+    for key, value in fm.items():
+        canonical = _ALIASES.get(key, key)
+        if canonical != key:
+            if canonical in fm and canonical != key:
+                inferences.append(
+                    f"dropped alias field {key!r} (canonical {canonical!r} already set)"
+                )
+                continue
+            inferences.append(f"renamed field {key!r} -> {canonical!r}")
+        out[canonical] = value
+    return out, inferences
+
+
+def normalize_okf_doc(path: Path, *, default_tier: str, category: str | None) -> NormalizedOKF:
+    """Normalize one OKF doc into the governance profile.
+
+    ``default_tier`` seeds a missing ``tier`` (required). ``category`` is stamped
+    when the doc lacks one and the caller passed ``--category``.
+    """
+    text = path.read_text(encoding="utf-8")
+    raw_fm, body = parse_frontmatter(text)
+    fm, inferences = _apply_aliases(dict(raw_fm))
+    needs_review: list[str] = []
+
+    # id (required): synthesize from the filename stem when absent — flag it,
+    # because a stable id normally comes from the author.
+    if not fm.get("id"):
+        fm["id"] = path.stem
+        inferences.append(f"missing id; synthesized {fm['id']!r} from filename")
+        needs_review.append(
+            f"{path.name}: id was synthesized from the filename; confirm it is stable"
+        )
+
+    # type (required): default to standard when absent.
+    if not fm.get("type"):
+        fm["type"] = DEFAULT_TYPE
+        inferences.append(f"missing type; defaulted to {DEFAULT_TYPE!r}")
+    elif fm["type"] not in TYPES:
+        needs_review.append(
+            f"{path.name}: type {fm['type']!r} not in schema; defaulted to {DEFAULT_TYPE!r}"
+        )
+        fm["type"] = DEFAULT_TYPE
+
+    # status: force to draft on import (never auto-activate). If the source
+    # carried an in-force status, report that we downgraded it.
+    src_status = fm.get("status")
+    if src_status and src_status != DRAFT_STATUS:
+        if src_status in STATUSES:
+            inferences.append(f"status {src_status!r} downgraded to {DRAFT_STATUS!r} on import")
+        else:
+            needs_review.append(
+                f"{path.name}: source status {src_status!r} not in schema; set to {DRAFT_STATUS!r}"
+            )
+    fm["status"] = DRAFT_STATUS
+
+    # tier (required): normalize or default.
+    tier = fm.get("tier")
+    if not tier:
+        fm["tier"] = default_tier
+        inferences.append(f"missing tier; defaulted to {default_tier!r} (--tier)")
+    elif tier not in TIERS:
+        needs_review.append(
+            f"{path.name}: tier {tier!r} not in schema; defaulted to {default_tier!r} (--tier)"
+        )
+        fm["tier"] = default_tier
+
+    # Recommended fields — backfill so the output is lint-clean.
+    if not fm.get("title"):
+        fm["title"] = str(fm["id"]).replace("-", " ").replace("_", " ").strip() or path.stem
+        inferences.append(f"missing title; derived {fm['title']!r}")
+    if not fm.get("description"):
+        desc = first_sentence(body) or str(fm["title"])
+        fm["description"] = desc
+        inferences.append("missing description; derived from body")
+    tags = fm.get("tags")
+    if not tags:
+        fm["tags"] = [str(fm["type"])]
+        inferences.append("missing tags; defaulted to [type]")
+    elif not isinstance(tags, list):
+        fm["tags"] = [str(tags)]
+        inferences.append("tags coerced to a list")
+    else:
+        fm["tags"] = [str(t) for t in tags]
+    if not fm.get("timestamp"):
+        import datetime
+
+        fm["timestamp"] = datetime.date.today().isoformat()
+        inferences.append("missing timestamp; defaulted to today")
+    if category and not fm.get("category"):
+        fm["category"] = category
+
+    # Reorder to the canonical schema order for a clean, diff-stable file.
+    ordered = _reorder(fm)
+    return NormalizedOKF(
+        path=path, frontmatter=ordered, body=body, inferences=inferences, needs_review=needs_review
+    )
+
+
+_ORDER = ("id", "type", "status", "tier", "category", "title", "description", "tags", "timestamp")
+
+
+def _reorder(fm: dict[str, Any]) -> dict[str, Any]:
+    out: dict[str, Any] = {}
+    for key in _ORDER:
+        if key in fm:
+            out[key] = fm[key]
+    for key, value in fm.items():
+        if key not in out:
+            out[key] = value
+    return out
+
+
+def discover_okf_files(source: Path) -> list[Path]:
+    """Return the OKF ``.md`` files to normalize.
+
+    A single file is returned as-is. A directory is walked (non-recursively into
+    VCS/meta dirs) for ``.md`` files carrying frontmatter; index/template/log
+    reserved files are skipped.
+    """
+    from data_olympus.format.lint import discover_bundle_files
+
+    if source.is_file():
+        return [source]
+    # Reuse the bundle discovery walk so skip-dir / reserved-file semantics match
+    # the linter exactly.
+    return discover_bundle_files(source)

--- a/src/data_olympus/importer/run.py
+++ b/src/data_olympus/importer/run.py
@@ -75,18 +75,6 @@ def _existing_ids(out_dir: Path) -> set[str]:
     return ids
 
 
-def _read_marker(out_dir: Path) -> dict[str, object] | None:
-    """Return the parsed import marker, or None if absent/unreadable."""
-    marker = out_dir / _MARKER
-    if not marker.exists():
-        return None
-    try:
-        data = json.loads(marker.read_text(encoding="utf-8"))
-    except (ValueError, OSError):
-        return {}
-    return data if isinstance(data, dict) else {}
-
-
 def _clear_prior_import(out_dir: Path) -> None:
     """Delete files a previous importer run wrote into ``out_dir``.
 
@@ -94,14 +82,28 @@ def _clear_prior_import(out_dir: Path) -> None:
     files listed in the marker (not the whole directory) makes forced re-runs
     deterministic — generated ids restart from 1 in source order instead of
     drifting past the prior run's ids — without touching any file the importer
-    did not create (so a hand-added file next to the drafts is preserved)."""
-    marker = _read_marker(out_dir)
-    if not marker:
+    did not create (so a hand-added file next to the drafts is preserved).
+
+    Fails CLOSED: if the marker is absent, nothing to clear. If it exists but is
+    unreadable / not JSON / not a mapping / missing a ``created`` list, we cannot
+    know which files were ours, so we refuse rather than silently proceeding
+    (which would let ``--force`` churn ids or hit a confusing collision error)."""
+    marker = out_dir / _MARKER
+    if not marker.exists():
         return
-    created = marker.get("created")
-    if not isinstance(created, list):
-        return
-    for name in created:
+    try:
+        data = json.loads(marker.read_text(encoding="utf-8"))
+    except (ValueError, OSError) as exc:
+        raise ImportError_(
+            f"cannot force-overwrite {out_dir}: the import marker {_MARKER!r} is "
+            f"unreadable ({exc}). Clear the directory or choose a fresh --out."
+        ) from exc
+    if not isinstance(data, dict) or not isinstance(data.get("created"), list):
+        raise ImportError_(
+            f"cannot force-overwrite {out_dir}: the import marker {_MARKER!r} does not "
+            f"record which files were imported. Clear the directory or choose a fresh --out."
+        )
+    for name in data["created"]:
         if not isinstance(name, str):
             continue
         # Confine deletion to a direct child of out_dir (no traversal).

--- a/src/data_olympus/importer/run.py
+++ b/src/data_olympus/importer/run.py
@@ -1,0 +1,338 @@
+"""Importer orchestrator: dispatch by kind, write drafts, lint, build report.
+
+The importer NEVER touches git. It writes files into the output bundle dir and
+returns an ImportReport. Re-run safety: by default it REFUSES to write into an
+output dir that already contains importer-authored drafts (a marker file records
+prior runs); ``force=True`` overwrites. This makes re-runs deterministic and
+never silently duplicates or clobbers.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from data_olympus.format import discover_bundle_files, lint_files
+from data_olympus.format.frontmatter import parse_frontmatter
+
+from . import adr as adr_mod
+from . import flat as flat_mod
+from . import okf as okf_mod
+from .model import DraftDoc, ImportError_, ImportReport, LintFinding, SkippedSection
+from .stamp import (
+    IdAllocator,
+    assert_known_vocab,
+    build_frontmatter,
+    first_sentence,
+    normalize_tier,
+    render_document,
+    slugify,
+    tags_from_text,
+    title_from_heading,
+)
+
+KINDS = ("claude-md", "agents-md", "gemini-md", "cursorrules", "adr", "okf")
+
+# Marker written into an output dir the importer created/wrote to. Its presence
+# is what "refuse-on-rerun" keys off of, so a re-run is detected even if the
+# operator deletes the drafts but keeps the dir.
+_MARKER = ".data-olympus-import"
+
+# Default id prefixes per kind (overridable with --id-prefix).
+_DEFAULT_PREFIX = {
+    "claude-md": "CLAUDE",
+    "agents-md": "AGENTS",
+    "gemini-md": "GEMINI",
+    "cursorrules": "CURSOR",
+    "okf": "OKF",
+}
+
+_DEDUP_NEXT_STEPS = (
+    "Review each draft, then activate with a status change once vetted.",
+    "To converge with an EXISTING knowledge base instead of duplicating it, run "
+    "the dedup pass: call the kb_cleanup_plan MCP tool (or POST "
+    "/api/v1/onboarding/cleanup-plan) with these files as local_files. It "
+    "classifies each draft as imported_duplicate / partial_overlap / unique and "
+    "proposes thin-pointer replacements for exact duplicates.",
+    "The importer wrote drafts only; nothing was committed to git and nothing "
+    "was activated.",
+)
+
+
+def _existing_ids(out_dir: Path) -> set[str]:
+    """Collect ids already present under ``out_dir`` so we never collide."""
+    ids: set[str] = set()
+    if not out_dir.is_dir():
+        return ids
+    for md in out_dir.rglob("*.md"):
+        try:
+            fm, _ = parse_frontmatter(md.read_text(encoding="utf-8"))
+        except (ValueError, OSError):
+            continue
+        doc_id = fm.get("id")
+        if isinstance(doc_id, str) and doc_id:
+            ids.add(doc_id)
+    return ids
+
+
+def _check_rerun(out_dir: Path, *, force: bool) -> None:
+    """Enforce refuse-on-rerun unless ``force``.
+
+    Refuses when the marker exists OR the dir already holds any front-mattered
+    ``.md`` file (so importing into a hand-authored bundle without --force is
+    also refused, protecting existing content from silent clobber)."""
+    if force:
+        return
+    marker = out_dir / _MARKER
+    if marker.exists():
+        raise ImportError_(
+            f"refusing to re-import: {out_dir} was already used as an import target "
+            f"(marker {_MARKER!r} present). Re-run with --force to overwrite, or "
+            f"choose a fresh --out directory."
+        )
+    if out_dir.is_dir():
+        for md in out_dir.rglob("*.md"):
+            try:
+                fm, _ = parse_frontmatter(md.read_text(encoding="utf-8"))
+            except (ValueError, OSError):
+                continue
+            if fm:
+                raise ImportError_(
+                    f"refusing to write into non-empty bundle {out_dir} "
+                    f"(found governed file {md.name!r}). Use a fresh --out directory "
+                    f"or pass --force to overwrite."
+                )
+
+
+def _default_out(source: Path, kind: str) -> Path:
+    """Derive a default output dir next to the source when --out is omitted."""
+    base = source.parent if source.is_file() else source
+    return base / f"imported-{kind}"
+
+
+def _flat_drafts(
+    source: Path, *, kind: str, tier: str, category: str | None, id_prefix: str, existing: set[str]
+) -> tuple[list[DraftDoc], list[SkippedSection]]:
+    text = source.read_text(encoding="utf-8")
+    sections = flat_mod.split_flat(text)
+    alloc = IdAllocator(id_prefix, existing)
+    drafts: list[DraftDoc] = []
+    skipped: list[SkippedSection] = []
+    used_names: set[str] = set()
+    for sec in sections:
+        if sec.body_len < flat_mod.MIN_BODY_CHARS:
+            skipped.append(
+                SkippedSection(
+                    heading=sec.heading,
+                    reason=f"body too short ({sec.body_len} < {flat_mod.MIN_BODY_CHARS} chars)",
+                )
+            )
+            continue
+        doc_id = alloc.next()
+        title = title_from_heading(sec.heading, fallback=doc_id)
+        description = first_sentence(sec.body) or title
+        tags = tags_from_text(sec.heading + "\n" + sec.body, fallback=kind.replace("-md", ""))
+        fm = build_frontmatter(
+            doc_id=doc_id,
+            doc_type="standard",
+            status="draft",
+            tier=tier,
+            title=title,
+            description=description,
+            tags=tags,
+            category=category,
+        )
+        stem = _unique_stem(slugify(title, fallback=doc_id.lower()), used_names)
+        drafts.append(
+            DraftDoc(
+                filename=f"{stem}.md",
+                frontmatter=fm,
+                body=sec.body,
+                inferences=[f"{doc_id}: title from heading {sec.heading!r}"],
+            )
+        )
+    return drafts, skipped
+
+
+def _adr_drafts(
+    source: Path, *, tier: str, category: str | None, existing: set[str]
+) -> tuple[list[DraftDoc], list[SkippedSection]]:
+    files = adr_mod.discover_adr_files(source)
+    if not files:
+        raise ImportError_(
+            f"no adr-tools files (NNNN-title.md) found under {source}. "
+            f"Point --kind adr at a doc/adr directory."
+        )
+    alloc = IdAllocator("ADR", existing)
+    drafts: list[DraftDoc] = []
+    used_names: set[str] = set()
+    for f in files:
+        parsed = adr_mod.parse_adr_file(f)
+        if parsed is None:  # pragma: no cover - discover already filtered
+            continue
+        alloc.reserve(parsed.doc_id)
+        extra: dict[str, object] = {}
+        if parsed.supersedes:
+            extra["supersedes"] = (
+                parsed.supersedes if len(parsed.supersedes) > 1 else parsed.supersedes[0]
+            )
+        if parsed.superseded_by:
+            extra["superseded_by"] = parsed.superseded_by
+        fm = build_frontmatter(
+            doc_id=parsed.doc_id,
+            doc_type="decision",
+            status=parsed.status,
+            tier=tier,
+            title=parsed.title,
+            description=adr_mod.description_for(parsed),
+            tags=tags_from_text(parsed.title + "\n" + parsed.body, fallback="decision"),
+            category=category,
+            extra=extra or None,
+        )
+        stem = _unique_stem(f"{parsed.doc_id.lower()}-{parsed.slug}", used_names)
+        drafts.append(
+            DraftDoc(
+                filename=f"{stem}.md",
+                frontmatter=fm,
+                body=parsed.body,
+                inferences=parsed.inferences,
+                needs_review=parsed.needs_review,
+            )
+        )
+    return drafts, []
+
+
+def _okf_drafts(
+    source: Path, *, tier: str, category: str | None, existing: set[str]
+) -> tuple[list[DraftDoc], list[SkippedSection]]:
+    files = okf_mod.discover_okf_files(source)
+    if not files:
+        raise ImportError_(f"no markdown files to normalize under {source}")
+    drafts: list[DraftDoc] = []
+    used_names: set[str] = set()
+    seen_ids: set[str] = set(existing)
+    for f in files:
+        norm = okf_mod.normalize_okf_doc(f, default_tier=tier, category=category)
+        doc_id = str(norm.frontmatter["id"])
+        needs_review = list(norm.needs_review)
+        if doc_id in seen_ids:
+            needs_review.append(
+                f"{f.name}: id {doc_id!r} collides with another imported/existing doc; "
+                f"resolve before activation"
+            )
+        seen_ids.add(doc_id)
+        stem = _unique_stem(slugify(doc_id, fallback=f.stem), used_names)
+        drafts.append(
+            DraftDoc(
+                filename=f"{stem}.md",
+                frontmatter=norm.frontmatter,
+                body=norm.body,
+                inferences=[f"{f.name}: {note}" for note in norm.inferences],
+                needs_review=needs_review,
+            )
+        )
+    return drafts, []
+
+
+def _unique_stem(stem: str, used: set[str]) -> str:
+    """Ensure a filename stem is unique within this run."""
+    candidate = stem or "concept"
+    n = 1
+    while candidate in used:
+        n += 1
+        candidate = f"{stem}-{n}"
+    used.add(candidate)
+    return candidate
+
+
+def run_import(
+    *,
+    source: str | Path,
+    kind: str,
+    tier: str,
+    out: str | Path | None = None,
+    category: str | None = None,
+    id_prefix: str | None = None,
+    force: bool = False,
+) -> ImportReport:
+    """Import ``source`` of the given ``kind`` into a governed draft bundle.
+
+    Returns an ImportReport. Raises ImportError_ on bad input or a refused
+    re-run. Never commits to git.
+    """
+    assert_known_vocab()
+    if kind not in KINDS:
+        raise ImportError_(f"unknown --kind {kind!r} (allowed: {', '.join(KINDS)})")
+    try:
+        tier = normalize_tier(tier)
+    except ValueError as exc:
+        raise ImportError_(str(exc)) from exc
+
+    source_path = Path(source)
+    if not source_path.exists():
+        raise ImportError_(f"source not found: {source_path}")
+
+    out_dir = Path(out) if out else _default_out(source_path, kind)
+    _check_rerun(out_dir, force=force)
+
+    existing = _existing_ids(out_dir)
+
+    if kind in ("claude-md", "agents-md", "gemini-md", "cursorrules"):
+        if not source_path.is_file():
+            raise ImportError_(f"--kind {kind} expects a file, got directory {source_path}")
+        prefix = id_prefix or _DEFAULT_PREFIX[kind]
+        drafts, skipped = _flat_drafts(
+            source_path, kind=kind, tier=tier, category=category,
+            id_prefix=prefix, existing=existing,
+        )
+    elif kind == "adr":
+        drafts, skipped = _adr_drafts(
+            source_path, tier=tier, category=category, existing=existing
+        )
+    else:  # okf
+        drafts, skipped = _okf_drafts(
+            source_path, tier=tier, category=category, existing=existing
+        )
+
+    if not drafts:
+        raise ImportError_(
+            f"no importable concepts found in {source_path} (every candidate section "
+            f"was too short or empty). Nothing written."
+        )
+
+    report = ImportReport(
+        kind=kind, source=str(source_path), out_dir=str(out_dir), skipped=skipped
+    )
+    out_dir.mkdir(parents=True, exist_ok=True)
+    for draft in drafts:
+        dest = out_dir / draft.filename
+        dest.write_text(render_document(draft.frontmatter, draft.body), encoding="utf-8")
+        report.created.append(draft.filename)
+        for note in draft.inferences:
+            report.inferences.append(note)
+        for note in draft.needs_review:
+            report.needs_review.append(note)
+        # Flag any non-draft status (ADR-derived) for human attention.
+        status = draft.frontmatter.get("status")
+        if status and status != "draft":
+            report.needs_review.append(
+                f"{draft.filename}: landed with status {status!r} (not draft); "
+                f"verify before activation"
+            )
+
+    # Record the marker so a future re-run without --force is refused.
+    (out_dir / _MARKER).write_text(
+        f"imported kind={kind} source={source_path}\n", encoding="utf-8"
+    )
+
+    # Lint the output over exactly the files we wrote (plus any pre-existing).
+    linted = discover_bundle_files(out_dir)
+    findings = lint_files(linted)
+    for path in sorted(findings):
+        rel = path.relative_to(out_dir)
+        for f in findings[path]:
+            report.lint.append(
+                LintFinding(path=str(rel), severity=f.severity, field=f.field, message=f.message)
+            )
+
+    report.next_steps = list(_DEDUP_NEXT_STEPS)
+    return report

--- a/src/data_olympus/importer/run.py
+++ b/src/data_olympus/importer/run.py
@@ -9,6 +9,7 @@ never silently duplicates or clobbers.
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 from data_olympus.format import discover_bundle_files, lint_files
@@ -72,6 +73,41 @@ def _existing_ids(out_dir: Path) -> set[str]:
         if isinstance(doc_id, str) and doc_id:
             ids.add(doc_id)
     return ids
+
+
+def _read_marker(out_dir: Path) -> dict[str, object] | None:
+    """Return the parsed import marker, or None if absent/unreadable."""
+    marker = out_dir / _MARKER
+    if not marker.exists():
+        return None
+    try:
+        data = json.loads(marker.read_text(encoding="utf-8"))
+    except (ValueError, OSError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _clear_prior_import(out_dir: Path) -> None:
+    """Delete files a previous importer run wrote into ``out_dir``.
+
+    Called only on a forced re-run of an importer-owned dir. Deleting exactly the
+    files listed in the marker (not the whole directory) makes forced re-runs
+    deterministic — generated ids restart from 1 in source order instead of
+    drifting past the prior run's ids — without touching any file the importer
+    did not create (so a hand-added file next to the drafts is preserved)."""
+    marker = _read_marker(out_dir)
+    if not marker:
+        return
+    created = marker.get("created")
+    if not isinstance(created, list):
+        return
+    for name in created:
+        if not isinstance(name, str):
+            continue
+        # Confine deletion to a direct child of out_dir (no traversal).
+        target = out_dir / name
+        if target.parent == out_dir and target.is_file():
+            target.unlink()
 
 
 def _check_rerun(out_dir: Path, *, force: bool) -> None:
@@ -162,15 +198,28 @@ def _adr_drafts(
             f"no adr-tools files (NNNN-title.md) found under {source}. "
             f"Point --kind adr at a doc/adr directory."
         )
-    alloc = IdAllocator("ADR", existing)
     drafts: list[DraftDoc] = []
     used_names: set[str] = set()
+    seen_ids: set[str] = set(existing)
     for f in files:
         parsed = adr_mod.parse_adr_file(f)
         if parsed is None:  # pragma: no cover - discover already filtered
             continue
-        alloc.reserve(parsed.doc_id)
-        extra: dict[str, object] = {}
+        # ID collision: the same ADR-NNNN id already exists in the output bundle
+        # (or two ADR files map to the same number). Refuse rather than write a
+        # bundle with a duplicate id that the linter cannot catch.
+        if parsed.doc_id in seen_ids:
+            raise ImportError_(
+                f"ADR id collision: {parsed.doc_id!r} (from {f.name}) already exists in "
+                f"the output bundle. Resolve the duplicate ADR number or choose a fresh "
+                f"--out directory."
+            )
+        seen_ids.add(parsed.doc_id)
+
+        # Draft-status invariant: imported ADRs ALWAYS land as draft so nothing
+        # auto-activates; the parsed adr-tools status is preserved verbatim in a
+        # non-activating ``source_status`` field for the human reviewer.
+        extra: dict[str, object] = {"source_status": parsed.status}
         if parsed.supersedes:
             extra["supersedes"] = (
                 parsed.supersedes if len(parsed.supersedes) > 1 else parsed.supersedes[0]
@@ -180,22 +229,33 @@ def _adr_drafts(
         fm = build_frontmatter(
             doc_id=parsed.doc_id,
             doc_type="decision",
-            status=parsed.status,
+            status="draft",
             tier=tier,
             title=parsed.title,
             description=adr_mod.description_for(parsed),
             tags=tags_from_text(parsed.title + "\n" + parsed.body, fallback="decision"),
             category=category,
-            extra=extra or None,
+            extra=extra,
         )
+        inferences = list(parsed.inferences)
+        needs_review = list(parsed.needs_review)
+        if parsed.status != "draft":
+            inferences.append(
+                f"adr-tools status {parsed.status!r} preserved in source_status; "
+                f"imported as draft"
+            )
+            needs_review.append(
+                f"{parsed.doc_id}: source ADR status was {parsed.status!r}; imported as "
+                f"draft (see source_status). Verify before activation."
+            )
         stem = _unique_stem(f"{parsed.doc_id.lower()}-{parsed.slug}", used_names)
         drafts.append(
             DraftDoc(
                 filename=f"{stem}.md",
                 frontmatter=fm,
                 body=parsed.body,
-                inferences=parsed.inferences,
-                needs_review=parsed.needs_review,
+                inferences=inferences,
+                needs_review=needs_review,
             )
         )
     return drafts, []
@@ -214,10 +274,14 @@ def _okf_drafts(
         norm = okf_mod.normalize_okf_doc(f, default_tier=tier, category=category)
         doc_id = str(norm.frontmatter["id"])
         needs_review = list(norm.needs_review)
+        # ID uniqueness is a bundle invariant the linter does not enforce across
+        # files, so a duplicate id would produce a structurally unsafe bundle
+        # while report.lint_clean stayed true. Refuse instead of writing it.
         if doc_id in seen_ids:
-            needs_review.append(
-                f"{f.name}: id {doc_id!r} collides with another imported/existing doc; "
-                f"resolve before activation"
+            raise ImportError_(
+                f"OKF id collision: {doc_id!r} (from {f.name}) already exists in the "
+                f"output bundle or was produced by another imported doc. Give the source "
+                f"docs distinct ids or choose a fresh --out directory."
             )
         seen_ids.add(doc_id)
         stem = _unique_stem(slugify(doc_id, fallback=f.stem), used_names)
@@ -274,6 +338,12 @@ def run_import(
     out_dir = Path(out) if out else _default_out(source_path, kind)
     _check_rerun(out_dir, force=force)
 
+    # On a forced re-run of an importer-owned dir, delete the prior run's files
+    # BEFORE computing existing ids so generated ids restart deterministically
+    # (Blocker: --force must not churn ids past the previous run).
+    if force:
+        _clear_prior_import(out_dir)
+
     existing = _existing_ids(out_dir)
 
     if kind in ("claude-md", "agents-md", "gemini-md", "cursorrules"):
@@ -319,9 +389,15 @@ def run_import(
                 f"verify before activation"
             )
 
-    # Record the marker so a future re-run without --force is refused.
+    # Record the marker (JSON) so a future re-run without --force is refused and
+    # a forced re-run can delete exactly the files this run created.
     (out_dir / _MARKER).write_text(
-        f"imported kind={kind} source={source_path}\n", encoding="utf-8"
+        json.dumps(
+            {"kind": kind, "source": str(source_path), "created": list(report.created)},
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
     )
 
     # Lint the output over exactly the files we wrote (plus any pre-existing).

--- a/src/data_olympus/importer/stamp.py
+++ b/src/data_olympus/importer/stamp.py
@@ -1,0 +1,227 @@
+"""Frontmatter stamping helpers for the importer.
+
+The governance vocabulary (types, statuses, tiers) is single-sourced from
+``data_olympus.format.validate`` — the importer never hardcodes a second copy.
+Everything stamped here lands as ``status: draft`` by default; the ADR path may
+carry a derived status, but the orchestrator flags any non-draft.
+"""
+
+from __future__ import annotations
+
+import datetime
+import re
+from typing import Any
+
+import yaml
+
+from data_olympus.format.validate import STATUSES, TIERS, TYPES
+
+DEFAULT_TYPE = "standard"
+DRAFT_STATUS = "draft"
+
+# A small, deterministic keyword -> tag map. Heuristic only: we never invent
+# facts, we only surface obvious topical tags from the source words. Empty when
+# nothing matches (the caller falls back to a generic tag so the recommended
+# ``tags`` field is always present and lint stays clean).
+_TAG_KEYWORDS: dict[str, str] = {
+    "security": "security",
+    "secret": "security",
+    "credential": "security",
+    "auth": "auth",
+    "test": "testing",
+    "git": "git",
+    "commit": "git",
+    "deploy": "deployment",
+    "kubernetes": "kubernetes",
+    "k8s": "kubernetes",
+    "docker": "docker",
+    "database": "database",
+    "sql": "database",
+    "api": "api",
+    "style": "style",
+    "format": "style",
+    "review": "review",
+    "workflow": "workflow",
+    "python": "python",
+    "typescript": "typescript",
+    "documentation": "docs",
+}
+
+# Strip a leading ATX heading marker and any trailing hashes.
+_HEADING_RE = re.compile(r"^\s{0,3}#{1,6}\s+(?P<text>.*?)\s*#*\s*$")
+# Split a body into sentences on the first period/question/exclamation followed
+# by whitespace. Deliberately simple: we only need the first sentence.
+_SENTENCE_END_RE = re.compile(r"(?<=[.!?])\s")
+_SLUG_RE = re.compile(r"[^a-z0-9]+")
+_ID_PREFIX_RE = re.compile(r"[^A-Za-z0-9]+")
+
+
+def assert_known_vocab() -> None:
+    """Fail fast if the defaults we stamp ever fall out of the schema vocab.
+
+    A cheap guard so a future schema rename cannot silently make the importer
+    emit lint-dirty drafts.
+    """
+    if DEFAULT_TYPE not in TYPES:  # pragma: no cover - guard
+        raise AssertionError(f"DEFAULT_TYPE {DEFAULT_TYPE!r} not in schema TYPES")
+    if DRAFT_STATUS not in STATUSES:  # pragma: no cover - guard
+        raise AssertionError(f"DRAFT_STATUS {DRAFT_STATUS!r} not in schema STATUSES")
+
+
+def normalize_tier(tier: str) -> str:
+    """Return ``tier`` if it is a valid schema tier, else raise ValueError.
+
+    Accepts the exact schema spelling (``T1``..``T4``, ``meta``) or a bare digit
+    (``1`` -> ``T1``). Anything else is rejected so a typo never produces a
+    lint-dirty draft.
+    """
+    t = tier.strip()
+    if t in TIERS:
+        return t
+    if t.isdigit() and f"T{t}" in TIERS:
+        return f"T{t}"
+    raise ValueError(f"invalid tier {tier!r} (allowed: {sorted(TIERS)})")
+
+
+def heading_text(line: str) -> str | None:
+    """Return the text of an ATX heading line, or None if not a heading."""
+    m = _HEADING_RE.match(line)
+    return m.group("text").strip() if m else None
+
+
+def title_from_heading(heading: str, fallback: str) -> str:
+    """Clean a heading into a title. Strips markdown emphasis/backticks."""
+    text = heading.strip().strip("*_`").strip()
+    return text or fallback
+
+
+def first_sentence(body: str, *, limit: int = 200) -> str:
+    """Return the first sentence of ``body`` as a one-line description.
+
+    Skips blank lines and heading lines; collapses inner whitespace; truncates
+    to ``limit`` chars. Returns '' when the body has no prose.
+    """
+    for raw in body.splitlines():
+        line = raw.strip()
+        if not line or heading_text(raw) is not None:
+            continue
+        # Drop leading bullet / list markers so the description reads cleanly.
+        line = re.sub(r"^([-*+]|\d+[.)])\s+", "", line)
+        if not line:
+            continue
+        sentence = _SENTENCE_END_RE.split(line, maxsplit=1)[0].strip()
+        sentence = re.sub(r"\s+", " ", sentence)
+        if len(sentence) > limit:
+            sentence = sentence[: limit - 1].rstrip() + "…"
+        return sentence
+    return ""
+
+
+def tags_from_text(text: str, *, fallback: str) -> list[str]:
+    """Heuristically derive topical tags from source words.
+
+    Deterministic and order-stable: scans the lowercased text once, collecting
+    each mapped tag in first-seen order. Falls back to ``[fallback]`` when
+    nothing matches so the recommended ``tags`` field is never empty.
+    """
+    lowered = text.lower()
+    seen: list[str] = []
+    for keyword, tag in _TAG_KEYWORDS.items():
+        if keyword in lowered and tag not in seen:
+            seen.append(tag)
+    return seen or [fallback]
+
+
+def slugify(text: str, *, fallback: str = "concept") -> str:
+    """Return a filesystem-safe lowercase slug for a filename stem."""
+    slug = _SLUG_RE.sub("-", text.lower()).strip("-")
+    return slug or fallback
+
+
+def sanitize_id_prefix(prefix: str) -> str:
+    """Normalize a user-supplied id prefix to ``[A-Za-z0-9]`` runs joined by '-'.
+
+    An id must not contain a colon (the index treats ``:`` in an id as invalid,
+    see markdown_parse.parse_file). Uppercasing is preserved so ``STD-ACME`` and
+    ``adr`` both round-trip as the user wrote them, minus separators.
+    """
+    cleaned = _ID_PREFIX_RE.sub("-", prefix).strip("-")
+    return cleaned or "IMP"
+
+
+class IdAllocator:
+    """Hand out unique, zero-padded sequential ids under a prefix.
+
+    Seeded with any ids already present in the output bundle so a re-run with
+    ``--force`` (or an import into a hand-authored dir) never reuses an id. The
+    padding width keeps filenames sortable for small corpora; ids past the pad
+    width simply grow (e.g. ``IMP-100``).
+    """
+
+    def __init__(self, prefix: str, existing: set[str] | None = None, *, width: int = 3) -> None:
+        self.prefix = sanitize_id_prefix(prefix)
+        self._used: set[str] = set(existing or set())
+        self._width = width
+        self._counter = 0
+
+    def next(self) -> str:
+        while True:
+            self._counter += 1
+            candidate = f"{self.prefix}-{self._counter:0{self._width}d}"
+            if candidate not in self._used:
+                self._used.add(candidate)
+                return candidate
+
+    def reserve(self, doc_id: str) -> None:
+        """Record an externally chosen id (e.g. an ADR number) as used."""
+        self._used.add(doc_id)
+
+
+def render_document(frontmatter: dict[str, Any], body: str) -> str:
+    """Serialize ``frontmatter`` (YAML) above the verbatim ``body``.
+
+    Uses ``yaml.safe_dump`` so no source value can forge a frontmatter key
+    (same hardening as tools_write._render_memory). ``sort_keys=False`` keeps
+    the schema field order we build. The body is preserved exactly; we only
+    guarantee a single trailing newline.
+    """
+    dumped = yaml.safe_dump(
+        frontmatter, sort_keys=False, default_flow_style=False, allow_unicode=True
+    )
+    return "---\n" + dumped + "---\n\n" + body.rstrip("\n") + "\n"
+
+
+def build_frontmatter(
+    *,
+    doc_id: str,
+    doc_type: str,
+    status: str,
+    tier: str,
+    title: str,
+    description: str,
+    tags: list[str],
+    category: str | None = None,
+    extra: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Assemble a schema-ordered frontmatter mapping.
+
+    Required fields first (id/type/status/tier), then the recommended fields
+    (title/description/tags/timestamp) so a stamped draft is lint-clean without
+    warnings. ``extra`` carries governance extensions (supersedes/superseded_by).
+    """
+    fm: dict[str, Any] = {
+        "id": doc_id,
+        "type": doc_type,
+        "status": status,
+        "tier": tier,
+    }
+    if category:
+        fm["category"] = category
+    fm["title"] = title
+    fm["description"] = description
+    fm["tags"] = [str(t) for t in tags]
+    fm["timestamp"] = datetime.date.today().isoformat()
+    if extra:
+        for key, value in extra.items():
+            fm[key] = value
+    return fm

--- a/tests/importer-fixtures/.cursorrules
+++ b/tests/importer-fixtures/.cursorrules
@@ -1,0 +1,12 @@
+Always write tests before implementation code. Every feature and bugfix must be
+covered by a test that fails before the change and passes after it. Keep the test
+suite fast and deterministic.
+
+Prefer composition over inheritance when structuring modules. Small focused
+functions are easier to test and reason about than deep class hierarchies. Avoid
+global mutable state in the request path.
+
+Use type hints on every public function. Run the type checker in CI and treat
+type errors as build failures rather than warnings.
+
+x

--- a/tests/importer-fixtures/AGENTS-nested.md
+++ b/tests/importer-fixtures/AGENTS-nested.md
@@ -1,0 +1,25 @@
+# House rules
+
+This top-level H1 is the document title. All the concepts below hang off H2
+headings, so the importer should split at the H2 level and keep each H2's H3
+subsections inside that concept rather than fragmenting them.
+
+## Testing policy
+
+Write tests before implementation. Keep the suite fast.
+
+### Unit tests
+
+Unit tests must not touch the network or the filesystem outside a temp dir.
+
+### Integration tests
+
+Integration tests may spin up a local server but must clean it up afterward.
+
+## Release policy
+
+Cut a release only from the release branch. Tag on merge, never by hand.
+
+### Versioning
+
+Follow semantic versioning. Pre-1.0, feature work is a minor bump.

--- a/tests/importer-fixtures/CLAUDE.md
+++ b/tests/importer-fixtures/CLAUDE.md
@@ -1,0 +1,35 @@
+# Project agent rules
+
+This preamble sits above the first real heading. It describes the overall
+philosophy of the project and how agents should behave when working here. It is
+several sentences long so that it clears the minimum body threshold and becomes
+its own draft concept rather than being dropped.
+
+## Writing style
+
+Do not use em-dashes. Use commas, parentheses, or two sentences instead.
+Follow the house style guide for length and tone. Keep documentation concise
+and prefer active voice throughout every document you produce.
+
+## Git workflow
+
+Never bypass pre-commit hooks. Always verify the branch is up to date with the
+remote before pushing. Use conventional commit messages for every commit so the
+changelog can be generated automatically from history.
+
+## Security defaults
+
+Never write credentials, secrets, or passwords to any file. All secrets must be
+prompted interactively or retrieved from the secrets manager. Never paste secret
+values into chat, plan files, or commit messages.
+
+## Deployment notes
+
+- Remember to configure the database connection pool.
+- The deployment script should retry on transient failures.
+- Kubernetes readiness probes need a longer initial delay for the API service.
+- Docker images must be rebuilt when the base image rotates its SSH host key.
+
+## TODO
+
+Fix later.

--- a/tests/importer-fixtures/adr-tools/doc/adr/0001-record-architecture-decisions.md
+++ b/tests/importer-fixtures/adr-tools/doc/adr/0001-record-architecture-decisions.md
@@ -1,0 +1,20 @@
+# 1. Record architecture decisions
+
+Date: 2024-01-10
+
+## Status
+
+Accepted
+
+## Context
+
+We need to record the architectural decisions made on this project so that new
+team members can understand why the system is built the way it is.
+
+## Decision
+
+We will use Architecture Decision Records, as described by Michael Nygard.
+
+## Consequences
+
+See Michael Nygard's article, linked above.

--- a/tests/importer-fixtures/adr-tools/doc/adr/0002-use-postgres.md
+++ b/tests/importer-fixtures/adr-tools/doc/adr/0002-use-postgres.md
@@ -1,0 +1,19 @@
+# 2. Use PostgreSQL for persistence
+
+Date: 2024-02-01
+
+## Status
+
+Superseded by [ADR-0004](0004-use-distributed-sql.md)
+
+## Context
+
+The application needs a relational datastore for transactional workloads.
+
+## Decision
+
+We will use PostgreSQL as the primary datastore.
+
+## Consequences
+
+Operational familiarity is high; scaling writes horizontally is harder.

--- a/tests/importer-fixtures/adr-tools/doc/adr/0004-use-distributed-sql.md
+++ b/tests/importer-fixtures/adr-tools/doc/adr/0004-use-distributed-sql.md
@@ -1,0 +1,22 @@
+# 4. Use a distributed SQL database
+
+Date: 2024-05-15
+
+## Status
+
+Accepted
+
+Supersedes ADR-0002
+
+## Context
+
+Write throughput outgrew a single PostgreSQL primary.
+
+## Decision
+
+We will migrate to a distributed SQL database that speaks the PostgreSQL wire
+protocol so application code changes little.
+
+## Consequences
+
+Horizontal write scaling is possible; operational complexity increases.

--- a/tests/importer-fixtures/okf/partial-concept.md
+++ b/tests/importer-fixtures/okf/partial-concept.md
@@ -1,0 +1,12 @@
+---
+id: OKF-RETRY
+kind: standard
+state: active
+name: Retry policy for outbound calls
+keywords: [reliability, networking]
+---
+# Retry policy
+
+All outbound HTTP calls use exponential backoff with jitter. The base delay is
+100ms and the cap is 30s. Idempotent requests may be retried up to five times;
+non-idempotent requests are never retried automatically.

--- a/tests/test_importer.py
+++ b/tests/test_importer.py
@@ -145,6 +145,44 @@ def test_split_flat_headingless_min_body():
 
 
 # --------------------------------------------------------------------------- #
+# Depth-aware heading split (nested headings stay with their parent concept)    #
+# --------------------------------------------------------------------------- #
+
+
+def test_nested_headings_split_at_h2_not_h3(tmp_path):
+    # One H1 title over several H2 concepts, each with H3 detail. The importer
+    # splits at H2 (not the lone H1, which would collapse into one concept, and
+    # not H3, which would over-split) and keeps each H2's H3 subsections in body.
+    report = run_import(
+        source=FIXTURES / "AGENTS-nested.md", kind="agents-md", tier="T3", out=tmp_path / "out"
+    )
+    titles = {d.frontmatter["title"] for d in _load_drafts(tmp_path / "out").values()}
+    assert "Testing policy" in titles
+    assert "Release policy" in titles
+    # The H3 subsections are NOT their own concepts.
+    assert "Unit tests" not in titles
+    assert "Versioning" not in titles
+    testing = next(
+        d for d in _load_drafts(tmp_path / "out").values()
+        if d.frontmatter["title"] == "Testing policy"
+    )
+    # Nested H3 content is preserved inside the parent concept body verbatim.
+    assert "### Unit tests" in testing.body
+    assert "must not touch the network" in testing.body
+    assert report.lint_clean
+
+
+def test_boundary_heading_line_kept_in_body(tmp_path):
+    run_import(source=FIXTURES / "CLAUDE.md", kind="claude-md", tier="T3", out=tmp_path / "out")
+    doc = next(
+        d for d in _load_drafts(tmp_path / "out").values()
+        if d.frontmatter["title"] == "Writing style"
+    )
+    # The concept keeps its own heading line so no source text is dropped.
+    assert "## Writing style" in doc.body
+
+
+# --------------------------------------------------------------------------- #
 # ADR directory: supersedes chain                                              #
 # --------------------------------------------------------------------------- #
 
@@ -162,21 +200,45 @@ def test_adr_maps_number_and_title(tmp_path):
 def test_adr_supersedes_chain(tmp_path):
     run_import(source=FIXTURES / "adr-tools", kind="adr", tier="meta", out=tmp_path / "out")
     by_id = {d.frontmatter["id"]: d for d in _load_drafts(tmp_path / "out").values()}
-    # 0002 was superseded by 0004; 0004 supersedes 0002.
-    assert by_id["ADR-0002"].frontmatter["status"] == "superseded"
+    # Draft-status invariant: imported ADRs land as draft, with the parsed
+    # adr-tools status preserved in source_status. supersedes chain is mapped.
+    assert by_id["ADR-0002"].frontmatter["status"] == "draft"
+    assert by_id["ADR-0002"].frontmatter["source_status"] == "superseded"
     assert by_id["ADR-0002"].frontmatter["superseded_by"] == "ADR-0004"
-    assert by_id["ADR-0004"].frontmatter["status"] == "accepted"
+    assert by_id["ADR-0004"].frontmatter["status"] == "draft"
+    assert by_id["ADR-0004"].frontmatter["source_status"] == "accepted"
     assert by_id["ADR-0004"].frontmatter["supersedes"] == "ADR-0002"
 
 
-def test_adr_non_draft_status_flagged_for_review(tmp_path):
+def test_adr_always_draft_status():
+    # No ADR may ever be written with an in-force status: the invariant is that
+    # imports never auto-activate.
+    from data_olympus.importer.run import _adr_drafts
+
+    drafts, _ = _adr_drafts(FIXTURES / "adr-tools", tier="meta", category=None, existing=set())
+    assert all(d.frontmatter["status"] == "draft" for d in drafts)
+
+
+def test_adr_source_status_flagged_for_review(tmp_path):
     report = run_import(
         source=FIXTURES / "adr-tools", kind="adr", tier="meta", out=tmp_path / "out"
     )
     joined = "\n".join(report.needs_review)
-    assert "not draft" in joined
-    # Every non-draft ADR is surfaced.
-    assert "ADR-0002".lower() in joined.lower() or "adr-0002" in joined.lower()
+    assert "source ADR status" in joined
+    # Every non-draft source status is surfaced for the reviewer.
+    assert "adr-0002" in joined.lower()
+
+
+def test_adr_id_collision_refused(tmp_path):
+    out = tmp_path / "out"
+    out.mkdir()
+    # Pre-seed the output dir with a doc carrying an id an import would produce.
+    (out / "ADR-0001.md").write_text(
+        "---\nid: ADR-0001\ntype: decision\nstatus: active\ntier: meta\n---\nx\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(ImportError_, match="ADR id collision"):
+        run_import(source=FIXTURES / "adr-tools", kind="adr", tier="meta", out=out, force=True)
 
 
 def test_adr_output_lint_clean(tmp_path):
@@ -223,6 +285,36 @@ def test_okf_missing_id_synthesized_and_flagged(tmp_path):
     assert any("synthesized from the filename" in n for n in report.needs_review)
 
 
+def test_okf_missing_status_reports_inference(tmp_path):
+    # A required field synthesized with a default must be reported, not invented
+    # silently.
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "c.md").write_text(
+        "---\nid: OKF-C\ntype: standard\ntier: T2\n---\nA concept with no status field set.\n",
+        encoding="utf-8",
+    )
+    report = run_import(source=src, kind="okf", tier="T2", out=tmp_path / "out")
+    assert any("missing status" in n for n in report.inferences)
+    doc = next(iter(_load_drafts(tmp_path / "out").values()))
+    assert doc.frontmatter["status"] == "draft"
+
+
+def test_okf_id_collision_refused(tmp_path):
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "a.md").write_text(
+        "---\nid: DUP\ntype: standard\ntier: T2\n---\nFirst concept sharing the duplicate id.\n",
+        encoding="utf-8",
+    )
+    (src / "b.md").write_text(
+        "---\nid: DUP\ntype: standard\ntier: T2\n---\nSecond concept sharing the duplicate id.\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(ImportError_, match="OKF id collision"):
+        run_import(source=src, kind="okf", tier="T2", out=tmp_path / "out")
+
+
 def test_okf_output_lint_clean(tmp_path):
     run_import(source=FIXTURES / "okf", kind="okf", tier="T2", out=tmp_path / "out")
     _assert_lint_clean(tmp_path / "out")
@@ -233,14 +325,14 @@ def test_okf_output_lint_clean(tmp_path):
 # --------------------------------------------------------------------------- #
 
 
-def test_everything_lands_as_draft_except_derived_adr(tmp_path):
-    # Flat + OKF are always draft.
+def test_everything_lands_as_draft(tmp_path):
+    # Flat, OKF, AND ADR all land as draft: nothing auto-activates.
     run_import(source=FIXTURES / "CLAUDE.md", kind="claude-md", tier="T3", out=tmp_path / "flat")
-    for doc in _load_drafts(tmp_path / "flat").values():
-        assert doc.frontmatter["status"] == "draft"
     run_import(source=FIXTURES / "okf", kind="okf", tier="T2", out=tmp_path / "okf")
-    for doc in _load_drafts(tmp_path / "okf").values():
-        assert doc.frontmatter["status"] == "draft"
+    run_import(source=FIXTURES / "adr-tools", kind="adr", tier="meta", out=tmp_path / "adr")
+    for bundle in ("flat", "okf", "adr"):
+        for doc in _load_drafts(tmp_path / bundle).values():
+            assert doc.frontmatter["status"] == "draft", f"{bundle}/{doc.path.name} not draft"
 
 
 def test_stamped_vocab_is_single_sourced():
@@ -280,16 +372,34 @@ def test_rerun_refused_without_force(tmp_path):
         run_import(source=FIXTURES / "CLAUDE.md", kind="claude-md", tier="T3", out=out)
 
 
-def test_rerun_with_force_overwrites_without_duplicating(tmp_path):
+def test_rerun_with_force_is_deterministic(tmp_path):
     out = tmp_path / "out"
     first = run_import(source=FIXTURES / "CLAUDE.md", kind="claude-md", tier="T3", out=out)
+    first_ids = sorted(d.frontmatter["id"] for d in _load_drafts(out).values())
     second = run_import(
         source=FIXTURES / "CLAUDE.md", kind="claude-md", tier="T3", out=out, force=True
     )
-    # Same set of files, no duplicates, ids do not drift into collisions.
+    second_ids = sorted(d.frontmatter["id"] for d in _load_drafts(out).values())
+    # Same files, no duplicates, and ids do NOT drift on a forced re-run: the
+    # prior import's files are cleared before allocation, so ids restart at 1.
     assert sorted(first.created) == sorted(second.created)
-    ids = [d.frontmatter["id"] for d in _load_drafts(out).values()]
-    assert len(ids) == len(set(ids))
+    assert first_ids == second_ids
+    assert len(second_ids) == len(set(second_ids))
+    assert second_ids[0].endswith("-001")
+
+
+def test_force_preserves_hand_added_file(tmp_path):
+    out = tmp_path / "out"
+    run_import(source=FIXTURES / "CLAUDE.md", kind="claude-md", tier="T3", out=out)
+    # A file the operator adds next to the drafts must survive a forced re-run.
+    (out / "manual.md").write_text(
+        "---\nid: MANUAL-1\ntype: standard\nstatus: draft\ntier: T3\n"
+        "title: t\ndescription: d\ntags: [x]\ntimestamp: 2026-01-01\n---\nkeep\n",
+        encoding="utf-8",
+    )
+    run_import(source=FIXTURES / "CLAUDE.md", kind="claude-md", tier="T3", out=out, force=True)
+    assert (out / "manual.md").exists()
+    assert (out / "manual.md").read_text(encoding="utf-8").endswith("keep\n")
 
 
 def test_refuses_to_write_into_existing_bundle(tmp_path):

--- a/tests/test_importer.py
+++ b/tests/test_importer.py
@@ -388,6 +388,17 @@ def test_rerun_with_force_is_deterministic(tmp_path):
     assert second_ids[0].endswith("-001")
 
 
+def test_force_fails_closed_on_unusable_marker(tmp_path):
+    # If the marker cannot tell us which files were imported, --force must refuse
+    # rather than silently proceed (which would churn ids or hit a confusing
+    # collision error later).
+    out = tmp_path / "out"
+    run_import(source=FIXTURES / "CLAUDE.md", kind="claude-md", tier="T3", out=out)
+    (out / ".data-olympus-import").write_text("not json at all", encoding="utf-8")
+    with pytest.raises(ImportError_, match="unreadable"):
+        run_import(source=FIXTURES / "CLAUDE.md", kind="claude-md", tier="T3", out=out, force=True)
+
+
 def test_force_preserves_hand_added_file(tmp_path):
     out = tmp_path / "out"
     run_import(source=FIXTURES / "CLAUDE.md", kind="claude-md", tier="T3", out=out)

--- a/tests/test_importer.py
+++ b/tests/test_importer.py
@@ -1,0 +1,361 @@
+"""Tests for the `data-olympus import` command and the importer package.
+
+Fixture-driven: exercises flat-file splitting (headings + heading-less bullet
+clusters), frontmatter stamping, unique ids, draft-status invariants, ADR
+supersedes-chain mapping, OKF normalization, lint-cleanliness, report contents,
+the --json shape, and refuse-on-rerun semantics.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from data_olympus.cli.main import main
+from data_olympus.format import Document, discover_bundle_files, lint_files
+from data_olympus.format.validate import STATUSES, TIERS, TYPES
+from data_olympus.importer import ImportError_, run_import
+from data_olympus.importer.flat import MIN_BODY_CHARS, split_flat
+
+FIXTURES = Path(__file__).parent / "importer-fixtures"
+
+
+def _load_drafts(out_dir: Path) -> dict[str, Document]:
+    """Return {filename: Document} for every non-reserved .md written."""
+    return {p.name: Document.load(p) for p in discover_bundle_files(out_dir)}
+
+
+def _assert_lint_clean(out_dir: Path) -> None:
+    findings = lint_files(discover_bundle_files(out_dir))
+    errors = {
+        p: [f for f in fs if f.severity == "error"] for p, fs in findings.items()
+    }
+    errors = {p: fs for p, fs in errors.items() if fs}
+    assert not errors, f"expected lint-clean output, got errors: {errors}"
+
+
+# --------------------------------------------------------------------------- #
+# Flat file: CLAUDE.md (headings + preamble + heading-less bullet tail)         #
+# --------------------------------------------------------------------------- #
+
+
+def test_flat_claude_md_splits_on_headings(tmp_path):
+    report = run_import(
+        source=FIXTURES / "CLAUDE.md", kind="claude-md", tier="T3", out=tmp_path / "out"
+    )
+    # Preamble + 5 real headings = 6 candidates; the "TODO" stub is too short.
+    assert "TODO" in [s.heading for s in report.skipped]
+    titles = {Document.load(tmp_path / "out" / n).frontmatter["title"] for n in report.created}
+    assert "Writing style" in titles
+    assert "Git workflow" in titles
+    assert "Security defaults" in titles
+    # Preamble becomes its own draft (it clears the length threshold).
+    assert "Project agent rules" in titles
+
+
+def test_flat_stamps_required_frontmatter_and_draft_status(tmp_path):
+    report = run_import(
+        source=FIXTURES / "CLAUDE.md", kind="claude-md", tier="T3", out=tmp_path / "out"
+    )
+    for doc in _load_drafts(tmp_path / "out").values():
+        assert doc.frontmatter["status"] == "draft"
+        assert doc.frontmatter["type"] == "standard"
+        assert doc.frontmatter["tier"] == "T3"
+        assert doc.frontmatter["id"]
+        # recommended fields present so lint stays warning-free
+        assert doc.frontmatter["title"]
+        assert doc.frontmatter["description"]
+        assert isinstance(doc.frontmatter["tags"], list) and doc.frontmatter["tags"]
+    assert report.lint_clean
+
+
+def test_flat_ids_are_unique_and_non_colliding(tmp_path):
+    run_import(source=FIXTURES / "CLAUDE.md", kind="claude-md", tier="T3", out=tmp_path / "out")
+    ids = [d.frontmatter["id"] for d in _load_drafts(tmp_path / "out").values()]
+    assert len(ids) == len(set(ids)), f"duplicate ids: {ids}"
+    assert all(i.startswith("CLAUDE-") for i in ids)
+
+
+def test_flat_body_preserved_verbatim(tmp_path):
+    run_import(source=FIXTURES / "CLAUDE.md", kind="claude-md", tier="T3", out=tmp_path / "out")
+    doc = next(
+        d for d in _load_drafts(tmp_path / "out").values()
+        if d.frontmatter["title"] == "Writing style"
+    )
+    assert "Do not use em-dashes." in doc.body
+    # The words are never rewritten by the importer.
+    assert "em-dashes" in doc.body
+
+
+def test_flat_output_is_lint_clean(tmp_path):
+    run_import(source=FIXTURES / "CLAUDE.md", kind="claude-md", tier="T3", out=tmp_path / "out")
+    _assert_lint_clean(tmp_path / "out")
+
+
+def test_id_prefix_override(tmp_path):
+    run_import(
+        source=FIXTURES / "CLAUDE.md", kind="claude-md", tier="T3",
+        out=tmp_path / "out", id_prefix="STD-ACME",
+    )
+    ids = [d.frontmatter["id"] for d in _load_drafts(tmp_path / "out").values()]
+    assert all(i.startswith("STD-ACME-") for i in ids)
+    # No colons in generated ids (the index rejects ':' in an id).
+    assert all(":" not in i for i in ids)
+
+
+def test_category_stamped_when_flag_given(tmp_path):
+    run_import(
+        source=FIXTURES / "CLAUDE.md", kind="claude-md", tier="T3",
+        out=tmp_path / "out", category="agent-rules",
+    )
+    for doc in _load_drafts(tmp_path / "out").values():
+        assert doc.frontmatter["category"] == "agent-rules"
+
+
+# --------------------------------------------------------------------------- #
+# Heading-less file: .cursorrules -> bullet clusters                            #
+# --------------------------------------------------------------------------- #
+
+
+def test_cursorrules_without_headings_splits_into_clusters(tmp_path):
+    report = run_import(
+        source=FIXTURES / ".cursorrules", kind="cursorrules", tier="T2", out=tmp_path / "out"
+    )
+    # Three prose clusters clear the threshold; the trailing "x" cluster is short.
+    assert len(report.created) == 3
+    assert "x" in [s.heading for s in report.skipped]
+    _assert_lint_clean(tmp_path / "out")
+
+
+def test_cursorrules_derives_titles_from_first_line(tmp_path):
+    run_import(
+        source=FIXTURES / ".cursorrules", kind="cursorrules", tier="T2", out=tmp_path / "out"
+    )
+    titles = {d.frontmatter["title"] for d in _load_drafts(tmp_path / "out").values()}
+    assert any("test" in t.lower() for t in titles)
+
+
+def test_split_flat_headingless_min_body():
+    text = "short\n\nthis is a much longer line that clears the minimum body threshold easily.\n"
+    secs = split_flat(text)
+    long_secs = [s for s in secs if s.body_len >= MIN_BODY_CHARS]
+    assert len(long_secs) == 1
+
+
+# --------------------------------------------------------------------------- #
+# ADR directory: supersedes chain                                              #
+# --------------------------------------------------------------------------- #
+
+
+def test_adr_maps_number_and_title(tmp_path):
+    run_import(source=FIXTURES / "adr-tools", kind="adr", tier="meta", out=tmp_path / "out")
+    docs = _load_drafts(tmp_path / "out")
+    by_id = {d.frontmatter["id"]: d for d in docs.values()}
+    assert set(by_id) == {"ADR-0001", "ADR-0002", "ADR-0004"}
+    # Title strips the leading "N. " ordinal.
+    assert by_id["ADR-0002"].frontmatter["title"] == "Use PostgreSQL for persistence"
+    assert by_id["ADR-0002"].frontmatter["type"] == "decision"
+
+
+def test_adr_supersedes_chain(tmp_path):
+    run_import(source=FIXTURES / "adr-tools", kind="adr", tier="meta", out=tmp_path / "out")
+    by_id = {d.frontmatter["id"]: d for d in _load_drafts(tmp_path / "out").values()}
+    # 0002 was superseded by 0004; 0004 supersedes 0002.
+    assert by_id["ADR-0002"].frontmatter["status"] == "superseded"
+    assert by_id["ADR-0002"].frontmatter["superseded_by"] == "ADR-0004"
+    assert by_id["ADR-0004"].frontmatter["status"] == "accepted"
+    assert by_id["ADR-0004"].frontmatter["supersedes"] == "ADR-0002"
+
+
+def test_adr_non_draft_status_flagged_for_review(tmp_path):
+    report = run_import(
+        source=FIXTURES / "adr-tools", kind="adr", tier="meta", out=tmp_path / "out"
+    )
+    joined = "\n".join(report.needs_review)
+    assert "not draft" in joined
+    # Every non-draft ADR is surfaced.
+    assert "ADR-0002".lower() in joined.lower() or "adr-0002" in joined.lower()
+
+
+def test_adr_output_lint_clean(tmp_path):
+    run_import(source=FIXTURES / "adr-tools", kind="adr", tier="meta", out=tmp_path / "out")
+    _assert_lint_clean(tmp_path / "out")
+
+
+def test_adr_no_files_raises(tmp_path):
+    (tmp_path / "empty").mkdir()
+    with pytest.raises(ImportError_, match="no adr-tools files"):
+        run_import(source=tmp_path / "empty", kind="adr", tier="meta", out=tmp_path / "out")
+
+
+# --------------------------------------------------------------------------- #
+# OKF normalization                                                            #
+# --------------------------------------------------------------------------- #
+
+
+def test_okf_normalizes_aliases_and_downgrades_status(tmp_path):
+    report = run_import(source=FIXTURES / "okf", kind="okf", tier="T2", out=tmp_path / "out")
+    doc = next(iter(_load_drafts(tmp_path / "out").values()))
+    assert doc.frontmatter["id"] == "OKF-RETRY"
+    assert doc.frontmatter["type"] == "standard"  # from alias 'kind'
+    assert doc.frontmatter["status"] == "draft"  # 'active' downgraded
+    assert doc.frontmatter["tier"] == "T2"  # filled from --tier
+    assert doc.frontmatter["title"] == "Retry policy for outbound calls"  # from 'name'
+    assert set(doc.frontmatter["tags"]) == {"reliability", "networking"}  # from 'keywords'
+    joined = "\n".join(report.inferences)
+    assert "downgraded to 'draft'" in joined
+    assert "renamed field 'kind'" in joined
+
+
+def test_okf_missing_id_synthesized_and_flagged(tmp_path):
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "no-id.md").write_text(
+        "---\ntype: standard\n---\nA concept with no id at all in its frontmatter block.\n",
+        encoding="utf-8",
+    )
+    report = run_import(source=src, kind="okf", tier="T3", out=tmp_path / "out")
+    doc = next(iter(_load_drafts(tmp_path / "out").values()))
+    assert doc.frontmatter["id"] == "no-id"
+    assert any("synthesized" in n for n in report.inferences)
+    assert any("synthesized from the filename" in n for n in report.needs_review)
+
+
+def test_okf_output_lint_clean(tmp_path):
+    run_import(source=FIXTURES / "okf", kind="okf", tier="T2", out=tmp_path / "out")
+    _assert_lint_clean(tmp_path / "out")
+
+
+# --------------------------------------------------------------------------- #
+# Cross-cutting invariants                                                     #
+# --------------------------------------------------------------------------- #
+
+
+def test_everything_lands_as_draft_except_derived_adr(tmp_path):
+    # Flat + OKF are always draft.
+    run_import(source=FIXTURES / "CLAUDE.md", kind="claude-md", tier="T3", out=tmp_path / "flat")
+    for doc in _load_drafts(tmp_path / "flat").values():
+        assert doc.frontmatter["status"] == "draft"
+    run_import(source=FIXTURES / "okf", kind="okf", tier="T2", out=tmp_path / "okf")
+    for doc in _load_drafts(tmp_path / "okf").values():
+        assert doc.frontmatter["status"] == "draft"
+
+
+def test_stamped_vocab_is_single_sourced():
+    # The importer must only stamp values the schema knows.
+    from data_olympus.importer.stamp import DEFAULT_TYPE, DRAFT_STATUS
+
+    assert DEFAULT_TYPE in TYPES
+    assert DRAFT_STATUS in STATUSES
+    # And a bad tier is rejected against the real TIERS set.
+    from data_olympus.importer.stamp import normalize_tier
+
+    assert normalize_tier("2") == "T2"
+    assert "T2" in TIERS
+    with pytest.raises(ValueError):
+        normalize_tier("T9")
+
+
+def test_unknown_kind_raises(tmp_path):
+    with pytest.raises(ImportError_, match="unknown --kind"):
+        run_import(source=FIXTURES / "CLAUDE.md", kind="bogus", tier="T3", out=tmp_path / "out")
+
+
+def test_source_not_found_raises(tmp_path):
+    with pytest.raises(ImportError_, match="source not found"):
+        run_import(source=tmp_path / "nope.md", kind="claude-md", tier="T3", out=tmp_path / "out")
+
+
+# --------------------------------------------------------------------------- #
+# Re-run semantics: REFUSE by default, --force overwrites                       #
+# --------------------------------------------------------------------------- #
+
+
+def test_rerun_refused_without_force(tmp_path):
+    out = tmp_path / "out"
+    run_import(source=FIXTURES / "CLAUDE.md", kind="claude-md", tier="T3", out=out)
+    with pytest.raises(ImportError_, match="refusing to re-import"):
+        run_import(source=FIXTURES / "CLAUDE.md", kind="claude-md", tier="T3", out=out)
+
+
+def test_rerun_with_force_overwrites_without_duplicating(tmp_path):
+    out = tmp_path / "out"
+    first = run_import(source=FIXTURES / "CLAUDE.md", kind="claude-md", tier="T3", out=out)
+    second = run_import(
+        source=FIXTURES / "CLAUDE.md", kind="claude-md", tier="T3", out=out, force=True
+    )
+    # Same set of files, no duplicates, ids do not drift into collisions.
+    assert sorted(first.created) == sorted(second.created)
+    ids = [d.frontmatter["id"] for d in _load_drafts(out).values()]
+    assert len(ids) == len(set(ids))
+
+
+def test_refuses_to_write_into_existing_bundle(tmp_path):
+    out = tmp_path / "out"
+    out.mkdir()
+    (out / "hand-authored.md").write_text(
+        "---\nid: HAND-1\ntype: standard\nstatus: active\ntier: T1\n---\nkeep me\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(ImportError_, match="refusing to write into non-empty bundle"):
+        run_import(source=FIXTURES / "CLAUDE.md", kind="claude-md", tier="T3", out=out)
+    # The pre-existing file is untouched.
+    assert (out / "hand-authored.md").read_text(encoding="utf-8").endswith("keep me\n")
+
+
+# --------------------------------------------------------------------------- #
+# CLI wiring + --json shape                                                    #
+# --------------------------------------------------------------------------- #
+
+
+def test_cli_import_human_output(tmp_path, capsys):
+    code = main([
+        "import", str(FIXTURES / "CLAUDE.md"),
+        "--kind", "claude-md", "--tier", "T3", "--out", str(tmp_path / "out"),
+    ])
+    out = capsys.readouterr().out
+    assert code == 0
+    assert "Imported claude-md" in out
+    assert "created 5 draft(s)" in out
+    assert "next steps" in out
+    assert "kb_cleanup_plan" in out  # dedup seam pointer present
+
+
+def test_cli_import_json_shape(tmp_path, capsys):
+    code = main([
+        "import", str(FIXTURES / "adr-tools"),
+        "--kind", "adr", "--tier", "meta", "--out", str(tmp_path / "out"), "--json",
+    ])
+    assert code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["kind"] == "adr"
+    assert set(payload) == {
+        "kind", "source", "out_dir", "created", "skipped", "inferences",
+        "needs_review", "lint", "lint_clean", "next_steps",
+    }
+    assert payload["lint_clean"] is True
+    assert isinstance(payload["created"], list) and payload["created"]
+    assert any("kb_cleanup_plan" in s for s in payload["next_steps"])
+
+
+def test_cli_import_bad_tier_exits_2(tmp_path, capsys):
+    code = main([
+        "import", str(FIXTURES / "CLAUDE.md"),
+        "--kind", "claude-md", "--tier", "T9", "--out", str(tmp_path / "out"),
+    ])
+    err = capsys.readouterr().err
+    assert code == 2
+    assert "invalid tier" in err
+
+
+def test_cli_import_rerun_exits_2(tmp_path, capsys):
+    args = [
+        "import", str(FIXTURES / "CLAUDE.md"),
+        "--kind", "claude-md", "--tier", "T3", "--out", str(tmp_path / "out"),
+    ]
+    assert main(args) == 0
+    capsys.readouterr()
+    assert main(args) == 2
+    assert "refusing to re-import" in capsys.readouterr().err


### PR DESCRIPTION
## Summary

Adds `data-olympus import <source> --kind claude-md|agents-md|gemini-md|cursorrules|adr|okf --tier <tier> [--out ...] [--category ...] [--id-prefix ...] [--force] [--json]`, migrating an existing agent-rule corpus into a governed **draft** bundle (issue #67). This is the biggest missing on-ramp: today migration from flat rule files / ADR repos / OKF bundles is fully manual, and docs already claimed these could be imported with no tooling behind the claim.

New module `src/data_olympus/importer/` (model, stamp, flat, adr, okf, run) plus CLI wiring in `cli/import_cmd.py` + `cli/main.py`. No changes to `tools_write.py`, `server.py`, `index.py`, or `onboarding.py`.

## Heuristics

- **Flat rule files** (CLAUDE.md / AGENTS.md / GEMINI.md / .cursorrules): split at the shallowest heading depth that repeats (so one H1 title over several H2 concepts splits at H2, keeping each H2's nested H3 subsections inside the parent concept, and preserving the boundary heading line in the body). Heading-less files fall back to blank-line bullet-cluster grouping. Each concept becomes a draft with a generated `<prefix>-NNN` id, `type: standard`, `status: draft`, tier/category from flags, title from the heading, description from the first prose sentence, and heuristic tags. Original text preserved verbatim. Sections too short to be a real concept are skipped and reported.
- **adr** (adr-tools `doc/adr/NNNN-title.md`): number+title -> `ADR-NNNN`/title (ordinal stripped), `## Status` parsed into `supersedes` / `superseded_by` refs, `type: decision`. The parsed adr-tools status is preserved in a non-activating `source_status` field; the concept lands as `status: draft`.
- **okf**: existing frontmatter is normalized — alias field names renamed to canonical keys, missing required fields filled with draft-safe defaults, every inference reported.

**Invariants:** everything lands as `status: draft` (nothing auto-activates, nothing is committed to git). Duplicate ids are refused for ADR and OKF (the linter cannot catch cross-file duplicate ids, so a duplicate would otherwise pass while `lint_clean` stayed true). Type/status/tier vocabularies are single-sourced from `format/validate.py`. Output is run through the existing validate/lint machinery (lint-clean on the happy path) and the report points at `kb_cleanup_plan` for dedup. Re-running into the same out dir is **refused** unless `--force`, which deletes exactly the files the prior run wrote (deterministic ids, hand-added files preserved) and fails closed if the marker is unusable.

## Test evidence

Fixture-driven suite `tests/test_importer.py` (37 tests): split boundaries incl. nested-heading fixture, frontmatter stamping, unique non-colliding ids, draft-status invariant, ADR supersedes chain, ADR/OKF collision refusal, OKF alias normalization + missing-field inferences, lint-cleanliness, report contents + `--json` shape, and force/refuse re-run semantics.

- `uv run pytest` — full suite green (1 pre-existing unrelated skip: `sentence_transformers` not installed).
- `uv run ruff check .` — clean.
- `uv run mypy src` — clean (59 files).
- `scripts/check_changelog.py` and `scripts/check_doc_consistency.py` — ok.

## Peer review (codex)

Reviewed via `codex exec` (read-only). First pass: 3 Blockers, 2 Concerns, 1 Nit — all accepted and fixed:
- **Blocker:** ADR wrote in-force `accepted`/`superseded` -> now always `status: draft` with `source_status` preserved and flagged.
- **Blocker:** duplicate ids were written while `lint_clean` stayed true -> ADR+OKF collisions now refused.
- **Blocker:** `--force` churned ids -> marker records created files; force deletes exactly those before allocation.
- **Concern:** flat split flushed on every heading (over-split, dropped heading lines) -> depth-aware split keeping nested subsections and the heading line.
- **Concern:** OKF silently defaulted a missing status -> now reported as an inference.
- **Nit:** "five source kinds" -> six.

Second pass (re-review of the fixes): confirmed all blockers resolved; raised 1 Concern (unusable/legacy marker could silently lose `--force` determinism) and 1 Nit (split docstring wording) — both fixed (fail closed on unusable marker; docstring clarified). Verdict: clean apart from those two, now addressed.

Closes #67.