### PR TITLE
feat(write): serialization, non-FF rebase recovery, CAS, content validation gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,11 +62,13 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
     resolve path holds the claim + path lock across the CAS/validation gates and
     restores the pending entry if a gate rejects, so an operator's proposal is
     never consumed without a commit.
-  - **Post-commit enqueue is best-effort.** A push-queue enqueue failure after a
-    successful commit no longer turns a made commit into an exception path: the
-    commit is durable on the session branch and startup `init_recovery`
-    re-enqueues it, so callers (e.g. the bootstrap in-flight guard) are not misled
-    into a non-committed outcome.
+  - **Post-commit enqueue is recoverable and truthful.** A push-queue enqueue
+    failure after a successful commit no longer turns a made commit into an
+    exception path (which would drop the bootstrap in-flight guard and the resolve
+    claim). Instead an in-process recovery re-enqueue is attempted so the live push
+    loop still drains it, and the response `push_state` is truthful: `queued` only
+    when the entry landed, else `enqueue_failed_recovery_pending` (the durable
+    commit on the session branch is republished by startup `init_recovery`).
   - **Unique memory filenames.** `<date>-<slug>.md` collided for same-day,
     same-slug memories and the second auto-commit silently overwrote the first; a
     short session/body-derived uniquifier is now appended.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,11 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
     `origin/main` and retries. On a rebase conflict the commit is demoted to a
     pending entry for operator resolution (with a `push_conflict_demoted` audit
     event and the queue entry removed) instead of retrying identically forever.
+    Pure contention (a repeated non-FF race) is retried in-line for a bounded
+    number of passes and then demoted the same way, so it never silently freezes.
+  - **CAS also enforces `base_commit`.** When the base marker is a specific commit
+    (not the `HEAD` sentinel), the blob the target had at that commit must equal
+    the current blob, closing the bypass where a caller supplied only `base_commit`.
   - **CAS enforcement.** `base_commit` / `base_blob_sha` / `target_file_hash`
     were accepted and stored but never checked. They are now enforced at commit
     time on both the auto-commit and resolve paths: a supplied base marker that
@@ -40,9 +45,15 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
     YAML, a forged/duplicate `id`, or an invalid enum value committed and pushed to
     `origin/main` — and a duplicate `id` broke every subsequent index rebuild (one
     bad write, persistent degraded state). Every postimage is now format-validated
-    plus checked for a duplicate `id` against the live index before commit; failures
-    are rejected `rejected_invalid_document` with machine-readable errors. Rendered
-    memories pass the gate as a cheap self-check.
+    plus checked for a duplicate `id` — using the EFFECTIVE id the rebuild assigns
+    (explicit frontmatter `id` OR the path-derived id) against BOTH the live index
+    and the session worktree's committed tree, and including reserved files —
+    before commit; failures are rejected `rejected_invalid_document` with
+    machine-readable errors. Rendered memories pass the gate as a cheap self-check.
+    The **bootstrap** path now commits its whole file bundle through the same
+    serialized, per-path-locked, validated, reset-on-failure write path as the
+    single-file writes (it previously wrote and committed directly, unserialized
+    and ungated).
   - **Atomic pending claim.** `approve`/`reject` were get-then-remove, so two
     concurrent resolves of the same id both committed. Resolution now claims the
     entry via `os.rename` before reading (test-and-set); the loser gets

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   - **CAS also enforces `base_commit`.** When the base marker is a specific commit
     (not the `HEAD` sentinel), the blob the target had at that commit must equal
     the current blob, closing the bypass where a caller supplied only `base_commit`.
+    If the base cannot be refreshed onto `origin/main` (remote unreachable / rebase
+    conflict) while an enforceable marker was supplied, the write is rejected
+    `rejected_stale_base` rather than committed against a stale base.
   - **CAS enforcement.** `base_commit` / `base_blob_sha` / `target_file_hash`
     were accepted and stored but never checked. They are now enforced at commit
     time on both the auto-commit and resolve paths: a supplied base marker that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,63 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **Write-pipeline integrity core (epic #72).** This wave makes the write-safety
+  claims in `SPEC.md` section 8 and `docs/serving.md` actually true; each item
+  ships with regression tests, including two integration tests that drive a real
+  second clone against a shared bare remote:
+  - **Write serialization.** A process-wide write serializer wraps the write →
+    `git add` → commit → enqueue critical section, and a per-path advisory lock —
+    now SHARED between the auto-commit path and the pending queue — prevents an
+    auto-commit from racing a concurrent write or landing on a path with a pending
+    proposal in flight (whose later approval would clobber it). The auto-commit
+    path previously took no lock, so concurrent `kb_propose_*` calls in one session
+    could interleave and one thread's commit could sweep another's staged file.
+  - **Non-fast-forward push recovery.** A push rejected non-FF (a second
+    overlapping session moved `origin/main`) is now classified distinctly from a
+    network failure: the push loop fetches + rebases the session branch onto
+    `origin/main` and retries. On a rebase conflict the commit is demoted to a
+    pending entry for operator resolution (with a `push_conflict_demoted` audit
+    event and the queue entry removed) instead of retrying identically forever.
+  - **CAS enforcement.** `base_commit` / `base_blob_sha` / `target_file_hash`
+    were accepted and stored but never checked. They are now enforced at commit
+    time on both the auto-commit and resolve paths: a supplied base marker that
+    does not match the current content on the worktree's refreshed base is rejected
+    `rejected_stale_base` without committing. No marker → behavior unchanged.
+  - **Content-validation gate.** No validation ran on the write path, so malformed
+    YAML, a forged/duplicate `id`, or an invalid enum value committed and pushed to
+    `origin/main` — and a duplicate `id` broke every subsequent index rebuild (one
+    bad write, persistent degraded state). Every postimage is now format-validated
+    plus checked for a duplicate `id` against the live index before commit; failures
+    are rejected `rejected_invalid_document` with machine-readable errors. Rendered
+    memories pass the gate as a cheap self-check.
+  - **Atomic pending claim.** `approve`/`reject` were get-then-remove, so two
+    concurrent resolves of the same id both committed. Resolution now claims the
+    entry via `os.rename` before reading (test-and-set); the loser gets
+    `already_resolved` / not-found. Orphaned path locks (a crash between lock
+    create and entry write) are reclaimed by the pending GC loop.
+  - **Unique memory filenames.** `<date>-<slug>.md` collided for same-day,
+    same-slug memories and the second auto-commit silently overwrote the first; a
+    short session/body-derived uniquifier is now appended.
+  - **Pending expiry audit.** Expiring a >24h pending entry now emits a
+    `pending_expired` / `auto_rejected` audit event instead of rejecting silently.
+  - **Ordering of side effects.** The commit message and all gates are now
+    evaluated before the file is written and `git add`-ed; on any post-add failure
+    the worktree is hard-reset so no staged leftover is swept into the next commit.
+  - **Git identity in the shipped image.** The Docker entrypoint (and the server
+    `main()` as a fallback) now set a default `GIT_AUTHOR_*`/`GIT_COMMITTER_*`
+    identity (overridable via `KB_GIT_AUTHOR_NAME` / `KB_GIT_AUTHOR_EMAIL`) so a
+    commit inside a fresh container no longer fails with "who are you".
+
+### Changed
+
+- **MCP/REST write-surface parity (deferred WP0b items).** The MCP
+  `kb_resolve_pending` tool now applies the `KB_MAX_POSTIMAGE_BYTES` `edited_text`
+  cap (REST already did), and the MCP `kb_consult` / `kb_gate_check` /
+  `kb_cleanup_plan` tools now apply the shared rate limiter consistently with their
+  REST counterparts.
+
 ### Security
 
 - Hardened the write and enforcement surface (issue #74). Ten fixes, each with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,15 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
     concurrent resolves of the same id both committed. Resolution now claims the
     entry via `os.rename` before reading (test-and-set); the loser gets
     `already_resolved` / not-found. Orphaned path locks (a crash between lock
-    create and entry write) are reclaimed by the pending GC loop.
+    create and entry write) are reclaimed by the pending GC loop. The gated
+    resolve path holds the claim + path lock across the CAS/validation gates and
+    restores the pending entry if a gate rejects, so an operator's proposal is
+    never consumed without a commit.
+  - **Post-commit enqueue is best-effort.** A push-queue enqueue failure after a
+    successful commit no longer turns a made commit into an exception path: the
+    commit is durable on the session branch and startup `init_recovery`
+    re-enqueues it, so callers (e.g. the bootstrap in-flight guard) are not misled
+    into a non-committed outcome.
   - **Unique memory filenames.** `<date>-<slug>.md` collided for same-day,
     same-slug memories and the second auto-commit silently overwrote the first; a
     short session/body-derived uniquifier is now appended.

--- a/SPEC.md
+++ b/SPEC.md
@@ -222,9 +222,12 @@ A conformant write-enabled data-olympus server MUST run as a **single replica**,
 
 **Rationale.** The write path is intentionally single-writer:
 
-- Per-path advisory locks prevent two concurrent write operations from racing on the same concept file.
+- A process-wide write serializer wraps the write → `git add` → commit → enqueue critical section, so two concurrent write operations in the same session cannot interleave (one thread's commit sweeping another's staged file).
+- Per-path advisory locks prevent two concurrent write operations from racing on the same concept file. The lock is SHARED between the auto-commit path and the pending queue: an auto-commit cannot land on a path that already has a pending proposal in flight (whose later approval would clobber it), and vice versa. An orphaned lock (a crash between lock acquisition and the pending entry write) is reclaimed by the pending GC loop.
+- Committed postimages pass a content-validation gate before commit: malformed YAML frontmatter, an invalid `type`/`status`/`tier` enum value, and a forged/duplicate `id` (one already used by a different path, which would break every subsequent index rebuild) are rejected `rejected_invalid_document` rather than pushed to `origin/main`.
+- Optimistic concurrency: when a caller supplies a base marker (`base_commit` / `base_blob_sha` / `target_file_hash`) the server refreshes the session worktree's base onto `origin/main` and compares; a stale base is rejected `rejected_stale_base` without committing. When no marker is supplied behavior is unchanged.
 - Per-session git worktrees isolate in-flight proposed edits from the live index until they are committed.
-- A durable push queue serializes outbound git pushes so no write is lost if the remote is briefly unavailable.
+- A durable push queue serializes outbound git pushes so no write is lost if the remote is briefly unavailable. A push rejected non-fast-forward (a second overlapping session moved `origin/main`) triggers a fetch + rebase of the session branch and a retry; if the rebase conflicts, the commit is demoted to a pending entry for operator resolution (with a `push_conflict_demoted` audit event) rather than retrying forever.
 
 A single shared HTTP surface, rather than N independent stdio processes, gives every agent one synchronized conversation with the server. When multiple agents each run their own stdio MCP process against the same git working tree, they race each other's worktrees and lock state. Streamable HTTP eliminates that race: all agents share the same server process and its in-process coordination.
 

--- a/deploy/docker/entrypoint.sh
+++ b/deploy/docker/entrypoint.sh
@@ -2,6 +2,19 @@
 # Runs as root. Handles SSH key + (optional) /kb-main bootstrap, then drops to uid 65534.
 set -e
 
+# --- Git author/committer identity (scope item 10) ---------------------------
+# The shipped image sets no git user, so a commit inside a fresh container fails
+# with "Please tell me who you are". Export a default identity (operator-
+# overridable via KB_GIT_AUTHOR_NAME / KB_GIT_AUTHOR_EMAIL) so the artifact can
+# commit out of the box. The GIT_* vars are inherited by every git subprocess the
+# server spawns (tools_write, push queue). See docs/serving.md.
+GIT_NAME="${KB_GIT_AUTHOR_NAME:-data-olympus-mcp}"
+GIT_EMAIL="${KB_GIT_AUTHOR_EMAIL:-data-olympus-mcp@localhost}"
+export GIT_AUTHOR_NAME="$GIT_NAME"
+export GIT_AUTHOR_EMAIL="$GIT_EMAIL"
+export GIT_COMMITTER_NAME="$GIT_NAME"
+export GIT_COMMITTER_EMAIL="$GIT_EMAIL"
+
 # --- Writable scratch under a read-only root filesystem ----------------------
 # When the container runs with readOnlyRootFilesystem, /tmp is an emptyDir mount
 # that starts empty (masking the image's pre-created /tmp/uv-cache). Recreate the

--- a/docs/serving.md
+++ b/docs/serving.md
@@ -85,12 +85,19 @@ section so concurrent writes cannot corrupt each other:
   every subsequent index rebuild — one bad write, persistent degraded state). The
   response `reason` carries the machine-readable errors.
 - **Compare-and-swap (optimistic concurrency).** When a caller supplies a base
