### PR TITLE
feat(dist): PyPI packaging, trusted-publishing workflow, data-olympus setup wizard

### DIFF
--- a/.github/workflows/publish-pypi-reusable.yml
+++ b/.github/workflows/publish-pypi-reusable.yml
@@ -1,0 +1,93 @@
+# .github/workflows/publish-pypi-reusable.yml
+#
+# INERT UNTIL OPERATOR SETUP. This workflow uploads to PyPI via Trusted
+# Publishing (OIDC, no API token). It CANNOT succeed until the operator creates
+# a pending publisher on pypi.org. PyPI binds the publisher to the TOP-LEVEL
+# workflow that starts the run, and this reusable workflow is called from TWO of
+# them, so BOTH need a publisher (same owner=knaisoma, repo=data-olympus,
+# environment=pypi):
+#   - workflow=tag-release.yml     (PRIMARY: normal main-merge release path)
+#   - workflow=publish-pypi.yml    (fallback: human-pushed tag / manual dispatch)
+# See docs/releases/pypi-trusted-publishing.md for the exact click-path. Until
+# then the `upload` job's publish STEP fails (nothing is uploaded); the `build`
+# job and `twine check` still pass, so the release tag/image are unaffected.
+name: publish-pypi-reusable
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: "git ref to build from (tag or sha)"
+        required: true
+        type: string
+      upload:
+        description: "upload to PyPI (false = build + twine check only)"
+        required: false
+        default: false
+        type: boolean
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.ref }}
+          fetch-depth: 0
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v7
+      - name: Build sdist + wheel
+        run: uv build
+      - name: Verify metadata (twine check)
+        run: uvx twine check --strict dist/*
+      - name: Smoke-test the built wheel
+        # Confirms the console entry point and the packaged bin/ machinery ship
+        # correctly, so a broken build is caught BEFORE any PyPI upload.
+        run: |
+          uvx --from ./dist/*.whl data-olympus --help
+          uvx --from ./dist/*.whl data-olympus setup --check --no-version-check
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+          if-no-files-found: error
+
+  upload:
+    # Only runs on a real release (upload=true). On PR dry-runs this job is
+    # skipped, so packaging PRs get build + twine check with no upload.
+    needs: build
+    if: inputs.upload
+    runs-on: ubuntu-latest
+    # Trusted Publishing requires the `pypi` environment name to match the
+    # pending-publisher config on pypi.org.
+    environment:
+      name: pypi
+      url: https://pypi.org/p/data-olympus
+    permissions:
+      # id-token: write is what mints the OIDC token gh-action-pypi-publish
+      # exchanges for a short-lived upload credential. No secret token exists.
+      id-token: write
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - name: Publish to PyPI (Trusted Publishing)
+        uses: pypa/gh-action-pypi-publish@release/v1
+        # continue-on-error keeps this INERT until the operator configures the
+        # pypi.org Trusted Publisher: before that, the OIDC exchange fails, but a
+        # failed upload here must not fail the release (the tag + image are already
+        # published by the caller). Once the publisher exists the upload succeeds.
+        # A step-level continue-on-error is the correct mechanism; a `uses:` job in
+        # the caller cannot carry continue-on-error.
+        continue-on-error: true
+        # No `password:` / token: OIDC Trusted Publishing only. skip-existing so a
+        # partial-failure rerun of an already-uploaded version is a no-op, not an
+        # error (mirrors the idempotent tag/image/release jobs).
+        with:
+          skip-existing: true

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,0 +1,103 @@
+# .github/workflows/publish-pypi.yml
+#
+# INERT UNTIL OPERATOR SETUP. The `upload` path (real releases + manual tag)
+# cannot succeed until the operator configures a PyPI Trusted Publisher on
+# pypi.org: owner=knaisoma, repo=data-olympus, workflow=publish-pypi.yml,
+# environment=pypi. See docs/releases/pypi-trusted-publishing.md.
+#
+# NORMAL RELEASE PATH: this file is NOT the primary release trigger. The live
+# release chain is tag-release.yml (on: push main -> should_tag.py -> tag pushed
+# with GITHUB_TOKEN). Because GITHUB_TOKEN-created tag pushes do NOT trigger
+# `on: push tags` workflows, the `release` job below does not fire in the normal
+# flow; tag-release.yml calls publish-pypi-reusable.yml directly (mirroring how
+# it builds the image). This file provides two things tag-release.yml cannot:
+#   1. a PR-time DRY RUN (build + twine check, no upload) for packaging changes;
+#   2. a manual-tag / human-pushed-tag FALLBACK (same rationale as
+#      release-image.yml's tag trigger, STD-U-810 section 9).
+name: Publish to PyPI
+
+on:
+  # DRY RUN on PRs that touch packaging. Build + twine check only, never upload.
+  pull_request:
+    paths:
+      - "pyproject.toml"
+      - "src/**"
+      - "bin/**"
+      - ".github/workflows/publish-pypi*.yml"
+  # FALLBACK for a human-pushed tag (tag-release.yml's GITHUB_TOKEN push does not
+  # reach here). Real upload.
+  push:
+    tags:
+      - "v*"
+  # Manual re-publish of a specific ref. Only a `v*` RELEASE TAG uploads; any
+  # other ref (a branch like release/0.3.0, or a raw SHA) is built + twine-checked
+  # DRY-RUN only, never uploaded. This keeps the "PyPI artifacts come only from
+  # release tags" invariant even for a hand-triggered run.
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "release tag to publish (must be v*); any other ref is dry-run only"
+        required: true
+
+jobs:
+  dry-run:
+    if: github.event_name == 'pull_request'
+    uses: ./.github/workflows/publish-pypi-reusable.yml
+    with:
+      ref: ${{ github.sha }}
+      upload: false
+    permissions:
+      contents: read
+
+  release:
+    if: github.event_name == 'push' && github.ref_type == 'tag'
+    uses: ./.github/workflows/publish-pypi-reusable.yml
+    with:
+      ref: ${{ github.ref_name }}
+      upload: true
+    permissions:
+      contents: read
+      id-token: write
+
+  # Validate the manual input BEFORE any upload: upload is enabled only when the
+  # ref is a `v<semver>` tag AND resolves to an existing tag object. Otherwise the
+  # manual job runs upload=false.
+  validate-manual:
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      upload: ${{ steps.check.outputs.upload }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - name: Decide whether this ref may upload
+        id: check
+        env:
+          REF: ${{ inputs.ref }}
+        run: |
+          upload=false
+          # Must look like v<major>.<minor>.<patch>(suffix) AND be a real tag.
+          if printf '%s' "$REF" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+'; then
+            if git rev-parse -q --verify "refs/tags/$REF" >/dev/null; then
+              upload=true
+            else
+              echo "::warning::ref '$REF' is not an existing tag; dry-run only"
+            fi
+          else
+            echo "::warning::ref '$REF' is not a v* release tag; dry-run only"
+          fi
+          echo "upload=$upload" >> "$GITHUB_OUTPUT"
+
+  manual:
+    needs: validate-manual
+    if: github.event_name == 'workflow_dispatch'
+    uses: ./.github/workflows/publish-pypi-reusable.yml
+    with:
+      ref: ${{ inputs.ref }}
+      upload: ${{ needs.validate-manual.outputs.upload == 'true' }}
+    permissions:
+      contents: read
+      id-token: write

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -63,6 +63,29 @@ jobs:
       contents: read
       packages: write
 
+  # Publish sdist + wheel to PyPI via Trusted Publishing (OIDC, no token). Runs
+  # off the SAME decided tag as build-image, so a release publishes the image AND
+  # the package from one main-push flow. This is the primary PyPI path: the tag is
+  # pushed with GITHUB_TOKEN, which does NOT trigger publish-pypi.yml's `on: push
+  # tags`, so we call the reusable workflow here (exactly as build-image does).
+  #
+  # INERT UNTIL OPERATOR SETUP: until the pypi.org Trusted Publisher exists, the
+  # upload STEP inside the reusable workflow no-ops on failure (that step carries
+  # continue-on-error, which is only valid on a step, not on a `uses:` job like
+  # this one). So this job still succeeds pre-setup and does not block the GitHub
+  # Release; once the publisher is configured the upload succeeds for real. See
+  # docs/releases/pypi-trusted-publishing.md.
+  publish-pypi:
+    needs: decide
+    if: needs.decide.outputs.tag != ''
+    uses: ./.github/workflows/publish-pypi-reusable.yml
+    with:
+      ref: ${{ needs.decide.outputs.tag }}
+      upload: true
+    permissions:
+      contents: read
+      id-token: write
+
   release:
     needs: [decide, build-image]
     if: needs.decide.outputs.tag != ''

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,32 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **PyPI distribution + `data-olympus setup` wizard** (issue #70). The package is
+  now installable from PyPI (`uvx data-olympus`, `uv tool install data-olympus`),
+  published by the release chain via GitHub Actions Trusted Publishing (OIDC, no
+  API token). A new `.github/workflows/publish-pypi-reusable.yml` builds the
+  sdist + wheel, runs `twine check --strict` and a wheel smoke test, and uploads
+  through `pypa/gh-action-pypi-publish` to the `pypi` environment;
+  `tag-release.yml` calls it off the same decided tag as the container image, and
+  `.github/workflows/publish-pypi.yml` adds a PR-time dry run (build + twine
+  check, no upload) plus a manual-tag fallback. The publish path is **inert until
+  the operator completes the one-time pypi.org publisher setup** documented in
+  `docs/releases/pypi-trusted-publishing.md`. The wheel now ships the enforcement
+  machinery (`bin/kb-enforce-hook`, `_kb_enforce.py`, the OpenCode gate plugin)
+  as package data so the wizard works from a clean install.
+- **`data-olympus setup`** (new `src/data_olympus/setup_wizard.py` + CLI
+  subcommand): an idempotent, first-run/update wizard that probes the server
+  endpoint (`/api/v1/health`), detects installed agents (Claude Code, Codex,
+  Gemini, OpenCode), writes each agent's MCP registration with timestamped
+  backups (preferring `claude mcp add` / `codex mcp add` when the CLI is present,
+  merging documented config files otherwise), offers enforcement-hook install via
+  the existing provider registry, and prints a doctor summary (endpoint
+  reachability, agents wired, hooks installed, installed vs latest version with
+  offline-tolerant PyPI/GitHub lookup). `data-olympus setup --check` is a fully
+  read-only summary and update-check path.
+- `data_olympus.__version__` now reads from the installed distribution metadata
+  instead of a hand-maintained literal, so it cannot drift from the packaging
+  version the release chain tags on.
 - Specified `applies_when` in SPEC.md (WP4c, 0.3.0). `applies_when` is the
   highest-weight indexed field in `Index.search` (tied with `title`, ahead of
   `description` and body) and one of the three discriminating columns for the
@@ -217,6 +243,12 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   timeout (default 60s), so a hung git remote can no longer block the loop that
   answers the readiness probe. A push timeout is classified as a retryable
   failure.
+- Quickstart and adoption docs lead with the `uvx data-olympus` / `uv tool
+  install` install path and the setup wizard (issue #70). The adoption guide's
+  per-agent wiring section is corrected to the current registration surfaces
+  (Claude Code via `claude mcp add`, not a hand-edited `~/.claude/settings.json`;
+  Codex via `codex mcp add`; Gemini's `"type": "http"`; OpenCode's `mcp-remote`
+  wrapper).
 
 > Scope note: this wave makes write-path failures **visible** and recovers
 > orphaned commits. It does **not** fix the non-fast-forward publication stall

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -209,17 +209,69 @@ normally.
 Register the MCP endpoint with your agent. The server exposes MCP over
 streamable HTTP at `http://<host>:8080/mcp` (or the port you configured).
 
-For Claude Code, add an entry to `~/.claude/settings.json`:
+### Easiest: the setup wizard
+
+```bash
+data-olympus setup
+```
+
+The wizard probes the endpoint, detects which of Claude Code, Codex, Gemini, and
+OpenCode are installed, writes each agent's MCP registration (with a timestamped
+backup of any file it edits, and idempotent re-runs), optionally installs the
+enforcement hooks, and prints a doctor summary. `data-olympus setup --check` runs
+the same summary read-only and never changes anything.
+
+### Manual per-agent registration
+
+If you prefer to wire agents by hand, use the CURRENT surface for each. These are
+the same commands/files the wizard uses. Replace `http://localhost:8080` with
+your endpoint.
+
+**Claude Code** (use the `claude mcp` CLI; it writes `~/.claude.json`, not
+`settings.json`):
+
+```bash
+claude mcp add --transport http data-olympus http://localhost:8080/mcp
+```
+
+**Codex** (use the `codex mcp` CLI; it writes `[mcp_servers.*]` in
+`~/.codex/config.toml`):
+
+```bash
+codex mcp add data-olympus --url http://localhost:8080/mcp
+```
+
+**Gemini / Antigravity** (merge into `~/.gemini/settings.json`; note the explicit
+`"type": "http"`):
 
 ```json
 {
   "mcpServers": {
-    "my-kb": {
-      "url": "http://localhost:8080/mcp"
+    "data-olympus": {
+      "url": "http://localhost:8080/mcp",
+      "type": "http"
     }
   }
 }
 ```
+
+**OpenCode** (no native remote-HTTP transport; wrap via `mcp-remote` under the
+top-level `mcp` key in `~/.config/opencode/opencode.json`):
+
+```json
+{
+  "mcp": {
+    "data-olympus": {
+      "type": "local",
+      "command": ["npx", "-y", "mcp-remote", "http://localhost:8080/mcp", "--allow-http"],
+      "enabled": true
+    }
+  }
+}
+```
+
+Restart each agent's session after registering. Verify by asking it to call
+`kb_search`.
 
 The `kb` CLI in `bin/kb` is a thin client for the same HTTP API. Set
 `KB_ENDPOINT` and use it from the shell or from agent-invoked scripts:

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -6,6 +6,37 @@ with Python 3.13 and uv.
 
 ## 1. Install
 
+### Install from PyPI (recommended)
+
+Run the CLI directly with no clone, using `uvx`:
+
+```bash
+uvx data-olympus --help
+```
+
+Or install it as a persistent tool:
+
+```bash
+uv tool install data-olympus
+data-olympus --help
+```
+
+Then run the guided setup wizard to probe your server endpoint, wire your
+coding agents (Claude Code, Codex, Gemini, OpenCode), and optionally install the
+enforcement hooks:
+
+```bash
+data-olympus setup          # interactive
+data-olympus setup --check  # read-only doctor summary (also the update check)
+```
+
+> The PyPI package is published by the release chain via Trusted Publishing.
+> Until the one-time pypi.org publisher is configured (see
+> `docs/releases/pypi-trusted-publishing.md`), install from source with the dev
+> path below.
+
+### Install from source (development)
+
 ```bash
 # From the repo root
 uv venv && uv pip install -e '.[dev]'

--- a/docs/releases/pypi-trusted-publishing.md
+++ b/docs/releases/pypi-trusted-publishing.md
@@ -1,0 +1,94 @@
+# PyPI publishing (Trusted Publishing) — one-time operator setup
+
+The release chain builds an sdist + wheel and uploads them to PyPI using
+[Trusted Publishing](https://docs.pypi.org/trusted-publishers/) (OpenID Connect).
+**No API token is stored anywhere** (not in repo secrets, not in the workflow).
+GitHub mints a short-lived OIDC token at release time and PyPI exchanges it for a
+one-shot upload credential.
+
+The publish workflow is **inert until you complete the pypi.org setup below.**
+Until then, every release still tags, builds the container image, and publishes a
+GitHub Release normally; only the PyPI upload step fails (and it is marked
+`continue-on-error`, so it does not block the release). Once the pending
+publisher exists, the next release uploads to PyPI with no further action.
+
+## What binds the publisher
+
+Trusted Publishing matches four values exactly. Ours are:
+
+- **PyPI project name:** `data-olympus`
+- **Owner (GitHub org/user):** `knaisoma`
+- **Repository:** `data-olympus`
+- **Workflow filename:** `publish-pypi.yml`
+- **Environment name:** `pypi`
+
+The `environment: pypi` and `workflow filename` come from
+`.github/workflows/publish-pypi-reusable.yml` (the reusable workflow that does the
+upload) and `.github/workflows/publish-pypi.yml` (the caller PyPI knows about).
+When PyPI validates the OIDC claim it checks the **top-level workflow** that
+started the run. Both `publish-pypi.yml` (manual/tag fallback) and
+`tag-release.yml` (the normal release path) call the reusable upload workflow, so
+register a pending publisher for **each** top-level workflow filename you release
+from (see step 2b).
+
+## One-time steps on pypi.org
+
+You do this once. There is no project yet, so create a **pending publisher**
+(PyPI supports binding a publisher before the project's first upload).
+
+### Step 1 — sign in
+
+1. Go to <https://pypi.org> and log in (create an account first if needed).
+2. Confirm 2FA is enabled on the account (PyPI requires it for uploads).
+
+### Step 2 — add the pending publisher
+
+1. Open <https://pypi.org/manage/account/publishing/>.
+2. Scroll to **"Add a new pending publisher"** and select the **GitHub** tab.
+3. Fill in **exactly**:
+   - **PyPI Project Name:** `data-olympus`
+   - **Owner:** `knaisoma`
+   - **Repository name:** `data-olympus`
+   - **Workflow name:** `publish-pypi.yml`
+   - **Environment name:** `pypi`
+4. Click **Add**.
+
+### Step 2b — add the second publisher for the primary release path
+
+The normal release runs from `tag-release.yml`, not `publish-pypi.yml`. Add a
+second pending publisher identical to step 2 but with:
+
+- **Workflow name:** `tag-release.yml`
+
+(Everything else the same: owner `knaisoma`, repo `data-olympus`, environment
+`pypi`, project `data-olympus`.) Without this, releases cut by the normal
+main-merge flow would fail the OIDC check; the `publish-pypi.yml` publisher alone
+only covers the manual-tag / dispatch fallback.
+
+### Step 3 — create the GitHub `pypi` environment (recommended)
+
+1. In the GitHub repo: **Settings → Environments → New environment**, name it
+   `pypi`.
+2. Optionally add required reviewers or a branch/tag protection rule so only
+   release tags can deploy to it. (The workflow already scopes `id-token: write`
+   to the `pypi` environment.)
+
+## Verifying after a release
+
+1. After the first release that runs with the publisher configured, check the
+   **Publish to PyPI** job in the Actions run — the upload step should succeed.
+2. Confirm the project page exists: <https://pypi.org/project/data-olympus/>.
+3. Smoke-test the published artifact:
+
+   ```bash
+   uvx --from data-olympus data-olympus --help
+   uv tool install data-olympus
+   data-olympus setup --check
+   ```
+
+## PR dry-run (no setup needed)
+
+Every PR that touches `pyproject.toml`, `src/`, `bin/`, or the publish workflows
+runs a **dry run**: `uv build` + `twine check --strict` + a wheel smoke test, with
+no upload. This catches packaging regressions before a release without needing
+any PyPI credentials.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,13 +2,34 @@
 name = "data-olympus"
 version = "0.2.0"
 description = "Governance-grade knowledge-base format (OKF-compatible) plus CLI and single-writer MCP server"
+readme = "README.md"
 requires-python = ">=3.13"
-license = { text = "Apache-2.0" }
+license = "Apache-2.0"
+license-files = ["LICENSE", "NOTICE"]
+authors = [{ name = "knaisoma" }]
+keywords = ["knowledge-base", "mcp", "okf", "governance", "rag", "agents"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Software Development :: Documentation",
+    "Topic :: Software Development :: Libraries",
+    "Typing :: Typed",
+]
 dependencies = [
     "pyyaml>=6.0",
     "fastmcp>=3.2.0,<4",
     "pydantic>=2.9",
 ]
+
+[project.urls]
+Homepage = "https://github.com/knaisoma/data-olympus"
+Repository = "https://github.com/knaisoma/data-olympus"
+Issues = "https://github.com/knaisoma/data-olympus/issues"
+Changelog = "https://github.com/knaisoma/data-olympus/blob/main/CHANGELOG.md"
 
 [project.optional-dependencies]
 # Optional local-embedding hybrid ranking (issue #42). NOT a core dependency:
@@ -48,6 +69,33 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/data_olympus"]
+
+# Ship the bin/ enforcement machinery (kb-enforce-hook dispatcher, the
+# _kb_enforce.py provider registry, and the OpenCode gate plugin) INSIDE the
+# wheel at data_olympus/_bin/. The `data-olympus setup` wizard resolves this
+# packaged path to install per-agent enforcement hooks for a pip/uvx install
+# where no repo checkout exists. `setup_wizard.bin_root()` prefers this path and
+# falls back to the repo bin/ for editable dev installs.
+[tool.hatch.build.targets.wheel.force-include]
+"bin/kb" = "data_olympus/_bin/kb"
+"bin/kb-enforce-hook" = "data_olympus/_bin/kb-enforce-hook"
+"bin/_kb_enforce.py" = "data_olympus/_bin/_kb_enforce.py"
+"bin/_kb_fallback.py" = "data_olympus/_bin/_kb_fallback.py"
+"bin/_kb_detect_workspace.sh" = "data_olympus/_bin/_kb_detect_workspace.sh"
+"bin/opencode/data-olympus-gate.ts" = "data_olympus/_bin/opencode/data-olympus-gate.ts"
+
+# The sdist must carry bin/ so `uv build` from a clean checkout can produce the
+# wheel above. hatchling includes tracked files by default; make it explicit.
+[tool.hatch.build.targets.sdist]
+include = [
+    "src/data_olympus",
+    "bin",
+    "README.md",
+    "LICENSE",
+    "NOTICE",
+    "SPEC.md",
+    "CHANGELOG.md",
+]
 
 [tool.ruff]
 line-length = 100

--- a/src/data_olympus/__init__.py
+++ b/src/data_olympus/__init__.py
@@ -1,3 +1,14 @@
 """data-olympus: governance-grade knowledge-base format, CLI, and MCP server."""
 
-__version__ = "0.1.0"
+from __future__ import annotations
+
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _pkg_version
+
+try:
+    # Single source of truth: the installed distribution's version (declared in
+    # pyproject [project].version). Reading it here keeps `data_olympus.__version__`
+    # from drifting out of sync with the packaging metadata the release chain tags on.
+    __version__ = _pkg_version("data-olympus")
+except PackageNotFoundError:  # pragma: no cover - only when running from a raw tree
+    __version__ = "0.0.0+unknown"

--- a/src/data_olympus/cli/main.py
+++ b/src/data_olympus/cli/main.py
@@ -60,6 +60,16 @@ def _cmd_visualize(args: argparse.Namespace) -> int:
     return 0
 
 
+def _cmd_setup(args: argparse.Namespace) -> int:
+    from data_olympus import setup_wizard
+    return setup_wizard.run(
+        argv_endpoint=args.endpoint,
+        check_only=args.check,
+        assume_yes=args.yes,
+        no_version_check=args.no_version_check,
+    )
+
+
 def _cmd_report(args: argparse.Namespace) -> int:
     from data_olympus.cli.report_cmd import resolve_default_workspace, run_report
     return run_report(
@@ -90,6 +100,26 @@ def build_parser() -> argparse.ArgumentParser:
     )
     p_viz.add_argument("--name", default=None, help="display name in the viewer header")
     p_viz.set_defaults(func=_cmd_visualize)
+    p_setup = sub.add_parser(
+        "setup", help="guided first-run/update: probe endpoint, wire agents, install hooks"
+    )
+    p_setup.add_argument(
+        "--endpoint", default=None,
+        help="server endpoint (default: $KB_ENDPOINT or http://localhost:8080)",
+    )
+    p_setup.add_argument(
+        "--check", action="store_true",
+        help="read-only doctor summary (also the update-check path); changes nothing",
+    )
+    p_setup.add_argument(
+        "-y", "--yes", action="store_true",
+        help="non-interactive: accept defaults (register detected agents, skip hook prompts)",
+    )
+    p_setup.add_argument(
+        "--no-version-check", action="store_true",
+        help="skip the PyPI/GitHub latest-version lookup (fully offline)",
+    )
+    p_setup.set_defaults(func=_cmd_setup)
     p_report = sub.add_parser("report", help="report governed changes lacking a consultation")
     p_report.add_argument("--workspace", default=None,
                           help="workspace label (default: main-worktree basename)")

--- a/src/data_olympus/setup_wizard.py
+++ b/src/data_olympus/setup_wizard.py
@@ -1,0 +1,751 @@
+"""`data-olympus setup`: guided first-run + update wizard.
+
+Steps (idempotent; a re-run is the update path):
+
+1. probe/choose the server endpoint (health check against /api/v1/health)
+2. detect installed agents (Claude Code, Codex, Gemini, OpenCode)
+3. write MCP registration config per agent, with timestamped backups
+4. offer enforcement-hook install via the shipped bin/_kb_enforce.py machinery
+5. doctor summary (endpoint, agents wired, hooks, version vs latest on PyPI)
+
+`data-olympus setup --check` prints the doctor summary WITHOUT changing anything.
+This is also the update-check path.
+
+Design notes:
+
+- All network and filesystem effects go through small, individually testable
+  helpers. The interactive `run()` orchestrates; `check()` never mutates.
+- Config writes always back up an existing file first (`<file>.do-bak-<ts>`)
+  and MERGE into any existing MCP-server map rather than clobbering it.
+- Agent registration uses the CURRENT surface per agent (verified against the
+  live `claude mcp` / `codex mcp` CLIs), not stale docs. Claude Code and Codex
+  prefer their CLI when present; Gemini and OpenCode merge documented config
+  files. When a preferred CLI is absent we fall back to the documented file and
+  print the exact manual command.
+- No private/company endpoint is ever hard-coded: the default prompt is
+  http://localhost:8080, matching the public example bundle.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TextIO
+
+from data_olympus import __version__ as INSTALLED_VERSION
+
+# Type aliases keep the long injection-seam signatures under the line limit.
+CliRunner = Callable[[list[str]], "subprocess.CompletedProcess[str]"]
+EnforceRunner = Callable[[list[str], dict[str, str]], "subprocess.CompletedProcess[str]"]
+Opener = Callable[[str, float], object]
+Fetcher = Callable[[str, float], bytes]
+
+DEFAULT_ENDPOINT = "http://localhost:8080"
+MCP_SERVER_NAME = "data-olympus"
+_HEALTH_TIMEOUT = 5.0
+_PYPI_TIMEOUT = 5.0
+_BACKUP_SUFFIX = "do-bak"
+
+
+# --------------------------------------------------------------------------- #
+# Packaged bin/ resolution
+# --------------------------------------------------------------------------- #
+def bin_root() -> Path:
+    """Directory holding the enforcement machinery (kb-enforce-hook, _kb_enforce.py).
+
+    Prefers the copy shipped inside the installed wheel (data_olympus/_bin/), so a
+    pip/uvx install with no repo checkout still works. Falls back to the repo-root
+    bin/ for an editable dev install.
+    """
+    packaged = Path(__file__).resolve().parent / "_bin"
+    if (packaged / "_kb_enforce.py").is_file():
+        return packaged
+    # Editable/dev layout: <repo>/src/data_olympus/setup_wizard.py -> <repo>/bin
+    return Path(__file__).resolve().parents[2] / "bin"
+
+
+def enforce_script() -> Path:
+    return bin_root() / "_kb_enforce.py"
+
+
+# --------------------------------------------------------------------------- #
+# Endpoint probing
+# --------------------------------------------------------------------------- #
+@dataclass
+class HealthResult:
+    reachable: bool
+    endpoint: str
+    detail: str
+    kb_commit: str | None = None
+
+
+def probe_endpoint(
+    endpoint: str, *, opener: Opener | None = None
+) -> HealthResult:
+    """GET <endpoint>/api/v1/health. Never raises; returns a HealthResult.
+
+    `opener` is an injection seam for tests: called as opener(url, timeout) and
+    expected to return an object with `.status` and `.read()` (a urlopen-like
+    context manager is also accepted).
+    """
+    endpoint = endpoint.rstrip("/")
+    url = f"{endpoint}/api/v1/health"
+    _open = opener or _default_opener
+    try:
+        resp = _open(url, _HEALTH_TIMEOUT)
+        # Support both a context manager (urlopen) and a bare response (tests):
+        # enter the CM if present, else use the object directly.
+        enter = getattr(resp, "__enter__", None)
+        exit_ = getattr(resp, "__exit__", None)
+        r = enter() if callable(enter) else resp
+        try:
+            status = getattr(r, "status", None)
+            body = r.read()  # type: ignore[union-attr]
+        finally:
+            if callable(exit_):
+                exit_(None, None, None)
+    except (urllib.error.URLError, OSError, ValueError) as exc:
+        return HealthResult(False, endpoint, f"cannot reach {url}: {exc}")
+    if status != 200:
+        return HealthResult(False, endpoint, f"{url} returned HTTP {status}")
+    kb_commit = None
+    try:
+        payload = json.loads(body.decode() if isinstance(body, bytes) else body)
+        if isinstance(payload, dict):
+            kb_commit = payload.get("kb_commit") or payload.get("commit")
+    except (ValueError, AttributeError):
+        pass
+    return HealthResult(True, endpoint, f"{url} reachable (HTTP 200)", kb_commit)
+
+
+def _default_opener(url: str, timeout: float) -> object:  # pragma: no cover
+    return urllib.request.urlopen(url, timeout=timeout)
+
+
+# --------------------------------------------------------------------------- #
+# Agent detection
+# --------------------------------------------------------------------------- #
+@dataclass
+class Agent:
+    key: str
+    label: str
+    # Detection: a config dir under HOME, and/or a binary on PATH.
+    config_dir: str  # relative to HOME, e.g. ".claude"
+    binaries: tuple[str, ...] = ()
+    detected: bool = False
+    detected_via: str = ""
+
+
+def _home(env: dict[str, str] | None = None) -> Path:
+    env = env if env is not None else dict(os.environ)
+    override = env.get("KB_ENFORCE_HOME")
+    if override:
+        return Path(override)
+    return Path(os.path.expanduser("~"))
+
+
+def _which(name: str, env: dict[str, str] | None = None) -> str | None:
+    path = (env or os.environ).get("PATH")
+    return shutil.which(name, path=path)
+
+
+def detect_agents(
+    *, env: dict[str, str] | None = None, home: Path | None = None
+) -> list[Agent]:
+    """Detect installed agents by config-dir presence or binary on PATH.
+
+    Detection is deliberately permissive: EITHER a known config dir OR a known
+    binary marks the agent as present, so the wizard offers to wire an agent the
+    operator uses even before its first run created a config tree.
+    """
+    env = env if env is not None else dict(os.environ)
+    home = home if home is not None else _home(env)
+    specs = [
+        Agent("claude-code", "Claude Code", ".claude", ("claude",)),
+        Agent("codex", "Codex", ".codex", ("codex",)),
+        Agent("gemini", "Gemini / Antigravity", ".gemini", ("gemini", "agy")),
+        Agent("opencode", "OpenCode", ".config/opencode", ("opencode",)),
+    ]
+    out: list[Agent] = []
+    for spec in specs:
+        via = ""
+        if (home / spec.config_dir).is_dir():
+            via = f"config dir ~/{spec.config_dir}"
+        else:
+            for b in spec.binaries:
+                if _which(b, env):
+                    via = f"binary '{b}' on PATH"
+                    break
+        out.append(
+            Agent(
+                key=spec.key,
+                label=spec.label,
+                config_dir=spec.config_dir,
+                binaries=spec.binaries,
+                detected=bool(via),
+                detected_via=via,
+            )
+        )
+    return out
+
+
+# --------------------------------------------------------------------------- #
+# Config write helpers (backup + merge, idempotent)
+# --------------------------------------------------------------------------- #
+def backup_file(target: Path, *, now: float | None = None) -> Path | None:
+    """Copy target to a timestamped sibling before it is edited. No-op if absent."""
+    if not target.exists():
+        return None
+    ts = time.strftime("%Y%m%d-%H%M%S", time.localtime(now))
+    dest = target.with_suffix(target.suffix + f".{_BACKUP_SUFFIX}-{ts}")
+    shutil.copy2(target, dest)
+    return dest
+
+
+def _load_json(target: Path) -> dict[str, object]:
+    if target.exists() and target.read_text().strip():
+        loaded = json.loads(target.read_text())
+        return loaded if isinstance(loaded, dict) else {}
+    return {}
+
+
+def merge_mcp_json(
+    existing: dict[str, object], *, name: str, url: str, extra: dict[str, object] | None = None
+) -> tuple[dict[str, object], bool]:
+    """Merge an HTTP MCP server entry into an mcpServers-style JSON map.
+
+    Returns (new_doc, changed). Idempotent: re-running with the same url leaves
+    the doc unchanged and returns changed=False.
+    """
+    doc: dict[str, object] = json.loads(json.dumps(existing))  # deep copy
+    servers = doc.get("mcpServers")
+    if not isinstance(servers, dict):
+        servers = {}
+        doc["mcpServers"] = servers
+    entry: dict[str, object] = {"url": url}
+    if extra:
+        entry.update(extra)
+    if servers.get(name) == entry:
+        return doc, False
+    servers[name] = entry
+    return doc, True
+
+
+@dataclass
+class WriteResult:
+    agent: str
+    action: str  # "cli", "file", "manual", "skipped", "unchanged"
+    detail: str
+    backup: Path | None = None
+    changed: bool = False
+
+
+def write_json_registration(
+    target: Path,
+    *,
+    agent: str,
+    name: str,
+    url: str,
+    extra: dict[str, object] | None = None,
+    now: float | None = None,
+) -> WriteResult:
+    """Back up + merge an HTTP MCP entry into a JSON config file. Idempotent."""
+    existing = _load_json(target)
+    new_doc, changed = merge_mcp_json(existing, name=name, url=url, extra=extra)
+    if not changed:
+        return WriteResult(agent, "unchanged", f"{target} already registers '{name}'")
+    backup = backup_file(target, now=now)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(json.dumps(new_doc, indent=2) + "\n")
+    return WriteResult(
+        agent, "file", f"wrote '{name}' -> {url} into {target}", backup=backup, changed=True
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Per-agent registration
+# --------------------------------------------------------------------------- #
+def _run_cli(argv: list[str]) -> subprocess.CompletedProcess[str]:  # pragma: no cover
+    return subprocess.run(argv, capture_output=True, text=True, timeout=30)
+
+
+def register_claude(
+    url: str,
+    *,
+    home: Path,
+    env: dict[str, str],
+    runner: CliRunner | None = None,
+    now: float | None = None,
+) -> WriteResult:
+    """Register with Claude Code.
+
+    Current surface (verified via `claude mcp add --help`):
+        claude mcp add --transport http data-olympus <url>/mcp
+    The old guidance (hand-editing ~/.claude/settings.json mcpServers) is stale;
+    the CLI writes ~/.claude.json. Prefer the CLI when `claude` is on PATH, else
+    print the exact manual command and skip a silent file write to avoid landing
+    the entry in a file the CLI does not read.
+
+    Even though the CLI owns the write, we back up its target file (~/.claude.json)
+    first so the wizard's "every registration is backed up" guarantee holds across
+    CLI-backed and file-backed agents alike.
+    """
+    mcp_url = url.rstrip("/") + "/mcp"
+    if _which("claude", env):
+        run = runner or _run_cli
+        backup = backup_file(home / ".claude.json", now=now)
+        argv = ["claude", "mcp", "add", "--transport", "http", MCP_SERVER_NAME, mcp_url]
+        proc = run(argv)
+        if proc.returncode == 0:
+            return WriteResult(
+                "claude-code", "cli", f"registered via `claude mcp add` -> {mcp_url}",
+                backup=backup, changed=True,
+            )
+        # `claude mcp add` fails if the name already exists: treat as unchanged.
+        combined = (proc.stdout or "") + (proc.stderr or "")
+        if "already exists" in combined.lower():
+            return WriteResult(
+                "claude-code", "unchanged",
+                f"'{MCP_SERVER_NAME}' already registered with Claude Code",
+            )
+        return WriteResult(
+            "claude-code", "manual",
+            "claude CLI present but `mcp add` failed; run manually: "
+            f"claude mcp add --transport http {MCP_SERVER_NAME} {mcp_url} "
+            f"(error: {combined.strip()[:200]})",
+        )
+    return WriteResult(
+        "claude-code", "manual",
+        "claude CLI not on PATH. Run: "
+        f"claude mcp add --transport http {MCP_SERVER_NAME} {mcp_url}",
+    )
+
+
+def register_codex(
+    url: str,
+    *,
+    home: Path,
+    env: dict[str, str],
+    runner: CliRunner | None = None,
+    now: float | None = None,
+) -> WriteResult:
+    """Register with Codex.
+
+    Current surface (verified via `codex mcp add --help`):
+        codex mcp add data-olympus --url <url>/mcp
+    Prefer the CLI when `codex` is on PATH; else print the exact command. Codex
+    stores servers under [mcp_servers.<name>] in ~/.codex/config.toml (TOML). We
+    do not hand-write that file, but we back it up before the CLI mutates it so
+    the wizard's backup guarantee holds for CLI-backed agents too.
+    """
+    mcp_url = url.rstrip("/") + "/mcp"
+    if _which("codex", env):
+        run = runner or _run_cli
+        backup = backup_file(home / ".codex" / "config.toml", now=now)
+        argv = ["codex", "mcp", "add", MCP_SERVER_NAME, "--url", mcp_url]
+        proc = run(argv)
+        if proc.returncode == 0:
+            return WriteResult(
+                "codex", "cli", f"registered via `codex mcp add` -> {mcp_url}",
+                backup=backup, changed=True,
+            )
+        combined = (proc.stdout or "") + (proc.stderr or "")
+        if "already" in combined.lower() and "exist" in combined.lower():
+            return WriteResult(
+                "codex", "unchanged", f"'{MCP_SERVER_NAME}' already registered with Codex"
+            )
+        return WriteResult(
+            "codex", "manual",
+            "codex CLI present but `mcp add` failed; run manually: "
+            f"codex mcp add {MCP_SERVER_NAME} --url {mcp_url} "
+            f"(error: {combined.strip()[:200]})",
+        )
+    return WriteResult(
+        "codex", "manual",
+        f"codex CLI not on PATH. Run: codex mcp add {MCP_SERVER_NAME} --url {mcp_url}",
+    )
+
+
+def register_gemini(url: str, *, home: Path, now: float | None = None) -> WriteResult:
+    """Register with Gemini / Antigravity by merging ~/.gemini/settings.json.
+
+    Gemini's MCP servers live under mcpServers with an explicit "type": "http"
+    (not "transport"). No stable `gemini mcp add` CLI surface is assumed, so we
+    write the documented file with a backup.
+    """
+    mcp_url = url.rstrip("/") + "/mcp"
+    target = home / ".gemini" / "settings.json"
+    return write_json_registration(
+        target, agent="gemini", name=MCP_SERVER_NAME, url=mcp_url,
+        extra={"type": "http"}, now=now,
+    )
+
+
+def register_opencode(url: str, *, home: Path, now: float | None = None) -> WriteResult:
+    """Register with OpenCode by merging ~/.config/opencode/opencode.json.
+
+    OpenCode has no native remote-HTTP MCP transport; it wraps the endpoint as a
+    local command through mcp-remote. The server map lives under the top-level
+    "mcp" key (not "mcpServers").
+    """
+    mcp_url = url.rstrip("/") + "/mcp"
+    target = home / ".config" / "opencode" / "opencode.json"
+    entry = {
+        "type": "local",
+        "command": ["npx", "-y", "mcp-remote", mcp_url, "--allow-http"],
+        "enabled": True,
+    }
+    existing = _load_json(target)
+    doc: dict[str, object] = json.loads(json.dumps(existing))
+    servers = doc.get("mcp")
+    if not isinstance(servers, dict):
+        servers = {}
+        doc["mcp"] = servers
+    if servers.get(MCP_SERVER_NAME) == entry:
+        return WriteResult(
+            "opencode", "unchanged", f"{target} already registers '{MCP_SERVER_NAME}'"
+        )
+    servers[MCP_SERVER_NAME] = entry
+    backup = backup_file(target, now=now)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(json.dumps(doc, indent=2) + "\n")
+    return WriteResult(
+        "opencode", "file", f"wrote '{MCP_SERVER_NAME}' -> {mcp_url} into {target}",
+        backup=backup, changed=True,
+    )
+
+
+def register_agent(
+    key: str,
+    url: str,
+    *,
+    home: Path,
+    env: dict[str, str],
+    runner: CliRunner | None = None,
+    now: float | None = None,
+) -> WriteResult:
+    if key == "claude-code":
+        return register_claude(url, home=home, env=env, runner=runner, now=now)
+    if key == "codex":
+        return register_codex(url, home=home, env=env, runner=runner, now=now)
+    if key == "gemini":
+        return register_gemini(url, home=home, now=now)
+    if key == "opencode":
+        return register_opencode(url, home=home, now=now)
+    return WriteResult(key, "skipped", f"no registration handler for '{key}'")
+
+
+# --------------------------------------------------------------------------- #
+# Enforcement hooks (delegates to the shipped _kb_enforce.py)
+# --------------------------------------------------------------------------- #
+def install_enforcement(
+    agent_key: str,
+    *,
+    env: dict[str, str],
+    runner: EnforceRunner | None = None,
+) -> WriteResult:
+    """Invoke the shipped provider registry: `_kb_enforce.py install --agent <key>`.
+
+    The provider backs up the target settings file and writes MARKER-tagged hook
+    entries; it is itself idempotent, so re-running is safe.
+    """
+    script = enforce_script()
+    if not script.is_file():
+        return WriteResult(
+            agent_key, "skipped",
+            f"enforcement machinery not found at {script}; skipping hook install",
+        )
+    argv = [sys.executable, str(script), "install", "--agent", agent_key]
+    run = runner or _run_enforce
+    proc = run(argv, env)
+    detail = (proc.stdout or "").strip() or (proc.stderr or "").strip()
+    if proc.returncode == 0:
+        return WriteResult(agent_key, "file", detail or "enforcement installed", changed=True)
+    return WriteResult(
+        agent_key, "manual",
+        f"enforcement install failed (rc={proc.returncode}): {detail[:200]}",
+    )
+
+
+def _run_enforce(  # pragma: no cover
+    argv: list[str], env: dict[str, str]
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(argv, capture_output=True, text=True, timeout=30, env=env)
+
+
+def enforcement_status(
+    *,
+    env: dict[str, str],
+    runner: EnforceRunner | None = None,
+) -> str:
+    """Return the multi-agent `_kb_enforce.py status` output (read-only)."""
+    script = enforce_script()
+    if not script.is_file():
+        return f"enforcement machinery not found at {script}"
+    argv = [sys.executable, str(script), "status"]
+    run = runner or _run_enforce
+    proc = run(argv, env)
+    return (proc.stdout or "").strip() or (proc.stderr or "").strip() or "(no status output)"
+
+
+# --------------------------------------------------------------------------- #
+# Version check (offline-tolerant)
+# --------------------------------------------------------------------------- #
+@dataclass
+class VersionInfo:
+    installed: str
+    latest: str | None
+    source: str  # "pypi", "github", "offline"
+    detail: str = ""
+
+
+def latest_version(
+    *, fetcher: Fetcher | None = None
+) -> VersionInfo:
+    """Look up the latest published version, tolerant of being offline.
+
+    Tries PyPI's JSON API first, then the GitHub releases API. Any failure
+    degrades to source="offline" with latest=None; the wizard never errors on a
+    missing network.
+    """
+    fetch = fetcher or _default_fetch
+    # 1. PyPI
+    try:
+        raw = fetch("https://pypi.org/pypi/data-olympus/json", _PYPI_TIMEOUT)
+        data = json.loads(raw.decode() if isinstance(raw, bytes) else raw)
+        latest = data.get("info", {}).get("version")
+        if latest:
+            return VersionInfo(INSTALLED_VERSION, latest, "pypi")
+    except (urllib.error.URLError, OSError, ValueError, KeyError):
+        pass
+    # 2. GitHub releases (works even before the first PyPI publish)
+    try:
+        raw = fetch(
+            "https://api.github.com/repos/knaisoma/data-olympus/releases/latest",
+            _PYPI_TIMEOUT,
+        )
+        data = json.loads(raw.decode() if isinstance(raw, bytes) else raw)
+        tag = data.get("tag_name")
+        if tag:
+            return VersionInfo(INSTALLED_VERSION, tag.lstrip("v"), "github")
+    except (urllib.error.URLError, OSError, ValueError, KeyError):
+        pass
+    return VersionInfo(
+        INSTALLED_VERSION, None, "offline",
+        "could not reach PyPI or GitHub; skipping update check",
+    )
+
+
+def _default_fetch(url: str, timeout: float) -> bytes:  # pragma: no cover
+    req = urllib.request.Request(url, headers={"Accept": "application/json"})
+    with urllib.request.urlopen(req, timeout=timeout) as r:
+        data: bytes = r.read()
+    return data
+
+
+def _version_tuple(v: str) -> tuple[int, ...]:
+    parts: list[int] = []
+    for chunk in v.split("+")[0].split("-")[0].split("."):
+        num = "".join(c for c in chunk if c.isdigit())
+        parts.append(int(num) if num else 0)
+    return tuple(parts)
+
+
+def compare_versions(info: VersionInfo) -> str:
+    """Human-readable one-liner about installed vs latest."""
+    if info.latest is None:
+        return f"version {info.installed} installed ({info.detail})"
+    try:
+        newer = _version_tuple(info.latest) > _version_tuple(info.installed)
+    except ValueError:
+        newer = info.installed != info.latest
+    if newer:
+        return (
+            f"version {info.installed} installed; {info.latest} available on "
+            f"{info.source} (run `uv tool upgrade data-olympus`)"
+        )
+    return f"version {info.installed} installed (latest on {info.source})"
+
+
+# --------------------------------------------------------------------------- #
+# Doctor summary (read-only)
+# --------------------------------------------------------------------------- #
+@dataclass
+class Doctor:
+    endpoint: HealthResult
+    agents: list[Agent]
+    enforcement: str
+    version: str
+    lines: list[str] = field(default_factory=list)
+
+
+def build_doctor(
+    endpoint: str,
+    *,
+    env: dict[str, str] | None = None,
+    home: Path | None = None,
+    opener: Opener | None = None,
+    version_fetcher: Fetcher | None = None,
+    enforce_runner: EnforceRunner | None = None,
+    check_version: bool = True,
+) -> Doctor:
+    """Assemble a read-only doctor report. Performs NO writes."""
+    env = env if env is not None else dict(os.environ)
+    home = home if home is not None else _home(env)
+    health = probe_endpoint(endpoint, opener=opener)
+    agents = detect_agents(env=env, home=home)
+    enforcement = enforcement_status(env=env, runner=enforce_runner)
+    if check_version:
+        ver_line = compare_versions(latest_version(fetcher=version_fetcher))
+    else:
+        ver_line = f"version {INSTALLED_VERSION} installed (version check skipped)"
+
+    lines: list[str] = []
+    ep_mark = "OK" if health.reachable else "!!"
+    lines.append(f"[{ep_mark}] endpoint: {health.detail}")
+    detected = [a for a in agents if a.detected]
+    if detected:
+        for a in detected:
+            lines.append(f"[OK] agent: {a.label} detected ({a.detected_via})")
+    else:
+        lines.append("[--] agent: none detected")
+    for a in agents:
+        if not a.detected:
+            lines.append(f"[--] agent: {a.label} not detected")
+    lines.append("[..] enforcement hooks:")
+    for eline in enforcement.splitlines():
+        lines.append(f"       {eline}")
+    lines.append(f"[..] {ver_line}")
+    return Doctor(health, agents, enforcement, ver_line, lines)
+
+
+# --------------------------------------------------------------------------- #
+# Interactive orchestration
+# --------------------------------------------------------------------------- #
+def _prompt(text: str, default: str, *, stream_in: TextIO, stream_out: TextIO) -> str:
+    stream_out.write(f"{text} [{default}]: ")
+    stream_out.flush()
+    line = stream_in.readline()
+    if not line:
+        return default
+    line = line.strip()
+    return line or default
+
+
+def _confirm(text: str, *, default: bool, stream_in: TextIO, stream_out: TextIO) -> bool:
+    suffix = "Y/n" if default else "y/N"
+    stream_out.write(f"{text} [{suffix}]: ")
+    stream_out.flush()
+    line = stream_in.readline()
+    if not line:
+        return default
+    ans = line.strip().lower()
+    if not ans:
+        return default
+    return ans in ("y", "yes")
+
+
+def run(
+    *,
+    argv_endpoint: str | None = None,
+    check_only: bool = False,
+    assume_yes: bool = False,
+    no_version_check: bool = False,
+    env: dict[str, str] | None = None,
+    home: Path | None = None,
+    stream_in: TextIO | None = None,
+    stream_out: TextIO | None = None,
+    opener: Opener | None = None,
+) -> int:
+    """Entry point behind `data-olympus setup`.
+
+    check_only=True is fully read-only (the `--check` / update-check path).
+    """
+    env = env if env is not None else dict(os.environ)
+    home = home if home is not None else _home(env)
+    stream_in = stream_in or sys.stdin
+    stream_out = stream_out or sys.stdout
+    interactive = stream_in.isatty() if hasattr(stream_in, "isatty") else False
+
+    def out(msg: str = "") -> None:
+        stream_out.write(msg + "\n")
+
+    if check_only:
+        doctor = build_doctor(
+            argv_endpoint or env.get("KB_ENDPOINT", DEFAULT_ENDPOINT),
+            env=env, home=home, opener=opener, check_version=not no_version_check,
+        )
+        out("data-olympus setup --check")
+        out("")
+        for line in doctor.lines:
+            out(line)
+        return 0
+
+    out("data-olympus setup")
+    out("=" * 40)
+
+    # 1. Endpoint
+    default_ep = argv_endpoint or env.get("KB_ENDPOINT", DEFAULT_ENDPOINT)
+    if interactive and not assume_yes:
+        endpoint = _prompt(
+            "Server endpoint", default_ep, stream_in=stream_in, stream_out=stream_out
+        )
+    else:
+        endpoint = default_ep
+    health = probe_endpoint(endpoint, opener=opener)
+    mark = "OK" if health.reachable else "WARNING"
+    out(f"[{mark}] {health.detail}")
+    if not health.reachable:
+        out(
+            "  The endpoint is not reachable now. Registration will still be written; "
+            "start the server and re-run `data-olympus setup --check` to verify."
+        )
+
+    # 2. Detect agents
+    out("")
+    out("Detecting agents...")
+    agents = detect_agents(env=env, home=home)
+    detected = [a for a in agents if a.detected]
+    if not detected:
+        out("  No agents detected. Nothing to wire.")
+    for a in detected:
+        out(f"  - {a.label} ({a.detected_via})")
+
+    # 3 + 4. Register + enforcement, per detected agent
+    for a in detected:
+        do_reg = assume_yes or not interactive or _confirm(
+            f"Register data-olympus MCP with {a.label}?",
+            default=True, stream_in=stream_in, stream_out=stream_out,
+        )
+        if do_reg:
+            res = register_agent(a.key, endpoint, home=home, env=env)
+            out(f"  [{res.action}] {a.label}: {res.detail}")
+            if res.backup:
+                out(f"        backup: {res.backup}")
+        do_hook = assume_yes or not interactive or _confirm(
+            f"Install enforcement hooks for {a.label}?",
+            default=False, stream_in=stream_in, stream_out=stream_out,
+        )
+        if do_hook:
+            hres = install_enforcement(a.key, env=env)
+            out(f"  [{hres.action}] {a.label} hooks: {hres.detail}")
+
+    # 5. Doctor
+    out("")
+    out("Doctor summary")
+    out("-" * 40)
+    doctor = build_doctor(
+        endpoint, env=env, home=home, opener=opener, check_version=not no_version_check,
+    )
+    for line in doctor.lines:
+        out(line)
+    return 0

--- a/tests/test_packaging_metadata.py
+++ b/tests/test_packaging_metadata.py
@@ -1,0 +1,51 @@
+"""Static checks on packaging metadata that the wizard + release depend on."""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _pyproject() -> dict:
+    return tomllib.loads((_ROOT / "pyproject.toml").read_text())
+
+
+def test_setup_console_entry_present():
+    scripts = _pyproject()["project"]["scripts"]
+    assert scripts["data-olympus"] == "data_olympus.cli.main:main"
+
+
+def test_wheel_force_includes_enforcement_machinery():
+    """The wizard invokes bin/_kb_enforce.py + kb-enforce-hook at runtime, so the
+    wheel MUST ship them under data_olympus/_bin/."""
+    force = _pyproject()["tool"]["hatch"]["build"]["targets"]["wheel"]["force-include"]
+    targets = set(force.values())
+    assert "data_olympus/_bin/_kb_enforce.py" in targets
+    assert "data_olympus/_bin/kb-enforce-hook" in targets
+    assert "data_olympus/_bin/opencode/data-olympus-gate.ts" in targets
+    # sources exist in the tree
+    for src in force:
+        assert (_ROOT / src).exists(), src
+
+
+def test_license_and_metadata_declared():
+    project = _pyproject()["project"]
+    assert project["license"] == "Apache-2.0"
+    assert project["readme"] == "README.md"
+    assert "Repository" in project["urls"]
+    assert any("3.13" in c for c in project["classifiers"])
+
+
+def test_sdist_includes_bin():
+    include = _pyproject()["tool"]["hatch"]["build"]["targets"]["sdist"]["include"]
+    assert "bin" in include
+
+
+def test_bin_root_resolves_to_shipped_or_repo():
+    """setup_wizard.bin_root() must point at a dir that actually holds the
+    enforce script (repo bin/ in the dev tree, packaged _bin/ once installed)."""
+    from data_olympus import setup_wizard as w
+
+    assert w.enforce_script().is_file()

--- a/tests/test_publish_workflows.py
+++ b/tests/test_publish_workflows.py
@@ -1,0 +1,115 @@
+"""Syntactic + structural checks on the PyPI publish workflows and packaging.
+
+Keeps the release wiring honest without needing a live GitHub Actions run:
+- the workflow YAML parses;
+- the reusable upload job is trusted-publishing + inert-until-setup shaped;
+- the normal release path (tag-release.yml) calls the reusable publish workflow;
+- the PR dry-run does not upload.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+_ROOT = Path(__file__).resolve().parents[1]
+_WF = _ROOT / ".github" / "workflows"
+
+
+def _load(name: str) -> dict:
+    return yaml.safe_load((_WF / name).read_text())
+
+
+def test_all_workflow_yaml_parses():
+    for wf in _WF.glob("*.y*ml"):
+        assert yaml.safe_load(wf.read_text()) is not None, wf.name
+
+
+def test_reusable_publish_uses_trusted_publishing():
+    doc = _load("publish-pypi-reusable.yml")
+    upload = doc["jobs"]["upload"]
+    # OIDC trusted publishing: id-token write, pypi environment, no token.
+    assert upload["permissions"]["id-token"] == "write"
+    assert upload["environment"]["name"] == "pypi"
+    steps = upload["steps"]
+    publish = next(s for s in steps if "pypa/gh-action-pypi-publish" in str(s.get("uses", "")))
+    # No password/token: trusted publishing only.
+    assert "password" not in (publish.get("with") or {})
+    # skip-existing makes a partial-failure rerun idempotent.
+    assert publish["with"]["skip-existing"] is True
+
+
+def test_reusable_upload_gated_on_input():
+    doc = _load("publish-pypi-reusable.yml")
+    # upload job only runs when the caller asks for upload=true. GitHub accepts a
+    # bare expression at job-level `if`, so YAML loads it without the ${{ }} wrap.
+    assert doc["jobs"]["upload"]["if"] == "inputs.upload"
+
+
+def test_reusable_build_runs_twine_check():
+    doc = _load("publish-pypi-reusable.yml")
+    build = doc["jobs"]["build"]
+    cmds = " ".join(str(s.get("run", "")) for s in build["steps"])
+    assert "twine check" in cmds
+    assert "uv build" in cmds
+
+
+def test_publish_pr_dry_run_does_not_upload():
+    doc = _load("publish-pypi.yml")
+    dry = doc["jobs"]["dry-run"]
+    assert dry["with"]["upload"] is False
+    # dry-run fires on pull_request only.
+    assert "pull_request" in dry["if"]
+
+
+def test_tag_release_calls_publish_reusable():
+    doc = _load("tag-release.yml")
+    pub = doc["jobs"]["publish-pypi"]
+    assert pub["uses"].endswith("publish-pypi-reusable.yml")
+    assert pub["with"]["upload"] is True
+    assert pub["permissions"]["id-token"] == "write"
+    # It keys off the same decided tag as the image build.
+    assert pub["with"]["ref"] == "${{ needs.decide.outputs.tag }}"
+
+
+def test_publish_step_inert_until_setup():
+    """The upload step (not the caller job) carries continue-on-error, so a
+    pre-setup PyPI failure never blocks the release. continue-on-error is invalid
+    on a `uses:` job, so it MUST live on the step."""
+    doc = _load("publish-pypi-reusable.yml")
+    steps = doc["jobs"]["upload"]["steps"]
+    publish = next(s for s in steps if "pypa/gh-action-pypi-publish" in str(s.get("uses", "")))
+    assert publish["continue-on-error"] is True
+
+
+def test_manual_dispatch_uploads_only_for_validated_release_tag():
+    """workflow_dispatch must not let an arbitrary branch/SHA upload to PyPI: the
+    manual job's upload flag is gated on a validate step that only allows v* tags."""
+    doc = _load("publish-pypi.yml")
+    jobs = doc["jobs"]
+    assert "validate-manual" in jobs
+    validate = jobs["validate-manual"]
+    # It computes an `upload` output from the input ref.
+    assert "upload" in validate["outputs"]
+    check = " ".join(str(s.get("run", "")) for s in validate["steps"])
+    # Guards on a v-semver tag pattern and an existing tag object.
+    assert "v[0-9]" in check
+    assert "refs/tags/" in check
+    # The manual publish job keys its upload off the validate output, not a bare true.
+    manual = jobs["manual"]
+    assert manual["needs"] == "validate-manual"
+    assert "validate-manual.outputs.upload" in manual["with"]["upload"]
+
+
+def test_publish_pr_dry_run_ref_is_not_untrusted():
+    """The reusable workflow's ref must come from a trusted source, never event
+    body fields (injection guard)."""
+    doc = _load("publish-pypi.yml")
+    for job in ("dry-run", "release", "manual"):
+        ref = doc["jobs"][job]["with"]["ref"]
+        assert ref in (
+            "${{ github.sha }}",
+            "${{ github.ref_name }}",
+            "${{ inputs.ref }}",
+        ), (job, ref)

--- a/tests/test_setup_wizard.py
+++ b/tests/test_setup_wizard.py
@@ -1,0 +1,431 @@
+"""Headless tests for the `data-olympus setup` wizard.
+
+All network + subprocess effects are injected, so nothing here touches a real
+endpoint, a real agent CLI, or the real HOME.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import subprocess
+from typing import TYPE_CHECKING
+
+from data_olympus import setup_wizard as w
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+# --------------------------------------------------------------------------- #
+# Fixtures / fakes
+# --------------------------------------------------------------------------- #
+class _FakeResp:
+    def __init__(self, status: int, body: bytes) -> None:
+        self.status = status
+        self._body = body
+
+    def read(self) -> bytes:
+        return self._body
+
+
+def _opener(status: int, body: dict | None = None):
+    payload = json.dumps(body or {}).encode()
+
+    def open_fn(url: str, timeout: float):  # noqa: ARG001
+        return _FakeResp(status, payload)
+
+    return open_fn
+
+
+def _raising_opener(exc: Exception):
+    def open_fn(url: str, timeout: float):  # noqa: ARG001
+        raise exc
+
+    return open_fn
+
+
+def _completed(returncode: int, stdout: str = "", stderr: str = ""):
+    return subprocess.CompletedProcess([], returncode, stdout=stdout, stderr=stderr)
+
+
+# --------------------------------------------------------------------------- #
+# Endpoint probe
+# --------------------------------------------------------------------------- #
+def test_probe_endpoint_healthy():
+    res = w.probe_endpoint(
+        "http://localhost:8080/", opener=_opener(200, {"kb_commit": "abc123"})
+    )
+    assert res.reachable is True
+    assert res.kb_commit == "abc123"
+    assert res.endpoint == "http://localhost:8080"
+
+
+def test_probe_endpoint_non_200():
+    res = w.probe_endpoint("http://x", opener=_opener(503))
+    assert res.reachable is False
+    assert "503" in res.detail
+
+
+def test_probe_endpoint_unreachable_never_raises():
+    res = w.probe_endpoint("http://x", opener=_raising_opener(OSError("refused")))
+    assert res.reachable is False
+    assert "cannot reach" in res.detail
+
+
+# --------------------------------------------------------------------------- #
+# Agent detection
+# --------------------------------------------------------------------------- #
+def test_detect_agents_via_config_dir(tmp_path: Path):
+    (tmp_path / ".claude").mkdir()
+    (tmp_path / ".config" / "opencode").mkdir(parents=True)
+    agents = {a.key: a for a in w.detect_agents(env={"PATH": ""}, home=tmp_path)}
+    assert agents["claude-code"].detected
+    assert "config dir" in agents["claude-code"].detected_via
+    assert agents["opencode"].detected
+    assert not agents["codex"].detected
+    assert not agents["gemini"].detected
+
+
+def test_detect_agents_via_binary_on_path(tmp_path: Path):
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    fake = bindir / "codex"
+    fake.write_text("#!/bin/sh\n")
+    fake.chmod(0o755)
+    home = tmp_path / "home"
+    home.mkdir()
+    agents = {a.key: a for a in w.detect_agents(env={"PATH": str(bindir)}, home=home)}
+    assert agents["codex"].detected
+    assert "binary 'codex'" in agents["codex"].detected_via
+    assert not agents["claude-code"].detected
+
+
+def test_detect_agents_none(tmp_path: Path):
+    agents = w.detect_agents(env={"PATH": ""}, home=tmp_path)
+    assert all(not a.detected for a in agents)
+
+
+# --------------------------------------------------------------------------- #
+# Backup + merge idempotency
+# --------------------------------------------------------------------------- #
+def test_backup_file_creates_timestamped_copy(tmp_path: Path):
+    target = tmp_path / "settings.json"
+    target.write_text('{"a": 1}')
+    backup = w.backup_file(target, now=0)
+    assert backup is not None
+    assert backup.exists()
+    assert backup.read_text() == '{"a": 1}'
+    assert w._BACKUP_SUFFIX in backup.name
+
+
+def test_backup_file_absent_is_noop(tmp_path: Path):
+    assert w.backup_file(tmp_path / "nope.json") is None
+
+
+def test_merge_mcp_json_adds_entry():
+    doc, changed = w.merge_mcp_json({}, name="data-olympus", url="http://x/mcp")
+    assert changed is True
+    assert doc["mcpServers"]["data-olympus"] == {"url": "http://x/mcp"}
+
+
+def test_merge_mcp_json_preserves_other_servers():
+    existing = {"mcpServers": {"other": {"url": "http://other"}}}
+    doc, changed = w.merge_mcp_json(existing, name="data-olympus", url="http://x/mcp")
+    assert changed is True
+    assert doc["mcpServers"]["other"] == {"url": "http://other"}
+    assert doc["mcpServers"]["data-olympus"] == {"url": "http://x/mcp"}
+    # original untouched (deep copy)
+    assert "data-olympus" not in existing["mcpServers"]
+
+
+def test_merge_mcp_json_idempotent():
+    existing = {"mcpServers": {"data-olympus": {"url": "http://x/mcp"}}}
+    _doc, changed = w.merge_mcp_json(existing, name="data-olympus", url="http://x/mcp")
+    assert changed is False
+
+
+def test_write_json_registration_backs_up_and_merges(tmp_path: Path):
+    target = tmp_path / ".gemini" / "settings.json"
+    target.parent.mkdir(parents=True)
+    target.write_text(json.dumps({"mcpServers": {"keep": {"url": "u"}}}))
+    res = w.write_json_registration(
+        target, agent="gemini", name="data-olympus", url="http://x/mcp",
+        extra={"type": "http"}, now=0,
+    )
+    assert res.changed is True
+    assert res.backup is not None and res.backup.exists()
+    doc = json.loads(target.read_text())
+    assert doc["mcpServers"]["keep"] == {"url": "u"}
+    assert doc["mcpServers"]["data-olympus"] == {"url": "http://x/mcp", "type": "http"}
+
+
+def test_write_json_registration_idempotent_no_backup(tmp_path: Path):
+    target = tmp_path / "c.json"
+    target.write_text(json.dumps({"mcpServers": {"data-olympus": {"url": "http://x/mcp"}}}))
+    res = w.write_json_registration(
+        target, agent="gemini", name="data-olympus", url="http://x/mcp", now=0
+    )
+    assert res.action == "unchanged"
+    assert res.changed is False
+    # no backup file was created
+    assert list(target.parent.glob("*.do-bak-*")) == []
+
+
+# --------------------------------------------------------------------------- #
+# Per-agent registration
+# --------------------------------------------------------------------------- #
+def test_register_claude_uses_cli_when_present(tmp_path: Path):
+    calls: list[list[str]] = []
+
+    def runner(argv):
+        calls.append(argv)
+        return _completed(0, stdout="Added stdio MCP server data-olympus")
+
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    (bindir / "claude").write_text("#!/bin/sh\n")
+    (bindir / "claude").chmod(0o755)
+    res = w.register_claude(
+        "http://x", home=tmp_path, env={"PATH": str(bindir)}, runner=runner, now=0
+    )
+    assert res.action == "cli"
+    assert res.changed is True
+    assert calls[0] == [
+        "claude", "mcp", "add", "--transport", "http", "data-olympus", "http://x/mcp"
+    ]
+
+
+def test_register_claude_manual_when_cli_absent(tmp_path: Path):
+    res = w.register_claude("http://x", home=tmp_path, env={"PATH": ""})
+    assert res.action == "manual"
+    assert "claude mcp add --transport http data-olympus http://x/mcp" in res.detail
+
+
+def test_register_claude_already_exists_is_unchanged(tmp_path: Path):
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    (bindir / "claude").write_text("#!/bin/sh\n")
+    (bindir / "claude").chmod(0o755)
+
+    def runner(argv):  # noqa: ARG001
+        return _completed(1, stderr="MCP server data-olympus already exists")
+
+    res = w.register_claude(
+        "http://x", home=tmp_path, env={"PATH": str(bindir)}, runner=runner, now=0
+    )
+    assert res.action == "unchanged"
+
+
+def test_register_codex_uses_cli(tmp_path: Path):
+    calls: list[list[str]] = []
+
+    def runner(argv):
+        calls.append(argv)
+        return _completed(0)
+
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    (bindir / "codex").write_text("#!/bin/sh\n")
+    (bindir / "codex").chmod(0o755)
+    res = w.register_codex(
+        "http://x/", home=tmp_path, env={"PATH": str(bindir)}, runner=runner, now=0
+    )
+    assert res.action == "cli"
+    assert calls[0] == ["codex", "mcp", "add", "data-olympus", "--url", "http://x/mcp"]
+
+
+def test_register_claude_backs_up_cli_owned_config(tmp_path: Path):
+    """The CLI owns the write, but the wizard still backs up ~/.claude.json so the
+    'every registration is backed up' guarantee holds for CLI-backed agents."""
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    (bindir / "claude").write_text("#!/bin/sh\n")
+    (bindir / "claude").chmod(0o755)
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / ".claude.json").write_text('{"mcpServers": {}}')
+    res = w.register_claude(
+        "http://x", home=home, env={"PATH": str(bindir)},
+        runner=lambda argv: _completed(0), now=0,  # noqa: ARG005
+    )
+    assert res.backup is not None and res.backup.exists()
+    assert res.backup.read_text() == '{"mcpServers": {}}'
+
+
+def test_register_codex_backs_up_cli_owned_config(tmp_path: Path):
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    (bindir / "codex").write_text("#!/bin/sh\n")
+    (bindir / "codex").chmod(0o755)
+    home = tmp_path / "home"
+    (home / ".codex").mkdir(parents=True)
+    (home / ".codex" / "config.toml").write_text("model = 'o3'\n")
+    res = w.register_codex(
+        "http://x", home=home, env={"PATH": str(bindir)},
+        runner=lambda argv: _completed(0), now=0,  # noqa: ARG005
+    )
+    assert res.backup is not None and res.backup.exists()
+
+
+def test_register_gemini_writes_http_type(tmp_path: Path):
+    res = w.register_gemini("http://x", home=tmp_path, now=0)
+    doc = json.loads((tmp_path / ".gemini" / "settings.json").read_text())
+    assert doc["mcpServers"]["data-olympus"] == {"url": "http://x/mcp", "type": "http"}
+    assert res.changed is True
+
+
+def test_register_opencode_writes_local_wrapper(tmp_path: Path):
+    res = w.register_opencode("http://x", home=tmp_path, now=0)
+    doc = json.loads((tmp_path / ".config" / "opencode" / "opencode.json").read_text())
+    entry = doc["mcp"]["data-olympus"]
+    assert entry["type"] == "local"
+    assert entry["command"] == ["npx", "-y", "mcp-remote", "http://x/mcp", "--allow-http"]
+    assert entry["enabled"] is True
+    assert res.changed is True
+
+
+def test_register_opencode_idempotent(tmp_path: Path):
+    w.register_opencode("http://x", home=tmp_path, now=0)
+    res2 = w.register_opencode("http://x", home=tmp_path, now=0)
+    assert res2.action == "unchanged"
+
+
+# --------------------------------------------------------------------------- #
+# Enforcement delegation
+# --------------------------------------------------------------------------- #
+def test_install_enforcement_invokes_shipped_script(monkeypatch, tmp_path: Path):
+    fake_script = tmp_path / "_kb_enforce.py"
+    fake_script.write_text("# stub")
+    monkeypatch.setattr(w, "enforce_script", lambda: fake_script)
+    captured: dict = {}
+
+    def runner(argv, env):
+        captured["argv"] = argv
+        captured["env"] = env
+        return _completed(0, stdout="installed data-olympus enforcement")
+
+    res = w.install_enforcement("claude-code", env={"X": "1"}, runner=runner)
+    assert res.changed is True
+    assert captured["argv"][1:] == [str(fake_script), "install", "--agent", "claude-code"]
+
+
+def test_install_enforcement_missing_script_skips(monkeypatch, tmp_path: Path):
+    monkeypatch.setattr(w, "enforce_script", lambda: tmp_path / "absent.py")
+    res = w.install_enforcement("codex", env={})
+    assert res.action == "skipped"
+
+
+# --------------------------------------------------------------------------- #
+# Version check (offline fallback)
+# --------------------------------------------------------------------------- #
+def test_latest_version_from_pypi():
+    def fetch(url, timeout):  # noqa: ARG001
+        assert "pypi.org" in url
+        return json.dumps({"info": {"version": "9.9.9"}}).encode()
+
+    info = w.latest_version(fetcher=fetch)
+    assert info.latest == "9.9.9"
+    assert info.source == "pypi"
+
+
+def test_latest_version_falls_back_to_github():
+    def fetch(url, timeout):  # noqa: ARG001
+        if "pypi.org" in url:
+            raise OSError("no pypi yet")
+        return json.dumps({"tag_name": "v1.2.3"}).encode()
+
+    info = w.latest_version(fetcher=fetch)
+    assert info.latest == "1.2.3"
+    assert info.source == "github"
+
+
+def test_latest_version_offline():
+    def fetch(url, timeout):  # noqa: ARG001
+        raise OSError("no network")
+
+    info = w.latest_version(fetcher=fetch)
+    assert info.latest is None
+    assert info.source == "offline"
+
+
+def test_compare_versions_newer_available():
+    info = w.VersionInfo(installed="0.2.0", latest="0.3.0", source="pypi")
+    assert "0.3.0 available" in w.compare_versions(info)
+
+
+def test_compare_versions_offline():
+    info = w.VersionInfo(installed="0.2.0", latest=None, source="offline", detail="no net")
+    line = w.compare_versions(info)
+    assert "0.2.0 installed" in line
+    assert "no net" in line
+
+
+# --------------------------------------------------------------------------- #
+# Doctor (read-only)
+# --------------------------------------------------------------------------- #
+def test_build_doctor_is_read_only(tmp_path: Path):
+    (tmp_path / ".claude").mkdir()
+
+    def enforce_runner(argv, env):  # noqa: ARG001
+        return _completed(0, stdout="claude-code: not installed")
+
+    doctor = w.build_doctor(
+        "http://x",
+        env={"PATH": ""},
+        home=tmp_path,
+        opener=_opener(200, {"kb_commit": "c"}),
+        enforce_runner=enforce_runner,
+        check_version=False,
+    )
+    assert doctor.endpoint.reachable is True
+    assert any("Claude Code detected" in line for line in doctor.lines)
+    # No files created beyond the pre-existing .claude dir.
+    assert set(p.name for p in tmp_path.iterdir()) == {".claude"}
+
+
+# --------------------------------------------------------------------------- #
+# run(): --check is read-only; interactive orchestration
+# --------------------------------------------------------------------------- #
+def test_run_check_mode_read_only(tmp_path: Path):
+    out = io.StringIO()
+
+    def enforce_runner(argv, env):  # noqa: ARG001
+        return _completed(0, stdout="claude-code: not installed")
+
+    # Monkeypatch enforcement_status via a wrapper: build_doctor calls the real
+    # one, so point enforce_script at a stub-less path by using check_version off.
+    rc = w.run(
+        check_only=True,
+        no_version_check=True,
+        env={"PATH": "", "KB_ENDPOINT": "http://x"},
+        home=tmp_path,
+        stream_out=out,
+        opener=_opener(200),
+    )
+    assert rc == 0
+    text = out.getvalue()
+    assert "setup --check" in text
+    # nothing was written into the fake home
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_run_yes_mode_registers_detected(tmp_path: Path, monkeypatch):
+    # Detect gemini via config dir; assume_yes registers it (file-based, no CLI).
+    (tmp_path / ".gemini").mkdir()
+    monkeypatch.setattr(w, "enforce_script", lambda: tmp_path / "absent.py")
+    out = io.StringIO()
+    rc = w.run(
+        argv_endpoint="http://x",
+        assume_yes=True,
+        no_version_check=True,
+        env={"PATH": ""},
+        home=tmp_path,
+        stream_in=io.StringIO(""),
+        stream_out=out,
+        opener=_opener(200),
+    )
+    assert rc == 0
+    # gemini settings.json was written
+    doc = json.loads((tmp_path / ".gemini" / "settings.json").read_text())
+    assert "data-olympus" in doc["mcpServers"]

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,5 +1,14 @@
+import tomllib
+from pathlib import Path
+
 import data_olympus
 
 
 def test_package_imports_and_exposes_version():
-    assert data_olympus.__version__ == "0.1.0"
+    # __version__ is read from the installed distribution metadata, which is the
+    # pyproject [project].version the release chain tags on. Assert they agree
+    # rather than pinning a literal that would silently drift each release.
+    pyproject = tomllib.loads(
+        (Path(__file__).resolve().parents[1] / "pyproject.toml").read_text()
+    )
+    assert data_olympus.__version__ == pyproject["project"]["version"]


### PR DESCRIPTION
## Summary

Ships data-olympus on PyPI and adds a guided `data-olympus setup` wizard (closes #70).

- **Packaging** (`pyproject.toml`): readme, `license = "Apache-2.0"` + license-files, classifiers, project urls, keywords. The wheel now force-includes the `bin/` enforcement machinery under `data_olympus/_bin/` so the wizard works from a clean `uvx`/`uv tool install` with no repo checkout. `data_olympus.__version__` now reads from installed distribution metadata (no drift from the tagged version).
- **Publish workflow** (`publish-pypi-reusable.yml` + `publish-pypi.yml`, wired into `tag-release.yml`): builds sdist+wheel, `twine check --strict`, wheel smoke test, uploads via `pypa/gh-action-pypi-publish` using **Trusted Publishing** (OIDC, `id-token: write`, `environment: pypi`, **no API token**). The normal release path calls the reusable workflow from `tag-release.yml` off the same decided tag as the container image (the tag is pushed with `GITHUB_TOKEN`, which does not fire `on: push tags`, so mirroring the image path is required). PRs touching packaging get a build+twine-check **dry run** (no upload). Inert until the operator completes the pypi.org setup (see below).
- **Wizard** (`src/data_olympus/setup_wizard.py` + `data-olympus setup`): probes the endpoint (`/api/v1/health`), detects Claude Code/Codex/Gemini/OpenCode, writes each agent's MCP registration with timestamped backups + idempotent merge (prefers `claude mcp add --transport http` / `codex mcp add --url` when the CLI is present; documented config files otherwise), offers enforcement-hook install via the existing provider registry, and prints a doctor summary (endpoint, agents wired, hooks, installed-vs-latest version with offline-tolerant PyPI/GitHub lookup). `data-olympus setup --check` is fully read-only.
- **Docs**: quickstart + adoption lead with the `uvx data-olympus` install path and the wizard; the adoption agent-wiring section is corrected to current registration surfaces (fixes the audit finding that Claude Code guidance was stale).

## One-time pypi.org operator setup (REQUIRED before the first publish)

The publish path is **inert until this is done**. Full click-path in `docs/releases/pypi-trusted-publishing.md`. PyPI binds a Trusted Publisher to the **top-level** workflow, and the reusable upload workflow is called from two of them, so add **two** pending publishers:

1. Sign in at https://pypi.org (2FA required).
2. Go to https://pypi.org/manage/account/publishing/ → "Add a new pending publisher" → GitHub tab.
3. Add publisher #1 (PRIMARY, normal releases):
   - PyPI Project Name: `data-olympus`
   - Owner: `knaisoma`
   - Repository name: `data-olympus`
   - Workflow name: `tag-release.yml`
   - Environment name: `pypi`
4. Add publisher #2 (fallback: human-pushed tag / manual dispatch), identical but Workflow name: `publish-pypi.yml`.
5. (Recommended) In the GitHub repo, Settings → Environments → create `pypi`, optionally restricting deploys to release tags.

Until both publishers exist, releases still tag, build the image, and publish a GitHub Release; only the PyPI upload step no-ops (it carries step-level `continue-on-error`).

## Test evidence

- `ruff check .` — clean.
- `mypy src` — Success, no issues (52 files).
- `uv run pytest -q` — full suite passes (1 skip: optional `sentence_transformers` bench dep).
- New tests: `tests/test_setup_wizard.py` (detection, backup+merge idempotency, endpoint probe, per-agent registration incl. CLI-owned config backup, offline version fallback, `--check` read-only), `tests/test_publish_workflows.py` (YAML parses, trusted-publishing shape, dry-run no-upload, tag-release wiring, manual-dispatch tag gate), `tests/test_packaging_metadata.py`.
- `uv build` + `twine check --strict dist/*` — both sdist and wheel PASSED.
- `uvx --from ./dist/*.whl data-olympus --help` and `... setup --check --no-version-check` — work; the wizard resolves the packaged `_bin/_kb_enforce.py` when installed from the wheel.
- `actionlint .github/workflows/*.yml` — clean.
- `bats -r tests` — 66/66 (CLI contract unaffected).

## Peer review (codex)

Static read-only review of `origin/release/0.3.0...HEAD`. Verdict was **BLOCKED** on one finding, now fixed; re-verified clean:

- **Blocker (FIXED):** manual `workflow_dispatch` could upload an arbitrary branch/SHA to PyPI (`upload: true` on any ref), violating the release-tag-only invariant. Fixed: a `validate-manual` job now allows upload only when the input ref matches `v<semver>` **and** resolves to an existing tag; any other ref is dry-run only. Test: `test_manual_dispatch_uploads_only_for_validated_release_tag`.
- **Concern (FIXED):** Claude/Codex CLI-backed registrations were not backed up while the wizard advertised backups. Fixed: the wizard now backs up `~/.claude.json` / `~/.codex/config.toml` before invoking the CLI. Tests: `test_register_claude_backs_up_cli_owned_config`, `test_register_codex_backs_up_cli_owned_config`.
- **Nit (FIXED):** the reusable-workflow header named only `publish-pypi.yml` as the PyPI binding; corrected to state both `tag-release.yml` (primary) and `publish-pypi.yml` (fallback).

Codex verified OK: same-decided-tag flow, PR dry-run no-upload, trusted-publishing config (id-token/environment/no-password/step-level continue-on-error), wheel force-include ships what the wizard invokes, JSON writes backed up + idempotent, current CLI registration, `--check` read-only by code path.