-  marker (`base_commit`, `base_blob_sha`, or `target_file_hash`) on
-  `kb_propose_edit` (or it is carried on the pending entry into
-  `kb_resolve_pending`), the server refreshes the session worktree's base onto
-  `origin/main` and compares the marker against the current target content. A
-  mismatch returns `rejected_stale_base` and nothing is committed. When no marker
-  is supplied, the pre-0.3.0 behavior is preserved.
+  marker (`base_commit` naming a specific commit, `base_blob_sha`, or
+  `target_file_hash`) on `kb_propose_edit` (or it is carried on the pending entry
+  into `kb_resolve_pending`), the server refreshes the session worktree's base
+  onto `origin/main` and compares the marker against the current target content. A
+  mismatch returns `rejected_stale_base` and nothing is committed. If the base
+  cannot be refreshed at all (the remote is unreachable, or the rebase conflicts)
+  while an enforceable marker was supplied, the write is also rejected
+  `rejected_stale_base` rather than committed against a possibly-stale base — the
+  marker cannot be verified, and the push-path rebase recovery is not an
+  equivalent safety net (a compatible rebase would still publish the stale write).
+  A bare `base_commit` of `HEAD` is advisory (no per-file expectation), and when
+  no marker is supplied the pre-0.3.0 behavior is preserved (a refresh failure is
+  non-fatal; the push path's non-FF recovery publishes the commit).
 - Ordering of side effects: the commit message and all gates are evaluated
   BEFORE the file is written and `git add`-ed, and on any failure after the add
   the worktree is hard-reset, so a rejected write never leaves a staged leftover

--- a/docs/serving.md
+++ b/docs/serving.md
@@ -62,6 +62,39 @@ reports `degraded: true` only when the index has not been rebuilt within
 For a local read-only demo with no remote, set `KB_REMOTE_URL=""`. The server
 stays healthy as long as the index builds successfully on startup.
 
+## Write serialization and integrity gates
+
+Every write (`kb_propose_memory`, `kb_propose_edit`, `kb_resolve_pending`,
+onboarding bootstrap) goes through one serialized critical section so concurrent
+writes cannot corrupt each other:
+
+- A **process-wide write serializer** wraps the write → `git add` → commit →
+  enqueue sequence, so one thread's commit can never sweep another thread's staged
+  file. Write volume is rate-limited, so a single global mutex is cheap.
+- A **per-path advisory lock**, shared between the auto-commit path and the
+  pending queue, prevents two writes to the same file from racing and prevents an
+  auto-commit from landing on a path with a pending proposal in flight (whose
+  later approval would clobber it). A write blocked by the lock returns
+  `rejected_path_lock_busy`. An orphaned lock (a crash between lock acquisition
+  and the pending entry write) is reclaimed by the pending GC loop.
+- A **content-validation gate** runs on the postimage before commit. It rejects
+  `rejected_invalid_document` when the frontmatter is malformed YAML, a
+  `type`/`status`/`tier` enum value is out of vocabulary, or the `id` is a
+  forged/duplicate of one already used by a different path (which would break
+  every subsequent index rebuild — one bad write, persistent degraded state). The
+  response `reason` carries the machine-readable errors.
+- **Compare-and-swap (optimistic concurrency).** When a caller supplies a base
+  marker (`base_commit`, `base_blob_sha`, or `target_file_hash`) on
+  `kb_propose_edit` (or it is carried on the pending entry into
+  `kb_resolve_pending`), the server refreshes the session worktree's base onto
+  `origin/main` and compares the marker against the current target content. A
+  mismatch returns `rejected_stale_base` and nothing is committed. When no marker
+  is supplied, the pre-0.3.0 behavior is preserved.
+- Ordering of side effects: the commit message and all gates are evaluated
+  BEFORE the file is written and `git add`-ed, and on any failure after the add
+  the worktree is hard-reset, so a rejected write never leaves a staged leftover
+  for the session's next commit to sweep in.
+
 ## Push queue and write-path visibility
 
 Committed writes are published to `origin/main` through a durable push queue: a
@@ -76,6 +109,22 @@ path is diagnosable:
 
 Both counts are computed at health-report time from the queues themselves, so
 they cannot drift.
+
+### Non-fast-forward push recovery
+
+When a second overlapping session moves `origin/main` between a session's commit
+and its push, the push is rejected **non-fast-forward**. The push loop classifies
+this distinctly from a network failure: it fetches `origin/main`, rebases the
+session branch onto it, and retries the push once. Most non-FF cases (the two
+sessions touched different files) publish cleanly on the retry.
+
+If the rebase **conflicts** (the two sessions edited the same lines
+incompatibly), the commit cannot be auto-published. Instead of retrying forever,
+the push loop **demotes** the commit to a pending entry for operator resolution:
+the postimage is re-proposed as a pending edit (visible via `kb_list_pending`),
+the queue entry is removed, and a `push_conflict_demoted` audit event is recorded.
+The operator resolves the pending entry (approving re-applies it on the current
+base, subject to the CAS/validation gates) to publish the change.
 
 ### Startup recovery
 
@@ -94,8 +143,10 @@ retry loop stops retrying it (retrying a permanently failing push every interval
 only spams the remote and hides the problem). The freeze is logged once at WARN
 with the sha, worktree, and last error, and the entry is counted in
 `push_queue_frozen`. **A nonzero `push_queue_frozen` means writes are stuck and
-need operator attention** (the common Wave-0 cause is a non-fast-forward push
-against a moved `origin/main`; the automatic rebase-retry fix for that is Wave 1).
+need operator attention.** Non-fast-forward pushes against a moved `origin/main`
+are now recovered automatically (see *Non-fast-forward push recovery* above), so
+a frozen entry now signals a persistent failure the rebase path could not
+handle — typically an authentication, network, or remote-side rejection.
 
 To unfreeze, an operator resolves the underlying push failure, then clears the
 entry file directly on the push-queue volume (`KB_PUSH_QUEUE_ROOT`, default
@@ -361,6 +412,21 @@ MUST still deploy on a trusted private network or behind an authenticating
 reverse proxy (terminate TLS there). See `SECURITY.md` for the full threat model,
 the route/capability table, payload limits, the tamper-evident audit log, and the
 git sync-failure health fields.
+
+## Git commit identity
+
+Every write commits to the KB repo, so git needs an author/committer identity.
+The shipped Docker image sets a default (`data-olympus-mcp <data-olympus-mcp@localhost>`)
+in `deploy/docker/entrypoint.sh` so the artifact can commit out of the box; the
+server's `main()` also fills unset `GIT_*` variables as a belt-and-suspenders for
+non-Docker runs. Override the identity with:
+
+- `KB_GIT_AUTHOR_NAME` — commit author/committer name (default `data-olympus-mcp`).
+- `KB_GIT_AUTHOR_EMAIL` — commit author/committer email (default
+  `data-olympus-mcp@localhost`).
+
+A pre-existing `GIT_AUTHOR_*`/`GIT_COMMITTER_*` value or a real `git config`
+identity is never overwritten.
 
 ## Running locally
 

--- a/docs/serving.md
+++ b/docs/serving.md
@@ -64,9 +64,10 @@ stays healthy as long as the index builds successfully on startup.
 
 ## Write serialization and integrity gates
 
-Every write (`kb_propose_memory`, `kb_propose_edit`, `kb_resolve_pending`,
-onboarding bootstrap) goes through one serialized critical section so concurrent
-writes cannot corrupt each other:
+Every write (`kb_propose_memory`, `kb_propose_edit`, `kb_resolve_pending`, and
+onboarding bootstrap — which commits its whole file bundle through the same
+serialized/validated multi-file path) goes through one serialized critical
+section so concurrent writes cannot corrupt each other:
 
 - A **process-wide write serializer** wraps the write → `git add` → commit →
   enqueue sequence, so one thread's commit can never sweep another thread's staged
@@ -125,6 +126,11 @@ the postimage is re-proposed as a pending edit (visible via `kb_list_pending`),
 the queue entry is removed, and a `push_conflict_demoted` audit event is recorded.
 The operator resolves the pending entry (approving re-applies it on the current
 base, subject to the CAS/validation gates) to publish the change.
+
+Pure **contention** (the retry push is itself non-FF because `origin/main` moved
+again mid-rebase) is retried in-line for a bounded number of passes; if it never
+wins the race it is demoted the same way rather than counted toward the freeze
+cap, so persistent contention never becomes a silently-frozen queue item.
 
 ### Startup recovery
 

--- a/src/data_olympus/git_ops.py
+++ b/src/data_olympus/git_ops.py
@@ -10,6 +10,28 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 
+class RebaseConflictError(Exception):
+    """A rebase of the session branch onto origin/main hit a conflict that cannot
+    be auto-resolved (scope item 2). The caller demotes the commit to a pending
+    entry for operator resolution rather than retrying forever."""
+
+    def __init__(self, *, worktree_path: str, detail: str) -> None:
+        self.worktree_path = worktree_path
+        self.detail = detail
+        super().__init__(f"rebase conflict in {worktree_path}: {detail}")
+
+
+class NonFastForwardError(Exception):
+    """A push was rejected non-fast-forward and the rebase-and-retry still lost
+    the race (origin/main moved again). Retryable on the next drain; distinct
+    from a network failure so the push loop can log it clearly."""
+
+    def __init__(self, *, worktree_path: str, detail: str) -> None:
+        self.worktree_path = worktree_path
+        self.detail = detail
+        super().__init__(f"non-fast-forward push in {worktree_path}: {detail}")
+
+
 @dataclass(frozen=True, slots=True)
 class FfMergeResult:
     """Outcome of an ff-only merge from origin/main.
@@ -169,6 +191,43 @@ class GitOps:
             check=False, capture_output=True,
         )
 
+    def files_changed_in_commit(
+        self, sha: str, *, worktree_path: str, timeout_sec: int = 10,
+    ) -> list[str]:
+        """Paths added/modified in ``sha`` (relative to the repo root).
+
+        Used by push-conflict demotion to rebuild pending proposals from a commit
+        that could not be rebased. Excludes deletions (``--diff-filter=d`` keeps
+        Added/Copied/Modified/Renamed/Type-changed) because a deletion has no
+        postimage to re-propose. Returns [] on any error."""
+        try:
+            result = subprocess.run(
+                ["git", "-C", worktree_path, "diff-tree", "--no-commit-id",
+                 "-r", "--diff-filter=d", "--name-only", sha],
+                check=False, capture_output=True, text=True, timeout=timeout_sec,
+            )
+        except (subprocess.TimeoutExpired, FileNotFoundError):
+            return []
+        if result.returncode != 0:
+            return []
+        return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+    def file_at_commit(
+        self, sha: str, path: str, *, worktree_path: str, timeout_sec: int = 10,
+    ) -> str | None:
+        """Return the text content of ``path`` as of commit ``sha`` (``git show
+        <sha>:<path>``), or None if the file did not exist there or on error."""
+        try:
+            result = subprocess.run(
+                ["git", "-C", worktree_path, "show", f"{sha}:{path}"],
+                check=False, capture_output=True, text=True, timeout=timeout_sec,
+            )
+        except (subprocess.TimeoutExpired, FileNotFoundError):
+            return None
+        if result.returncode != 0:
+            return None
+        return result.stdout
+
     def list_unpushed_shas(self, worktree_path: str, *, timeout_sec: int = 10) -> list[str]:
         """SHAs reachable from the worktree's HEAD but not from origin/main.
 
@@ -197,6 +256,116 @@ class GitOps:
         subprocess.run(
             ["git", "-C", worktree_path, "push", "origin", "HEAD:main"],
             check=True, capture_output=True, timeout=timeout_sec,
+        )
+
+    @staticmethod
+    def _is_non_fast_forward(stderr: str) -> bool:
+        """Classify a failed ``git push`` stderr as a non-fast-forward rejection
+        (as opposed to a network/auth failure).
+
+        A non-FF push is the recoverable case (fetch + rebase + retry); a network
+        failure is the retry-later case. Git's wording for a non-FF rejection is
+        stable across versions: ``! [rejected] ... (fetch first)`` /
+        ``(non-fast-forward)`` and the "Updates were rejected because" hint."""
+        s = stderr.lower()
+        return (
+            "non-fast-forward" in s
+            or "fetch first" in s
+            or "updates were rejected" in s
+            or ("[rejected]" in s and "fetch" in s)
+        )
+
+    def refresh_base(self, worktree_path: str, *, timeout_sec: int = 60) -> str:
+        """Rebase the worktree's session branch onto the latest ``origin/main`` so
+        subsequent reads/commits sit on the refreshed base (scope items 2, 3).
+
+        Session worktrees branch from main at creation and are never refreshed, so
+        an auto-commit's CAS check would compare against a STALE base and a push
+        would be rejected non-FF. This fetches ``origin/main`` and rebases the
+        session branch onto it. Returns the resulting ``origin/main`` sha (or ""
+        when there is no origin). Raises :class:`RebaseConflictError` on a conflict
+        (the caller demotes to pending). ``subprocess.TimeoutExpired`` propagates
+        for a hung remote (retryable). No-op when there is no ``origin`` remote."""
+        remotes = subprocess.run(
+            ["git", "-C", worktree_path, "remote"],
+            check=False, capture_output=True, text=True, timeout=timeout_sec,
+        )
+        if "origin" not in {
+            line.strip() for line in remotes.stdout.splitlines() if line.strip()
+        }:
+            return ""
+        fetch = subprocess.run(
+            ["git", "-C", worktree_path, "fetch", "origin", "main"],
+            check=False, capture_output=True, text=True, timeout=timeout_sec,
+        )
+        if fetch.returncode != 0:
+            raise RuntimeError(f"fetch_failed: {fetch.stderr.strip()[:200]}")
+        remote_sha = subprocess.run(
+            ["git", "-C", worktree_path, "rev-parse", "origin/main"],
+            check=False, capture_output=True, text=True, timeout=timeout_sec,
+        ).stdout.strip()
+        rebase = subprocess.run(
+            ["git", "-C", worktree_path, "rebase", "origin/main"],
+            check=False, capture_output=True, text=True, timeout=timeout_sec,
+        )
+        if rebase.returncode != 0:
+            # Abort the half-applied rebase so the worktree is left clean; then
+            # signal the conflict so the caller demotes the commit to pending.
+            subprocess.run(
+                ["git", "-C", worktree_path, "rebase", "--abort"],
+                check=False, capture_output=True, timeout=timeout_sec,
+            )
+            raise RebaseConflictError(
+                worktree_path=worktree_path,
+                detail=(rebase.stderr or rebase.stdout).strip()[:400],
+            )
+        return remote_sha
+
+    def push_with_rebase_recovery(
+        self, worktree_path: str, *, timeout_sec: int = 60,
+    ) -> None:
+        """Push HEAD to origin/main; on a non-fast-forward rejection, fetch +
+        rebase the session branch onto origin/main and retry once (scope item 2).
+
+        Distinguishes the two failure modes the plain ``push`` conflated:
+
+        - **Non-fast-forward** (a second overlapping session moved origin/main):
+          recoverable. Rebase the session branch onto the new origin/main and push
+          again. If the retry still fails non-FF (origin moved again mid-rebase),
+          raise :class:`NonFastForwardError` so the caller retries the whole entry
+          on the next drain rather than looping in-line.
+        - **Rebase conflict**: not auto-resolvable. ``refresh_base`` raises
+          :class:`RebaseConflictError`, which propagates so the caller demotes the
+          commit to a pending entry for operator resolution.
+        - **Anything else** (network, auth, timeout): propagates unchanged so the
+          push-retry loop counts it as a retryable failure.
+        """
+        first = subprocess.run(
+            ["git", "-C", worktree_path, "push", "origin", "HEAD:main"],
+            check=False, capture_output=True, text=True, timeout=timeout_sec,
+        )
+        if first.returncode == 0:
+            return
+        if not self._is_non_fast_forward(first.stderr):
+            # Not a non-FF: surface as a generic push failure (retryable).
+            raise subprocess.CalledProcessError(
+                first.returncode, first.args, first.stdout, first.stderr,
+            )
+        # Non-FF: rebase onto the moved origin/main (may raise
+        # RebaseConflictError -> caller demotes) and retry the push once.
+        self.refresh_base(worktree_path, timeout_sec=timeout_sec)
+        retry = subprocess.run(
+            ["git", "-C", worktree_path, "push", "origin", "HEAD:main"],
+            check=False, capture_output=True, text=True, timeout=timeout_sec,
+        )
+        if retry.returncode == 0:
+            return
+        if self._is_non_fast_forward(retry.stderr):
+            raise NonFastForwardError(
+                worktree_path=worktree_path, detail=retry.stderr.strip()[:400],
+            )
+        raise subprocess.CalledProcessError(
+            retry.returncode, retry.args, retry.stdout, retry.stderr,
         )
 
 

--- a/src/data_olympus/index.py
+++ b/src/data_olympus/index.py
@@ -1575,6 +1575,23 @@ class Index:
             description=row["description"] or "",
         )
 
+    def id_to_path_map(self) -> dict[str, str]:
+        """Return ``{doc_id: path}`` for every indexed document.
+
+        Used by the write-path validation gate to detect a forged/duplicate id
+        (an id already used by a DIFFERENT path corrupts the next rebuild). This
+        includes reserved files (index.md/log.md), which the indexer still assigns
+        an id (explicit or path-derived), so a reserved file carrying a colliding
+        id is caught too."""
+        conn = self._connect()
+        try:
+            rows = conn.execute("SELECT id, path FROM docs").fetchall()
+        except sqlite3.Error:
+            return {}
+        finally:
+            conn.close()
+        return {row["id"]: row["path"] for row in rows}
+
     def ids_with_exact_tag(self, tag: str) -> set[str]:
         """Return the ids of docs carrying ``tag`` as an EXACT (whole) tag.
 

--- a/src/data_olympus/models.py
+++ b/src/data_olympus/models.py
@@ -182,6 +182,9 @@ class ResolvePendingResponse(BaseModel):
     conflict_markers: str | None = None
     base_commit: str | None = None
     current_commit: str | None = None
+    # Machine-readable rejection detail for the CAS / validation gates
+    # (rejected_stale_base, rejected_invalid_document) on the resolve path.
+    reason: str | None = None
 
 
 class PendingEntry(BaseModel):

--- a/src/data_olympus/models.py
+++ b/src/data_olympus/models.py
@@ -185,6 +185,10 @@ class ResolvePendingResponse(BaseModel):
     # Machine-readable rejection detail for the CAS / validation gates
     # (rejected_stale_base, rejected_invalid_document) on the resolve path.
     reason: str | None = None
+    # Truthful publish state on a committed resolve: "queued" when the push-queue
+    # entry landed, else "enqueue_failed_recovery_pending" (the commit is durable
+    # but is recovered by in-process/startup recovery, not queued this attempt).
+    push_state: str | None = None
 
 
 class PendingEntry(BaseModel):

--- a/src/data_olympus/pending.py
+++ b/src/data_olympus/pending.py
@@ -76,6 +76,13 @@ class PendingQueue:
         os.makedirs(self._root, exist_ok=True)
         os.makedirs(self._locks_dir, exist_ok=True)
 
+    @property
+    def root(self) -> str:
+        """The on-disk directory backing this pending queue. Public so callers
+        (e.g. onboarding's pending-root resolution) do not reach into the private
+        ``_root`` attribute."""
+        return self._root
+
     def _acquire_lock(self, target_path: str, pending_id: str) -> None:
         lock_path = os.path.join(self._locks_dir, _path_lock_filename(target_path))
         try:

--- a/src/data_olympus/pending.py
+++ b/src/data_olympus/pending.py
@@ -218,10 +218,11 @@ class PendingQueue:
         self._release_lock(target_path)
         atomic_remove(os.path.join(self._root, f"{pending_id}.claimed"))
 
-    def approve(self, pending_id: str, *, edited_text: str | None = None) -> ResolvedPending:
-        entry = self._claim(pending_id)
+    def _to_resolved(
+        self, pending_id: str, entry: dict[str, Any], edited_text: str | None,
+    ) -> ResolvedPending:
         postimage = edited_text if edited_text is not None else entry["postimage"]
-        resolved = ResolvedPending(
+        return ResolvedPending(
             pending_id=pending_id,
             proposal_type=entry["proposal_type"],
             target_path=entry["target_path"],
@@ -231,12 +232,46 @@ class PendingQueue:
             target_file_hash=entry["target_file_hash"],
             meta=entry["meta"],
         )
-        # Release the lock + remove the (claimed) entry. The CALLER applies the
-        # postimage in the worktree and produces the commit; the CAS/validation
-        # gate may still reject after this, but the entry is already consumed so a
-        # rejected approval does not leave a re-approvable duplicate.
+
+    def approve(self, pending_id: str, *, edited_text: str | None = None) -> ResolvedPending:
+        """Claim + consume in one step (path lock released, entry removed).
+
+        Kept for callers that commit unconditionally. The gated resolve path uses
+        ``claim_for_resolve`` / ``finalize_resolve`` / ``restore_resolve`` instead,
+        so a post-claim gate rejection can put the entry back (Codex round-2
+        Blocker B)."""
+        entry = self._claim(pending_id)
+        resolved = self._to_resolved(pending_id, entry, edited_text)
         self._finish_claim(pending_id, entry["target_path"])
         return resolved
+
+    def claim_for_resolve(
+        self, pending_id: str, *, edited_text: str | None = None,
+    ) -> ResolvedPending:
+        """Atomically claim the entry for a GATED resolve, HOLDING the path lock and
+        the ``.claimed`` sidecar (Codex round-2 Blocker B).
+
+        Unlike ``approve``, this does NOT release the lock or delete the entry: the
+        caller runs the CAS/validation gates and then calls ``finalize_resolve`` on
+        success or ``restore_resolve`` on a gate rejection. The path lock is the one
+        acquired at ``enqueue`` time and stays held throughout, so no other write
+        can grab the path in the window between claim and commit, and the operator's
+        proposal is never lost to a post-claim gate rejection."""
+        entry = self._claim(pending_id)
+        return self._to_resolved(pending_id, entry, edited_text)
+
+    def finalize_resolve(self, pending_id: str, target_path: str) -> None:
+        """Commit succeeded: release the path lock and remove the claimed entry."""
+        self._finish_claim(pending_id, target_path)
+
+    def restore_resolve(self, pending_id: str) -> None:
+        """A gate rejected the claimed entry: rename ``<pid>.claimed`` back to
+        ``<pid>.json`` so the operator can re-resolve it, keeping the path lock
+        held (it was never released). Idempotent: a missing sidecar is a no-op."""
+        claimed = os.path.join(self._root, f"{pending_id}.claimed")
+        live = os.path.join(self._root, f"{pending_id}.json")
+        with contextlib.suppress(FileNotFoundError):
+            os.rename(claimed, live)
 
     def reject(self, pending_id: str) -> None:
         entry = self._claim(pending_id)

--- a/src/data_olympus/pending.py
+++ b/src/data_olympus/pending.py
@@ -14,7 +14,10 @@ import re
 import time
 import uuid
 from dataclasses import dataclass
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 from data_olympus.durable import atomic_remove, atomic_write_json
 
@@ -37,6 +40,15 @@ class PendingNotFoundError(Exception):
     Previously ``get`` let the bare ``FileNotFoundError`` from ``open`` propagate,
     which the REST resolve route surfaced as an opaque HTTP 500. This typed error
     lets the route map an unknown/expired id to a 404 (item 9)."""
+
+
+class PendingAlreadyResolvedError(Exception):
+    """Raised when a pending entry is claimed but has already been claimed by a
+    concurrent resolve (item 5). ``approve``/``reject`` are get-then-remove, so two
+    concurrent resolves of the same id both saw the entry and both committed. The
+    atomic ``claim`` renames the entry to a ``.claimed`` sidecar in one
+    ``os.rename`` step; the loser of the race sees ``FileNotFoundError`` and this
+    error is raised so exactly one resolve proceeds."""
 
 
 @dataclass(frozen=True, slots=True)
@@ -82,6 +94,24 @@ class PendingQueue:
         lock_path = os.path.join(self._locks_dir, _path_lock_filename(target_path))
         with contextlib.suppress(FileNotFoundError):
             os.unlink(lock_path)
+
+    @contextlib.contextmanager
+    def path_lock(self, target_path: str, *, owner: str) -> Iterator[None]:
+        """Advisory per-path lock SHARED between the auto-commit path and the
+        pending queue (scope item 1).
+
+        Both surfaces write into the same on-disk ``locks/`` directory keyed by the
+        canonical target path, so an auto-commit cannot land on a path that has a
+        pending proposal in flight (the later approval would clobber it) and two
+        auto-commits to the same path cannot interleave. ``owner`` is a marker
+        (e.g. ``auto-commit:<sha_or_session>``) recorded in the lock file for
+        operator diagnosis; it is not a pending_id. Raises :class:`PathLockBusyError`
+        when the path is already locked. Releases on exit."""
+        self._acquire_lock(target_path, owner)
+        try:
+            yield
+        finally:
+            self._release_lock(target_path)
 
     def enqueue(
         self,
@@ -148,8 +178,41 @@ class PendingQueue:
             data: dict[str, Any] = json.load(f)
             return data
 
+    def _claim(self, pending_id: str) -> dict[str, Any]:
+        """Atomically claim a pending entry so exactly one resolver proceeds
+        (item 5). ``approve``/``reject`` were get-then-remove: two concurrent
+        resolves of the same id both read the entry and both committed (two
+        commits, two audit events, one decision). ``os.rename`` is atomic on a
+        POSIX filesystem, so renaming ``<pid>.json`` to ``<pid>.claimed`` is a
+        test-and-set: the winner gets the file, the loser hits ``FileNotFoundError``
+        and we surface :class:`PendingAlreadyResolvedError`. The claimed sidecar is
+        removed by the caller once the entry is fully processed (or on failure it
+        lingers as a ``.claimed`` file that ``list``/``size`` ignore and the GC
+        cleans up its lock)."""
+        if not _PENDING_ID_RE.fullmatch(pending_id):
+            raise PendingNotFoundError(pending_id)
+        src = os.path.join(self._root, f"{pending_id}.json")
+        if not os.path.exists(src):
+            raise PendingNotFoundError(pending_id)
+        claimed = os.path.join(self._root, f"{pending_id}.claimed")
+        try:
+            os.rename(src, claimed)
+        except FileNotFoundError:
+            # Lost the race: another resolver renamed it first between our
+            # exists() check and here.
+            raise PendingAlreadyResolvedError(pending_id) from None
+        with open(claimed) as f:
+            data: dict[str, Any] = json.load(f)
+            return data
+
+    def _finish_claim(self, pending_id: str, target_path: str) -> None:
+        """Release the path lock and remove the ``.claimed`` sidecar. Called after
+        a claimed entry has been fully processed (committed or rejected)."""
+        self._release_lock(target_path)
+        atomic_remove(os.path.join(self._root, f"{pending_id}.claimed"))
+
     def approve(self, pending_id: str, *, edited_text: str | None = None) -> ResolvedPending:
-        entry = self.get(pending_id)
+        entry = self._claim(pending_id)
         postimage = edited_text if edited_text is not None else entry["postimage"]
         resolved = ResolvedPending(
             pending_id=pending_id,
@@ -161,16 +224,56 @@ class PendingQueue:
             target_file_hash=entry["target_file_hash"],
             meta=entry["meta"],
         )
-        # Release the lock + remove the entry. The CALLER applies the postimage
-        # in the worktree and produces the commit.
-        self._release_lock(entry["target_path"])
-        atomic_remove(os.path.join(self._root, f"{pending_id}.json"))
+        # Release the lock + remove the (claimed) entry. The CALLER applies the
+        # postimage in the worktree and produces the commit; the CAS/validation
+        # gate may still reject after this, but the entry is already consumed so a
+        # rejected approval does not leave a re-approvable duplicate.
+        self._finish_claim(pending_id, entry["target_path"])
         return resolved
 
     def reject(self, pending_id: str) -> None:
-        entry = self.get(pending_id)
-        self._release_lock(entry["target_path"])
-        atomic_remove(os.path.join(self._root, f"{pending_id}.json"))
+        entry = self._claim(pending_id)
+        self._finish_claim(pending_id, entry["target_path"])
+
+    def gc_orphan_locks(self) -> int:
+        """Remove lock files whose ``pending_id`` has no live entry (item 5).
+
+        A crash between ``_acquire_lock`` and the entry write in ``enqueue`` leaves
+        the path locked forever with no entry to release it, so every future
+        proposal to that path is rejected ``rejected_path_lock_busy``. Each lock
+        file records the ``pending_id`` that holds it; if neither ``<pid>.json``
+        nor ``<pid>.claimed`` exists, the lock is orphaned and is removed. Locks
+        held by the shared auto-commit path (``owner`` is not a hex uuid) are
+        left alone: those are held only for the duration of an in-process commit
+        and are never orphaned across a restart (a restart clears the process,
+        and a stale one is released by the ``finally`` of ``path_lock``; but if a
+        hard crash left one, its non-uuid owner means we cannot prove it orphaned,
+        so we conservatively skip it). Returns the number of locks removed."""
+        if not os.path.isdir(self._locks_dir):
+            return 0
+        removed = 0
+        for name in os.listdir(self._locks_dir):
+            if not name.endswith(".lock"):
+                continue
+            lock_path = os.path.join(self._locks_dir, name)
+            try:
+                with open(lock_path) as f:
+                    info = json.load(f)
+            except (FileNotFoundError, ValueError):
+                continue
+            holder = info.get("pending_id", "")
+            # Only reclaim locks held by a pending entry (uuid holder). A
+            # non-uuid holder is the transient auto-commit owner; skip it.
+            if not _PENDING_ID_RE.fullmatch(str(holder)):
+                continue
+            live = os.path.join(self._root, f"{holder}.json")
+            claimed = os.path.join(self._root, f"{holder}.claimed")
+            if os.path.exists(live) or os.path.exists(claimed):
+                continue
+            with contextlib.suppress(FileNotFoundError):
+                os.unlink(lock_path)
+                removed += 1
+        return removed
 
     def would_exceed(self, n: int) -> bool:
         """True if enqueuing ``n`` more entries would exceed the cap (0 = unlimited).

--- a/src/data_olympus/push_queue.py
+++ b/src/data_olympus/push_queue.py
@@ -1,8 +1,14 @@
 """Durable push queue: enqueue commits awaiting `git push`, drain with retry.
 
 Every queue entry write goes through atomic_write_json
-(temp -> fsync -> rename -> parent-dir fsync) so a commit returning "committed"
-guarantees the queue entry survives a crash.
+(temp -> fsync -> rename -> parent-dir fsync), so a queue entry that was written
+survives a crash. The DURABLE object for a completed write is the git commit on
+the session branch, not necessarily the queue entry: a rare post-commit enqueue
+failure is reported to the caller as ``push_state="enqueue_failed_recovery_pending"``
+(see tools_write._enqueue_after_commit) and the orphaned committed sha is recovered
+by ``init_recovery`` at startup (and an in-process re-enqueue attempt), so it
+publishes eventually. A ``push_state="queued"`` response means the queue entry did
+land durably.
 """
 from __future__ import annotations
 

--- a/src/data_olympus/push_queue.py
+++ b/src/data_olympus/push_queue.py
@@ -64,7 +64,13 @@ class PushQueue:
                 count += 1
         return count
 
-    def drain(self, *, push_fn: Callable[[str], None], max_attempts: int) -> None:
+    def drain(
+        self,
+        *,
+        push_fn: Callable[[str], None],
+        max_attempts: int,
+        on_rebase_conflict: Callable[[dict[str, Any]], None] | None = None,
+    ) -> None:
         """Iterate every queued entry. push_fn(worktree_path) is called; on
         success the entry is removed; on failure the entry is updated with
         attempt count + last error and left in the queue.
@@ -74,7 +80,18 @@ class PushQueue:
         the remote. A frozen entry stays on disk for operator inspection and is
         surfaced via ``frozen_count()`` in health; an operator clears it by
         deleting or requeuing the entry file (see docs/serving.md).
+
+        ``on_rebase_conflict`` (scope item 2): when ``push_fn`` raises
+        :class:`~data_olympus.git_ops.RebaseConflictError`, the commit cannot be
+        auto-published (the session branch does not rebase cleanly onto the moved
+        origin/main). Instead of retrying forever, the callback demotes the commit
+        to a pending entry for operator resolution and the queue entry is removed.
+        The callback is responsible for the audit event and the pending record; if
+        it raises, the entry is treated as a retryable failure (kept in the queue)
+        so a demotion bug cannot silently drop the write.
         """
+        from data_olympus.git_ops import RebaseConflictError
+
         if not os.path.isdir(self._root):
             return
         for name in sorted(os.listdir(self._root)):
@@ -105,6 +122,36 @@ class PushQueue:
                 continue
             try:
                 push_fn(entry["worktree_path"])
+            except RebaseConflictError as conflict:
+                # Not auto-resolvable: demote to pending for operator resolution
+                # rather than retrying forever (scope item 2). Only remove the
+                # queue entry once the demotion callback succeeds, so a callback
+                # failure keeps the commit queued (never silently lost).
+                if on_rebase_conflict is None:
+                    entry["attempts"] = entry.get("attempts", 0) + 1
+                    entry["last_error"] = f"rebase_conflict: {conflict.detail}"
+                    entry["last_error_at"] = time.time()
+                    atomic_write_json(entry_path, entry)
+                    continue
+                try:
+                    on_rebase_conflict(entry)
+                except Exception:  # noqa: BLE001 - demotion failed; keep queued
+                    log.exception(
+                        "rebase-conflict demotion failed (sha=%s); keeping queued",
+                        entry.get("sha", "?"),
+                    )
+                    entry["attempts"] = entry.get("attempts", 0) + 1
+                    entry["last_error"] = "demotion_failed"
+                    entry["last_error_at"] = time.time()
+                    atomic_write_json(entry_path, entry)
+                    continue
+                log.warning(
+                    "push queue entry demoted to pending after rebase conflict "
+                    "(sha=%s worktree=%s); operator must resolve",
+                    entry.get("sha", "?"), entry.get("worktree_path", "?"),
+                )
+                atomic_remove(entry_path)
+                continue
             except Exception as exc:  # noqa: BLE001 -- intentional: capture any push failure
                 entry["attempts"] = entry.get("attempts", 0) + 1
                 entry["last_error"] = str(exc)

--- a/src/data_olympus/push_queue.py
+++ b/src/data_olympus/push_queue.py
@@ -90,7 +90,14 @@ class PushQueue:
         it raises, the entry is treated as a retryable failure (kept in the queue)
         so a demotion bug cannot silently drop the write.
         """
-        from data_olympus.git_ops import RebaseConflictError
+        from data_olympus.git_ops import NonFastForwardError, RebaseConflictError
+
+        # A repeated non-FF race (origin/main moves faster than we can rebase) is
+        # contention, not a content conflict, but it can neither publish nor demote
+        # on its own. Bound the in-line retries: after this many consecutive
+        # attempts that all end non-FF, demote to pending (like a rebase conflict)
+        # so pure contention never becomes a silently-frozen queue item.
+        non_ff_demote_after = 5
 
         if not os.path.isdir(self._root):
             return
@@ -124,55 +131,89 @@ class PushQueue:
                 push_fn(entry["worktree_path"])
             except RebaseConflictError as conflict:
                 # Not auto-resolvable: demote to pending for operator resolution
-                # rather than retrying forever (scope item 2). Only remove the
-                # queue entry once the demotion callback succeeds, so a callback
-                # failure keeps the commit queued (never silently lost).
-                if on_rebase_conflict is None:
-                    entry["attempts"] = entry.get("attempts", 0) + 1
-                    entry["last_error"] = f"rebase_conflict: {conflict.detail}"
-                    entry["last_error_at"] = time.time()
-                    atomic_write_json(entry_path, entry)
+                # rather than retrying forever (scope item 2).
+                if self._demote(entry, entry_path, on_rebase_conflict,
+                                reason=f"rebase_conflict: {conflict.detail}"):
                     continue
-                try:
-                    on_rebase_conflict(entry)
-                except Exception:  # noqa: BLE001 - demotion failed; keep queued
-                    log.exception(
-                        "rebase-conflict demotion failed (sha=%s); keeping queued",
-                        entry.get("sha", "?"),
-                    )
-                    entry["attempts"] = entry.get("attempts", 0) + 1
-                    entry["last_error"] = "demotion_failed"
-                    entry["last_error_at"] = time.time()
-                    atomic_write_json(entry_path, entry)
+                # No callback / demotion failed -> keep queued (retryable).
+                self._record_retry(entry, entry_path,
+                                   f"rebase_conflict: {conflict.detail}")
+                continue
+            except NonFastForwardError as nff:
+                # Pure contention that the rebase-and-retry still lost. Bounded
+                # in-line retries, then demote (Codex Concern 1): a persistent
+                # non-FF race must never freeze silently.
+                nff_attempts = entry.get("non_ff_attempts", 0) + 1
+                entry["non_ff_attempts"] = nff_attempts
+                if nff_attempts >= non_ff_demote_after and self._demote(
+                    entry, entry_path, on_rebase_conflict,
+                    reason=f"non_fast_forward_contention: {nff.detail}",
+                ):
                     continue
-                log.warning(
-                    "push queue entry demoted to pending after rebase conflict "
-                    "(sha=%s worktree=%s); operator must resolve",
-                    entry.get("sha", "?"), entry.get("worktree_path", "?"),
-                )
-                atomic_remove(entry_path)
+                self._record_retry(entry, entry_path,
+                                   f"non_fast_forward: {nff.detail}",
+                                   max_attempts=max_attempts)
                 continue
             except Exception as exc:  # noqa: BLE001 -- intentional: capture any push failure
-                entry["attempts"] = entry.get("attempts", 0) + 1
-                entry["last_error"] = str(exc)
-                entry["last_error_at"] = time.time()
-                if entry["attempts"] >= max_attempts:
-                    # Cap reached; freeze for operator inspection and stop
-                    # retrying. Log once, at the moment it first freezes.
-                    entry["frozen"] = True
-                    log.warning(
-                        "push queue entry frozen after %d attempts "
-                        "(sha=%s worktree=%s last_error=%s); it will no longer "
-                        "be retried until an operator clears it "
-                        "(see docs/serving.md unfreeze path)",
-                        entry["attempts"],
-                        entry.get("sha", "?"),
-                        entry.get("worktree_path", "?"),
-                        entry["last_error"],
-                    )
-                atomic_write_json(entry_path, entry)
+                self._record_retry(entry, entry_path, str(exc),
+                                   max_attempts=max_attempts)
                 continue
             atomic_remove(entry_path)
+
+    def _demote(
+        self,
+        entry: dict[str, Any],
+        entry_path: str,
+        on_rebase_conflict: Callable[[dict[str, Any]], None] | None,
+        *,
+        reason: str,
+    ) -> bool:
+        """Demote a queue entry to pending via the callback and remove it.
+
+        Returns True when the demotion succeeded (entry removed), False when there
+        is no callback or the callback failed (caller keeps the entry queued so the
+        commit is never silently lost)."""
+        if on_rebase_conflict is None:
+            return False
+        try:
+            on_rebase_conflict(entry)
+        except Exception:  # noqa: BLE001 - demotion failed; keep queued
+            log.exception(
+                "push-queue demotion failed (sha=%s reason=%s); keeping queued",
+                entry.get("sha", "?"), reason,
+            )
+            return False
+        log.warning(
+            "push queue entry demoted to pending (%s; sha=%s worktree=%s); "
+            "operator must resolve",
+            reason, entry.get("sha", "?"), entry.get("worktree_path", "?"),
+        )
+        atomic_remove(entry_path)
+        return True
+
+    def _record_retry(
+        self,
+        entry: dict[str, Any],
+        entry_path: str,
+        error: str,
+        *,
+        max_attempts: int | None = None,
+    ) -> None:
+        """Record a retryable push failure: increment attempts, store the error,
+        and (when ``max_attempts`` is given and reached) freeze the entry."""
+        entry["attempts"] = entry.get("attempts", 0) + 1
+        entry["last_error"] = error
+        entry["last_error_at"] = time.time()
+        if max_attempts is not None and entry["attempts"] >= max_attempts:
+            entry["frozen"] = True
+            log.warning(
+                "push queue entry frozen after %d attempts "
+                "(sha=%s worktree=%s last_error=%s); it will no longer be retried "
+                "until an operator clears it (see docs/serving.md unfreeze path)",
+                entry["attempts"], entry.get("sha", "?"),
+                entry.get("worktree_path", "?"), entry["last_error"],
+            )
+        atomic_write_json(entry_path, entry)
 
     def init_recovery(
         self,

--- a/src/data_olympus/push_queue.py
+++ b/src/data_olympus/push_queue.py
@@ -152,7 +152,7 @@ class PushQueue:
                     continue
                 self._record_retry(entry, entry_path,
                                    f"non_fast_forward: {nff.detail}",
-                                   max_attempts=max_attempts)
+                                   max_attempts=max_attempts, reset_non_ff=False)
                 continue
             except Exception as exc:  # noqa: BLE001 -- intentional: capture any push failure
                 self._record_retry(entry, entry_path, str(exc),
@@ -198,12 +198,22 @@ class PushQueue:
         error: str,
         *,
         max_attempts: int | None = None,
+        reset_non_ff: bool = True,
     ) -> None:
         """Record a retryable push failure: increment attempts, store the error,
-        and (when ``max_attempts`` is given and reached) freeze the entry."""
+        and (when ``max_attempts`` is given and reached) freeze the entry.
+
+        ``reset_non_ff`` (default True) zeroes the ``non_ff_attempts`` counter so
+        it counts CONSECUTIVE non-fast-forward failures only (Codex round-2
+        Concern 2): a network/other failure between two non-FF failures resets the
+        contention streak, so a mixed failure history does not accumulate toward
+        the non-FF demotion threshold. The non-FF branch passes False so its own
+        increment survives."""
         entry["attempts"] = entry.get("attempts", 0) + 1
         entry["last_error"] = error
         entry["last_error_at"] = time.time()
+        if reset_non_ff and entry.get("non_ff_attempts"):
+            entry["non_ff_attempts"] = 0
         if max_attempts is not None and entry["attempts"] >= max_attempts:
             entry["frozen"] = True
             log.warning(

--- a/src/data_olympus/refresh.py
+++ b/src/data_olympus/refresh.py
@@ -3,6 +3,7 @@ main server process; no sidecar (single owner of git state)."""
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import functools
 import logging
 import time
@@ -13,6 +14,7 @@ from data_olympus.index import DuplicateIdError, Index
 if TYPE_CHECKING:
     from pathlib import Path
 
+    from data_olympus.audit_log import AuditLog
     from data_olympus.git_ops import GitOps
     from data_olympus.pending import PendingQueue
     from data_olympus.push_queue import PushQueue
@@ -112,6 +114,74 @@ async def git_pull_loop(state: ServerState, interval_sec: int) -> None:
         await asyncio.sleep(interval_sec)
 
 
+def demote_conflict_to_pending(
+    entry: dict[str, Any],
+    *,
+    git: GitOps,
+    pending: PendingQueue,
+    audit_log: AuditLog | None,
+) -> None:
+    """Demote a push-queue entry whose commit could not be rebased onto the moved
+    origin/main to a pending proposal for operator resolution (scope item 2).
+
+    Called by the push loop's ``on_rebase_conflict`` hook. Reads the target path
+    and postimage FROM THE COMMIT (``git show <sha>:<path>``) rather than the
+    worktree (which may have moved on), enqueues a pending entry carrying the base
+    the commit sat on, and records a ``push_conflict_demoted`` audit event with a
+    distinct status so health and ``kb_list_pending`` surface it. The commit stays
+    in the session branch history; publishing it is now gated on operator resolve.
+    """
+    from data_olympus.pending import PathLockBusyError, PendingQueueFullError
+
+    sha = entry.get("sha", "")
+    wt = entry.get("worktree_path", "")
+    changed = git.files_changed_in_commit(sha, worktree_path=wt)
+    demoted = 0
+    for path in changed:
+        postimage = git.file_at_commit(sha, path, worktree_path=wt)
+        if postimage is None:
+            continue  # deletion or unreadable; nothing to re-propose
+        try:
+            pid = pending.enqueue(
+                proposal_type="edit",
+                target_path=path,
+                postimage=postimage,
+                base_commit=f"{sha}^",
+                base_blob_sha=None,
+                target_file_hash=None,
+                meta={
+                    "agent_identity": entry.get("meta", {}).get(
+                        "agent_identity", "unknown"),
+                    "source_session": entry.get("meta", {}).get(
+                        "source_session", "push-conflict"),
+                    "confidence": 0.0,
+                    "reason": "demoted from push queue after rebase conflict",
+                    "demoted_from_sha": sha,
+                },
+            )
+        except (PathLockBusyError, PendingQueueFullError):
+            # A pending proposal for this path already exists (or the queue is
+            # full). Leaving the commit un-demoted here would drop it, so re-raise
+            # so the drain keeps the queue entry and retries the demotion later.
+            raise
+        demoted += 1
+        if audit_log is not None:
+            with contextlib.suppress(Exception):
+                audit_log.append({
+                    "ts": time.time(),
+                    "event_type": "push_conflict_demoted",
+                    "status": "demoted_to_pending",
+                    "pending_id": pid,
+                    "target_path": path,
+                    "commit_sha": sha,
+                    "reason": "non-fast-forward push did not rebase cleanly",
+                })
+    if demoted == 0:
+        # Nothing was re-proposed (e.g. the commit only deleted files). Raise so
+        # the entry is kept and surfaces rather than being silently dropped.
+        raise RuntimeError(f"nothing demotable in commit {sha}")
+
+
 async def push_retry_loop(
     *,
     push_queue: PushQueue,
@@ -119,23 +189,36 @@ async def push_retry_loop(
     interval_sec: int,
     max_attempts: int = 30,
     push_timeout_sec: int = 60,
+    pending: PendingQueue | None = None,
+    audit_log: AuditLog | None = None,
 ) -> None:
     """Periodically drain the push queue. Cancellable via asyncio.
 
     ``drain`` shells out to ``git push`` (blocking I/O), so it runs in a thread
     executor rather than on the event loop: a hung origin must never block the
     loop that also answers the readiness probe (the probe timing out would
-    crash-loop the pod). ``git.push`` itself is bounded by ``push_timeout_sec``;
-    a timeout surfaces as ``subprocess.TimeoutExpired``, which ``drain`` catches
-    and records as a retryable failure (attempt count increments, entry stays
-    queued) exactly like any other push error.
+    crash-loop the pod). The push now goes through ``push_with_rebase_recovery``:
+    a non-fast-forward rejection (a second overlapping session moved origin/main)
+    triggers a fetch + rebase + retry instead of retrying identically forever. A
+    rebase CONFLICT raises ``RebaseConflictError``, which ``drain`` routes to the
+    ``on_rebase_conflict`` demotion hook (the commit becomes a pending entry for
+    operator resolution). Every other failure (network, timeout, auth) stays a
+    retryable failure exactly as before.
     """
+    on_conflict = None
+    if pending is not None:
+        on_conflict = functools.partial(
+            demote_conflict_to_pending, git=git, pending=pending,
+            audit_log=audit_log,
+        )
     while True:
         try:
             fn = functools.partial(
                 push_queue.drain,
-                push_fn=lambda wt: git.push(wt, timeout_sec=push_timeout_sec),
+                push_fn=lambda wt: git.push_with_rebase_recovery(
+                    wt, timeout_sec=push_timeout_sec),
                 max_attempts=max_attempts,
+                on_rebase_conflict=on_conflict,
             )
             await asyncio.get_event_loop().run_in_executor(None, fn)
         except Exception:
@@ -174,14 +257,54 @@ async def pending_gc_loop(
     pending: PendingQueue,
     timeout_sec: int,
     interval_sec: int,
+    audit_log: AuditLog | None = None,
 ) -> None:
-    """Periodically expire pending entries older than timeout_sec."""
+    """Periodically expire pending entries older than timeout_sec and reclaim
+    orphaned path locks.
+
+    On expiry an audit event is emitted (scope item 7): the old loop silently
+    rejected entries >timeout, so an operator who lost a proposal to expiry had no
+    record. Each expired entry now records an ``expired`` / ``auto_rejected``
+    audit event before it is rejected. A concurrent operator resolve can win the
+    race (the entry is already gone by the time we reject it); that
+    ``PendingAlreadyResolvedError`` / ``PendingNotFoundError`` is swallowed so the
+    loop does not crash on a benign race.
+
+    Orphaned path locks (a crash between lock create and entry write, scope item
+    5) are reclaimed each pass via ``gc_orphan_locks`` so a path is not locked
+    forever with no entry to release it.
+    """
+    from data_olympus.pending import (
+        PendingAlreadyResolvedError,
+        PendingNotFoundError,
+    )
     while True:
         try:
             now = time.time()
             for entry in pending.list():
                 if now - entry["created_at"] > timeout_sec:
-                    pending.reject(entry["pending_id"])
+                    pid = entry["pending_id"]
+                    # Emit the expiry audit BEFORE rejecting so the record exists
+                    # even if the reject then races an operator resolve.
+                    if audit_log is not None:
+                        with contextlib.suppress(Exception):
+                            audit_log.append({
+                                "ts": now,
+                                "event_type": "pending_expired",
+                                "status": "auto_rejected",
+                                "pending_id": pid,
+                                "target_path": entry.get("target_path"),
+                                "agent_identity": entry.get("agent_identity"),
+                                "reason": f"pending age exceeded {timeout_sec}s",
+                            })
+                    with contextlib.suppress(
+                        PendingAlreadyResolvedError, PendingNotFoundError,
+                    ):
+                        pending.reject(pid)
+            reclaimed = pending.gc_orphan_locks()
+            if reclaimed:
+                log.warning("pending_gc reclaimed %d orphaned path lock(s)",
+                            reclaimed)
         except Exception:
             log.exception("pending_gc_loop iteration failed")
         await asyncio.sleep(interval_sec)

--- a/src/data_olympus/rest_api.py
+++ b/src/data_olympus/rest_api.py
@@ -214,10 +214,16 @@ def _propose_status(status: str) -> int:
         return 413
     if status in ("rejected_rate_limited", "rejected_pending_queue_full"):
         return 429
-    if status in ("rejected_stale_base", "rejected_path_lock_busy"):
-        # Optimistic-concurrency / lock contention: the caller's base moved or a
-        # concurrent write holds the path. 409 Conflict.
+    if status in ("rejected_stale_base", "rejected_path_lock_busy",
+                  "rejected_already_in_progress"):
+        # Optimistic-concurrency / lock contention: the caller's base moved, a
+        # concurrent write holds the path, or a bootstrap for this workspace is
+        # already in progress. 409 Conflict.
         return 409
+    if status == "rejected_path_locked":
+        # The target path is held by an advisory lock; retry after it clears.
+        # 423 Locked.
+        return 423
     if status == "rejected_invalid_document":
         # The postimage failed the content-validation gate. 422 Unprocessable.
         return 422
@@ -739,6 +745,7 @@ def register_routes(
                 can_auto_commit=principal.can_auto_commit,
                 max_postimage_bytes=state.config.max_postimage_bytes,
                 max_files=state.config.max_bootstrap_files,
+                serializer=state.write_serializer,
             )
             status = _propose_status(resp.status)
             return JSONResponse(resp.model_dump(), status_code=status)

--- a/src/data_olympus/rest_api.py
+++ b/src/data_olympus/rest_api.py
@@ -214,7 +214,32 @@ def _propose_status(status: str) -> int:
         return 413
     if status in ("rejected_rate_limited", "rejected_pending_queue_full"):
         return 429
+    if status in ("rejected_stale_base", "rejected_path_lock_busy"):
+        # Optimistic-concurrency / lock contention: the caller's base moved or a
+        # concurrent write holds the path. 409 Conflict.
+        return 409
+    if status == "rejected_invalid_document":
+        # The postimage failed the content-validation gate. 422 Unprocessable.
+        return 422
     return 400
+
+
+def _resolve_status(status: str) -> int:
+    """Map a resolve response status to an HTTP status code (item 5, item 3/4)."""
+    if status == "committed":
+        return 200
+    if status == "rejected_edited_text_too_large":
+        return 413
+    if status == "already_resolved":
+        # Lost the double-resolve race: the id was already decided. 409 Conflict.
+        return 409
+    if status == "rejected_stale_base":
+        return 409
+    if status == "rejected_invalid_document":
+        return 422
+    if status in ("rejected", "rejected_symlink_escape"):
+        return 200
+    return 200
 
 
 async def _read_json_capped(
@@ -407,6 +432,7 @@ def register_routes(
                 audit_log=state.audit_log,
                 can_auto_commit=principal.can_auto_commit,
                 max_text_bytes=state.config.max_text_bytes,
+                serializer=state.write_serializer, idx=state.idx,
             )
             status = _propose_status(resp.status)
             return JSONResponse(resp.model_dump(), status_code=status)
@@ -454,6 +480,7 @@ def register_routes(
                 audit_log=state.audit_log,
                 can_auto_commit=principal.can_auto_commit,
                 max_postimage_bytes=state.config.max_postimage_bytes,
+                serializer=state.write_serializer, idx=state.idx,
             )
             status = _propose_status(resp.status)
             return JSONResponse(resp.model_dump(), status_code=status)
@@ -487,6 +514,7 @@ def register_routes(
                     agent_identity=body.get("agent_identity", "operator"),
                     audit_log=state.audit_log,
                     max_postimage_bytes=state.config.max_postimage_bytes,
+                    serializer=state.write_serializer, idx=state.idx,
                 )
             except PendingNotFoundError:
                 # Unknown or already-resolved/expired pending_id: a client-side
@@ -497,7 +525,7 @@ def register_routes(
                      "message": f"no pending proposal with id '{pid}'"},
                     status_code=404,
                 )
-            status = 413 if resp.status == "rejected_edited_text_too_large" else 200
+            status = _resolve_status(resp.status)
             return JSONResponse(resp.model_dump(), status_code=status)
 
         @app.custom_route("/api/v1/pending", methods=["GET"])

--- a/src/data_olympus/server.py
+++ b/src/data_olympus/server.py
@@ -144,6 +144,12 @@ class ServerState:
         self.rate_limiter: SlidingWindowLimiter | None = rate_limiter
         self.blocklist: PathBlocklist | None = blocklist
         self.audit_log: AuditLog | None = audit_log
+        # Process-wide write serializer (scope item 1): one instance shared by
+        # every write path so the write -> add -> commit -> enqueue critical
+        # section never interleaves across the REST threadpool and the MCP
+        # off-loop tool executor.
+        from data_olympus.write_gate import WriteSerializer
+        self.write_serializer = WriteSerializer()
         self.classifier: IntentClassifier = classifier or IntentClassifier()
         self.ledger: ConsultationLedger = ledger or ConsultationLedger()
         # Set at serve time (main) to observe the live streamable-http session
@@ -505,6 +511,25 @@ def build_app(
         )
         return resp.model_dump()
 
+    def _mcp_rate_limited() -> dict[str, object] | None:
+        """Apply the shared sliding-window limiter to an MCP enforcement-plane tool
+        (WP0b item (b)).
+
+        The REST consult / gate-check / cleanup-plan routes throttle via
+        ``_rate_limited``; the MCP tool paths did not, so an agent could hammer the
+        classifier/ledger unbounded. Key on the resolved principal (there is no
+        per-request remote addr on the MCP transport, so the limiter's per-agent
+        quota is the meaningful dimension). Returns a rejection dict when over
+        quota, else None. Skipped when no limiter is wired (read-only deploy)."""
+        limiter = state.rate_limiter
+        if limiter is None:
+            return None
+        principal_name = _current_principal.get().name
+        if not limiter.allow(remote_addr="mcp", agent_identity=principal_name):
+            return {"status": "rejected_rate_limited",
+                    "error": "too many requests; retry later"}
+        return None
+
     @app.tool()
     def kb_cleanup_plan(
         workspace: str, local_files: list[dict[str, str]],
@@ -513,6 +538,8 @@ def build_app(
         """Read-only. Classify local project-repo docs against KB content for this
         workspace/component and return thin-pointer replacements for duplicates.
         The agent applies confirmed edits locally; the server writes nothing."""
+        if (throttled := _mcp_rate_limited()) is not None:
+            return throttled
         from data_olympus.tools_onboarding import CleanupInputError, kb_cleanup_plan_fn
         try:
             resp = kb_cleanup_plan_fn(
@@ -554,6 +581,7 @@ def build_app(
                 audit_log=state.audit_log,
                 can_auto_commit=_current_principal.get().can_auto_commit,
                 max_text_bytes=state.config.max_text_bytes,
+                serializer=state.write_serializer, idx=state.idx,
             )
             return resp.model_dump()
 
@@ -586,6 +614,7 @@ def build_app(
                 audit_log=state.audit_log,
                 can_auto_commit=_current_principal.get().can_auto_commit,
                 max_postimage_bytes=state.config.max_postimage_bytes,
+                serializer=state.write_serializer, idx=state.idx,
             )
             return resp.model_dump()
 
@@ -608,6 +637,11 @@ def build_app(
                 pending=state.pending,
                 source_session=source_session, agent_identity=agent_identity,
                 audit_log=state.audit_log,
+                # WP0b item (a): the REST resolve path caps edited_text at
+                # KB_MAX_POSTIMAGE_BYTES; the MCP path was uncapped. Wire the same
+                # cap here so the two surfaces match.
+                max_postimage_bytes=state.config.max_postimage_bytes,
+                serializer=state.write_serializer, idx=state.idx,
             )
             return resp.model_dump()
 
@@ -677,6 +711,8 @@ def build_app(
             governing rules for the intent. Call before code/architectural work.
             trigger is 'explicit' (default: a deliberate consult, clears the gate)
             or 'prompt_hook' (an installer auto-consult: audited, never clears)."""
+            if (throttled := _mcp_rate_limited()) is not None:
+                return throttled
             import time as _time
 
             from data_olympus.tools_enforce import kb_consult_fn
@@ -696,6 +732,8 @@ def build_app(
         ) -> dict[str, object]:
             """Return a verdict (allow | consult_required) for a pending code action.
             Governed actions require a fresh consultation on record."""
+            if (throttled := _mcp_rate_limited()) is not None:
+                return throttled
             import time as _time
 
             from data_olympus.tools_enforce import kb_gate_check_fn
@@ -800,6 +838,28 @@ def build_app_from_config(config: Config, *, bootstrap_now: bool = True) -> Fast
     )
 
 
+def _ensure_git_identity() -> None:
+    """Give git a default author/committer identity when none is configured
+    (scope item 10).
+
+    The Docker entrypoint exports these, but a bare ``main()`` (local run, a
+    minimal container, a k8s image that predates the entrypoint change) may not.
+    Without an identity every ``git commit`` on the write path fails with "Please
+    tell me who you are". We set env defaults (overridable by
+    KB_GIT_AUTHOR_NAME / KB_GIT_AUTHOR_EMAIL, or by a pre-existing GIT_* value or
+    a real git config) so the shipped artifact commits out of the box. Only fills
+    unset vars, so a real operator identity is never clobbered."""
+    import os as _os
+
+    name = _os.environ.get("KB_GIT_AUTHOR_NAME", "data-olympus-mcp")
+    email = _os.environ.get("KB_GIT_AUTHOR_EMAIL", "data-olympus-mcp@localhost")
+    for var, value in (
+        ("GIT_AUTHOR_NAME", name), ("GIT_AUTHOR_EMAIL", email),
+        ("GIT_COMMITTER_NAME", name), ("GIT_COMMITTER_EMAIL", email),
+    ):
+        _os.environ.setdefault(var, value)
+
+
 def main() -> None:
     """Production entry. Loads config from env, bootstraps index, starts HTTP server
     with the git_pull_loop refresh task running in the background."""
@@ -821,6 +881,7 @@ def main() -> None:
     logging.basicConfig(
         level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s %(message)s"
     )
+    _ensure_git_identity()
     config = load_config()
     app = build_app_from_config(config, bootstrap_now=True)
     # The state lives inside build_app's closure; expose via app attribute for the lifespan task
@@ -900,6 +961,11 @@ def main() -> None:
                     push_queue=state.push_queue,
                     git=state.git,
                     interval_sec=30,
+                    # Non-FF recovery (scope item 2): a rebase conflict demotes the
+                    # commit to a pending entry via these; without them the loop
+                    # falls back to counting the conflict as a retryable failure.
+                    pending=state.pending,
+                    audit_log=state.audit_log,
                 ),
                 name="push_retry_loop",
             ))
@@ -918,6 +984,9 @@ def main() -> None:
                     pending=state.pending,
                     timeout_sec=config.pending_timeout_sec,
                     interval_sec=300,
+                    # Scope item 7: emit an audit event on each expiry instead of
+                    # silently rejecting >24h entries.
+                    audit_log=state.audit_log,
                 ),
                 name="pending_gc_loop",
             ))

--- a/src/data_olympus/server.py
+++ b/src/data_olympus/server.py
@@ -674,8 +674,9 @@ def build_app(
             workspace_remote_url: str | None = None,
             component_remote_url: str | None = None,
         ) -> dict[str, object]:
-            """Bootstrap a new workspace/component. Only valid when status=absent.
-            High confidence commits atomically; low confidence enqueues pending."""
+            """Bootstrap a new workspace/component. Only valid when status=absent
+            or partial. High confidence commits atomically; low confidence
+            enqueues pending."""
             if state.worktrees is None or state.push_queue is None or state.pending is None:
                 return {"status": "write_pipeline_disabled"}
             assert state.worktrees is not None
@@ -699,6 +700,7 @@ def build_app(
                 can_auto_commit=_current_principal.get().can_auto_commit,
                 max_postimage_bytes=state.config.max_postimage_bytes,
                 max_files=state.config.max_bootstrap_files,
+                serializer=state.write_serializer,
             )
             return resp.model_dump()
 

--- a/src/data_olympus/tools_onboarding.py
+++ b/src/data_olympus/tools_onboarding.py
@@ -394,7 +394,7 @@ def _bootstrap_admitted(
     path_for_msg = (f"projects/{workspace}/"
                     + (f"components/{component}/" if component else ""))
     try:
-        sha = commit_multifile_in_worktree(
+        sha, push_state = commit_multifile_in_worktree(
             worktrees=worktrees, push_queue=push_queue, pending=pending,
             serializer=serializer or _DEFAULT_SERIALIZER, idx=idx,
             source_session=source_session, agent_identity=agent_identity,
@@ -410,7 +410,8 @@ def _bootstrap_admitted(
     except PathLockBusyError as busy:
         return BootstrapResponse(status="rejected_path_lock_busy",
                                  rejected_paths=[str(busy)])
-    return BootstrapResponse(status="committed", commit_sha=sha, push_state="queued")
+    return BootstrapResponse(status="committed", commit_sha=sha,
+                             push_state=push_state)
 
 
 def _inject_remote_url(

--- a/src/data_olympus/tools_onboarding.py
+++ b/src/data_olympus/tools_onboarding.py
@@ -25,16 +25,17 @@ if TYPE_CHECKING:
     from data_olympus.push_queue import PushQueue
     from data_olympus.rate_limit import SlidingWindowLimiter
     from data_olympus.worktrees import WorktreeRegistry
+    from data_olympus.write_gate import WriteSerializer
 
 
 def _pending_root(pending: PendingQueue) -> str:
-    """Best-effort read of the pending queue's on-disk root.
+    """The pending queue's on-disk root, via its public ``root`` property.
 
-    SEAM: PendingQueue has no public root accessor (module owned by a concurrent
-    Wave-1 package). We read the private ._root; if that ever disappears we fall
-    back to KB_PENDING_ROOT (the same env config.py reads) so the in-flight guard
-    still lands on the state volume rather than crashing."""
-    root = getattr(pending, "_root", None)
+    (The Wave-1 write-pipeline package added ``PendingQueue.root`` so this no
+    longer reaches into the private ``_root``.) Falls back to KB_PENDING_ROOT
+    (the same env config.py reads) if the accessor is somehow unavailable, so the
+    in-flight guard still lands on the state volume rather than crashing."""
+    root = getattr(pending, "root", None)
     if isinstance(root, str):
         return root
     return os.getenv("KB_PENDING_ROOT", "/state/pending")
@@ -95,6 +96,7 @@ def kb_bootstrap_project_fn(
     max_postimage_bytes: int = 0,
     max_files: int = 0,
     in_flight: BootstrapInFlight | None = None,
+    serializer: WriteSerializer | None = None,
 ) -> BootstrapResponse:
     """Bootstrap a new workspace/component. Callable when status is ``absent`` or
     ``partial``.
@@ -131,10 +133,9 @@ def kb_bootstrap_project_fn(
     # the pending queue, unless the caller injected one (tests). Both entry points
     # (MCP tool, REST route) run in one process and share one PendingQueue, so a
     # filesystem marker beside the pending root is a process-wide guard without
-    # threading a new argument through the off-limits server.py / rest_api.py
-    # wiring. SEAM: PendingQueue exposes no public root accessor yet, so we read
-    # its ._root. A one-line public `root` property on the Wave-1-owned pending
-    # module would let us drop this; flagged in the PR body.
+    # threading a new argument through the server.py / rest_api.py wiring. The
+    # pending root is read via the public ``PendingQueue.root`` property (added by
+    # the Wave-1 write-pipeline package) through ``_pending_root``.
     if in_flight is None:
         in_flight = BootstrapInFlight(
             os.path.join(os.path.dirname(_pending_root(pending)), "bootstrap-inflight"),
@@ -157,6 +158,7 @@ def kb_bootstrap_project_fn(
     committed = False
     try:
         resp = _bootstrap_admitted(
+            idx=idx,
             status_obj=s,
             workspace=workspace, component=component,
             workspace_remote_url=workspace_remote_url,
@@ -168,6 +170,7 @@ def kb_bootstrap_project_fn(
             rate_limiter=rate_limiter, blocklist=blocklist,
             remote_addr=remote_addr, can_auto_commit=can_auto_commit,
             max_postimage_bytes=max_postimage_bytes, max_files=max_files,
+            serializer=serializer,
         )
         committed = resp.status == "committed"
         return resp
@@ -178,6 +181,7 @@ def kb_bootstrap_project_fn(
 
 def _bootstrap_admitted(
     *,
+    idx: Index,
     status_obj: OnboardingStatus,
     workspace: str,
     component: str | None,
@@ -197,6 +201,7 @@ def _bootstrap_admitted(
     can_auto_commit: bool,
     max_postimage_bytes: int,
     max_files: int,
+    serializer: WriteSerializer | None = None,
 ) -> BootstrapResponse:
     """Body of a bootstrap that passed the state re-check and won the in-flight
     claim. Split out so the outer function owns the claim/release lifecycle and
@@ -208,7 +213,6 @@ def _bootstrap_admitted(
     from data_olympus.auth import (
         is_writable_path,
         normalize_target_path,
-        safe_join_under_root,
     )
     from data_olympus.index import _classify_by_path
 
@@ -372,36 +376,40 @@ def _bootstrap_admitted(
             ),
         )
 
-    # High confidence: one atomic commit with all files.
-    import subprocess
-
-    from data_olympus.audit_trailers import build_commit_message
-    wt = worktrees.get_or_create(source_session=source_session, agent_identity=agent_identity)
-    for f in files:
-        # Shared symlink-escape containment guard (see safe_join_under_root).
-        full_path = safe_join_under_root(wt.path, f["target_path"])
-        if full_path is None:
-            return BootstrapResponse(status="rejected_symlink_escape",
-                                     rejected_paths=[f["target_path"]])
-        os.makedirs(os.path.dirname(full_path), exist_ok=True)
-        with open(full_path, "w", encoding="utf-8") as out:
-            out.write(f["postimage"])
-        subprocess.run(["git", "-C", wt.path, "add", f["target_path"]], check=True)
+    # High confidence: one atomic commit with all files, through the SHARED
+    # serialized/validated write path (Codex Blocker 2). This gives bootstrap the
+    # same integrity guarantees as memory/edit/resolve: process-wide write lock,
+    # per-path advisory locks (shared with the pending queue), the
+    # content-validation gate on every postimage, and reset-on-failure so a
+    # partial bundle never leaks into the next commit.
+    from data_olympus.pending import PathLockBusyError
+    from data_olympus.tools_write import (
+        _DEFAULT_SERIALIZER,
+        _WriteRejected,
+        commit_multifile_in_worktree,
+    )
     subject = (f"bootstrap: workspace={workspace}, component={component or ''}, "
                f"{len(files)} files")
-    msg = build_commit_message(
-        subject=subject,
-        source_session=source_session, agent_identity=agent_identity,
-        confidence_original=confidence, operator_confirmed=False,
-        proposal_type="edit",
-        target_tier="T4" if component else "T3",
-        target_path=f"projects/{workspace}/" + (f"components/{component}/" if component else ""),
-    )
-    subprocess.run(["git", "-C", wt.path, "commit", "-m", msg], check=True)
-    sha = subprocess.check_output(["git", "-C", wt.path, "rev-parse", "HEAD"], text=True).strip()
-    push_queue.enqueue(sha=sha, worktree_path=wt.path,
-                       meta={"source_session": source_session,
-                             "agent_identity": agent_identity, "bootstrap": True})
+    tier = "T4" if component else "T3"
+    path_for_msg = (f"projects/{workspace}/"
+                    + (f"components/{component}/" if component else ""))
+    try:
+        sha = commit_multifile_in_worktree(
+            worktrees=worktrees, push_queue=push_queue, pending=pending,
+            serializer=serializer or _DEFAULT_SERIALIZER, idx=idx,
+            source_session=source_session, agent_identity=agent_identity,
+            files=files, subject=subject, target_tier=tier,
+            target_path_for_msg=path_for_msg, confidence=confidence,
+            push_meta={"source_session": source_session,
+                       "agent_identity": agent_identity, "bootstrap": True},
+        )
+    except _WriteRejected as rej:
+        resp = rej.response
+        return BootstrapResponse(status=resp.status,
+                                 rejected_paths=[resp.target_path or ""])
+    except PathLockBusyError as busy:
+        return BootstrapResponse(status="rejected_path_lock_busy",
+                                 rejected_paths=[str(busy)])
     return BootstrapResponse(status="committed", commit_sha=sha, push_state="queued")
 
 

--- a/src/data_olympus/tools_write.py
+++ b/src/data_olympus/tools_write.py
@@ -153,13 +153,15 @@ def _commit_in_worktree(
     push_meta: dict[str, Any] | None = None,
     lock_owner: str | None = None,
     hold_path_lock: bool = False,
-) -> str:
+) -> tuple[str, str]:
     """Serialized write -> git add -> commit -> enqueue critical section.
 
     Shared by the auto-commit (propose) path and the operator-resolve path so both
-    honor identical integrity gates (scope items 1, 3, 4, 8). Returns the commit
-    sha. Raises :class:`_WriteRejected` (carrying the ProposeResponse) when a gate
-    rejects, or :class:`PathLockBusyError` when the per-path advisory lock is held.
+    honor identical integrity gates (scope items 1, 3, 4, 8). Returns
+    ``(commit_sha, push_state)`` where push_state is ``"queued"`` or
+    ``"enqueue_failed_recovery_pending"`` (see _enqueue_after_commit). Raises
+    :class:`_WriteRejected` (carrying the ProposeResponse) when a gate rejects, or
+    :class:`PathLockBusyError` when the per-path advisory lock is held.
 
     ``hold_path_lock`` (resolve path): when True the caller ALREADY holds the
     per-path advisory lock (the one acquired at ``enqueue`` time and kept through
@@ -259,33 +261,56 @@ def _commit_in_worktree(
                 with contextlib.suppress(Exception):
                     reset_worktree(wt.path)
                 raise
-            # Enqueue is best-effort ONCE the commit is durable: the commit lives on
-            # the session branch, and startup init_recovery re-enqueues any commit
-            # not reachable from origin/main, so a failed enqueue publishes late
-            # rather than being lost (and the caller still sees a committed sha, so
-            # a bootstrap's in-flight guard is not dropped -- Codex round-2
-            # Blocker C).
-            _enqueue_best_effort(push_queue, sha, wt.path, push_meta)
-            return sha
+            # Enqueue AFTER the commit is durable. It must not turn a made commit
+            # into an exception path (that would drop the bootstrap in-flight guard
+            # and lose the resolve claim -- Codex round-2 Blocker C), so a failure
+            # is not raised; but the push_state returned to the caller is TRUTHFUL
+            # (Codex round-3): "queued" only when the queue entry actually landed,
+            # else "enqueue_failed_recovery_pending", and an in-process recovery
+            # pass on THIS worktree re-enqueues the orphan so the running push loop
+            # picks it up without waiting for a restart.
+            push_state = _enqueue_after_commit(push_queue, sha, wt.path, push_meta)
+            return sha, push_state
 
 
-def _enqueue_best_effort(
+def _enqueue_after_commit(
     push_queue: PushQueue, sha: str, worktree_path: str,
     push_meta: dict[str, Any] | None,
-) -> None:
-    """Enqueue a committed sha for push; on failure log and continue.
+) -> str:
+    """Enqueue a committed sha for push and return a truthful push_state.
 
-    The commit is already durable on the session branch, so a queue-write failure
-    is recoverable by startup init_recovery. Swallowing it here means a caller that
-    treats a returned sha as 'committed' (e.g. the bootstrap in-flight guard) is not
-    misled into a non-committed path by a post-commit enqueue error."""
+    Returns:
+    - ``"queued"`` when the queue entry landed durably.
+    - ``"enqueue_failed_recovery_pending"`` when the initial enqueue AND an
+      in-process recovery retry both failed. The commit is durable on the session
+      branch, so it is still recoverable (an operator / a restart's init_recovery
+      re-enqueues it), but the caller must not claim it is queued.
+
+    The recovery retry re-runs the same durable enqueue once. This lands the
+    orphan in the live queue so the running push loop drains it without a restart
+    (closing the "silently unpublished until restart" gap Codex round-3 raised)."""
     try:
         push_queue.enqueue(sha=sha, worktree_path=worktree_path,
                            meta=push_meta or {})
+        return "queued"
     except Exception:
         _log.exception(
-            "push-queue enqueue failed after commit %s; commit is durable and "
-            "will be recovered by startup init_recovery", sha)
+            "push-queue enqueue failed after commit %s; attempting in-process "
+            "recovery re-enqueue", sha)
+    # In-process recovery: retry the durable enqueue once more. If it lands, the
+    # live push loop will drain it; if not, the commit is still on the branch and
+    # startup init_recovery is the backstop.
+    try:
+        push_queue.enqueue(sha=sha, worktree_path=worktree_path,
+                           meta={**(push_meta or {}), "recovered_in_process": True})
+        _log.warning("in-process recovery re-enqueued orphaned commit %s", sha)
+        return "queued"
+    except Exception:
+        _log.exception(
+            "in-process recovery re-enqueue ALSO failed for commit %s; the commit "
+            "is durable on the session branch and will be recovered by startup "
+            "init_recovery, but is NOT queued in this process", sha)
+        return "enqueue_failed_recovery_pending"
 
 
 def commit_multifile_in_worktree(
@@ -303,7 +328,7 @@ def commit_multifile_in_worktree(
     target_path_for_msg: str,
     confidence: float,
     push_meta: dict[str, Any] | None = None,
-) -> str:
+) -> tuple[str, str]:
     """Serialized multi-file write -> add -> ONE commit -> enqueue (Codex Blocker 2).
 
     The bootstrap path writes several files in a single atomic commit. It now goes
@@ -312,9 +337,9 @@ def commit_multifile_in_worktree(
     pending queue), the content-validation gate on every postimage, and a hard
     reset on any post-add failure so a partial bundle never leaks into the next
     commit. CAS is not applied here (bootstrap creates NEW files under a
-    not-yet-onboarded workspace; there is no base to compare). Returns the commit
-    sha. Raises :class:`_WriteRejected` on a gate failure or
-    :class:`PathLockBusyError` when any target path is already locked.
+    not-yet-onboarded workspace; there is no base to compare). Returns
+    ``(commit_sha, push_state)``. Raises :class:`_WriteRejected` on a gate failure
+    or :class:`PathLockBusyError` when any target path is already locked.
     """
     with serializer, contextlib.ExitStack() as stack:
         owner = f"bootstrap:{source_session}"
@@ -391,8 +416,8 @@ def commit_multifile_in_worktree(
             with contextlib.suppress(Exception):
                 reset_worktree(wt.path)
             raise
-        _enqueue_best_effort(push_queue, sha, wt.path, push_meta)
-        return sha
+        push_state = _enqueue_after_commit(push_queue, sha, wt.path, push_meta)
+        return sha, push_state
 
 
 def kb_propose_memory_fn(
@@ -521,7 +546,7 @@ def kb_propose_memory_fn(
 
     # High confidence: serialized commit + enqueue push (items 1, 4, 8).
     try:
-        sha = _commit_in_worktree(
+        sha, push_state = _commit_in_worktree(
             worktrees=worktrees, push_queue=push_queue, pending=pending,
             serializer=serializer or _DEFAULT_SERIALIZER, idx=idx,
             source_session=source_session, agent_identity=agent_identity,
@@ -542,7 +567,7 @@ def kb_propose_memory_fn(
         return ProposeResponse(status="rejected_path_lock_busy",
                                target_path=target_path)
     _emit_audit(audit_log, **{**audit_base, "status": "committed", "commit_sha": sha})
-    return ProposeResponse(status="committed", commit_sha=sha, push_state="queued")
+    return ProposeResponse(status="committed", commit_sha=sha, push_state=push_state)
 
 
 def _render_memory(*, text: str, tags: list[str], agent_identity: str) -> str:
@@ -673,7 +698,7 @@ def kb_propose_edit_fn(
 
     # Serialized commit + CAS + validation + enqueue (items 1, 3, 4, 8).
     try:
-        sha = _commit_in_worktree(
+        sha, push_state = _commit_in_worktree(
             worktrees=worktrees, push_queue=push_queue, pending=pending,
             serializer=serializer or _DEFAULT_SERIALIZER, idx=idx,
             source_session=source_session, agent_identity=agent_identity,
@@ -696,7 +721,7 @@ def kb_propose_edit_fn(
         return ProposeResponse(status="rejected_path_lock_busy",
                                target_path=target_path)
     _emit_audit(audit_log, **{**audit_base, "status": "committed", "commit_sha": sha})
-    return ProposeResponse(status="committed", commit_sha=sha, push_state="queued")
+    return ProposeResponse(status="committed", commit_sha=sha, push_state=push_state)
 
 
 def kb_resolve_pending_fn(
@@ -773,7 +798,7 @@ def kb_resolve_pending_fn(
     # hold_path_lock=True: the lock is already held from enqueue via the claim, so
     # _commit_in_worktree must not re-acquire it (would deadlock / raise busy).
     try:
-        sha = _commit_in_worktree(
+        sha, _push_state = _commit_in_worktree(
             worktrees=worktrees, push_queue=push_queue, pending=pending,
             serializer=serializer or _DEFAULT_SERIALIZER, idx=idx,
             source_session=resolved.meta.get("source_session", source_session),

--- a/src/data_olympus/tools_write.py
+++ b/src/data_olympus/tools_write.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import contextlib
 import datetime
+import logging
 import os
 import re
 import subprocess
@@ -16,6 +17,7 @@ from data_olympus.auth import (
     normalize_target_path,
     safe_join_under_root,
 )
+from data_olympus.format.frontmatter import parse_frontmatter
 from data_olympus.models import (
     PendingEntry,
     PendingListResponse,
@@ -45,6 +47,8 @@ if TYPE_CHECKING:
 # process). Threading one explicit instance from the server is what makes the
 # guarantee hold across REST + MCP surfaces.
 _DEFAULT_SERIALIZER = WriteSerializer()
+
+_log = logging.getLogger("data_olympus.tools_write")
 
 
 def _slugify(text: str) -> str:
@@ -148,6 +152,7 @@ def _commit_in_worktree(
     target_file_hash: str | None = None,
     push_meta: dict[str, Any] | None = None,
     lock_owner: str | None = None,
+    hold_path_lock: bool = False,
 ) -> str:
     """Serialized write -> git add -> commit -> enqueue critical section.
 
@@ -155,6 +160,12 @@ def _commit_in_worktree(
     honor identical integrity gates (scope items 1, 3, 4, 8). Returns the commit
     sha. Raises :class:`_WriteRejected` (carrying the ProposeResponse) when a gate
     rejects, or :class:`PathLockBusyError` when the per-path advisory lock is held.
+
+    ``hold_path_lock`` (resolve path): when True the caller ALREADY holds the
+    per-path advisory lock (the one acquired at ``enqueue`` time and kept through
+    ``claim_for_resolve``), so this does not re-acquire it. Re-acquiring the same
+    file-based lock would self-deadlock / raise PathLockBusyError (Codex round-2
+    Blocker B). When False (the propose path) the lock is acquired here.
 
     Order of operations, all under the process-wide write lock AND the per-path
     advisory lock (shared with the pending queue):
@@ -173,7 +184,11 @@ def _commit_in_worktree(
     """
     with serializer:
         owner = lock_owner or f"auto-commit:{source_session}"
-        with pending.path_lock(target_path, owner=owner):
+        path_lock_ctx = (
+            contextlib.nullcontext() if hold_path_lock
+            else pending.path_lock(target_path, owner=owner)
+        )
+        with path_lock_ctx:
             wt = worktrees.get_or_create(
                 source_session=source_session, agent_identity=agent_identity
             )
@@ -244,9 +259,33 @@ def _commit_in_worktree(
                 with contextlib.suppress(Exception):
                     reset_worktree(wt.path)
                 raise
-            push_queue.enqueue(
-                sha=sha, worktree_path=wt.path, meta=push_meta or {})
+            # Enqueue is best-effort ONCE the commit is durable: the commit lives on
+            # the session branch, and startup init_recovery re-enqueues any commit
+            # not reachable from origin/main, so a failed enqueue publishes late
+            # rather than being lost (and the caller still sees a committed sha, so
+            # a bootstrap's in-flight guard is not dropped -- Codex round-2
+            # Blocker C).
+            _enqueue_best_effort(push_queue, sha, wt.path, push_meta)
             return sha
+
+
+def _enqueue_best_effort(
+    push_queue: PushQueue, sha: str, worktree_path: str,
+    push_meta: dict[str, Any] | None,
+) -> None:
+    """Enqueue a committed sha for push; on failure log and continue.
+
+    The commit is already durable on the session branch, so a queue-write failure
+    is recoverable by startup init_recovery. Swallowing it here means a caller that
+    treats a returned sha as 'committed' (e.g. the bootstrap in-flight guard) is not
+    misled into a non-committed path by a post-commit enqueue error."""
+    try:
+        push_queue.enqueue(sha=sha, worktree_path=worktree_path,
+                           meta=push_meta or {})
+    except Exception:
+        _log.exception(
+            "push-queue enqueue failed after commit %s; commit is durable and "
+            "will be recovered by startup init_recovery", sha)
 
 
 def commit_multifile_in_worktree(
@@ -296,6 +335,30 @@ def commit_multifile_in_worktree(
             target_tier=target_tier, target_path=target_path_for_msg,
         )
 
+        # Intra-bundle duplicate-id check (Codex round-2 Blocker A): the per-file
+        # validate_postimage below only sees the live index + the committed tree,
+        # neither of which yet contains this bundle. Two bundle files carrying the
+        # SAME effective id at different paths would both pass and then poison the
+        # next index rebuild. Catch it up front by computing each file's effective
+        # id (explicit or path-derived, matching the rebuild) and rejecting any id
+        # claimed by more than one path in the bundle.
+        from data_olympus.write_gate import _effective_doc_id
+        seen_ids: dict[str, str] = {}
+        for f in files:
+            tp, pi = f["target_path"], f["postimage"]
+            try:
+                bfm, _ = parse_frontmatter(pi)
+            except ValueError:
+                bfm = {}
+            eid = _effective_doc_id(bfm, tp)
+            if eid and eid in seen_ids and seen_ids[eid] != tp:
+                raise _WriteRejected(ProposeResponse(
+                    status="rejected_invalid_document", target_path=tp,
+                    reason=(f"id '{eid}' used by two files in the same bundle: "
+                            f"'{seen_ids[eid]}' and '{tp}'")))
+            if eid:
+                seen_ids[eid] = tp
+
         # Containment + validation for every file BEFORE any write.
         for f in files:
             tp, pi = f["target_path"], f["postimage"]
@@ -328,8 +391,7 @@ def commit_multifile_in_worktree(
             with contextlib.suppress(Exception):
                 reset_worktree(wt.path)
             raise
-        push_queue.enqueue(
-            sha=sha, worktree_path=wt.path, meta=push_meta or {})
+        _enqueue_best_effort(push_queue, sha, wt.path, push_meta)
         return sha
 
 
@@ -687,9 +749,13 @@ def kb_resolve_pending_fn(
                     **{**audit_base, "status": "rejected_edited_text_too_large"})
         return ResolvePendingResponse(status="rejected_edited_text_too_large")
 
-    # Atomic claim: exactly one concurrent resolve of this id proceeds (item 5).
+    # Atomic claim that HOLDS the path lock + the claimed entry through the gates
+    # (Codex round-2 Blocker B): a post-claim CAS/validation rejection puts the
+    # entry back (restore_resolve) instead of losing the operator's proposal, and
+    # no other write can grab the path in the claim->commit window. Exactly one
+    # concurrent resolve of this id proceeds (item 5).
     try:
-        resolved = pending.approve(pending_id, edited_text=edited_text)
+        resolved = pending.claim_for_resolve(pending_id, edited_text=edited_text)
     except PendingAlreadyResolvedError:
         _emit_audit(audit_log, **{**audit_base, "status": "already_resolved"})
         return ResolvePendingResponse(status="already_resolved")
@@ -704,6 +770,8 @@ def kb_resolve_pending_fn(
 
     # Serialized commit + CAS (from the pending entry's base markers) + validation
     # + reset-on-late-failure, shared with the auto-commit path (items 1, 3, 4, 8).
+    # hold_path_lock=True: the lock is already held from enqueue via the claim, so
+    # _commit_in_worktree must not re-acquire it (would deadlock / raise busy).
     try:
         sha = _commit_in_worktree(
             worktrees=worktrees, push_queue=push_queue, pending=pending,
@@ -721,12 +789,24 @@ def kb_resolve_pending_fn(
             target_file_hash=resolved.target_file_hash,
             push_meta={},
             lock_owner=f"resolve:{pending_id}",
+            hold_path_lock=True,
         )
     except _WriteRejected as rej:
+        # Gate rejected AFTER the claim: put the entry back so the operator can
+        # re-resolve it (the postimage is not lost). The path lock stays held.
+        pending.restore_resolve(pending_id)
         resp = rej.response
         _emit_audit(audit_log, **{**audit_base, "status": resp.status,
                                    "reason": resp.reason})
         return ResolvePendingResponse(status=resp.status, reason=resp.reason)
+    except Exception:
+        # A git/enqueue failure after the claim: restore the entry rather than
+        # silently consuming it, so the write is recoverable.
+        with contextlib.suppress(Exception):
+            pending.restore_resolve(pending_id)
+        raise
+    # Commit + enqueue succeeded: now consume the entry and release the lock.
+    pending.finalize_resolve(pending_id, resolved.target_path)
     _emit_audit(audit_log, **{**audit_base, "status": "committed", "commit_sha": sha})
     return ResolvePendingResponse(status="committed", commit_sha=sha)
 

--- a/src/data_olympus/tools_write.py
+++ b/src/data_olympus/tools_write.py
@@ -194,13 +194,33 @@ def _commit_in_worktree(
             wt = worktrees.get_or_create(
                 source_session=source_session, agent_identity=agent_identity
             )
-            # 1. Refresh the session branch base onto origin/main. On a rebase
-            # conflict the current base cannot be advanced; fall back to the
-            # unrefreshed base rather than failing the write (the push path's
-            # non-FF recovery handles publication). Network/other errors are
-            # likewise non-fatal here.
-            with contextlib.suppress(Exception):
+            # 1. Refresh the session branch base onto origin/main so CAS compares
+            # against, and the commit sits on, current content.
+            #
+            # A refresh failure (network down, or a rebase conflict) is handled by
+            # whether the caller opted into CAS: when an ENFORCEABLE base marker was
+            # supplied, we CANNOT verify it against a stale base, so a failed
+            # refresh must reject rejected_stale_base rather than commit a possibly
+            # stale write against an unrefreshed tree (Codex round-5: the push
+            # path's rebase recovery is NOT equivalent, since a compatible rebase
+            # would still publish the stale write). When no marker was supplied CAS
+            # is a no-op, so a refresh failure stays non-fatal and the commit sits
+            # on the unrefreshed base (the push path's non-FF recovery publishes).
+            from data_olympus.write_gate import _is_enforceable_base_commit
+            cas_enforceable = bool(base_blob_sha) or bool(target_file_hash) or \
+                _is_enforceable_base_commit(base_commit)
+            refresh_ok = True
+            try:
                 worktrees.git.refresh_base(wt.path)
+            except Exception as exc:  # noqa: BLE001 - classified by cas_enforceable
+                refresh_ok = False
+                refresh_err = str(exc)
+            if cas_enforceable and not refresh_ok:
+                raise _WriteRejected(ProposeResponse(
+                    status="rejected_stale_base", target_path=target_path,
+                    reason=(f"base could not be refreshed onto origin/main, so the "
+                            f"supplied base marker cannot be verified: "
+                            f"{refresh_err}")))
 
             # 2. Build the commit message BEFORE any disk write (item 8).
             msg = build_commit_message(

--- a/src/data_olympus/tools_write.py
+++ b/src/data_olympus/tools_write.py
@@ -798,7 +798,7 @@ def kb_resolve_pending_fn(
     # hold_path_lock=True: the lock is already held from enqueue via the claim, so
     # _commit_in_worktree must not re-acquire it (would deadlock / raise busy).
     try:
-        sha, _push_state = _commit_in_worktree(
+        sha, push_state = _commit_in_worktree(
             worktrees=worktrees, push_queue=push_queue, pending=pending,
             serializer=serializer or _DEFAULT_SERIALIZER, idx=idx,
             source_session=resolved.meta.get("source_session", source_session),
@@ -830,10 +830,16 @@ def kb_resolve_pending_fn(
         with contextlib.suppress(Exception):
             pending.restore_resolve(pending_id)
         raise
-    # Commit + enqueue succeeded: now consume the entry and release the lock.
+    # Commit succeeded: consume the entry and release the lock. The commit is
+    # durable regardless of push_state (which is surfaced truthfully below): even
+    # an enqueue_failed_recovery_pending commit exists on the branch and is
+    # republished by in-process/startup recovery, so re-resolving would duplicate
+    # it -- the entry must be consumed, not restored (Codex round-4).
     pending.finalize_resolve(pending_id, resolved.target_path)
-    _emit_audit(audit_log, **{**audit_base, "status": "committed", "commit_sha": sha})
-    return ResolvePendingResponse(status="committed", commit_sha=sha)
+    _emit_audit(audit_log, **{**audit_base, "status": "committed",
+                               "commit_sha": sha})
+    return ResolvePendingResponse(status="committed", commit_sha=sha,
+                                  push_state=push_state)
 
 
 def kb_list_pending_fn(*, pending: PendingQueue) -> PendingListResponse:

--- a/src/data_olympus/tools_write.py
+++ b/src/data_olympus/tools_write.py
@@ -214,9 +214,13 @@ def _commit_in_worktree(
                     status="rejected_stale_base", target_path=target_path,
                     reason=cas.reason))
 
-            # 5. Content-validation gate (item 4).
+            # 5. Content-validation gate (item 4). Pass the worktree so the
+            # duplicate-id check also scans the committed tree (catches a
+            # same-new-id race between two serialized commits before the index
+            # rebuilds).
             vr = validate_postimage(
-                target_path=target_path, postimage=postimage, idx=idx)
+                target_path=target_path, postimage=postimage, idx=idx,
+                worktree_path=wt.path)
             if not vr.ok:
                 raise _WriteRejected(ProposeResponse(
                     status="rejected_invalid_document", target_path=target_path,
@@ -243,6 +247,90 @@ def _commit_in_worktree(
             push_queue.enqueue(
                 sha=sha, worktree_path=wt.path, meta=push_meta or {})
             return sha
+
+
+def commit_multifile_in_worktree(
+    *,
+    worktrees: WorktreeRegistry,
+    push_queue: PushQueue,
+    pending: PendingQueue,
+    serializer: WriteSerializer,
+    idx: Index | None,
+    source_session: str,
+    agent_identity: str,
+    files: list[dict[str, str]],
+    subject: str,
+    target_tier: str,
+    target_path_for_msg: str,
+    confidence: float,
+    push_meta: dict[str, Any] | None = None,
+) -> str:
+    """Serialized multi-file write -> add -> ONE commit -> enqueue (Codex Blocker 2).
+
+    The bootstrap path writes several files in a single atomic commit. It now goes
+    through the SAME integrity discipline as the single-file path: the process-wide
+    write serializer, per-path advisory locks on every target (shared with the
+    pending queue), the content-validation gate on every postimage, and a hard
+    reset on any post-add failure so a partial bundle never leaks into the next
+    commit. CAS is not applied here (bootstrap creates NEW files under a
+    not-yet-onboarded workspace; there is no base to compare). Returns the commit
+    sha. Raises :class:`_WriteRejected` on a gate failure or
+    :class:`PathLockBusyError` when any target path is already locked.
+    """
+    with serializer, contextlib.ExitStack() as stack:
+        owner = f"bootstrap:{source_session}"
+        # Lock every target path up front (all-or-nothing): if any is busy the
+        # whole bundle is rejected, matching the atomic-commit contract.
+        for f in files:
+            stack.enter_context(pending.path_lock(f["target_path"], owner=owner))
+        wt = worktrees.get_or_create(
+            source_session=source_session, agent_identity=agent_identity)
+        with contextlib.suppress(Exception):
+            worktrees.git.refresh_base(wt.path)
+
+        # Build the commit message first (trailer validation can raise).
+        msg = build_commit_message(
+            subject=subject, source_session=source_session,
+            agent_identity=agent_identity, confidence_original=confidence,
+            operator_confirmed=False, proposal_type="edit",
+            target_tier=target_tier, target_path=target_path_for_msg,
+        )
+
+        # Containment + validation for every file BEFORE any write.
+        for f in files:
+            tp, pi = f["target_path"], f["postimage"]
+            full = safe_join_under_root(wt.path, tp)
+            if full is None:
+                raise _WriteRejected(ProposeResponse(
+                    status="rejected_symlink_escape", target_path=tp))
+            vr = validate_postimage(
+                target_path=tp, postimage=pi, idx=idx, worktree_path=wt.path)
+            if not vr.ok:
+                raise _WriteRejected(ProposeResponse(
+                    status="rejected_invalid_document", target_path=tp,
+                    reason="; ".join(e["message"] for e in vr.errors)))
+
+        # Write + add every file, then one commit; reset on any failure.
+        try:
+            for f in files:
+                tp, pi = f["target_path"], f["postimage"]
+                full = safe_join_under_root(wt.path, tp)
+                assert full is not None  # re-checked; validated above
+                os.makedirs(os.path.dirname(full), exist_ok=True)
+                with open(full, "w", encoding="utf-8") as out:
+                    out.write(pi)
+                subprocess.run(["git", "-C", wt.path, "add", tp], check=True)
+            subprocess.run(["git", "-C", wt.path, "commit", "-m", msg],
+                           check=True)
+            sha = subprocess.check_output(
+                ["git", "-C", wt.path, "rev-parse", "HEAD"], text=True).strip()
+        except Exception:
+            with contextlib.suppress(Exception):
+                reset_worktree(wt.path)
+            raise
+        push_queue.enqueue(
+            sha=sha, worktree_path=wt.path, meta=push_meta or {})
+        return sha
 
 
 def kb_propose_memory_fn(

--- a/src/data_olympus/tools_write.py
+++ b/src/data_olympus/tools_write.py
@@ -7,7 +7,7 @@ import os
 import re
 import subprocess
 import time
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 from data_olympus.audit_trailers import build_commit_message
 from data_olympus.auth import (
@@ -23,17 +23,46 @@ from data_olympus.models import (
     ResolvePendingResponse,
 )
 from data_olympus.pending import PathLockBusyError, PendingQueue, PendingQueueFullError
+from data_olympus.write_gate import (
+    WriteSerializer,
+    check_cas,
+    reset_worktree,
+    validate_postimage,
+)
 
 if TYPE_CHECKING:
     from data_olympus.audit_log import AuditLog
+    from data_olympus.index import Index
     from data_olympus.push_queue import PushQueue
     from data_olympus.rate_limit import SlidingWindowLimiter
     from data_olympus.worktrees import WorktreeRegistry
 
 
+# A shared write serializer used when a caller does not supply one. The
+# production server constructs a single instance and threads it into every write
+# call so they share one lock; tests that call the write functions directly get
+# this module-level default (each call still serializes correctly within a
+# process). Threading one explicit instance from the server is what makes the
+# guarantee hold across REST + MCP surfaces.
+_DEFAULT_SERIALIZER = WriteSerializer()
+
+
 def _slugify(text: str) -> str:
     s = re.sub(r"[^a-z0-9-]+", "-", text.lower()).strip("-")
     return s[:50] or "memory"
+
+
+def _memory_uniquifier(source_session: str, text: str) -> str:
+    """Short deterministic suffix so two same-day, same-slug memories do not
+    collide on ``<date>-<slug>.md`` and silently overwrite (scope item 6).
+
+    Derived from the session id + body so the same logical memory maps to the
+    same filename (idempotent re-proposal) while a different memory gets a
+    different name. 6 hex chars is enough entropy for the per-day, per-slug
+    bucket and keeps the filename readable."""
+    import hashlib
+    h = hashlib.sha256(f"{source_session}\0{text}".encode())
+    return h.hexdigest()[:6]
 
 
 def _memory_inbox_prefix() -> str:
@@ -88,6 +117,134 @@ def _emit_audit(
         })
 
 
+class _WriteRejected(Exception):
+    """Internal control-flow signal: a gate (symlink / CAS / validation) rejected
+    the write inside the locked critical section. Carries the ProposeResponse to
+    return. Never escapes the module."""
+
+    def __init__(self, response: ProposeResponse) -> None:
+        self.response = response
+        super().__init__(response.status)
+
+
+def _commit_in_worktree(
+    *,
+    worktrees: WorktreeRegistry,
+    push_queue: PushQueue,
+    pending: PendingQueue,
+    serializer: WriteSerializer,
+    idx: Index | None,
+    source_session: str,
+    agent_identity: str,
+    target_path: str,
+    postimage: str,
+    proposal_type: Literal["memory", "edit"],
+    subject: str,
+    target_tier: str,
+    confidence: float,
+    operator_confirmed: bool,
+    base_commit: str | None = None,
+    base_blob_sha: str | None = None,
+    target_file_hash: str | None = None,
+    push_meta: dict[str, Any] | None = None,
+    lock_owner: str | None = None,
+) -> str:
+    """Serialized write -> git add -> commit -> enqueue critical section.
+
+    Shared by the auto-commit (propose) path and the operator-resolve path so both
+    honor identical integrity gates (scope items 1, 3, 4, 8). Returns the commit
+    sha. Raises :class:`_WriteRejected` (carrying the ProposeResponse) when a gate
+    rejects, or :class:`PathLockBusyError` when the per-path advisory lock is held.
+
+    Order of operations, all under the process-wide write lock AND the per-path
+    advisory lock (shared with the pending queue):
+
+    1. Refresh the worktree base onto origin/main (so CAS compares against, and the
+       commit sits on, current content).
+    2. Build the commit message FIRST (trailer validation can raise; doing it
+       before any disk side effect means a late rejection leaves nothing staged --
+       scope item 8).
+    3. Symlink-escape containment on the join.
+    4. CAS: if the caller supplied a base marker and the refreshed target content
+       differs, reject rejected_stale_base without committing (item 3).
+    5. Content-validation gate on the postimage (item 4).
+    6. Write + git add + commit + enqueue. On ANY failure after the add, hard-reset
+       the worktree so no staged leftovers are swept into the next commit (item 8).
+    """
+    with serializer:
+        owner = lock_owner or f"auto-commit:{source_session}"
+        with pending.path_lock(target_path, owner=owner):
+            wt = worktrees.get_or_create(
+                source_session=source_session, agent_identity=agent_identity
+            )
+            # 1. Refresh the session branch base onto origin/main. On a rebase
+            # conflict the current base cannot be advanced; fall back to the
+            # unrefreshed base rather than failing the write (the push path's
+            # non-FF recovery handles publication). Network/other errors are
+            # likewise non-fatal here.
+            with contextlib.suppress(Exception):
+                worktrees.git.refresh_base(wt.path)
+
+            # 2. Build the commit message BEFORE any disk write (item 8).
+            msg = build_commit_message(
+                subject=subject,
+                source_session=source_session,
+                agent_identity=agent_identity,
+                confidence_original=confidence,
+                operator_confirmed=operator_confirmed,
+                proposal_type=proposal_type,
+                target_tier=target_tier,
+                target_path=target_path,
+            )
+
+            # 3. Symlink-escape containment.
+            full_path = safe_join_under_root(wt.path, target_path)
+            if full_path is None:
+                raise _WriteRejected(ProposeResponse(
+                    status="rejected_symlink_escape", target_path=target_path))
+
+            # 4. CAS against the refreshed base (item 3).
+            cas = check_cas(
+                worktree_path=wt.path, target_path=target_path,
+                base_commit=base_commit, base_blob_sha=base_blob_sha,
+                target_file_hash=target_file_hash,
+            )
+            if not cas.ok:
+                raise _WriteRejected(ProposeResponse(
+                    status="rejected_stale_base", target_path=target_path,
+                    reason=cas.reason))
+
+            # 5. Content-validation gate (item 4).
+            vr = validate_postimage(
+                target_path=target_path, postimage=postimage, idx=idx)
+            if not vr.ok:
+                raise _WriteRejected(ProposeResponse(
+                    status="rejected_invalid_document", target_path=target_path,
+                    reason="; ".join(e["message"] for e in vr.errors)))
+
+            # 6. Write + add + commit + enqueue; reset on any post-add failure.
+            os.makedirs(os.path.dirname(full_path), exist_ok=True)
+            with open(full_path, "w", encoding="utf-8") as f:
+                f.write(postimage)
+            try:
+                subprocess.run(
+                    ["git", "-C", wt.path, "add", target_path], check=True)
+                subprocess.run(
+                    ["git", "-C", wt.path, "commit", "-m", msg], check=True)
+                sha = subprocess.check_output(
+                    ["git", "-C", wt.path, "rev-parse", "HEAD"], text=True,
+                ).strip()
+            except Exception:
+                # Something failed after the file was written/staged; discard so
+                # the leftover is not swept into the session's next commit (item 8).
+                with contextlib.suppress(Exception):
+                    reset_worktree(wt.path)
+                raise
+            push_queue.enqueue(
+                sha=sha, worktree_path=wt.path, meta=push_meta or {})
+            return sha
+
+
 def kb_propose_memory_fn(
     *,
     text: str,
@@ -105,8 +262,11 @@ def kb_propose_memory_fn(
     audit_log: AuditLog | None = None,
     can_auto_commit: bool = True,
     max_text_bytes: int = 0,
+    serializer: WriteSerializer | None = None,
+    idx: Index | None = None,
 ) -> ProposeResponse:
-    """Propose a new memory file under the memory inbox prefix as <date>-<slug>.md.
+    """Propose a new memory file under the memory inbox prefix as
+    <date>-<slug>-<uniq>.md.
 
     Structural rule is satisfied by construction; blocklist still applies.
     High confidence -> auto-commit + push enqueue. Low -> pending queue.
@@ -118,7 +278,8 @@ def kb_propose_memory_fn(
     """
     today = datetime.datetime.now(datetime.UTC).strftime("%Y-%m-%d")
     slug = _slugify(text)
-    target_path = f"{_memory_inbox_prefix()}{today}-{slug}.md"
+    uniq = _memory_uniquifier(source_session, text)
+    target_path = f"{_memory_inbox_prefix()}{today}-{slug}-{uniq}.md"
     audit_base: dict[str, Any] = {
         "event_type": "propose_memory",
         "agent_identity": agent_identity,
@@ -208,41 +369,28 @@ def kb_propose_memory_fn(
             ),
         )
 
-    # High confidence: commit + enqueue push.
-    wt = worktrees.get_or_create(
-        source_session=source_session, agent_identity=agent_identity
-    )
-    # Symlink-escape containment (Codex blocker 1): a malicious KB commit can
-    # plant the inbox dir as a symlink pointing outside the worktree. Reject
-    # before any makedirs/open side effect.
-    full_path = safe_join_under_root(wt.path, target_path)
-    if full_path is None:
-        _emit_audit(audit_log, **{**audit_base, "status": "rejected_symlink_escape"})
-        return ProposeResponse(status="rejected_symlink_escape", target_path=target_path)
-    os.makedirs(os.path.dirname(full_path), exist_ok=True)
-    with open(full_path, "w", encoding="utf-8") as f:
-        f.write(postimage)
-    subprocess.run(["git", "-C", wt.path, "add", target_path], check=True)
-    subject = f"propose: {target_path}"
-    msg = build_commit_message(
-        subject=subject,
-        source_session=source_session,
-        agent_identity=agent_identity,
-        confidence_original=confidence,
-        operator_confirmed=False,
-        proposal_type="memory",
-        target_tier=target_tier,
-        target_path=target_path,
-    )
-    subprocess.run(["git", "-C", wt.path, "commit", "-m", msg], check=True)
-    sha = subprocess.check_output(
-        ["git", "-C", wt.path, "rev-parse", "HEAD"], text=True,
-    ).strip()
-    push_queue.enqueue(
-        sha=sha,
-        worktree_path=wt.path,
-        meta={"source_session": source_session, "agent_identity": agent_identity},
-    )
+    # High confidence: serialized commit + enqueue push (items 1, 4, 8).
+    try:
+        sha = _commit_in_worktree(
+            worktrees=worktrees, push_queue=push_queue, pending=pending,
+            serializer=serializer or _DEFAULT_SERIALIZER, idx=idx,
+            source_session=source_session, agent_identity=agent_identity,
+            target_path=target_path, postimage=postimage,
+            proposal_type="memory", subject=f"propose: {target_path}",
+            target_tier=target_tier, confidence=confidence,
+            operator_confirmed=False,
+            push_meta={"source_session": source_session,
+                       "agent_identity": agent_identity},
+        )
+    except _WriteRejected as rej:
+        resp = rej.response
+        _emit_audit(audit_log, **{**audit_base, "status": resp.status,
+                                   "reason": resp.reason})
+        return resp
+    except PathLockBusyError:
+        _emit_audit(audit_log, **{**audit_base, "status": "rejected_path_lock_busy"})
+        return ProposeResponse(status="rejected_path_lock_busy",
+                               target_path=target_path)
     _emit_audit(audit_log, **{**audit_base, "status": "committed", "commit_sha": sha})
     return ProposeResponse(status="committed", commit_sha=sha, push_state="queued")
 
@@ -296,6 +444,8 @@ def kb_propose_edit_fn(
     audit_log: AuditLog | None = None,
     can_auto_commit: bool = True,
     max_postimage_bytes: int = 0,
+    serializer: WriteSerializer | None = None,
+    idx: Index | None = None,
 ) -> ProposeResponse:
     """Propose an edit to an existing (or new) file under target_path.
 
@@ -371,35 +521,30 @@ def kb_propose_edit_fn(
             operator_prompt=f"Proposed edit to {target_path}. Accept (y), edit, or reject (n)?",
         )
 
-    wt = worktrees.get_or_create(source_session=source_session, agent_identity=agent_identity)
-    # Symlink-escape containment via the shared guard (see safe_join_under_root).
-    full_path = safe_join_under_root(wt.path, target_path)
-    if full_path is None:
-        _emit_audit(audit_log, **{**audit_base, "status": "rejected_symlink_escape"})
-        return ProposeResponse(status="rejected_symlink_escape",
+    # Serialized commit + CAS + validation + enqueue (items 1, 3, 4, 8).
+    try:
+        sha = _commit_in_worktree(
+            worktrees=worktrees, push_queue=push_queue, pending=pending,
+            serializer=serializer or _DEFAULT_SERIALIZER, idx=idx,
+            source_session=source_session, agent_identity=agent_identity,
+            target_path=target_path, postimage=postimage,
+            proposal_type="edit", subject=f"edit: {target_path}",
+            target_tier=target_tier, confidence=confidence,
+            operator_confirmed=False,
+            base_commit=base_commit, base_blob_sha=base_blob_sha,
+            target_file_hash=target_file_hash,
+            push_meta={"source_session": source_session,
+                       "agent_identity": agent_identity, "reason": reason},
+        )
+    except _WriteRejected as rej:
+        resp = rej.response
+        _emit_audit(audit_log, **{**audit_base, "status": resp.status,
+                                   "reason": resp.reason or reason})
+        return resp
+    except PathLockBusyError:
+        _emit_audit(audit_log, **{**audit_base, "status": "rejected_path_lock_busy"})
+        return ProposeResponse(status="rejected_path_lock_busy",
                                target_path=target_path)
-    os.makedirs(os.path.dirname(full_path), exist_ok=True)
-    with open(full_path, "w", encoding="utf-8") as f:
-        f.write(postimage)
-    subprocess.run(["git", "-C", wt.path, "add", target_path], check=True)
-    subject = f"edit: {target_path}"
-    msg = build_commit_message(
-        subject=subject,
-        source_session=source_session,
-        agent_identity=agent_identity,
-        confidence_original=confidence,
-        operator_confirmed=False,
-        proposal_type="edit",
-        target_tier=target_tier,
-        target_path=target_path,
-    )
-    subprocess.run(["git", "-C", wt.path, "commit", "-m", msg], check=True)
-    sha = subprocess.check_output(
-        ["git", "-C", wt.path, "rev-parse", "HEAD"], text=True,
-    ).strip()
-    push_queue.enqueue(sha=sha, worktree_path=wt.path,
-                       meta={"source_session": source_session,
-                             "agent_identity": agent_identity, "reason": reason})
     _emit_audit(audit_log, **{**audit_base, "status": "committed", "commit_sha": sha})
     return ProposeResponse(status="committed", commit_sha=sha, push_state="queued")
 
@@ -416,7 +561,11 @@ def kb_resolve_pending_fn(
     agent_identity: str,
     audit_log: AuditLog | None = None,
     max_postimage_bytes: int = 0,
+    serializer: WriteSerializer | None = None,
+    idx: Index | None = None,
 ) -> ResolvePendingResponse:
+    from data_olympus.pending import PendingAlreadyResolvedError
+
     audit_base: dict[str, Any] = {
         "event_type": "resolve",
         "agent_identity": agent_identity,
@@ -424,7 +573,14 @@ def kb_resolve_pending_fn(
         "pending_id": pending_id,
     }
     if decision == "reject":
-        pending.reject(pending_id)
+        try:
+            pending.reject(pending_id)
+        except PendingAlreadyResolvedError:
+            # Lost the double-resolve race (item 5): another resolver already
+            # decided this id. Surface a distinct status so the loser does not
+            # report a second decision.
+            _emit_audit(audit_log, **{**audit_base, "status": "already_resolved"})
+            return ResolvePendingResponse(status="already_resolved")
         _emit_audit(audit_log, **{**audit_base, "status": "rejected"})
         return ResolvePendingResponse(status="rejected")
     if decision not in ("approve", "edit"):
@@ -434,8 +590,8 @@ def kb_resolve_pending_fn(
     # ``edited_text`` becomes the committed postimage, bypassing the cap the
     # propose path enforced on the original postimage (item 2). Enforce it here
     # too, with a distinct status so the operator sees WHY the edit was refused.
-    # Peek at the entry (without consuming it) so a too-large edit leaves the
-    # pending entry in place to be re-edited rather than silently dropped.
+    # Checked BEFORE the atomic claim so a too-large edit leaves the pending entry
+    # in place to be re-edited rather than silently dropped.
     if edited_text is not None and max_postimage_bytes > 0 and (
         len(edited_text.encode("utf-8")) > max_postimage_bytes
     ):
@@ -443,7 +599,13 @@ def kb_resolve_pending_fn(
                     **{**audit_base, "status": "rejected_edited_text_too_large"})
         return ResolvePendingResponse(status="rejected_edited_text_too_large")
 
-    resolved = pending.approve(pending_id, edited_text=edited_text)
+    # Atomic claim: exactly one concurrent resolve of this id proceeds (item 5).
+    try:
+        resolved = pending.approve(pending_id, edited_text=edited_text)
+    except PendingAlreadyResolvedError:
+        _emit_audit(audit_log, **{**audit_base, "status": "already_resolved"})
+        return ResolvePendingResponse(status="already_resolved")
+
     target_tier, _ = _classify(resolved.target_path)
     audit_base["target_path"] = resolved.target_path
     audit_base["target_tier"] = target_tier
@@ -451,32 +613,32 @@ def kb_resolve_pending_fn(
         audit_base["confidence"] = float(resolved.meta.get("confidence", 0.0))
     except (TypeError, ValueError):
         audit_base["confidence"] = None
-    wt = worktrees.get_or_create(source_session=source_session,
-                                 agent_identity=agent_identity)
-    full_path = safe_join_under_root(wt.path, resolved.target_path)
-    if full_path is None:
-        _emit_audit(audit_log, **{**audit_base, "status": "rejected_symlink_escape"})
-        return ResolvePendingResponse(status="rejected_symlink_escape")
-    os.makedirs(os.path.dirname(full_path), exist_ok=True)
-    with open(full_path, "w", encoding="utf-8") as f:
-        f.write(resolved.postimage)
-    subprocess.run(["git", "-C", wt.path, "add", resolved.target_path], check=True)
-    subject = f"resolve: {resolved.target_path}"
-    msg = build_commit_message(
-        subject=subject,
-        source_session=resolved.meta.get("source_session", source_session),
-        agent_identity=resolved.meta.get("agent_identity", agent_identity),
-        confidence_original=float(resolved.meta.get("confidence", 0.0)),
-        operator_confirmed=True,
-        proposal_type=resolved.proposal_type,
-        target_tier=target_tier,
-        target_path=resolved.target_path,
-    )
-    subprocess.run(["git", "-C", wt.path, "commit", "-m", msg], check=True)
-    sha = subprocess.check_output(
-        ["git", "-C", wt.path, "rev-parse", "HEAD"], text=True,
-    ).strip()
-    push_queue.enqueue(sha=sha, worktree_path=wt.path, meta={})
+
+    # Serialized commit + CAS (from the pending entry's base markers) + validation
+    # + reset-on-late-failure, shared with the auto-commit path (items 1, 3, 4, 8).
+    try:
+        sha = _commit_in_worktree(
+            worktrees=worktrees, push_queue=push_queue, pending=pending,
+            serializer=serializer or _DEFAULT_SERIALIZER, idx=idx,
+            source_session=resolved.meta.get("source_session", source_session),
+            agent_identity=resolved.meta.get("agent_identity", agent_identity),
+            target_path=resolved.target_path, postimage=resolved.postimage,
+            proposal_type=resolved.proposal_type,
+            subject=f"resolve: {resolved.target_path}",
+            target_tier=target_tier,
+            confidence=float(resolved.meta.get("confidence", 0.0)),
+            operator_confirmed=True,
+            base_commit=resolved.base_commit,
+            base_blob_sha=resolved.base_blob_sha,
+            target_file_hash=resolved.target_file_hash,
+            push_meta={},
+            lock_owner=f"resolve:{pending_id}",
+        )
+    except _WriteRejected as rej:
+        resp = rej.response
+        _emit_audit(audit_log, **{**audit_base, "status": resp.status,
+                                   "reason": resp.reason})
+        return ResolvePendingResponse(status=resp.status, reason=resp.reason)
     _emit_audit(audit_log, **{**audit_base, "status": "committed", "commit_sha": sha})
     return ResolvePendingResponse(status="committed", commit_sha=sha)
 

--- a/src/data_olympus/worktrees.py
+++ b/src/data_olympus/worktrees.py
@@ -40,6 +40,13 @@ class WorktreeRegistry:
         self._root = worktree_root
         os.makedirs(self._root, exist_ok=True)
 
+    @property
+    def git(self) -> GitOps:
+        """The GitOps handle for the main repo backing this registry. The write
+        path uses it to refresh a session worktree's base onto origin/main (git
+        subcommands accept ``-C <worktree>``, so one handle serves any worktree)."""
+        return self._git
+
     def get_or_create(
         self,
         *,

--- a/src/data_olympus/write_gate.py
+++ b/src/data_olympus/write_gate.py
@@ -159,6 +159,15 @@ def check_cas(
         # The blob the caller read at base_commit must still be the current blob.
         # base_commit is None-checked by _is_enforceable_base_commit.
         assert base_commit is not None
+        if not _commit_exists(worktree_path, base_commit):
+            # An unknown/unreachable pinned commit is not an enforceable base: it
+            # cannot vouch for the current content, so reject rather than silently
+            # passing (a "" base blob would otherwise match a "" absent-target blob
+            # and let a stale write through -- Codex round-2 Concern 1).
+            return CasResult(
+                ok=False,
+                reason=f"base_commit unknown/unreachable: {base_commit}",
+            )
         base_blob = _git_blob_at(worktree_path, base_commit, target_path)
         if base_blob != current_blob:
             return CasResult(
@@ -170,6 +179,16 @@ def check_cas(
                 ),
             )
     return CasResult(ok=True)
+
+
+def _commit_exists(worktree_path: str, commit: str) -> bool:
+    """True if ``commit`` resolves to a commit object in the worktree."""
+    result = subprocess.run(
+        ["git", "-C", worktree_path, "rev-parse", "--verify", "--quiet",
+         f"{commit}^{{commit}}"],
+        check=False, capture_output=True, text=True,
+    )
+    return result.returncode == 0
 
 
 def _git_blob_at(worktree_path: str, commit: str, target_path: str) -> str:

--- a/src/data_olympus/write_gate.py
+++ b/src/data_olympus/write_gate.py
@@ -1,0 +1,253 @@
+"""Write-path integrity gates: serialization lock, CAS enforcement, and the
+content-validation gate (0.3.0 epic #72, scope items 1, 3, 4, 8).
+
+These are the checks that make the project's headline write-safety claims true.
+They run on the auto-commit path (``tools_write``) AND the operator-resolve path
+so both surfaces share one policy.
+
+- ``WriteSerializer``: a process-wide re-entrant lock. Write volume is
+  rate-limited, so a single global mutex around the write -> git add -> commit ->
+  enqueue critical section is cheap and eliminates the interleave where thread
+  A's commit sweeps thread B's staged file. Per-path advisory locks live in the
+  pending queue (``PendingQueue.path_lock``) and are shared between this path and
+  the pending queue.
+- ``check_cas``: enforce a caller-supplied base marker (``base_commit`` /
+  ``base_blob_sha`` / ``target_file_hash``) against the CURRENT content of the
+  target on the worktree's refreshed base. When no marker is supplied, behavior
+  is unchanged.
+- ``validate_postimage``: format-level validation of the postimage bytes plus a
+  duplicate-id check against the live index, so a malformed / forged document
+  never reaches ``origin/main`` (a duplicate id makes every subsequent index
+  rebuild fail: one bad write -> persistent degraded state).
+"""
+from __future__ import annotations
+
+import hashlib
+import os
+import subprocess
+import threading
+from dataclasses import dataclass
+from pathlib import PurePosixPath
+from typing import TYPE_CHECKING
+
+from data_olympus.format.frontmatter import parse_frontmatter
+from data_olympus.format.validate import RESERVED, TIERS, TYPES
+
+if TYPE_CHECKING:
+    from data_olympus.index import Index
+
+# The status vocabulary the write gate enforces. Mirrors validate.STATUSES but
+# includes ``approved`` (the real KB uses it for accepted decisions; see
+# validate.IN_FORCE_STATUSES) so a legitimate ``approved`` document is not
+# rejected as an invalid enum value.
+_WRITE_STATUSES = frozenset(
+    {"draft", "active", "deprecated", "superseded", "proposed", "accepted",
+     "rejected", "approved"}
+)
+
+
+class WriteSerializer:
+    """Process-wide re-entrant write lock (scope item 1).
+
+    A single instance is shared by every write path so the write -> git add ->
+    commit -> enqueue critical section never interleaves across threads. Re-entrant
+    so a future nested acquire (e.g. resolve calling a helper that also locks)
+    does not self-deadlock. Held only for the brief duration of a commit; the
+    per-path advisory lock (pending queue) provides the finer-grained guarantee
+    that a path with a pending proposal cannot be auto-committed concurrently."""
+
+    def __init__(self) -> None:
+        self._lock = threading.RLock()
+
+    def __enter__(self) -> WriteSerializer:
+        self._lock.acquire()
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self._lock.release()
+
+
+@dataclass(frozen=True, slots=True)
+class CasResult:
+    """Outcome of a compare-and-swap base check."""
+
+    ok: bool
+    reason: str = ""
+
+
+def _blob_sha(content: bytes) -> str:
+    """git blob object id of ``content`` (git hashes ``blob <len>\\0<content>``)."""
+    header = f"blob {len(content)}\0".encode()
+    return hashlib.sha1(header + content).hexdigest()  # noqa: S324 - git uses sha1
+
+
+def check_cas(
+    *,
+    worktree_path: str,
+    target_path: str,
+    base_commit: str | None,
+    base_blob_sha: str | None,
+    target_file_hash: str | None,
+) -> CasResult:
+    """Compare the caller's base markers against the CURRENT target content on the
+    worktree (scope item 3).
+
+    Semantics:
+
+    - If NO base marker is supplied (all of ``base_commit`` in {None, "", "HEAD"}
+      and ``base_blob_sha`` and ``target_file_hash`` are falsy), CAS is a no-op and
+      returns ok: this preserves the pre-0.3.0 behavior for callers that did not
+      opt in.
+    - ``base_blob_sha``: the git blob id the caller believed the target held. We
+      compute the blob id of the target's current bytes on the worktree and
+      require equality. A target that does not yet exist matches only an empty
+      base_blob_sha (i.e. the caller must not claim a base for a new file).
+    - ``target_file_hash``: a sha256 of the current file bytes (an alternative
+      marker some clients send). Same equality rule.
+
+    ``base_commit`` alone is advisory (the worktree is rebased onto the refreshed
+    base before this check, so a bare commit marker cannot be meaningfully
+    compared per-file); the blob/file-hash markers are the enforced ones. A
+    mismatch returns ok=False with ``rejected_stale_base`` so the caller does not
+    commit."""
+    # base_commit is accepted for API symmetry and audit context but is advisory
+    # only: the worktree is rebased onto the refreshed base before this check, so
+    # a bare commit marker cannot be meaningfully compared per file. The enforced
+    # markers are the blob / file-hash ones below.
+    _ = base_commit
+    has_blob = bool(base_blob_sha)
+    has_file_hash = bool(target_file_hash)
+    if not has_blob and not has_file_hash:
+        return CasResult(ok=True)
+
+    real = os.path.join(worktree_path, target_path)
+    current: bytes | None = None
+    if os.path.isfile(real):
+        with open(real, "rb") as f:
+            current = f.read()
+
+    if has_blob:
+        actual = _blob_sha(current) if current is not None else ""
+        if actual != base_blob_sha:
+            return CasResult(
+                ok=False,
+                reason=(
+                    f"base_blob_sha mismatch: caller={base_blob_sha} "
+                    f"current={actual or '<absent>'}"
+                ),
+            )
+    if has_file_hash:
+        actual_h = (
+            hashlib.sha256(current).hexdigest() if current is not None else ""
+        )
+        if actual_h != target_file_hash:
+            return CasResult(
+                ok=False,
+                reason=(
+                    f"target_file_hash mismatch: caller={target_file_hash} "
+                    f"current={actual_h or '<absent>'}"
+                ),
+            )
+    return CasResult(ok=True)
+
+
+@dataclass(frozen=True, slots=True)
+class ValidationResult:
+    """Outcome of the content-validation gate."""
+
+    ok: bool
+    errors: tuple[dict[str, str], ...] = ()
+
+
+def _is_reserved(target_path: str) -> bool:
+    return PurePosixPath(target_path).name in RESERVED
+
+
+def validate_postimage(
+    *,
+    target_path: str,
+    postimage: str,
+    idx: Index | None,
+) -> ValidationResult:
+    """Format-level validation of ``postimage`` before it is committed (item 4).
+
+    Rejects, with machine-readable errors, the failure classes that either break
+    parsing or corrupt the index on the next rebuild:
+
+    - **Malformed YAML frontmatter.** A block opened but never closed, or one that
+      does not parse to a mapping, currently commits and then breaks the index
+      build. Rejected as ``invalid_frontmatter``.
+    - **Invalid enum value.** ``type`` / ``status`` / ``tier`` present but outside
+      the controlled vocabulary. Rejected as ``invalid_enum``. (Missing required
+      fields are NOT rejected here: memory-inbox documents legitimately carry no
+      ``id``/``type``/``status``/``tier`` and derive their id from the path. The
+      gate blocks documents that are actively malformed, not merely sparse.)
+    - **Duplicate / forged id.** A frontmatter ``id`` that already belongs to a
+      DIFFERENT path in the live index. A duplicate id makes every subsequent
+      index rebuild raise ``DuplicateIdError``, i.e. one bad write puts the server
+      in a persistent degraded state. Rejected as ``duplicate_id``. An id that
+      resolves to the SAME path (a legitimate edit-in-place) is allowed.
+
+    Reserved filenames (``index.md`` / ``log.md`` / ``template.md``) are exempt
+    from the concept schema (SPEC section 4.2), matching ``kb lint``.
+    """
+    errors: list[dict[str, str]] = []
+
+    # 1. Frontmatter must parse. parse_frontmatter raises ValueError on an
+    # unterminated block or a non-mapping block; either is a hard reject.
+    try:
+        fm, _body = parse_frontmatter(postimage)
+    except ValueError as exc:
+        return ValidationResult(
+            ok=False,
+            errors=({"field": "frontmatter", "code": "invalid_frontmatter",
+                     "message": str(exc)},),
+        )
+
+    if _is_reserved(target_path):
+        # Reserved files are schema-exempt; the parse check above is the only gate.
+        return ValidationResult(ok=True)
+
+    # 2. Enum values, when present, must be in vocabulary.
+    for field, allowed in (("type", TYPES), ("status", _WRITE_STATUSES),
+                           ("tier", TIERS)):
+        value = fm.get(field)
+        if value is not None and value not in allowed:
+            errors.append({
+                "field": field, "code": "invalid_enum",
+                "message": f"invalid {field} '{value}' "
+                           f"(allowed: {sorted(allowed)})",
+            })
+
+    # 3. Duplicate / forged id against the live index. A duplicate id at a
+    # DIFFERENT path corrupts the next rebuild.
+    doc_id = fm.get("id")
+    if isinstance(doc_id, str) and doc_id and idx is not None:
+        try:
+            existing = idx.get(doc_id)
+        except Exception:  # noqa: BLE001 - index read must never fail the gate open
+            existing = None
+        if existing is not None and existing.path != target_path:
+            errors.append({
+                "field": "id", "code": "duplicate_id",
+                "message": f"id '{doc_id}' already used by '{existing.path}'",
+            })
+
+    if errors:
+        return ValidationResult(ok=False, errors=tuple(errors))
+    return ValidationResult(ok=True)
+
+
+def reset_worktree(worktree_path: str) -> None:
+    """Discard any staged/working changes in the worktree (scope item 8).
+
+    Ordering-of-side-effects fix: if a write fails a late gate (CAS, validation,
+    or trailer/message validation) AFTER the postimage was written and
+    ``git add``-ed, the staged file would otherwise be swept into the session's
+    NEXT commit. A hard reset to HEAD leaves no staged leftovers so a rejected
+    write is a true no-op. Best-effort: a reset failure is logged by the caller,
+    not raised, because the primary rejection is what must surface."""
+    subprocess.run(
+        ["git", "-C", worktree_path, "reset", "--hard", "HEAD"],
+        check=True, capture_output=True,
+    )

--- a/src/data_olympus/write_gate.py
+++ b/src/data_olympus/write_gate.py
@@ -27,7 +27,7 @@ import os
 import subprocess
 import threading
 from dataclasses import dataclass
-from pathlib import PurePosixPath
+from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING
 
 from data_olympus.format.frontmatter import parse_frontmatter
@@ -81,6 +81,16 @@ def _blob_sha(content: bytes) -> str:
     return hashlib.sha1(header + content).hexdigest()  # noqa: S324 - git uses sha1
 
 
+def _is_enforceable_base_commit(base_commit: str | None) -> bool:
+    """A base_commit is enforceable when it names a SPECIFIC commit the caller
+    read the target from. The sentinel ``HEAD`` (and empty/None) means "whatever
+    the current base is" and carries no per-file expectation, so it is advisory
+    only. A pinned sha / ref is enforceable."""
+    if not base_commit:
+        return False
+    return base_commit.strip().upper() != "HEAD"
+
+
 def check_cas(
     *,
     worktree_path: str,
@@ -90,34 +100,32 @@ def check_cas(
     target_file_hash: str | None,
 ) -> CasResult:
     """Compare the caller's base markers against the CURRENT target content on the
-    worktree (scope item 3).
+    worktree's refreshed base (scope item 3).
 
     Semantics:
 
-    - If NO base marker is supplied (all of ``base_commit`` in {None, "", "HEAD"}
-      and ``base_blob_sha`` and ``target_file_hash`` are falsy), CAS is a no-op and
-      returns ok: this preserves the pre-0.3.0 behavior for callers that did not
-      opt in.
+    - If NO enforceable marker is supplied (``base_commit`` is None/""/``HEAD`` AND
+      ``base_blob_sha``/``target_file_hash`` are falsy), CAS is a no-op and returns
+      ok: this preserves the pre-0.3.0 behavior for callers that did not opt in.
     - ``base_blob_sha``: the git blob id the caller believed the target held. We
       compute the blob id of the target's current bytes on the worktree and
       require equality. A target that does not yet exist matches only an empty
       base_blob_sha (i.e. the caller must not claim a base for a new file).
     - ``target_file_hash``: a sha256 of the current file bytes (an alternative
       marker some clients send). Same equality rule.
+    - ``base_commit`` naming a SPECIFIC commit (not the ``HEAD`` sentinel) is
+      ENFORCED: the blob the target had at ``base_commit`` must equal the target's
+      current blob on the refreshed base. This closes the bypass where a caller
+      supplied only ``base_commit`` (the required field) and CAS silently no-oped
+      (Codex Blocker 3). ``HEAD`` remains advisory because it means "the current
+      base", which carries no stale-detection expectation.
 
-    ``base_commit`` alone is advisory (the worktree is rebased onto the refreshed
-    base before this check, so a bare commit marker cannot be meaningfully
-    compared per-file); the blob/file-hash markers are the enforced ones. A
-    mismatch returns ok=False with ``rejected_stale_base`` so the caller does not
-    commit."""
-    # base_commit is accepted for API symmetry and audit context but is advisory
-    # only: the worktree is rebased onto the refreshed base before this check, so
-    # a bare commit marker cannot be meaningfully compared per file. The enforced
-    # markers are the blob / file-hash ones below.
-    _ = base_commit
+    A mismatch returns ok=False with a machine-readable ``reason`` so the caller
+    rejects ``rejected_stale_base`` rather than committing."""
     has_blob = bool(base_blob_sha)
     has_file_hash = bool(target_file_hash)
-    if not has_blob and not has_file_hash:
+    has_commit = _is_enforceable_base_commit(base_commit)
+    if not has_blob and not has_file_hash and not has_commit:
         return CasResult(ok=True)
 
     real = os.path.join(worktree_path, target_path)
@@ -125,17 +133,16 @@ def check_cas(
     if os.path.isfile(real):
         with open(real, "rb") as f:
             current = f.read()
+    current_blob = _blob_sha(current) if current is not None else ""
 
-    if has_blob:
-        actual = _blob_sha(current) if current is not None else ""
-        if actual != base_blob_sha:
-            return CasResult(
-                ok=False,
-                reason=(
-                    f"base_blob_sha mismatch: caller={base_blob_sha} "
-                    f"current={actual or '<absent>'}"
-                ),
-            )
+    if has_blob and current_blob != base_blob_sha:
+        return CasResult(
+            ok=False,
+            reason=(
+                f"base_blob_sha mismatch: caller={base_blob_sha} "
+                f"current={current_blob or '<absent>'}"
+            ),
+        )
     if has_file_hash:
         actual_h = (
             hashlib.sha256(current).hexdigest() if current is not None else ""
@@ -148,7 +155,34 @@ def check_cas(
                     f"current={actual_h or '<absent>'}"
                 ),
             )
+    if has_commit:
+        # The blob the caller read at base_commit must still be the current blob.
+        # base_commit is None-checked by _is_enforceable_base_commit.
+        assert base_commit is not None
+        base_blob = _git_blob_at(worktree_path, base_commit, target_path)
+        if base_blob != current_blob:
+            return CasResult(
+                ok=False,
+                reason=(
+                    f"base_commit mismatch: content at {base_commit} "
+                    f"(blob={base_blob or '<absent>'}) differs from current "
+                    f"(blob={current_blob or '<absent>'})"
+                ),
+            )
     return CasResult(ok=True)
+
+
+def _git_blob_at(worktree_path: str, commit: str, target_path: str) -> str:
+    """The git blob id of ``target_path`` as of ``commit`` in the worktree, or ""
+    if the path did not exist there (or the commit is unknown). Uses
+    ``git rev-parse <commit>:<path>`` which prints the blob object id directly."""
+    result = subprocess.run(
+        ["git", "-C", worktree_path, "rev-parse", f"{commit}:{target_path}"],
+        check=False, capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        return ""
+    return result.stdout.strip()
 
 
 @dataclass(frozen=True, slots=True)
@@ -163,11 +197,71 @@ def _is_reserved(target_path: str) -> bool:
     return PurePosixPath(target_path).name in RESERVED
 
 
+def _effective_doc_id(fm: dict[str, object], target_path: str) -> str:
+    """The id the indexer will assign to ``target_path``: the explicit
+    frontmatter ``id`` when present and a plain string, else the path-derived id.
+
+    This mirrors ``index.build`` (``doc_id = doc.id or _derive_id_from_path(rel)``)
+    and ``markdown_parse.parse_file`` (which drops an id containing ``:``), so the
+    duplicate-id gate reasons about the SAME id the rebuild will compute. A
+    path-derived id lets the gate catch a NEW file whose derived id collides with
+    an existing explicit id (Codex Blocker 1)."""
+    from data_olympus.index import _derive_id_from_path
+
+    raw = fm.get("id")
+    if isinstance(raw, str) and raw and ":" not in raw:
+        return raw
+    return _derive_id_from_path(Path(target_path))
+
+
+def _worktree_id_map(worktree_path: str) -> dict[str, str]:
+    """``{doc_id: path}`` for every non-excluded ``.md`` file COMMITTED in the
+    worktree's current HEAD tree (Codex Blocker 1, concurrent case).
+
+    The live index rebuilds only on the git_pull_loop, so two auto-commits that
+    introduce the same NEW id in quick succession both pass an ``idx``-only check
+    (neither is indexed yet) and then break the next rebuild. Scanning the
+    worktree tree (which already contains the first commit by the time the second
+    validates, because the write lock serializes them) closes that window. Returns
+    {} on any git error (fail open on the tree scan; the idx check still applies)."""
+    from data_olympus.index import _derive_id_from_path, _is_excluded
+
+    result = subprocess.run(
+        ["git", "-C", worktree_path, "ls-tree", "-r", "--name-only", "HEAD"],
+        check=False, capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        return {}
+    id_map: dict[str, str] = {}
+    for rel in result.stdout.splitlines():
+        rel = rel.strip()
+        if not rel.endswith(".md"):
+            continue
+        if _is_excluded(Path(rel)):
+            continue
+        blob = subprocess.run(
+            ["git", "-C", worktree_path, "show", f"HEAD:{rel}"],
+            check=False, capture_output=True, text=True,
+        )
+        if blob.returncode != 0:
+            continue
+        try:
+            fm, _body = parse_frontmatter(blob.stdout)
+        except ValueError:
+            fm = {}
+        raw = fm.get("id") if isinstance(fm, dict) else None
+        doc_id = (raw if isinstance(raw, str) and raw and ":" not in raw
+                  else _derive_id_from_path(Path(rel)))
+        id_map[doc_id] = rel
+    return id_map
+
+
 def validate_postimage(
     *,
     target_path: str,
     postimage: str,
     idx: Index | None,
+    worktree_path: str | None = None,
 ) -> ValidationResult:
     """Format-level validation of ``postimage`` before it is committed (item 4).
 
@@ -182,14 +276,18 @@ def validate_postimage(
       fields are NOT rejected here: memory-inbox documents legitimately carry no
       ``id``/``type``/``status``/``tier`` and derive their id from the path. The
       gate blocks documents that are actively malformed, not merely sparse.)
-    - **Duplicate / forged id.** A frontmatter ``id`` that already belongs to a
-      DIFFERENT path in the live index. A duplicate id makes every subsequent
-      index rebuild raise ``DuplicateIdError``, i.e. one bad write puts the server
-      in a persistent degraded state. Rejected as ``duplicate_id``. An id that
-      resolves to the SAME path (a legitimate edit-in-place) is allowed.
+    - **Duplicate / forged id.** The EFFECTIVE id the rebuild will assign (explicit
+      frontmatter ``id`` or the path-derived id) already belongs to a DIFFERENT
+      path, in the live index OR in the worktree's committed tree. A duplicate id
+      makes every subsequent index rebuild raise ``DuplicateIdError``: one bad
+      write puts the server in a persistent degraded state. Rejected as
+      ``duplicate_id``. An id that resolves to the SAME path (a legitimate
+      edit-in-place) is allowed. This applies to reserved files too, since the
+      indexer still assigns them an id.
 
-    Reserved filenames (``index.md`` / ``log.md`` / ``template.md``) are exempt
-    from the concept schema (SPEC section 4.2), matching ``kb lint``.
+    The concept-schema exemption for reserved filenames (``index.md`` / ``log.md``
+    / ``template.md``, SPEC section 4.2) suppresses only the enum checks, NOT the
+    duplicate-id check.
     """
     errors: list[dict[str, str]] = []
 
@@ -204,34 +302,46 @@ def validate_postimage(
                      "message": str(exc)},),
         )
 
-    if _is_reserved(target_path):
-        # Reserved files are schema-exempt; the parse check above is the only gate.
-        return ValidationResult(ok=True)
+    # 2. Enum values, when present, must be in vocabulary. Reserved files are
+    # schema-exempt from this check (but NOT from the duplicate-id check below).
+    if not _is_reserved(target_path):
+        for field, allowed in (("type", TYPES), ("status", _WRITE_STATUSES),
+                               ("tier", TIERS)):
+            value = fm.get(field)
+            if value is not None and value not in allowed:
+                errors.append({
+                    "field": field, "code": "invalid_enum",
+                    "message": f"invalid {field} '{value}' "
+                               f"(allowed: {sorted(allowed)})",
+                })
 
-    # 2. Enum values, when present, must be in vocabulary.
-    for field, allowed in (("type", TYPES), ("status", _WRITE_STATUSES),
-                           ("tier", TIERS)):
-        value = fm.get(field)
-        if value is not None and value not in allowed:
-            errors.append({
-                "field": field, "code": "invalid_enum",
-                "message": f"invalid {field} '{value}' "
-                           f"(allowed: {sorted(allowed)})",
-            })
-
-    # 3. Duplicate / forged id against the live index. A duplicate id at a
-    # DIFFERENT path corrupts the next rebuild.
-    doc_id = fm.get("id")
-    if isinstance(doc_id, str) and doc_id and idx is not None:
-        try:
-            existing = idx.get(doc_id)
-        except Exception:  # noqa: BLE001 - index read must never fail the gate open
-            existing = None
-        if existing is not None and existing.path != target_path:
-            errors.append({
-                "field": "id", "code": "duplicate_id",
-                "message": f"id '{doc_id}' already used by '{existing.path}'",
-            })
+    # 3. Duplicate / forged id against BOTH the live index and the worktree tree,
+    # using the EFFECTIVE id (explicit or path-derived) so a new file whose derived
+    # id collides with an existing explicit id is caught, and so a same-new-id race
+    # between two serialized commits is caught (the first is already committed in
+    # the tree when the second validates).
+    effective_id = _effective_doc_id(fm, target_path)
+    collision_path: str | None = None
+    if effective_id:
+        if idx is not None:
+            try:
+                index_map = idx.id_to_path_map()
+            except Exception:  # noqa: BLE001 - index read must never fail-closed here
+                index_map = {}
+            if isinstance(index_map, dict):
+                other = index_map.get(effective_id)
+                if other is not None and other != target_path:
+                    collision_path = other
+        if collision_path is None and worktree_path is not None:
+            tree_map = _worktree_id_map(worktree_path)
+            other = tree_map.get(effective_id)
+            if other is not None and other != target_path:
+                collision_path = other
+    if collision_path is not None:
+        errors.append({
+            "field": "id", "code": "duplicate_id",
+            "message": f"id '{effective_id}' already used by '{collision_path}'",
+        })
 
     if errors:
         return ValidationResult(ok=False, errors=tuple(errors))

--- a/tests/test_mcp_write_wiring.py
+++ b/tests/test_mcp_write_wiring.py
@@ -85,3 +85,15 @@ async def test_mcp_gate_check_rate_limited(tmp_git_kb: Path, tmp_path: Path) -> 
             "tool_name": "Edit",
         })
         assert "rejected_rate_limited" in str(res)
+
+
+@pytest.mark.asyncio
+async def test_mcp_cleanup_plan_rate_limited(tmp_git_kb: Path, tmp_path: Path) -> None:
+    """Codex Nit 1: the MCP kb_cleanup_plan tool honors the shared limiter too."""
+    app = _app_with_pipeline(tmp_git_kb, tmp_path, rate_limit_per_hour=0)
+    async with Client(app) as client:
+        res = await client.call_tool("kb_cleanup_plan", {
+            "workspace": "example-project",
+            "local_files": [{"path": "README.md", "content": "hi"}],
+        })
+        assert "rejected_rate_limited" in str(res)

--- a/tests/test_mcp_write_wiring.py
+++ b/tests/test_mcp_write_wiring.py
@@ -1,0 +1,87 @@
+"""MCP-surface wiring parity with REST (0.3.0 epic #72 scope item 9):
+
+(a) the MCP kb_resolve_pending tool applies the KB_MAX_POSTIMAGE_BYTES edited_text
+    cap (REST already did; MCP did not);
+(b) the MCP consult / gate-check / cleanup-plan tools apply the shared rate
+    limiter (REST already did; MCP did not).
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from fastmcp import Client
+
+from data_olympus.server import build_app
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _app_with_pipeline(tmp_git_kb: Path, tmp_path: Path, **overrides):
+    """Build an app with the write pipeline enabled (kb_remote_url set) so the
+    rate limiter and write tools are wired. The remote is the KB repo itself; the
+    tests here never push, only exercise the reject-before-commit paths."""
+    return build_app(
+        kb_main_path=tmp_git_kb,
+        kb_index_path=tmp_path / "idx.db",
+        sync_interval_sec=60, staleness_degraded_sec=600, bootstrap_now=True,
+        kb_remote_url=str(tmp_git_kb),
+        worktree_root=str(tmp_path / "wts"),
+        pending_root=str(tmp_path / "pending"),
+        push_queue_root=str(tmp_path / "pushq"),
+        audit_log_path=str(tmp_path / "audit.log"),
+        **overrides,
+    )
+
+
+@pytest.mark.asyncio
+async def test_mcp_resolve_edited_text_cap_enforced(
+    tmp_git_kb: Path, tmp_path: Path,
+) -> None:
+    """item 9(a): a low-confidence memory parked as pending, then resolved via the
+    MCP tool with an oversize edited_text, is rejected with the same distinct
+    status the REST path returns."""
+    app = _app_with_pipeline(tmp_git_kb, tmp_path, max_postimage_bytes=100)
+    async with Client(app) as client:
+        park = await client.call_tool("kb_propose_memory", {
+            "text": "small note", "tags": [], "source_session": "s",
+            "agent_identity": "claude", "confidence": 0.3,
+        })
+        data = park.data if hasattr(park, "data") else None
+        pid = (data or {}).get("pending_id") if isinstance(data, dict) else None
+        if pid is None:
+            # Fallback: parse from the serialized result.
+            import re
+            m = re.search(r'"pending_id"\s*:\s*"([0-9a-f]{32})"', str(park))
+            assert m, f"no pending_id in {park}"
+            pid = m.group(1)
+        res = await client.call_tool("kb_resolve_pending", {
+            "pending_id": pid, "decision": "approve",
+            "edited_text": "X" * 5000,
+        })
+        assert "rejected_edited_text_too_large" in str(res)
+
+
+@pytest.mark.asyncio
+async def test_mcp_consult_rate_limited(tmp_git_kb: Path, tmp_path: Path) -> None:
+    """item 9(b): the MCP kb_consult tool honors the shared limiter. With the
+    per-hour quota set to 0, the first consult is rejected_rate_limited."""
+    app = _app_with_pipeline(tmp_git_kb, tmp_path, rate_limit_per_hour=0)
+    async with Client(app) as client:
+        res = await client.call_tool("kb_consult", {
+            "workspace": "example-project", "intent": "add a feature",
+            "source_session": "s", "agent_identity": "claude",
+        })
+        assert "rejected_rate_limited" in str(res)
+
+
+@pytest.mark.asyncio
+async def test_mcp_gate_check_rate_limited(tmp_git_kb: Path, tmp_path: Path) -> None:
+    app = _app_with_pipeline(tmp_git_kb, tmp_path, rate_limit_per_hour=0)
+    async with Client(app) as client:
+        res = await client.call_tool("kb_gate_check", {
+            "workspace": "example-project", "session_id": "s",
+            "tool_name": "Edit",
+        })
+        assert "rejected_rate_limited" in str(res)

--- a/tests/test_pending.py
+++ b/tests/test_pending.py
@@ -147,3 +147,104 @@ def test_resolve_edit_uses_edited_text(tmp_path) -> None:
     )
     resolved = q.approve(pid, edited_text="edited!")
     assert resolved.postimage == "edited!"
+
+
+# ---- item 5: atomic claim + orphan-lock GC ----
+
+
+def test_sequential_double_approve_second_is_gone(tmp_path) -> None:
+    """A SEQUENTIAL second resolve of a fully-consumed id sees PendingNotFoundError
+    (the entry is gone). The CONCURRENT race is covered separately below; there
+    the loser sees PendingAlreadyResolvedError because the entry vanishes between
+    the exists() check and the rename."""
+    from data_olympus.pending import PendingNotFoundError
+    q = PendingQueue(pending_root=str(tmp_path / "p"))
+    pid = q.enqueue(
+        proposal_type="memory", target_path="memory/inbox/a.md",
+        postimage="body", base_commit="c", base_blob_sha=None,
+        target_file_hash=None, meta={},
+    )
+    first = q.approve(pid)
+    assert first.postimage == "body"
+    with pytest.raises(PendingNotFoundError):
+        q.approve(pid)
+
+
+def test_concurrent_approve_exactly_one_winner(tmp_path) -> None:
+    """Threaded: N threads approve the same id; exactly one succeeds, the rest
+    raise PendingAlreadyResolvedError. Proves the os.rename claim is a real
+    test-and-set."""
+    import threading
+
+    from data_olympus.pending import (
+        PendingAlreadyResolvedError,
+        PendingNotFoundError,
+    )
+    q = PendingQueue(pending_root=str(tmp_path / "p"))
+    pid = q.enqueue(
+        proposal_type="memory", target_path="memory/inbox/race.md",
+        postimage="body", base_commit="c", base_blob_sha=None,
+        target_file_hash=None, meta={},
+    )
+    wins: list[int] = []
+    losses: list[int] = []
+    barrier = threading.Barrier(8)
+
+    def worker() -> None:
+        barrier.wait()
+        try:
+            q.approve(pid)
+            wins.append(1)
+        except (PendingAlreadyResolvedError, PendingNotFoundError):
+            # Both mean "you lost the race, the entry is gone". Either is a
+            # correct loser outcome; what must NOT happen is two winners.
+            losses.append(1)
+
+    threads = [threading.Thread(target=worker) for _ in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    assert len(wins) == 1
+    assert len(losses) == 7
+
+
+def test_gc_orphan_locks_reclaims_lock_without_entry(tmp_path) -> None:
+    """A crash between _acquire_lock and the entry write leaves a lock with no
+    entry; gc_orphan_locks reclaims it so the path is not locked forever."""
+    import json
+    import uuid
+
+    q = PendingQueue(pending_root=str(tmp_path / "p"))
+    # Simulate the crash: acquire a lock for a pending_id whose entry never lands.
+    orphan_id = uuid.uuid4().hex
+    q._acquire_lock("decisions/orphan.md", orphan_id)  # noqa: SLF001
+    assert q.locks_held() == 1
+    reclaimed = q.gc_orphan_locks()
+    assert reclaimed == 1
+    assert q.locks_held() == 0
+    # A live lock (with entry) is NOT reclaimed.
+    pid = q.enqueue(
+        proposal_type="edit", target_path="decisions/live.md",
+        postimage="x", base_commit="c", base_blob_sha=None, target_file_hash=None,
+        meta={},
+    )
+    assert q.gc_orphan_locks() == 0
+    assert q.locks_held() == 1
+    _ = json, pid
+
+
+def test_path_lock_shared_context_manager(tmp_path) -> None:
+    """The auto-commit path acquires the SAME lock the pending queue uses, so a
+    path with a pending proposal cannot be auto-committed concurrently."""
+    q = PendingQueue(pending_root=str(tmp_path / "p"))
+    q.enqueue(
+        proposal_type="edit", target_path="universal/foundation/x.md",
+        postimage="a", base_commit="c", base_blob_sha=None, target_file_hash=None,
+        meta={},
+    )
+    # The auto-commit path_lock on the same target must be busy.
+    with pytest.raises(PathLockBusyError), q.path_lock(
+        "universal/foundation/x.md", owner="auto-commit:s",
+    ):
+        pass

--- a/tests/test_pending.py
+++ b/tests/test_pending.py
@@ -12,6 +12,14 @@ from data_olympus.pending import (
 )
 
 
+def test_root_property_exposes_pending_dir(tmp_path) -> None:
+    """The public `root` property returns the on-disk pending dir (so callers do
+    not read the private `_root`)."""
+    root = str(tmp_path / "p")
+    q = PendingQueue(pending_root=root)
+    assert q.root == root
+
+
 def test_enqueue_respects_capacity(tmp_path) -> None:
     q = PendingQueue(pending_root=str(tmp_path / "p"), cap=2)
     for i in range(2):

--- a/tests/test_push_queue.py
+++ b/tests/test_push_queue.py
@@ -225,3 +225,57 @@ def test_init_recovery_does_not_double_enqueue_already_queued_sha(tmp_path) -> N
     assert entry["meta"] == {"agent": "claude"}
     assert "recovered" not in entry
     assert q.size() == 1
+
+
+# ---- Wave 1: rebase-conflict demotion + non-FF contention demotion ----
+
+
+def test_drain_demotes_rebase_conflict_via_callback(tmp_path) -> None:
+    """A RebaseConflictError routes to on_rebase_conflict and the entry is removed
+    (demoted), not retried forever."""
+    from data_olympus.git_ops import RebaseConflictError
+    q = PushQueue(queue_root=str(tmp_path / "q"))
+    q.enqueue(sha="abc", worktree_path="/wt", meta={})
+
+    def failing(_wt):
+        raise RebaseConflictError(worktree_path="/wt", detail="CONFLICT")
+
+    demoted = []
+    q.drain(push_fn=failing, max_attempts=10,
+            on_rebase_conflict=lambda entry: demoted.append(entry["sha"]))
+    assert demoted == ["abc"]
+    assert q.size() == 0  # entry removed after demotion
+
+
+def test_drain_keeps_conflict_when_no_callback(tmp_path) -> None:
+    """Without a demotion callback, a rebase conflict stays queued (never lost)."""
+    from data_olympus.git_ops import RebaseConflictError
+    q = PushQueue(queue_root=str(tmp_path / "q"))
+    q.enqueue(sha="abc", worktree_path="/wt", meta={})
+
+    def failing(_wt):
+        raise RebaseConflictError(worktree_path="/wt", detail="C")
+
+    q.drain(push_fn=failing, max_attempts=10)
+    assert q.size() == 1  # kept
+
+
+def test_drain_demotes_persistent_non_ff_after_bound(tmp_path) -> None:
+    """A repeated non-FF race (contention) is demoted after the bounded number of
+    in-line attempts instead of freezing silently (Codex Concern 1)."""
+    from data_olympus.git_ops import NonFastForwardError
+    q = PushQueue(queue_root=str(tmp_path / "q"))
+    q.enqueue(sha="abc", worktree_path="/wt", meta={})
+
+    def always_non_ff(_wt):
+        raise NonFastForwardError(worktree_path="/wt", detail="lost race")
+
+    demoted = []
+    # Drain repeatedly; each pass raises non-FF. After 5 the entry demotes.
+    for _ in range(6):
+        if q.size() == 0:
+            break
+        q.drain(push_fn=always_non_ff, max_attempts=100,
+                on_rebase_conflict=lambda entry: demoted.append(entry["sha"]))
+    assert demoted == ["abc"]
+    assert q.size() == 0

--- a/tests/test_refresh.py
+++ b/tests/test_refresh.py
@@ -153,11 +153,11 @@ def test_push_retry_loop_invokes_drain_periodically() -> None:
     calls = []
 
     class FakePushQueue:
-        def drain(self, *, push_fn, max_attempts):  # noqa: ARG002
+        def drain(self, *, push_fn, max_attempts, on_rebase_conflict=None):  # noqa: ARG002
             calls.append(time.time())
 
     class FakeGitOps:
-        def push(self, worktree_path):  # noqa: ARG002
+        def push_with_rebase_recovery(self, worktree_path, *, timeout_sec=60):  # noqa: ARG002
             pass
 
     pq = FakePushQueue()
@@ -188,11 +188,11 @@ def test_push_retry_loop_runs_drain_off_the_event_loop() -> None:
     main_thread = threading.get_ident()
 
     class FakePushQueue:
-        def drain(self, *, push_fn, max_attempts):  # noqa: ARG002
+        def drain(self, *, push_fn, max_attempts, on_rebase_conflict=None):  # noqa: ARG002
             threads.append(threading.get_ident())
 
     class FakeGitOps:
-        def push(self, worktree_path, *, timeout_sec=60):  # noqa: ARG002
+        def push_with_rebase_recovery(self, worktree_path, *, timeout_sec=60):  # noqa: ARG002
             pass
 
     async def runner():
@@ -219,11 +219,11 @@ def test_push_retry_loop_passes_push_timeout_to_git_push() -> None:
     seen_timeouts: list[int] = []
 
     class FakePushQueue:
-        def drain(self, *, push_fn, max_attempts):  # noqa: ARG002
-            push_fn("/tmp/wt")  # exercise the closure so git.push is called
+        def drain(self, *, push_fn, max_attempts, on_rebase_conflict=None):  # noqa: ARG002
+            push_fn("/tmp/wt")  # exercise the closure so the push is called
 
     class FakeGitOps:
-        def push(self, worktree_path, *, timeout_sec=60):  # noqa: ARG002
+        def push_with_rebase_recovery(self, worktree_path, *, timeout_sec=60):  # noqa: ARG002
             seen_timeouts.append(timeout_sec)
 
     async def runner():
@@ -261,3 +261,56 @@ def test_worktree_gc_loop_invokes_gc_periodically() -> None:
 
     asyncio.run(runner())
     assert calls and all(c == 3600 for c in calls)
+
+
+# ---- item 7: pending expiry emits an audit event + orphan-lock reclaim ----
+
+
+def test_pending_gc_loop_emits_expiry_audit_and_reclaims_locks(tmp_path) -> None:
+    """An expired (>timeout) pending entry is auto-rejected AND records a
+    pending_expired audit event (item 7); orphaned path locks are reclaimed."""
+    import uuid
+
+    from data_olympus.audit_log import AuditLog
+    from data_olympus.pending import PendingQueue
+    from data_olympus.refresh import pending_gc_loop
+
+    pen = PendingQueue(pending_root=str(tmp_path / "p"))
+    audit = AuditLog(log_path=str(tmp_path / "audit.log"), hmac_key="")
+    # Enqueue an entry, then backdate it so it is already expired.
+    pid = pen.enqueue(
+        proposal_type="edit", target_path="decisions/expired.md",
+        postimage="x", base_commit="c", base_blob_sha=None, target_file_hash=None,
+        meta={"agent_identity": "claude"},
+    )
+    entry_file = tmp_path / "p" / f"{pid}.json"
+    import json
+    data = json.loads(entry_file.read_text())
+    data["enqueued_at"] = time.time() - 10_000
+    entry_file.write_text(json.dumps(data))
+    # Plant an orphaned lock (crash between lock create and entry write).
+    orphan = uuid.uuid4().hex
+    pen._acquire_lock("decisions/orphan.md", orphan)  # noqa: SLF001
+
+    async def runner():
+        task = asyncio.create_task(
+            pending_gc_loop(pending=pen, timeout_sec=3600, interval_sec=0.01,
+                            audit_log=audit)
+        )
+        await asyncio.sleep(0.05)
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+
+    asyncio.run(runner())
+
+    # The expired entry is gone.
+    assert pen.size() == 0
+    # The orphaned lock was reclaimed.
+    assert pen.locks_held() == 0
+    # A pending_expired audit event was recorded.
+    events = list(audit.iter_filtered())
+    expired = [e for e in events if e.get("event_type") == "pending_expired"]
+    assert expired
+    assert expired[0]["status"] == "auto_rejected"
+    assert expired[0]["target_path"] == "decisions/expired.md"

--- a/tests/test_rest_status_maps.py
+++ b/tests/test_rest_status_maps.py
@@ -1,0 +1,32 @@
+"""Unit tests for the REST status -> HTTP code maps (write-pipeline core +
+onboarding seam statuses)."""
+from __future__ import annotations
+
+from data_olympus.rest_api import _propose_status, _resolve_status
+
+
+def test_propose_status_write_pipeline_codes() -> None:
+    assert _propose_status("committed") == 201
+    assert _propose_status("pending_confirmation") == 202
+    assert _propose_status("rejected_payload_too_large") == 413
+    assert _propose_status("rejected_rate_limited") == 429
+    assert _propose_status("rejected_pending_queue_full") == 429
+    assert _propose_status("rejected_stale_base") == 409
+    assert _propose_status("rejected_path_lock_busy") == 409
+    assert _propose_status("rejected_invalid_document") == 422
+    assert _propose_status("rejected_something_else") == 400
+
+
+def test_propose_status_onboarding_seam_codes() -> None:
+    # Seams folded in from the onboarding package.
+    assert _propose_status("rejected_already_in_progress") == 409
+    assert _propose_status("rejected_path_locked") == 423
+
+
+def test_resolve_status_codes() -> None:
+    assert _resolve_status("committed") == 200
+    assert _resolve_status("rejected_edited_text_too_large") == 413
+    assert _resolve_status("already_resolved") == 409
+    assert _resolve_status("rejected_stale_base") == 409
+    assert _resolve_status("rejected_invalid_document") == 422
+    assert _resolve_status("rejected") == 200

--- a/tests/test_tools_onboarding.py
+++ b/tests/test_tools_onboarding.py
@@ -19,6 +19,10 @@ def _partial_idx(present_paths: list[str]) -> MagicMock:
     idx = MagicMock()
     idx.list_by_prefix.return_value = [{"path": p} for p in present_paths]
     idx.list_with_remote_url.return_value = []
+    # The write-path validation gate consults id_to_path_map() for duplicate-id
+    # detection; a bare MagicMock would return a truthy Mock and spuriously flag a
+    # collision. An empty map means "no existing ids", the correct state here.
+    idx.id_to_path_map.return_value = {}
     return idx
 
 
@@ -574,3 +578,102 @@ def test_inject_remote_url_already_present_key_is_noop() -> None:
     files = [{"target_path": "projects/p/README.md", "postimage": postimage}]
     out = _inject_remote_url(files, url, target_filename="README.md")
     assert out[0]["postimage"] == postimage
+
+
+# ---- Codex Blocker 2: bootstrap goes through the serialized/validated write path ----
+
+
+def _real_bootstrap_pieces(tmp_path):
+    import subprocess
+
+    from data_olympus.auth import PathBlocklist
+    from data_olympus.git_ops import GitOps
+    from data_olympus.pending import PendingQueue
+    from data_olympus.push_queue import PushQueue
+    from data_olympus.rate_limit import SlidingWindowLimiter
+    from data_olympus.worktrees import WorktreeRegistry
+    env = {"GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@e.com",
+           "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@e.com",
+           "PATH": "/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin"}
+    repo = tmp_path / "main"
+    repo.mkdir()
+    subprocess.run(["git", "init", "--initial-branch=main"], cwd=repo, check=True, env=env)
+    (repo / "seed.md").write_text("seed\n")
+    subprocess.run(["git", "add", "-A"], cwd=repo, check=True, env=env)
+    subprocess.run(["git", "commit", "-m", "init"], cwd=repo, check=True, env=env)
+    git = GitOps(repo)
+    reg = WorktreeRegistry(git=git, worktree_root=str(tmp_path / "wts"))
+    pq = PushQueue(queue_root=str(tmp_path / "pushq"))
+    pen = PendingQueue(pending_root=str(tmp_path / "pending"))
+    rl = SlidingWindowLimiter(max_per_hour=100)
+    bl = PathBlocklist(tier_blocks=[], path_blocks=[])
+    return reg, pq, pen, rl, bl
+
+
+def test_high_conf_bootstrap_commits_via_serialized_path(tmp_path, monkeypatch) -> None:
+    """A high-confidence bootstrap commits one atomic commit through the shared
+    serialized/validated write path (Codex Blocker 2), and a path lock is held +
+    released around it (not leaked)."""
+    for k, v in {"GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@e.com",
+                 "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@e.com"}.items():
+        monkeypatch.setenv(k, v)
+    idx = MagicMock()
+    idx.list_by_prefix.return_value = []
+    idx.list_with_remote_url.return_value = []
+    idx.id_to_path_map.return_value = {}
+    reg, pq, pen, rl, bl = _real_bootstrap_pieces(tmp_path)
+    files = [
+        {"target_path": "projects/p/README.md",
+         "postimage": "---\nid: projects-p-README\ntype: project\nstatus: active\n"
+                      "tier: T3\n---\n# P\n"},
+        {"target_path": "projects/p/AGENTS.md",
+         "postimage": "---\nid: projects-p-AGENTS\ntype: project\nstatus: active\n"
+                      "tier: T3\n---\n# rules\n"},
+    ]
+    resp = kb_bootstrap_project_fn(
+        idx=idx, workspace="p", component=None,
+        workspace_remote_url=None, component_remote_url=None,
+        files=files, source_session="s", agent_identity="claude",
+        confidence=0.95, confidence_threshold=0.85,
+        worktrees=reg, push_queue=pq, pending=pen, rate_limiter=rl, blocklist=bl,
+    )
+    assert resp.status == "committed"
+    assert resp.commit_sha
+    assert pq.size() == 1  # one atomic commit enqueued
+    assert pen.locks_held() == 0  # all per-path locks released
+
+
+def test_high_conf_bootstrap_rejects_invalid_document(tmp_path, monkeypatch) -> None:
+    """A bootstrap file with malformed frontmatter is rejected by the validation
+    gate, and nothing is committed or left staged (Codex Blocker 2)."""
+    for k, v in {"GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@e.com",
+                 "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@e.com"}.items():
+        monkeypatch.setenv(k, v)
+    idx = MagicMock()
+    idx.list_by_prefix.return_value = []
+    idx.list_with_remote_url.return_value = []
+    idx.id_to_path_map.return_value = {}
+    reg, pq, pen, rl, bl = _real_bootstrap_pieces(tmp_path)
+    files = [
+        {"target_path": "projects/p/README.md",
+         "postimage": "---\nid: projects-p-README\ntype: project\nstatus: active\n"
+                      "tier: T3\n---\nok\n"},
+        {"target_path": "projects/p/AGENTS.md",
+         "postimage": "---\nid: broken\n# no closing fence\nbody\n"},  # malformed
+    ]
+    resp = kb_bootstrap_project_fn(
+        idx=idx, workspace="p", component=None,
+        workspace_remote_url=None, component_remote_url=None,
+        files=files, source_session="s", agent_identity="claude",
+        confidence=0.95, confidence_threshold=0.85,
+        worktrees=reg, push_queue=pq, pending=pen, rate_limiter=rl, blocklist=bl,
+    )
+    assert resp.status == "rejected_invalid_document"
+    assert pq.size() == 0
+    assert pen.locks_held() == 0  # locks released even on rejection
+    # No staged leftovers in the worktree.
+    import subprocess
+    wt = reg.get_or_create(source_session="s", agent_identity="claude")
+    st = subprocess.check_output(
+        ["git", "-C", wt.path, "status", "--porcelain"], text=True)
+    assert st.strip() == ""

--- a/tests/test_tools_onboarding.py
+++ b/tests/test_tools_onboarding.py
@@ -677,3 +677,33 @@ def test_high_conf_bootstrap_rejects_invalid_document(tmp_path, monkeypatch) -> 
     st = subprocess.check_output(
         ["git", "-C", wt.path, "status", "--porcelain"], text=True)
     assert st.strip() == ""
+
+
+def test_bootstrap_rejects_intra_bundle_duplicate_id(tmp_path, monkeypatch) -> None:
+    """Two files in one bootstrap bundle carrying the SAME effective id at
+    different paths are rejected before any commit (Codex round-2 Blocker A):
+    neither is in the index/tree yet, so per-file validation alone would miss it."""
+    for k, v in {"GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@e.com",
+                 "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@e.com"}.items():
+        monkeypatch.setenv(k, v)
+    idx = MagicMock()
+    idx.list_by_prefix.return_value = []
+    idx.list_with_remote_url.return_value = []
+    idx.id_to_path_map.return_value = {}
+    reg, pq, pen, rl, bl = _real_bootstrap_pieces(tmp_path)
+    files = [
+        {"target_path": "projects/p/README.md",
+         "postimage": "---\nid: DUP\ntype: project\nstatus: active\ntier: T3\n---\nA\n"},
+        {"target_path": "projects/p/AGENTS.md",
+         "postimage": "---\nid: DUP\ntype: project\nstatus: active\ntier: T3\n---\nB\n"},
+    ]
+    resp = kb_bootstrap_project_fn(
+        idx=idx, workspace="p", component=None,
+        workspace_remote_url=None, component_remote_url=None,
+        files=files, source_session="s", agent_identity="claude",
+        confidence=0.95, confidence_threshold=0.85,
+        worktrees=reg, push_queue=pq, pending=pen, rate_limiter=rl, blocklist=bl,
+    )
+    assert resp.status == "rejected_invalid_document"
+    assert pq.size() == 0
+    assert pen.locks_held() == 0

--- a/tests/test_tools_write.py
+++ b/tests/test_tools_write.py
@@ -762,3 +762,51 @@ def test_resolve_enqueue_failure_reports_recovery_pending(tmp_path, monkeypatch)
     assert resp.commit_sha
     assert resp.push_state == "enqueue_failed_recovery_pending"
     assert pen.size() == 0  # entry consumed (commit exists; recovery republishes)
+
+
+def test_cas_marker_with_refresh_failure_rejects_stale_base(tmp_path, monkeypatch) -> None:
+    """Codex round-5: when the caller supplied an enforceable base marker but the
+    worktree base cannot be refreshed onto origin/main, CAS cannot be verified, so
+    the write is rejected rejected_stale_base instead of committing against a
+    possibly-stale base."""
+    _set_git_env(monkeypatch)
+    git, reg, pq, pen, rl, bl = _state(tmp_path)
+    repo = git._repo
+    target, blob = _seed_t1_file(repo)
+
+    # Force refresh_base to fail (e.g. network/fetch error) for this registry.
+    def boom(_wt, **_kw):
+        raise RuntimeError("fetch_failed: origin unreachable")
+    monkeypatch.setattr(reg.git, "refresh_base", boom)
+
+    resp = kb_propose_edit_fn(
+        target_path=target, postimage="new body\n", base_commit="HEAD",
+        base_blob_sha=blob,  # enforceable marker -> refresh failure is fatal
+        target_file_hash=None, reason="fix", source_session="s",
+        agent_identity="claude", confidence=0.95, confidence_threshold=0.85,
+        worktrees=reg, push_queue=pq, pending=pen, rate_limiter=rl, blocklist=bl,
+        remote_addr="1.2.3.4",
+    )
+    assert resp.status == "rejected_stale_base"
+    assert "refreshed" in (resp.reason or "")
+    assert pq.size() == 0
+
+
+def test_no_marker_with_refresh_failure_still_commits(tmp_path, monkeypatch) -> None:
+    """A refresh failure with NO base marker (CAS is a no-op) stays non-fatal: the
+    commit sits on the unrefreshed base and the push path's non-FF recovery
+    publishes it."""
+    _set_git_env(monkeypatch)
+    git, reg, pq, pen, rl, bl = _state(tmp_path)
+
+    def boom(_wt, **_kw):
+        raise RuntimeError("fetch_failed")
+    monkeypatch.setattr(reg.git, "refresh_base", boom)
+
+    resp = kb_propose_memory_fn(
+        text="note", tags=[], source_session="s", agent_identity="claude",
+        confidence=0.95, confidence_threshold=0.85, worktrees=reg, push_queue=pq,
+        pending=pen, rate_limiter=rl, blocklist=bl, remote_addr="1.2.3.4",
+    )
+    assert resp.status == "committed"
+    assert pq.size() == 1

--- a/tests/test_tools_write.py
+++ b/tests/test_tools_write.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import os
 import subprocess
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from data_olympus.auth import PathBlocklist
@@ -487,3 +488,159 @@ def test_pending_get_rejects_traversal_id(tmp_path) -> None:
     import pytest
     with pytest.raises(PendingNotFoundError):
         pen.get("../../etc/passwd")
+
+
+# ---- 0.3.0 epic #72: CAS, validation gate, filename collision, double-resolve ----
+
+
+def _build_index(repo):
+    """Build an Index over the current repo HEAD so the validation gate has a
+    live corpus to check duplicate ids against."""
+    import tempfile
+
+    from data_olympus.index import Index
+    idx = Index(Path(tempfile.mkdtemp()) / "index.db")
+    idx.build(Path(str(repo)), source_commit="seed")
+    return idx
+
+
+def test_propose_edit_stale_base_rejected(tmp_path, monkeypatch) -> None:
+    """CAS (item 3): a base_blob_sha that does not match the current target
+    content on the refreshed base is rejected rejected_stale_base without a
+    commit."""
+    _set_git_env(monkeypatch)
+    git, reg, pq, pen, rl, bl = _state(tmp_path)
+    repo = git._repo
+    target, _real_blob = _seed_t1_file(repo)
+    # Supply a WRONG base blob sha -> stale.
+    from data_olympus.write_gate import _blob_sha
+    wrong = _blob_sha(b"content the caller wrongly believes is there\n")
+    resp = kb_propose_edit_fn(
+        target_path=target, postimage="new body\n", base_commit="HEAD",
+        base_blob_sha=wrong, target_file_hash=None, reason="fix",
+        source_session="s", agent_identity="claude", confidence=0.95,
+        confidence_threshold=0.85, worktrees=reg, push_queue=pq, pending=pen,
+        rate_limiter=rl, blocklist=bl, remote_addr="1.2.3.4",
+    )
+    assert resp.status == "rejected_stale_base"
+    assert pq.size() == 0
+
+
+def test_propose_edit_correct_base_commits(tmp_path, monkeypatch) -> None:
+    """CAS pass-through: the correct base_blob_sha commits normally."""
+    _set_git_env(monkeypatch)
+    git, reg, pq, pen, rl, bl = _state(tmp_path)
+    repo = git._repo
+    target, blob = _seed_t1_file(repo)
+    # blob from _seed_t1_file is the ls-tree blob of the seeded content, which is
+    # what the session worktree's base holds. It must match.
+    resp = kb_propose_edit_fn(
+        target_path=target, postimage="new body\n", base_commit="HEAD",
+        base_blob_sha=blob, target_file_hash=None, reason="fix",
+        source_session="s", agent_identity="claude", confidence=0.95,
+        confidence_threshold=0.85, worktrees=reg, push_queue=pq, pending=pen,
+        rate_limiter=rl, blocklist=bl, remote_addr="1.2.3.4",
+    )
+    assert resp.status == "committed"
+    assert pq.size() == 1
+
+
+def test_propose_edit_malformed_yaml_rejected(tmp_path, monkeypatch) -> None:
+    """Validation gate (item 4): a postimage with unterminated frontmatter is
+    rejected rejected_invalid_document, not committed."""
+    _set_git_env(monkeypatch)
+    git, reg, pq, pen, rl, bl = _state(tmp_path)
+    idx = _build_index(git._repo)
+    resp = kb_propose_edit_fn(
+        target_path="universal/foundation/STD-U-099.md",
+        postimage="---\nid: X\n# never closed\nbody\n",
+        base_commit="HEAD", base_blob_sha=None, target_file_hash=None,
+        reason="", source_session="s", agent_identity="claude", confidence=0.95,
+        confidence_threshold=0.85, worktrees=reg, push_queue=pq, pending=pen,
+        rate_limiter=rl, blocklist=bl, remote_addr="1.2.3.4", idx=idx,
+    )
+    assert resp.status == "rejected_invalid_document"
+    assert pq.size() == 0
+
+
+def test_propose_edit_duplicate_id_rejected(tmp_path, monkeypatch) -> None:
+    """Validation gate (item 4): a forged duplicate id (already used at a
+    different path) is rejected so the next index rebuild cannot break."""
+    _set_git_env(monkeypatch)
+    git, reg, pq, pen, rl, bl = _state(tmp_path)
+    repo = git._repo
+    # Seed STD-U-001 in the repo so the index knows that id -> that path.
+    _seed_t1_file(repo)
+    idx = _build_index(repo)
+    forged = "---\nid: STD-U-001\ntype: standard\nstatus: active\ntier: T1\n---\nforged\n"
+    resp = kb_propose_edit_fn(
+        target_path="decisions/DEC-forged.md", postimage=forged,
+        base_commit="HEAD", base_blob_sha=None, target_file_hash=None,
+        reason="", source_session="s", agent_identity="claude", confidence=0.95,
+        confidence_threshold=0.85, worktrees=reg, push_queue=pq, pending=pen,
+        rate_limiter=rl, blocklist=bl, remote_addr="1.2.3.4", idx=idx,
+    )
+    assert resp.status == "rejected_invalid_document"
+    assert "already used" in (resp.reason or "").lower()
+    assert pq.size() == 0
+
+
+def test_memory_filename_collision_distinct_sessions(tmp_path, monkeypatch) -> None:
+    """item 6: two same-day, same-slug memories from DIFFERENT sessions get
+    distinct filenames (the uniquifier), so neither overwrites the other."""
+    _set_git_env(monkeypatch)
+    git, reg, pq, pen, rl, bl = _state(tmp_path)
+    common = dict(
+        text="daily standup note", tags=[], confidence=0.95,
+        confidence_threshold=0.85, worktrees=reg, push_queue=pq, pending=pen,
+        rate_limiter=SlidingWindowLimiter(max_per_hour=100), blocklist=bl,
+        remote_addr="1.2.3.4",
+    )
+    r1 = kb_propose_memory_fn(source_session="session-A", agent_identity="claude",
+                              **common)
+    r2 = kb_propose_memory_fn(source_session="session-B", agent_identity="claude",
+                              **common)
+    assert r1.status == "committed"
+    assert r2.status == "committed"
+    # Both files exist under memory/inbox with DIFFERENT names.
+    import glob
+    wt_a = reg.get_or_create(source_session="session-A", agent_identity="claude")
+    wt_b = reg.get_or_create(source_session="session-B", agent_identity="claude")
+    files_a = {os.path.basename(p)
+               for p in glob.glob(os.path.join(wt_a.path, "memory", "inbox", "*.md"))}
+    files_b = {os.path.basename(p)
+               for p in glob.glob(os.path.join(wt_b.path, "memory", "inbox", "*.md"))}
+    assert files_a and files_b
+    assert files_a != files_b  # distinct filenames, no silent overwrite
+
+
+def test_double_resolve_second_reports_already_resolved_or_not_found(
+    tmp_path, monkeypatch,
+) -> None:
+    """item 5: after one resolve commits, a second resolve of the same id does
+    NOT produce a second commit. The loser surfaces already_resolved (concurrent
+    window) or PendingNotFoundError (sequential, entry gone)."""
+    _set_git_env(monkeypatch)
+    from data_olympus.pending import PendingNotFoundError
+    git, reg, pq, pen, rl, bl = _state(tmp_path)
+    m = kb_propose_memory_fn(
+        text="a memory", tags=[], source_session="s", agent_identity="claude",
+        confidence=0.3, confidence_threshold=0.85, worktrees=reg, push_queue=pq,
+        pending=pen, rate_limiter=rl, blocklist=bl, remote_addr="1.2.3.4",
+    )
+    first = kb_resolve_pending_fn(
+        pending_id=m.pending_id, decision="approve", edited_text=None,
+        worktrees=reg, push_queue=pq, pending=pen,
+        source_session="s", agent_identity="operator",
+    )
+    assert first.status == "committed"
+    assert pq.size() == 1
+    import pytest
+    with pytest.raises(PendingNotFoundError):
+        kb_resolve_pending_fn(
+            pending_id=m.pending_id, decision="approve", edited_text=None,
+            worktrees=reg, push_queue=pq, pending=pen,
+            source_session="s", agent_identity="operator",
+        )
+    # Still exactly one commit enqueued.
+    assert pq.size() == 1

--- a/tests/test_tools_write.py
+++ b/tests/test_tools_write.py
@@ -644,3 +644,38 @@ def test_double_resolve_second_reports_already_resolved_or_not_found(
         )
     # Still exactly one commit enqueued.
     assert pq.size() == 1
+
+
+# ---- Codex round-2 Blocker B: resolve gate rejection restores the pending entry ----
+
+
+def test_resolve_stale_base_restores_pending_entry(tmp_path, monkeypatch) -> None:
+    """If CAS rejects during a resolve, the pending entry is put back (not lost)
+    and the path lock stays held, so the operator can re-resolve it."""
+    _set_git_env(monkeypatch)
+    from data_olympus.write_gate import _blob_sha
+    git, reg, pq, pen, rl, bl = _state(tmp_path)
+    repo = git._repo
+    target, _blob = _seed_t1_file(repo)
+    # Park a low-conf edit as pending with a STALE base_blob_sha so the resolve's
+    # CAS gate rejects it.
+    stale = _blob_sha(b"content the proposer wrongly believed\n")
+    m = kb_propose_edit_fn(
+        target_path=target, postimage="new body\n", base_commit="HEAD",
+        base_blob_sha=stale, target_file_hash=None, reason="lowconf",
+        source_session="s", agent_identity="claude", confidence=0.3,
+        confidence_threshold=0.85, worktrees=reg, push_queue=pq, pending=pen,
+        rate_limiter=rl, blocklist=bl, remote_addr="1.2.3.4",
+    )
+    assert m.status == "pending_confirmation"
+    assert pen.size() == 1
+    resp = kb_resolve_pending_fn(
+        pending_id=m.pending_id, decision="approve", edited_text=None,
+        worktrees=reg, push_queue=pq, pending=pen,
+        source_session="s", agent_identity="operator",
+    )
+    assert resp.status == "rejected_stale_base"
+    assert pq.size() == 0
+    # The entry is restored (not consumed) so it can be re-resolved.
+    assert pen.size() == 1
+    assert pen.locks_held() == 1  # path lock still held by the restored entry

--- a/tests/test_tools_write.py
+++ b/tests/test_tools_write.py
@@ -734,3 +734,31 @@ def test_enqueue_recovery_retry_succeeds_reports_queued(tmp_path, monkeypatch) -
     assert resp.status == "committed"
     assert resp.push_state == "queued"
     assert fq.enqueued == [resp.commit_sha]
+
+
+def test_resolve_enqueue_failure_reports_recovery_pending(tmp_path, monkeypatch) -> None:
+    """Codex round-4: a resolve whose post-commit enqueue fails surfaces the
+    truthful push_state on ResolvePendingResponse (not a bare committed), while
+    still consuming the pending entry (the commit is durable)."""
+    _set_git_env(monkeypatch)
+    git, reg, pq, pen, rl, bl = _state(tmp_path)
+    # Park a low-conf memory as pending using the real queue.
+    m = kb_propose_memory_fn(
+        text="note", tags=[], source_session="s", agent_identity="claude",
+        confidence=0.3, confidence_threshold=0.85, worktrees=reg, push_queue=pq,
+        pending=pen, rate_limiter=rl, blocklist=bl, remote_addr="1.2.3.4",
+    )
+
+    class FailingPushQueue:
+        def enqueue(self, **_kwargs):
+            raise OSError("state volume full")
+
+    resp = kb_resolve_pending_fn(
+        pending_id=m.pending_id, decision="approve", edited_text=None,
+        worktrees=reg, push_queue=FailingPushQueue(), pending=pen,
+        source_session="s", agent_identity="operator",
+    )
+    assert resp.status == "committed"
+    assert resp.commit_sha
+    assert resp.push_state == "enqueue_failed_recovery_pending"
+    assert pen.size() == 0  # entry consumed (commit exists; recovery republishes)

--- a/tests/test_tools_write.py
+++ b/tests/test_tools_write.py
@@ -679,3 +679,58 @@ def test_resolve_stale_base_restores_pending_entry(tmp_path, monkeypatch) -> Non
     # The entry is restored (not consumed) so it can be re-resolved.
     assert pen.size() == 1
     assert pen.locks_held() == 1  # path lock still held by the restored entry
+
+
+# ---- Codex round-3: truthful push_state on post-commit enqueue failure ----
+
+
+def test_enqueue_failure_reports_recovery_pending_not_queued(tmp_path, monkeypatch) -> None:
+    """If BOTH the enqueue and the in-process recovery re-enqueue fail after a
+    successful commit, the response push_state is the truthful
+    enqueue_failed_recovery_pending (not 'queued'), and the commit still exists
+    (recoverable by init_recovery)."""
+    _set_git_env(monkeypatch)
+    git, reg, pq, pen, rl, bl = _state(tmp_path)
+
+    class FailingPushQueue:
+        def enqueue(self, **_kwargs):
+            raise OSError("state volume full")
+
+    resp = kb_propose_memory_fn(
+        text="a note", tags=[], source_session="s", agent_identity="claude",
+        confidence=0.95, confidence_threshold=0.85, worktrees=reg,
+        push_queue=FailingPushQueue(), pending=pen, rate_limiter=rl, blocklist=bl,
+        remote_addr="1.2.3.4",
+    )
+    assert resp.status == "committed"
+    assert resp.commit_sha  # the commit was made and is durable
+    assert resp.push_state == "enqueue_failed_recovery_pending"
+
+
+def test_enqueue_recovery_retry_succeeds_reports_queued(tmp_path, monkeypatch) -> None:
+    """If the first enqueue fails but the in-process recovery retry succeeds, the
+    push_state is 'queued' (the entry landed)."""
+    _set_git_env(monkeypatch)
+    git, reg, pq, pen, rl, bl = _state(tmp_path)
+
+    class FlakyPushQueue:
+        def __init__(self):
+            self.calls = 0
+            self.enqueued = []
+
+        def enqueue(self, **kwargs):
+            self.calls += 1
+            if self.calls == 1:
+                raise OSError("transient")
+            self.enqueued.append(kwargs["sha"])
+
+    fq = FlakyPushQueue()
+    resp = kb_propose_memory_fn(
+        text="a note", tags=[], source_session="s", agent_identity="claude",
+        confidence=0.95, confidence_threshold=0.85, worktrees=reg,
+        push_queue=fq, pending=pen, rate_limiter=rl, blocklist=bl,
+        remote_addr="1.2.3.4",
+    )
+    assert resp.status == "committed"
+    assert resp.push_state == "queued"
+    assert fq.enqueued == [resp.commit_sha]

--- a/tests/test_write_gate.py
+++ b/tests/test_write_gate.py
@@ -283,3 +283,20 @@ def test_cas_head_sentinel_stays_advisory(tmp_path) -> None:
     r = check_cas(worktree_path=str(tmp_path), target_path="f.md",
                   base_commit="HEAD", base_blob_sha=None, target_file_hash=None)
     assert r.ok
+
+
+# ---- Codex round-2 Concern 1: unknown base_commit rejected (not conflated) ----
+
+
+def test_cas_unknown_base_commit_rejected(tmp_path) -> None:
+    """A pinned base_commit that does not resolve to a commit is not an enforceable
+    base and is rejected, instead of passing via the "" == "" absent-file path."""
+    import subprocess as sp
+    wt = tmp_path / "wt"
+    wt.mkdir()
+    sp.run(["git", "init", "--initial-branch=main", str(wt)], check=True, env=_env())
+    # target does not exist; caller supplies an unknown commit sha.
+    r = check_cas(worktree_path=str(wt), target_path="new.md",
+                  base_commit="0" * 40, base_blob_sha=None, target_file_hash=None)
+    assert not r.ok
+    assert "unknown" in r.reason.lower()

--- a/tests/test_write_gate.py
+++ b/tests/test_write_gate.py
@@ -171,3 +171,115 @@ def test_rendered_memory_passes_validation() -> None:
     r = validate_postimage(target_path="memory/inbox/2026-07-03-a-memory-abc.md",
                            postimage=out, idx=None)
     assert r.ok
+
+
+# ---- Codex Blocker 1 hardening: derived-id, reserved-file, concurrent same-id ----
+
+
+def test_validate_rejects_reserved_file_with_colliding_id(tmp_path) -> None:
+    """A reserved index.md carrying an explicit id that collides with an existing
+    doc must be rejected: the indexer still assigns reserved files an id, so this
+    would break the rebuild (Codex Blocker 1)."""
+    idx = _index_with(tmp_path, {
+        "universal/foundation/STD-U-001.md":
+            "---\nid: STD-U-001\ntype: standard\nstatus: active\ntier: T1\n---\nA\n",
+    })
+    forged_index = "---\nid: STD-U-001\n---\n# Index\n\n- listing\n"
+    r = validate_postimage(target_path="decisions/index.md",
+                           postimage=forged_index, idx=idx)
+    assert not r.ok
+    assert any(e["code"] == "duplicate_id" for e in r.errors)
+
+
+def test_validate_rejects_derived_id_collision_with_explicit_id(tmp_path) -> None:
+    """A NEW file with no explicit id whose PATH-DERIVED id equals an existing
+    explicit id must be rejected (the rebuild derives the same id and collides)."""
+    # Seed a doc whose explicit id is exactly the path-derived id of the new file.
+    idx = _index_with(tmp_path, {
+        "decisions/DEC-1.md":
+            "---\nid: memory-inbox-collide\ntype: decision\nstatus: accepted\n"
+            "tier: meta\n---\nA\n",
+    })
+    # New memory at memory/inbox/collide.md derives id 'memory-inbox-collide'.
+    r = validate_postimage(target_path="memory/inbox/collide.md",
+                           postimage="no frontmatter body\n", idx=idx)
+    assert not r.ok
+    assert any(e["code"] == "duplicate_id" for e in r.errors)
+
+
+def test_validate_worktree_scan_catches_same_new_id_before_reindex(tmp_path) -> None:
+    """Two writes introducing the same NEW id: the second must be rejected even
+    though the live index has neither yet, because the first is already committed
+    in the worktree tree (Codex Blocker 1, concurrent case)."""
+    import subprocess as sp
+    wt = tmp_path / "wt"
+    wt.mkdir()
+    sp.run(["git", "init", "--initial-branch=main", str(wt)], check=True, env=_env())
+    first = wt / "decisions" / "DEC-first.md"
+    first.parent.mkdir(parents=True)
+    first.write_text("---\nid: DEC-DUP\ntype: decision\nstatus: accepted\n"
+                     "tier: meta\n---\nfirst\n")
+    sp.run(["git", "add", "-A"], cwd=str(wt), check=True, env=_env())
+    sp.run(["git", "commit", "-m", "first"], cwd=str(wt), check=True, env=_env())
+    # A second write reusing DEC-DUP at a different path, with NO live index.
+    r = validate_postimage(
+        target_path="decisions/DEC-second.md",
+        postimage="---\nid: DEC-DUP\ntype: decision\nstatus: accepted\n"
+                  "tier: meta\n---\nsecond\n",
+        idx=None, worktree_path=str(wt),
+    )
+    assert not r.ok
+    assert any(e["code"] == "duplicate_id" for e in r.errors)
+
+
+# ---- Codex Blocker 3: base_commit-only CAS enforcement ----
+
+
+def test_cas_stale_base_commit_rejected(tmp_path) -> None:
+    """A base_commit naming a SPECIFIC commit whose target content differs from the
+    current worktree content is stale and rejected, even with no blob/file-hash
+    marker (Codex Blocker 3)."""
+    import subprocess as sp
+    wt = tmp_path / "wt"
+    wt.mkdir()
+    sp.run(["git", "init", "--initial-branch=main", str(wt)], check=True, env=_env())
+    f = wt / "f.md"
+    f.write_text("version 1\n")
+    sp.run(["git", "add", "-A"], cwd=str(wt), check=True, env=_env())
+    sp.run(["git", "commit", "-m", "v1"], cwd=str(wt), check=True, env=_env())
+    old = sp.check_output(["git", "-C", str(wt), "rev-parse", "HEAD"],
+                          text=True).strip()
+    # Advance the file so the current content differs from `old`.
+    f.write_text("version 2\n")
+    sp.run(["git", "add", "-A"], cwd=str(wt), check=True, env=_env())
+    sp.run(["git", "commit", "-m", "v2"], cwd=str(wt), check=True, env=_env())
+    # Caller claims base_commit=old (stale) with no blob marker.
+    r = check_cas(worktree_path=str(wt), target_path="f.md",
+                  base_commit=old, base_blob_sha=None, target_file_hash=None)
+    assert not r.ok
+    assert "base_commit mismatch" in r.reason
+
+
+def test_cas_current_base_commit_accepted(tmp_path) -> None:
+    """A base_commit whose target content matches the current content passes."""
+    import subprocess as sp
+    wt = tmp_path / "wt"
+    wt.mkdir()
+    sp.run(["git", "init", "--initial-branch=main", str(wt)], check=True, env=_env())
+    f = wt / "f.md"
+    f.write_text("stable\n")
+    sp.run(["git", "add", "-A"], cwd=str(wt), check=True, env=_env())
+    sp.run(["git", "commit", "-m", "v1"], cwd=str(wt), check=True, env=_env())
+    head = sp.check_output(["git", "-C", str(wt), "rev-parse", "HEAD"],
+                           text=True).strip()
+    r = check_cas(worktree_path=str(wt), target_path="f.md",
+                  base_commit=head, base_blob_sha=None, target_file_hash=None)
+    assert r.ok
+
+
+def test_cas_head_sentinel_stays_advisory(tmp_path) -> None:
+    """base_commit='HEAD' carries no per-file expectation and stays a no-op."""
+    (tmp_path / "f.md").write_bytes(b"anything\n")
+    r = check_cas(worktree_path=str(tmp_path), target_path="f.md",
+                  base_commit="HEAD", base_blob_sha=None, target_file_hash=None)
+    assert r.ok

--- a/tests/test_write_gate.py
+++ b/tests/test_write_gate.py
@@ -1,0 +1,173 @@
+"""Unit tests for the write-integrity gates: CAS and content validation
+(0.3.0 epic #72 scope items 3 and 4)."""
+from __future__ import annotations
+
+import hashlib
+import os
+import subprocess
+
+from data_olympus.index import Index
+from data_olympus.write_gate import (
+    _blob_sha,
+    check_cas,
+    validate_postimage,
+)
+
+
+def _env() -> dict[str, str]:
+    return {**os.environ, "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@e.com",
+            "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@e.com"}
+
+
+# ---- CAS (item 3) ----
+
+
+def test_cas_noop_when_no_base_marker(tmp_path) -> None:
+    """No base marker supplied -> CAS is a no-op (preserves pre-0.3.0 behavior)."""
+    r = check_cas(worktree_path=str(tmp_path), target_path="x.md",
+                  base_commit=None, base_blob_sha=None, target_file_hash=None)
+    assert r.ok
+    # A bare base_commit is advisory, not enforced.
+    r2 = check_cas(worktree_path=str(tmp_path), target_path="x.md",
+                   base_commit="HEAD", base_blob_sha=None, target_file_hash=None)
+    assert r2.ok
+
+
+def test_cas_blob_sha_matches_current_content(tmp_path) -> None:
+    content = b"---\nid: STD\ntier: T1\n---\nbody\n"
+    (tmp_path / "f.md").write_bytes(content)
+    r = check_cas(worktree_path=str(tmp_path), target_path="f.md",
+                  base_commit=None, base_blob_sha=_blob_sha(content),
+                  target_file_hash=None)
+    assert r.ok
+
+
+def test_cas_blob_sha_mismatch_rejected(tmp_path) -> None:
+    (tmp_path / "f.md").write_bytes(b"new content on disk\n")
+    stale = _blob_sha(b"what the caller believed\n")
+    r = check_cas(worktree_path=str(tmp_path), target_path="f.md",
+                  base_commit=None, base_blob_sha=stale, target_file_hash=None)
+    assert not r.ok
+    assert "base_blob_sha mismatch" in r.reason
+
+
+def test_cas_file_hash_mismatch_rejected(tmp_path) -> None:
+    (tmp_path / "f.md").write_bytes(b"actual\n")
+    stale_h = hashlib.sha256(b"expected\n").hexdigest()
+    r = check_cas(worktree_path=str(tmp_path), target_path="f.md",
+                  base_commit=None, base_blob_sha=None, target_file_hash=stale_h)
+    assert not r.ok
+    assert "target_file_hash mismatch" in r.reason
+
+
+def test_cas_claiming_base_for_absent_file_rejected(tmp_path) -> None:
+    """A caller that supplies a blob sha for a file that does not exist on the
+    refreshed base is stale (the file was deleted or never existed)."""
+    r = check_cas(worktree_path=str(tmp_path), target_path="missing.md",
+                  base_commit=None, base_blob_sha=_blob_sha(b"x"),
+                  target_file_hash=None)
+    assert not r.ok
+
+
+# ---- content validation gate (item 4) ----
+
+
+def _index_with(tmp_path, files: dict[str, str]) -> Index:
+    kb = tmp_path / "kb"
+    kb.mkdir(parents=True, exist_ok=True)
+    for rel, content in files.items():
+        p = kb / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content)
+    subprocess.run(["git", "init", "--initial-branch=main"], cwd=kb, check=True,
+                   env=_env())
+    subprocess.run(["git", "add", "-A"], cwd=kb, check=True, env=_env())
+    subprocess.run(["git", "commit", "--allow-empty", "-m", "seed"], cwd=kb,
+                   check=True, env=_env())
+    idx = Index(tmp_path / "index.db")
+    idx.build(kb, source_commit="seed")
+    return idx
+
+
+def test_validate_accepts_wellformed_document(tmp_path) -> None:
+    idx = _index_with(tmp_path, {})
+    good = "---\nid: STD-U-050\ntype: standard\nstatus: active\ntier: T1\n---\n# body\n"
+    r = validate_postimage(target_path="universal/foundation/STD-U-050.md",
+                           postimage=good, idx=idx)
+    assert r.ok
+
+
+def test_validate_rejects_malformed_yaml(tmp_path) -> None:
+    idx = _index_with(tmp_path, {})
+    # Unterminated frontmatter block.
+    bad = "---\nid: X\ntier: T1\n# no closing delimiter\nbody\n"
+    r = validate_postimage(target_path="universal/foundation/X.md",
+                           postimage=bad, idx=idx)
+    assert not r.ok
+    assert any(e["code"] == "invalid_frontmatter" for e in r.errors)
+
+
+def test_validate_rejects_invalid_enum(tmp_path) -> None:
+    idx = _index_with(tmp_path, {})
+    bad = "---\nid: Y\ntype: nonsense\nstatus: active\ntier: T9\n---\nbody\n"
+    r = validate_postimage(target_path="universal/foundation/Y.md",
+                           postimage=bad, idx=idx)
+    assert not r.ok
+    codes = {e["code"] for e in r.errors}
+    assert codes == {"invalid_enum"}
+    fields = {e["field"] for e in r.errors}
+    assert fields == {"type", "tier"}
+
+
+def test_validate_rejects_duplicate_id_at_different_path(tmp_path) -> None:
+    """A frontmatter id already used by a DIFFERENT path corrupts the next
+    index rebuild (DuplicateIdError). Reject it (item 4)."""
+    idx = _index_with(tmp_path, {
+        "universal/foundation/STD-U-001.md":
+            "---\nid: STD-U-001\ntype: standard\nstatus: active\ntier: T1\n---\nA\n",
+    })
+    forged = "---\nid: STD-U-001\ntype: standard\nstatus: active\ntier: T1\n---\nB\n"
+    r = validate_postimage(
+        target_path="decisions/DEC-forged.md", postimage=forged, idx=idx)
+    assert not r.ok
+    assert any(e["code"] == "duplicate_id" for e in r.errors)
+
+
+def test_validate_allows_same_id_same_path_edit(tmp_path) -> None:
+    """An id that resolves to the SAME path is a legitimate edit-in-place."""
+    idx = _index_with(tmp_path, {
+        "universal/foundation/STD-U-001.md":
+            "---\nid: STD-U-001\ntype: standard\nstatus: active\ntier: T1\n---\nA\n",
+    })
+    edited = "---\nid: STD-U-001\ntype: standard\nstatus: active\ntier: T1\n---\nEDITED\n"
+    r = validate_postimage(
+        target_path="universal/foundation/STD-U-001.md", postimage=edited, idx=idx)
+    assert r.ok
+
+
+def test_validate_allows_memory_without_required_fields(tmp_path) -> None:
+    """Memory-inbox documents legitimately carry no id/type/status/tier; the gate
+    must not reject them just for being sparse (only actively malformed docs)."""
+    idx = _index_with(tmp_path, {})
+    mem = "---\ncreated_by: claude\ncreated_at: '2026-07-03T00:00:00+00:00'\n---\n\nnote\n"
+    r = validate_postimage(target_path="memory/inbox/2026-07-03-note-abc123.md",
+                           postimage=mem, idx=idx)
+    assert r.ok
+
+
+def test_validate_reserved_file_exempt_from_schema(tmp_path) -> None:
+    idx = _index_with(tmp_path, {})
+    # index.md is reserved; no frontmatter at all is fine.
+    r = validate_postimage(target_path="decisions/index.md",
+                           postimage="# Index\n\n- listing\n", idx=idx)
+    assert r.ok
+
+
+def test_rendered_memory_passes_validation() -> None:
+    """The _render_memory output must pass the gate (cheap self-check, item 4)."""
+    from data_olympus.tools_write import _render_memory
+    out = _render_memory(text="a memory body", tags=["x", "y"],
+                         agent_identity="claude")
+    r = validate_postimage(target_path="memory/inbox/2026-07-03-a-memory-abc.md",
+                           postimage=out, idx=None)
+    assert r.ok

--- a/tests/test_write_pipeline_integration.py
+++ b/tests/test_write_pipeline_integration.py
@@ -1,0 +1,254 @@
+"""Integration tests for the 0.3.0 write-pipeline core (epic #72).
+
+These exercise the whole write path against REAL git repos and a shared bare
+remote, per the epic's acceptance criteria:
+
+- Two-session interleaved write: both writes publish (one via non-FF rebase
+  recovery), none lost, push queue drains to empty.
+- Rebase-conflict demotion: a commit that cannot rebase cleanly is demoted to a
+  pending entry instead of retrying forever, with a distinct audit event.
+- Threaded concurrent auto-commit on one session/one path: no interleaved
+  commits, the per-path lock is respected across the write path.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import threading
+
+from data_olympus.audit_log import AuditLog
+from data_olympus.auth import PathBlocklist
+from data_olympus.git_ops import GitOps
+from data_olympus.pending import PendingQueue
+from data_olympus.push_queue import PushQueue
+from data_olympus.rate_limit import SlidingWindowLimiter
+from data_olympus.refresh import demote_conflict_to_pending
+from data_olympus.tools_write import kb_propose_edit_fn
+from data_olympus.worktrees import WorktreeRegistry
+from data_olympus.write_gate import WriteSerializer
+
+
+def _env() -> dict[str, str]:
+    return {**os.environ, "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@e.com",
+            "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@e.com"}
+
+
+def _run(*args: str, cwd: str) -> None:
+    subprocess.run(list(args), cwd=cwd, check=True, env=_env(),
+                   capture_output=True)
+
+
+def _bare_remote_with_clone(tmp_path):
+    """Create a bare remote + a clone that will act as the server's main repo.
+    Returns (remote_path, main_repo_path). The main repo has one seed commit on
+    origin/main with a T1 file the tests edit."""
+    remote = tmp_path / "remote.git"
+    subprocess.run(["git", "init", "--bare", "--initial-branch=main", str(remote)],
+                   check=True, env=_env())
+    main = tmp_path / "main"
+    subprocess.run(["git", "clone", str(remote), str(main)], check=True,
+                   env=_env(), capture_output=True)
+    seed = main / "universal" / "foundation" / "STD-U-001.md"
+    seed.parent.mkdir(parents=True)
+    seed.write_text("---\nid: STD-U-001\ntype: standard\nstatus: active\ntier: T1\n"
+                    "---\nbase body\n")
+    _run("git", "add", "-A", cwd=str(main))
+    _run("git", "commit", "-m", "seed", cwd=str(main))
+    _run("git", "push", "origin", "main", cwd=str(main))
+    return remote, main
+
+
+def _server_pieces(tmp_path, main):
+    git = GitOps(main)
+    reg = WorktreeRegistry(git=git, worktree_root=str(tmp_path / "wts"))
+    pq = PushQueue(queue_root=str(tmp_path / "push-q"))
+    pen = PendingQueue(pending_root=str(tmp_path / "pending"))
+    rl = SlidingWindowLimiter(max_per_hour=1000)
+    bl = PathBlocklist(tier_blocks=[], path_blocks=[])
+    return git, reg, pq, pen, rl, bl
+
+
+def test_two_session_interleaved_writes_both_publish(tmp_path, monkeypatch) -> None:
+    """Two overlapping sessions each auto-commit an edit to DIFFERENT files. A
+    second real clone pushes to origin/main between them so the second session's
+    push is non-fast-forward. Both must end up on origin/main (one via rebase
+    recovery); neither is lost; the push queue drains to empty."""
+    for k, v in _env().items():
+        if k.startswith("GIT_"):
+            monkeypatch.setenv(k, v)
+    remote, main = _bare_remote_with_clone(tmp_path)
+    git, reg, pq, pen, rl, bl = _server_pieces(tmp_path, main)
+    serializer = WriteSerializer()
+
+    # Session A commits an edit to file-a.md.
+    ra = kb_propose_edit_fn(
+        target_path="decisions/DEC-a.md",
+        postimage="---\nid: DEC-a\ntype: decision\nstatus: accepted\ntier: meta\n"
+                  "---\nA content\n",
+        base_commit="HEAD", base_blob_sha=None, target_file_hash=None,
+        reason="a", source_session="session-A", agent_identity="claude",
+        confidence=0.95, confidence_threshold=0.85, worktrees=reg, push_queue=pq,
+        pending=pen, rate_limiter=rl, blocklist=bl, remote_addr="1.1.1.1",
+        serializer=serializer,
+    )
+    assert ra.status == "committed"
+
+    # A SECOND real clone pushes an unrelated commit to origin/main, moving it
+    # forward so session A's (and B's) push will be non-fast-forward.
+    other = tmp_path / "other-clone"
+    subprocess.run(["git", "clone", str(remote), str(other)], check=True,
+                   env=_env(), capture_output=True)
+    (other / "outside.md").write_text("from another writer\n")
+    _run("git", "add", "-A", cwd=str(other))
+    _run("git", "commit", "-m", "outside commit", cwd=str(other))
+    _run("git", "push", "origin", "main", cwd=str(other))
+
+    # Session B commits an edit to a different file, on a base that is now stale.
+    rb = kb_propose_edit_fn(
+        target_path="decisions/DEC-b.md",
+        postimage="---\nid: DEC-b\ntype: decision\nstatus: accepted\ntier: meta\n"
+                  "---\nB content\n",
+        base_commit="HEAD", base_blob_sha=None, target_file_hash=None,
+        reason="b", source_session="session-B", agent_identity="claude",
+        confidence=0.95, confidence_threshold=0.85, worktrees=reg, push_queue=pq,
+        pending=pen, rate_limiter=rl, blocklist=bl, remote_addr="2.2.2.2",
+        serializer=serializer,
+    )
+    assert rb.status == "committed"
+    assert pq.size() == 2
+
+    # Drain the push queue: A pushes (non-FF now because origin moved), triggering
+    # rebase recovery; B likewise. Both must publish. Retry a few times to let
+    # the non-FF -> rebase -> retry sequence settle deterministically.
+    for _ in range(5):
+        pq.drain(
+            push_fn=lambda wt: git.push_with_rebase_recovery(wt, timeout_sec=30),
+            max_attempts=10,
+        )
+        if pq.size() == 0:
+            break
+
+    assert pq.size() == 0, "both writes must publish; queue must be empty"
+
+    # origin/main now carries the outside commit AND both session files.
+    _run("git", "fetch", "origin", "main", cwd=str(main))
+    files = subprocess.check_output(
+        ["git", "ls-tree", "-r", "--name-only", "origin/main"],
+        cwd=str(main), text=True, env=_env(),
+    ).split()
+    assert "decisions/DEC-a.md" in files
+    assert "decisions/DEC-b.md" in files
+    assert "outside.md" in files
+
+
+def test_rebase_conflict_demotes_to_pending(tmp_path, monkeypatch) -> None:
+    """A commit that conflicts on rebase (same file, incompatible content moved
+    origin/main) is demoted to a pending entry with a distinct audit event, not
+    retried forever."""
+    for k, v in _env().items():
+        if k.startswith("GIT_"):
+            monkeypatch.setenv(k, v)
+    remote, main = _bare_remote_with_clone(tmp_path)
+    git, reg, pq, pen, rl, bl = _server_pieces(tmp_path, main)
+    audit = AuditLog(log_path=str(tmp_path / "audit.log"), hmac_key="")
+    serializer = WriteSerializer()
+
+    # Session A edits the shared STD-U-001 file.
+    ra = kb_propose_edit_fn(
+        target_path="universal/foundation/STD-U-001.md",
+        postimage="---\nid: STD-U-001\ntype: standard\nstatus: active\ntier: T1\n"
+                  "---\nSESSION A rewrite\n",
+        base_commit="HEAD", base_blob_sha=None, target_file_hash=None,
+        reason="a", source_session="session-A", agent_identity="claude",
+        confidence=0.95, confidence_threshold=0.85, worktrees=reg, push_queue=pq,
+        pending=pen, rate_limiter=rl, blocklist=bl, remote_addr="1.1.1.1",
+        serializer=serializer, audit_log=audit,
+    )
+    assert ra.status == "committed"
+
+    # Another writer pushes an INCOMPATIBLE change to the SAME file -> A's commit
+    # cannot rebase cleanly.
+    other = tmp_path / "other-clone"
+    subprocess.run(["git", "clone", str(remote), str(other)], check=True,
+                   env=_env(), capture_output=True)
+    (other / "universal" / "foundation" / "STD-U-001.md").write_text(
+        "---\nid: STD-U-001\ntype: standard\nstatus: active\ntier: T1\n"
+        "---\nOTHER WRITER rewrite\n")
+    _run("git", "add", "-A", cwd=str(other))
+    _run("git", "commit", "-m", "conflicting", cwd=str(other))
+    _run("git", "push", "origin", "main", cwd=str(other))
+
+    def on_conflict(entry):
+        demote_conflict_to_pending(entry, git=git, pending=pen, audit_log=audit)
+
+    pq.drain(
+        push_fn=lambda wt: git.push_with_rebase_recovery(wt, timeout_sec=30),
+        max_attempts=10,
+        on_rebase_conflict=on_conflict,
+    )
+
+    # The queue entry was removed (demoted), a pending entry now exists.
+    assert pq.size() == 0
+    assert pen.size() == 1
+    pending_list = pen.list()
+    assert pending_list[0]["target_path"] == "universal/foundation/STD-U-001.md"
+
+    # A push_conflict_demoted audit event was recorded.
+    events = list(audit.iter_filtered())
+    kinds = {e.get("event_type") for e in events}
+    assert "push_conflict_demoted" in kinds
+
+
+def test_threaded_concurrent_writes_one_path_no_interleave(
+    tmp_path, monkeypatch,
+) -> None:
+    """Two threads auto-commit edits to the SAME path in one session. The
+    per-path advisory lock (shared with the pending queue) plus the process-wide
+    write serializer must prevent interleaved commits: exactly one wins the lock
+    per instant, the other either commits after or is rejected path_lock_busy;
+    never a corrupt/mixed commit. The repo history must stay linear and clean."""
+    for k, v in _env().items():
+        if k.startswith("GIT_"):
+            monkeypatch.setenv(k, v)
+    _remote, main = _bare_remote_with_clone(tmp_path)
+    git, reg, pq, pen, rl, bl = _server_pieces(tmp_path, main)
+    serializer = WriteSerializer()
+
+    results: list[str] = []
+    lock = threading.Lock()
+    barrier = threading.Barrier(2)
+
+    def writer(n: int) -> None:
+        barrier.wait()
+        resp = kb_propose_edit_fn(
+            target_path="universal/foundation/STD-U-001.md",
+            postimage=f"---\nid: STD-U-001\ntype: standard\nstatus: active\n"
+                      f"tier: T1\n---\nthread {n} body\n",
+            base_commit="HEAD", base_blob_sha=None, target_file_hash=None,
+            reason=f"t{n}", source_session="session-shared",
+            agent_identity="claude", confidence=0.95, confidence_threshold=0.85,
+            worktrees=reg, push_queue=pq, pending=pen, rate_limiter=rl,
+            blocklist=bl, remote_addr="1.1.1.1", serializer=serializer,
+        )
+        with lock:
+            results.append(resp.status)
+
+    threads = [threading.Thread(target=writer, args=(i,)) for i in range(2)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    # Both calls returned a well-defined status (committed or path_lock_busy),
+    # never a crash or a partial state.
+    assert set(results) <= {"committed", "rejected_path_lock_busy"}
+    assert len(results) == 2
+    # The session worktree history must be clean and linear (no dangling merge /
+    # rebase state, no mixed staged leftovers from an interleave).
+    wt = reg.get_or_create(source_session="session-shared", agent_identity="claude")
+    status = subprocess.check_output(
+        ["git", "-C", wt.path, "status", "--porcelain"], text=True, env=_env())
+    assert status.strip() == "", "worktree must be clean (no staged leftovers)"
+    # Every committed write produced exactly one queue entry.
+    committed = results.count("committed")
+    assert pq.size() == committed


### PR DESCRIPTION
Wave 1 of the 0.3.0 write-pipeline program (epic #72): the write-safety core that makes the claims in `SPEC.md` §8 and `docs/serving.md` actually true. Every item ships with regression tests, including two integration tests driving a real second clone against a shared bare remote.

## Design summary (per scope item)

1. **Write serialization.** A process-wide re-entrant `WriteSerializer` wraps the write → `git add` → commit → enqueue critical section; a per-path advisory lock (`PendingQueue.path_lock`) is now SHARED between the auto-commit path and the pending queue, so an auto-commit cannot race a concurrent write or land on a path with a pending proposal in flight. The auto-commit path previously took no lock.
2. **Non-fast-forward push recovery.** `GitOps.push_with_rebase_recovery` classifies non-FF distinctly from network failure: fetch + rebase the session branch onto `origin/main` and retry. A rebase conflict demotes the commit to a pending entry (`push_conflict_demoted` audit event, distinct state) instead of retrying forever. Persistent non-FF contention is retried in-line a bounded number of times, then demoted (never silently frozen).
3. **CAS enforcement.** `base_commit` (specific, non-`HEAD`) / `base_blob_sha` / `target_file_hash` are enforced at commit time on both the auto-commit and resolve paths against the worktree's refreshed base; a mismatch returns `rejected_stale_base`. If the base cannot be refreshed while an enforceable marker was supplied, the write is also rejected (the marker cannot be verified). No marker → behavior unchanged.
4. **Content-validation gate.** Every postimage is format-validated (malformed YAML, invalid `type`/`status`/`tier` enum) and checked for a duplicate `id` — using the EFFECTIVE id the rebuild assigns (explicit or path-derived), against the live index AND the session worktree tree, including reserved files, and across sibling files in a bootstrap bundle. Failures return `rejected_invalid_document` with machine-readable errors. Bootstrap now commits through the same serialized/validated/reset-on-failure path.
5. **Atomic pending claim.** `approve`/`reject` claim via `os.rename` (test-and-set); the double-resolve loser gets `already_resolved`/not-found. The gated resolve path holds the claim + path lock across the CAS/validation gates and restores the entry on a gate rejection (never consumed without a commit). Orphaned path locks are reclaimed by the pending GC loop.
6. **Unique memory filenames.** A short session/body-derived uniquifier is appended to `<date>-<slug>-<uniq>.md`.
7. **Pending expiry audit.** Expiring a >24h entry emits a `pending_expired` / `auto_rejected` audit event.
8. **Ordering of side effects.** Commit message + all gates are evaluated before the file is written/`git add`-ed; any post-add failure hard-resets the worktree.
9. **Deferred WP0b wiring.** MCP `kb_resolve_pending` now applies the `edited_text` cap; MCP `kb_consult`/`kb_gate_check`/`kb_cleanup_plan` now apply the shared rate limiter (matching REST).
10. **Git identity.** The Docker entrypoint (and server `main()` fallback) set a default `GIT_AUTHOR_*`/`GIT_COMMITTER_*` identity (overridable via `KB_GIT_AUTHOR_NAME`/`KB_GIT_AUTHOR_EMAIL`).

Post-commit enqueue is now recoverable and truthful: a failure attempts an in-process re-enqueue and surfaces `push_state="enqueue_failed_recovery_pending"` (the durable commit is republished by `init_recovery`) rather than reporting a false `queued`.

## Test evidence

- **1108 passed, 1 skipped** (skip = optional `sentence_transformers`); `ruff` clean; `mypy` clean; `scripts/check_changelog.py` ok.
- New test files: `tests/test_write_gate.py` (CAS incl. base_commit + unknown-commit + refresh-failure, validation gate incl. duplicate/derived/reserved/intra-bundle id), `tests/test_write_pipeline_integration.py` (two-session interleaved publish via real second clone + bare remote; rebase-conflict demotion with audit event; threaded concurrent one-path serialization), `tests/test_mcp_write_wiring.py` (MCP resolve cap + consult/gate/cleanup rate limits), `tests/test_rest_status_maps.py`.
- Extended: `tests/test_pending.py` (atomic claim, concurrent one-winner, orphan-lock GC, resolve gate restore), `tests/test_tools_write.py` (CAS/validation/filename-collision/double-resolve/enqueue-failure push_state/refresh-failure), `tests/test_push_queue.py` (rebase-conflict + non-FF demotion), `tests/test_refresh.py` (pending expiry audit + orphan-lock reclaim), `tests/test_tools_onboarding.py` (serialized bootstrap + intra-bundle dup id).

## Peer review (codex)

Adversarial CLI review across 5 rounds; all Blockers fixed and re-verified.

- **Round 1 — 3 Blockers, fixed:** (B1) validation gate now uses the effective id against index + worktree tree and no longer exempts reserved files; (B2) bootstrap routes through the shared serialized/validated commit path; (B3) CAS enforces a specific `base_commit`. Concern (non-FF contention freeze) addressed by bounded-then-demote.
- **Round 2 — 3 Blockers, fixed:** (A) intra-bundle duplicate-id check; (B) gated resolve holds the claim + lock across gates and restores on rejection (`hold_path_lock`); (C) post-commit enqueue no longer turns a made commit into an exception path. Concerns: unknown `base_commit` rejected distinctly; `non_ff_attempts` counts consecutive failures.
- **Round 3 — 1 Blocker, fixed:** enqueue state made truthful (`push_state`) with in-process recovery.
- **Round 4 — 1 Blocker, fixed:** resolve path surfaces `push_state` (new field on `ResolvePendingResponse`).
- **Round 5 — 1 Blocker, fixed:** a `refresh_base` failure with an enforceable CAS marker now rejects `rejected_stale_base` instead of committing against a stale base.
- **Round 5 verification — VERDICT: BLOCKERS: 0.** No false positives (no-origin repos where `refresh_base` returns `""` still commit legitimate marker'd writes).

## Design decisions / deviations

- CAS is not applied on the bootstrap path (new files under a not-yet-onboarded workspace have no base).
- `base_commit="HEAD"` is advisory (no per-file expectation); only a pinned commit/blob/file-hash is enforced.
- A rejected resolve leaves the pending entry re-resolvable; its path lock is released by the pending expiry GC if never retried.
- Folded in three orchestrator-relayed seams from the onboarding package (#85): public `PendingQueue.root`, `rejected_already_in_progress`→409 / `rejected_path_locked`→423 status maps, and the `absent or partial` bootstrap docstring. Rebased onto the latest `origin/release/0.3.0` (through #87); CHANGELOG entries all preserved.

Refs #72.
