### PR TITLE
feat(read): token-compact tool responses by default with verbose opt-out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,40 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING (default response shape): token-compact read-tool responses (#65).**
+  The read tools `kb_search`, `kb_get`, `kb_list`, `kb_outline`, and `kb_health`
+  now return a **token-compact** representation **by default**, because their
+  consumer is almost always an LLM paying for every token. Measured against the
+  example-bundle this saves ~37% of tokens on `kb_search`, ~42% on `kb_list`,
+  ~41% on `kb_health`, and ~8% on `kb_get` (real-tokenizer, tiktoken cl100k;
+  26.6% aggregate). What changed in the default shape:
+  - `kb_search`: each hit is `{id, title, snippet}` plus `status` **only when the
+    hit is not currently in force** (e.g. `superseded`/`deprecated`) and `type`
+    when set. The `query` echo, the per-hit `path`, and the raw bm25 `score` are
+    dropped; snippets are capped at 160 chars. Array order still conveys rank; to
+    read a hit in full, call `kb_get(id)`.
+  - `kb_get`: keeps the full `content_markdown` body (unchanged) but trims the
+    envelope: `path`, `git_remote_url`, `last_modified_source`, and
+    `source_commit` are dropped, and empty `status`/`type`/`applies_when`/
+    `description` are omitted.
+  - `kb_list`: drops per-entry `path`; omits a null `category`.
+  - `kb_health`: keeps the core snapshot and omits diagnostic fields that are
+    null/empty (a no-error steady state no longer emits a run of nulls).
+  - `kb_outline`: already lean; its shape is unchanged.
+
+  **Opt out** with `verbose=true` (a REST query parameter, or the `verbose`
+  argument on each MCP tool), which restores the exact pre-#65 JSON shape
+  byte-for-byte. The bundled `kb` CLI requests `verbose=true` automatically, so
+  its output is unaffected. Any first-party or third-party consumer that parsed
+  the dropped fields (`query`, per-hit `path`/`score`, the full health envelope)
+  must either adopt the compact shape or pass `verbose=true`. A committed
+  measurement harness (`benchmarks/token_compact.py`,
+  `python -m benchmarks.token_compact`) reproduces the per-tool token table, and
+  a tokenizer-based regression test (`tests/test_token_compact_budget.py`) fails
+  loudly if a future change re-bloats the compact default.
+
 ### Added
 
 - **Write-pipeline integrity core (epic #72).** This wave makes the write-safety

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,18 +18,20 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   The read tools `kb_search`, `kb_get`, `kb_list`, `kb_outline`, and `kb_health`
   now return a **token-compact** representation **by default**, because their
   consumer is almost always an LLM paying for every token. Measured against the
-  example-bundle this saves ~37% of tokens on `kb_search`, ~42% on `kb_list`,
-  ~41% on `kb_health`, and ~8% on `kb_get` (real-tokenizer, tiktoken cl100k;
-  26.6% aggregate). What changed in the default shape:
+  example-bundle with a real tokenizer (tiktoken cl100k; reproduce with
+  `python -m benchmarks.token_compact --tokenizer tiktoken`) this saves ~37% of
+  tokens on `kb_search`, ~42% on `kb_list`, ~41% on `kb_health`, and ~6-7% on
+  `kb_get` (which keeps its full body and provenance); 26.1% aggregate. What
+  changed in the default shape:
   - `kb_search`: each hit is `{id, title, snippet}` plus `status` **only when the
     hit is not currently in force** (e.g. `superseded`/`deprecated`) and `type`
     when set. The `query` echo, the per-hit `path`, and the raw bm25 `score` are
     dropped; snippets are capped at 160 chars. Array order still conveys rank; to
     read a hit in full, call `kb_get(id)`.
-  - `kb_get`: keeps the full `content_markdown` body (unchanged) but trims the
-    envelope: `path`, `git_remote_url`, `last_modified_source`, and
-    `source_commit` are dropped, and empty `status`/`type`/`applies_when`/
-    `description` are omitted.
+  - `kb_get`: keeps the full `content_markdown` body (unchanged) plus
+    `source_commit`/`last_modified` provenance, and trims the envelope: `path`,
+    `git_remote_url`, and `last_modified_source` are dropped, and empty
+    `status`/`type`/`applies_when`/`description` are omitted.
   - `kb_list`: drops per-entry `path`; omits a null `category`.
   - `kb_health`: keeps the core snapshot and omits diagnostic fields that are
     null/empty (a no-error steady state no longer emits a run of nulls).
@@ -41,10 +43,13 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   its output is unaffected. Any first-party or third-party consumer that parsed
   the dropped fields (`query`, per-hit `path`/`score`, the full health envelope)
   must either adopt the compact shape or pass `verbose=true`. A committed
-  measurement harness (`benchmarks/token_compact.py`,
-  `python -m benchmarks.token_compact`) reproduces the per-tool token table, and
-  a tokenizer-based regression test (`tests/test_token_compact_budget.py`) fails
-  loudly if a future change re-bloats the compact default.
+  measurement harness (`benchmarks/token_compact.py`) reproduces the per-tool
+  token table under either tokenizer (`python -m benchmarks.token_compact`
+  defaults to the dependency-free `simple` splitter; add `--tokenizer tiktoken`
+  for the cl100k numbers quoted above), and a tokenizer-based regression test
+  (`tests/test_token_compact_budget.py`, with both a `simple` budget and a
+  `tiktoken` aggregate-savings guard) fails loudly if a future change re-bloats
+  the compact default.
 
 ### Added
 

--- a/benchmarks/token_compact.py
+++ b/benchmarks/token_compact.py
@@ -1,0 +1,199 @@
+"""Token-compact read-tool response measurement harness (issue #65).
+
+Renders representative kb_search / kb_get / kb_list / kb_outline / kb_health
+responses against the committed ``example-bundle`` in both the verbose (legacy)
+and compact (new default) shapes, and counts tokens with the SAME tokenizer used
+by the rest of the benchmark suite (:mod:`benchmarks.tokenizer`). The output is a
+per-tool before/after table plus an aggregate.
+
+This is a measuring instrument, not a test: it is deterministic (fixed corpus,
+fixed queries), reproducible (``python -m benchmarks.token_compact``), and its
+numbers are the evidence in the issue #65 PR body. The regression test in
+``tests/test_token_compact_budget.py`` calls :func:`measure` and asserts the
+compact default stays under a measured budget with headroom.
+"""
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+from benchmarks.tokenizer import Tokenizer, get_tokenizer
+from data_olympus.index import Index
+from data_olympus.tools_read import (
+    kb_get_fn,
+    kb_health_fn,
+    kb_list_fn,
+    kb_outline_fn,
+    kb_search_fn,
+    shape_response,
+)
+
+# Repo root is two levels up from this file (benchmarks/token_compact.py).
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+EXAMPLE_BUNDLE = _REPO_ROOT / "example-bundle"
+
+# Fixed representative scenarios. Each is (label, tool, kwargs). Kept small and
+# deterministic so the table reproduces byte-for-byte across runs.
+_SEARCH_QUERY = "commit message format"
+_SEARCH_QUERY_BROAD = "module standard commit secret"
+_GET_IDS = (
+    "STD-U-004",  # small standard with a supersession chain
+    "ADR-002",  # decision doc
+    "MEM-2026-06-20-nestjs-module-naming-collision",  # larger memory doc
+)
+
+
+@dataclass(frozen=True)
+class Row:
+    """One tool scenario measured in both modes."""
+
+    label: str
+    verbose_tokens: int
+    compact_tokens: int
+    verbose_bytes: int
+    compact_bytes: int
+
+    @property
+    def saved_tokens(self) -> int:
+        return self.verbose_tokens - self.compact_tokens
+
+    @property
+    def pct_saved(self) -> float:
+        if self.verbose_tokens == 0:
+            return 0.0
+        return 100.0 * self.saved_tokens / self.verbose_tokens
+
+
+@dataclass(frozen=True)
+class Report:
+    tokenizer_name: str
+    rows: list[Row]
+
+    @property
+    def total_verbose(self) -> int:
+        return sum(r.verbose_tokens for r in self.rows)
+
+    @property
+    def total_compact(self) -> int:
+        return sum(r.compact_tokens for r in self.rows)
+
+    @property
+    def total_pct_saved(self) -> float:
+        if self.total_verbose == 0:
+            return 0.0
+        return 100.0 * (self.total_verbose - self.total_compact) / self.total_verbose
+
+
+def _build_index(dest: Path) -> Index:
+    """Copy the example-bundle into a scratch git repo and build an Index over it.
+
+    A git repo is required so the index records real ``last_modified`` values;
+    the deterministic ``source_commit`` keeps token counts stable across runs.
+    """
+    kb = dest / "kb"
+    shutil.copytree(EXAMPLE_BUNDLE, kb)
+    env = {
+        "GIT_AUTHOR_NAME": "bench",
+        "GIT_AUTHOR_EMAIL": "bench@example.com",
+        "GIT_COMMITTER_NAME": "bench",
+        "GIT_COMMITTER_EMAIL": "bench@example.com",
+        "PATH": "/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin",
+    }
+    subprocess.run(["git", "init", "-q"], cwd=kb, env=env, check=True)
+    subprocess.run(["git", "add", "-A"], cwd=kb, env=env, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "bench"], cwd=kb, env=env, check=True)
+    idx = Index(dest / "index.db")
+    idx.build(kb, source_commit="bench0000")
+    return idx
+
+
+def _measure_row(label: str, resp: object, tok: Tokenizer) -> Row:
+    verbose = json.dumps(shape_response(resp, verbose=True), ensure_ascii=False)  # type: ignore[arg-type]
+    compact = json.dumps(shape_response(resp, verbose=False), ensure_ascii=False)  # type: ignore[arg-type]
+    return Row(
+        label=label,
+        verbose_tokens=tok.count(verbose),
+        compact_tokens=tok.count(compact),
+        verbose_bytes=len(verbose.encode()),
+        compact_bytes=len(compact.encode()),
+    )
+
+
+def measure(tokenizer: str = "simple") -> Report:
+    """Run every scenario and return a :class:`Report`."""
+    tok = get_tokenizer(tokenizer)
+    rows: list[Row] = []
+    with tempfile.TemporaryDirectory() as td:
+        idx = _build_index(Path(td))
+
+        rows.append(
+            _measure_row(
+                f"kb_search (limit 20, {_SEARCH_QUERY!r})",
+                kb_search_fn(idx=idx, query=_SEARCH_QUERY),
+                tok,
+            )
+        )
+        rows.append(
+            _measure_row(
+                f"kb_search (limit 100, {_SEARCH_QUERY_BROAD!r})",
+                kb_search_fn(idx=idx, query=_SEARCH_QUERY_BROAD, limit=100),
+                tok,
+            )
+        )
+        for did in _GET_IDS:
+            rows.append(_measure_row(f"kb_get ({did})", kb_get_fn(idx=idx, id=did), tok))
+        rows.append(_measure_row("kb_list (T1)", kb_list_fn(idx=idx, tier="T1"), tok))
+        rows.append(_measure_row("kb_outline", kb_outline_fn(idx=idx), tok))
+        rows.append(
+            _measure_row(
+                "kb_health",
+                kb_health_fn(idx=idx, last_git_pull_at=None, staleness_degraded_sec=3600),
+                tok,
+            )
+        )
+    return Report(tokenizer_name=tok.name, rows=rows)
+
+
+def format_markdown_table(report: Report) -> str:
+    """Render the report as the Markdown table used in the PR body / docs."""
+    lines = [
+        f"Tokenizer: `{report.tokenizer_name}`",
+        "",
+        "| Tool scenario | Verbose (tokens) | Compact (tokens) | Saved | % |",
+        "|---|---:|---:|---:|---:|",
+    ]
+    for r in report.rows:
+        lines.append(
+            f"| {r.label} | {r.verbose_tokens} | {r.compact_tokens} "
+            f"| {r.saved_tokens} | {r.pct_saved:.1f}% |"
+        )
+    lines.append(
+        f"| **Aggregate** | **{report.total_verbose}** | **{report.total_compact}** "
+        f"| **{report.total_verbose - report.total_compact}** "
+        f"| **{report.total_pct_saved:.1f}%** |"
+    )
+    return "\n".join(lines)
+
+
+def main() -> None:
+    import argparse
+
+    ap = argparse.ArgumentParser(
+        description="Measure token-compact read-tool responses (issue #65)."
+    )
+    ap.add_argument(
+        "--tokenizer",
+        default="simple",
+        help="tokenizer name: 'simple' (default, dependency-free) or 'tiktoken'.",
+    )
+    args = ap.parse_args()
+    report = measure(tokenizer=args.tokenizer)
+    print(format_markdown_table(report))
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/kb
+++ b/bin/kb
@@ -818,7 +818,11 @@ except Exception:
 # Subcommand dispatch
 case "$SUBCMD" in
   health)
-    if do_curl "$KB_ENDPOINT/api/v1/health"; then
+    # The CLI is an operator-facing tool: it requests verbose=true so the
+    # human-readable plain renderers below (which read fields the compact default
+    # trims, e.g. per-hit path and the full health envelope) keep working. The
+    # compact default serves LLM/MCP callers; see issue #65.
+    if do_curl "$KB_ENDPOINT/api/v1/health?verbose=true"; then
       # 503 with degraded:true body is the canonical degraded-health response
       # A degraded 503 is a valid response. The CLI must NOT treat it as endpoint-unreachable.
       if is_degraded && [[ "$NO_STALE" -eq 1 ]]; then
@@ -841,7 +845,7 @@ case "$SUBCMD" in
     fi
     ;;
   outline)
-    if do_curl "$KB_ENDPOINT/api/v1/outline"; then
+    if do_curl "$KB_ENDPOINT/api/v1/outline?verbose=true"; then
       if is_degraded && [[ "$NO_STALE" -eq 1 ]]; then
         echo "kb: REST response degraded:true and --no-stale set" >&2
         exit 2
@@ -865,7 +869,7 @@ case "$SUBCMD" in
     [[ ${#POSITIONAL[@]} -ge 1 ]] || { echo "kb: search requires QUERY" >&2; exit 64; }
     Q="${POSITIONAL[0]}"
     # Robust URL encoding for arbitrary characters in query and filters.
-    URL="$KB_ENDPOINT/api/v1/search?q=$(url_encode "$Q")&limit=$LIMIT"
+    URL="$KB_ENDPOINT/api/v1/search?q=$(url_encode "$Q")&limit=$LIMIT&verbose=true"
     [[ -n "$TIER" ]] && URL="$URL&tier=$(url_encode "$TIER")"
     [[ -n "$CATEGORY" ]] && URL="$URL&category=$(url_encode "$CATEGORY")"
     if do_curl "$URL"; then
@@ -894,7 +898,7 @@ case "$SUBCMD" in
   get)
     [[ ${#POSITIONAL[@]} -ge 1 ]] || { echo "kb: get requires ID" >&2; exit 64; }
     ID="${POSITIONAL[0]}"
-    URL="$KB_ENDPOINT/api/v1/get/$(url_encode "$ID")"
+    URL="$KB_ENDPOINT/api/v1/get/$(url_encode "$ID")?verbose=true"
     if do_curl "$URL"; then
       if [[ "$REST_STATUS" == "404" ]]; then
         echo "$REST_BODY" >&2; exit 1
@@ -924,7 +928,7 @@ case "$SUBCMD" in
     [[ ${#POSITIONAL[@]} -ge 1 ]] || { echo "kb: list requires TIER" >&2; exit 64; }
     LTIER="${POSITIONAL[0]}"
     LCAT="${POSITIONAL[1]:-}"
-    URL="$KB_ENDPOINT/api/v1/list?tier=$(url_encode "$LTIER")"
+    URL="$KB_ENDPOINT/api/v1/list?tier=$(url_encode "$LTIER")&verbose=true"
     [[ -n "$LCAT" ]] && URL="$URL&category=$(url_encode "$LCAT")"
     if do_curl "$URL"; then
       if is_degraded && [[ "$NO_STALE" -eq 1 ]]; then

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -79,6 +79,35 @@ curl -fsS "http://localhost:8080/api/v1/search?q=writing"
 curl -fsS http://localhost:8080/api/v1/outline
 ```
 
+### Compact responses by default
+
+The read tools (`kb_search`, `kb_get`, `kb_list`, `kb_outline`, `kb_health`)
+return a **token-compact** shape by default, because their consumer is almost
+always an LLM paying for every token in its context. Compared with the full
+representation, the compact default:
+
+- `kb_search`: each hit is `{id, title, snippet}` plus `status` **only when a hit
+  is not currently in force** (e.g. `superseded`) and `type` when set. The `query`
+  echo, the per-hit `path`, and the raw relevance `score` are dropped. To read a
+  hit in full, call `kb_get` with its `id`; array order conveys rank.
+- `kb_get`: keeps the full `content_markdown` body (that is why you call it) and
+  trims low-value envelope fields (`path`, `git_remote_url`,
+  `last_modified_source`, `source_commit`).
+- `kb_list`: drops the per-entry `path` (fetch via `kb_get(id)`).
+- `kb_health`: keeps the core snapshot and omits diagnostic fields that are unset.
+- `kb_outline`: already lean; unchanged.
+
+Pass `verbose=true` (REST query param, or the `verbose` MCP tool argument) to get
+the full legacy shape with every field:
+
+```bash
+# Full/legacy shape (query, path, score, and full health envelope restored)
+curl -fsS "http://localhost:8080/api/v1/search?q=writing&verbose=true"
+```
+
+The `kb` CLI always requests `verbose=true` so its plain-text output keeps
+showing paths.
+
 ## 4. Lifecycle-aware retrieval: in-force vs superseded
 
 The example bundle ships a real supersession pair in
@@ -96,8 +125,11 @@ history).
 curl -fsS "http://localhost:8080/api/v1/search?q=commit%20format&limit=5"
 ```
 
-The top two hits are `STD-U-004` (`status: active`) ranked ahead of
-`STD-U-003` (`status: superseded`) — both present, active first.
+The top two hits are `STD-U-004` (currently in force) ranked ahead of
+`STD-U-003` (`status: superseded`) — both present, active first. In the compact
+default the in-force hit carries no `status` field while the superseded hit shows
+`"status": "superseded"` (the deviation an agent must act on); add `verbose=true`
+to see `"status": "active"` spelled out on every hit.
 
 **`in_force=true`** is a hard filter, not a rerank: it excludes every
 not-currently-governing status (`superseded`, `deprecated`, `draft`,

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -90,9 +90,10 @@ representation, the compact default:
   is not currently in force** (e.g. `superseded`) and `type` when set. The `query`
   echo, the per-hit `path`, and the raw relevance `score` are dropped. To read a
   hit in full, call `kb_get` with its `id`; array order conveys rank.
-- `kb_get`: keeps the full `content_markdown` body (that is why you call it) and
-  trims low-value envelope fields (`path`, `git_remote_url`,
-  `last_modified_source`, `source_commit`).
+- `kb_get`: keeps the full `content_markdown` body (that is why you call it) plus
+  `source_commit`/`last_modified` provenance, and trims low-value envelope fields
+  (`path`, `git_remote_url`, `last_modified_source`). `path` is recoverable with
+  `kb_get(id, verbose=true)`.
 - `kb_list`: drops the per-entry `path` (fetch via `kb_get(id)`).
 - `kb_health`: keeps the core snapshot and omits diagnostic fields that are unset.
 - `kb_outline`: already lean; unchanged.

--- a/src/data_olympus/models.py
+++ b/src/data_olympus/models.py
@@ -217,12 +217,13 @@ class GetResponse(BaseModel):
 
         Keeps the full ``content_markdown`` body by default: agents call kb_get
         precisely to read the doc, so truncating it would break the primary use.
-        Trims only the low-value envelope fields that the body already implies or
-        that a caller rarely needs inline: ``path`` (derivable from ``id`` /
-        present in the body's own links), ``git_remote_url``,
-        ``last_modified_source``, and ``source_commit``. Omits empty ``status`` /
-        ``type`` / ``applies_when`` / ``description``. ``verbose=True`` restores
-        the full shape.
+        Retains provenance a direct caller needs: ``source_commit`` (the commit
+        the doc was read at) and ``last_modified`` are kept. Trims only low-value
+        envelope fields: ``path`` (recoverable with ``kb_get(id, verbose=True)``),
+        ``git_remote_url`` (null for most docs), and ``last_modified_source`` (a
+        provenance *label* like ``git``/``mtime-fallback``, not the timestamp).
+        Omits empty ``status`` / ``type`` / ``applies_when`` / ``description``.
+        ``verbose=True`` restores the full shape.
         """
         d: dict[str, object] = {
             "id": self.id,
@@ -241,6 +242,7 @@ class GetResponse(BaseModel):
             d["description"] = self.description
         d["content_markdown"] = self.content_markdown
         d["last_modified"] = self.last_modified
+        d["source_commit"] = self.source_commit
         return d
 
 

--- a/src/data_olympus/models.py
+++ b/src/data_olympus/models.py
@@ -3,6 +3,14 @@ from __future__ import annotations
 
 from pydantic import BaseModel, Field
 
+# Status values that mean "this guidance currently applies" (the in-force class,
+# mirrors index._IN_FORCE_STATUSES). In compact search hits, a hit's ``status``
+# is OMITTED when it is in-force or absent, and EMITTED only when it deviates
+# (superseded/deprecated/rejected/...), because a deviation is the signal an
+# agent must act on (do not follow superseded guidance) while the in-force
+# default carries no information. See issue #65.
+_IN_FORCE_STATUSES = frozenset({"active", "accepted", "approved"})
+
 
 class HealthResponse(BaseModel):
     """kb_health response. Slice 2A added write-side placeholders. Slice 2B adds
@@ -39,6 +47,38 @@ class HealthResponse(BaseModel):
     # Surfaced so session accumulation is diagnosable in production (issue #43).
     live_sessions: int | None = None
 
+    # Health fields always present in compact mode even when falsy, because a
+    # consumer branches on them (bin/kb and the REST 503 path read ``degraded``;
+    # a monitor reads the core snapshot). Everything else is a diagnostic that
+    # only matters when set, so compact mode omits it when None/empty.
+    _COMPACT_ALWAYS = (
+        "kb_commit",
+        "total_rules",
+        "degraded",
+        "db_size_bytes",
+        "staleness_seconds",
+        "index_built_at",
+        "pending_count",
+        "push_queue_size",
+        "last_index_build_status",
+    )
+
+    def compact_dump(self) -> dict[str, object]:
+        """Token-lean kb_health (issue #65). Keeps the core snapshot fields a
+        consumer always branches on; omits the many diagnostic fields when they
+        are ``None`` or an empty list (a no-error steady state carries a run of
+        nulls that cost tokens and say nothing). This filter is generic, so a
+        field a concurrent package adds flows through unchanged: it appears in
+        compact output only when populated. ``verbose=True`` restores the full,
+        every-field shape."""
+        full = self.model_dump()
+        always = set(self._COMPACT_ALWAYS)
+        out: dict[str, object] = {}
+        for k, v in full.items():
+            if k in always or (v is not None and v != []):
+                out[k] = v
+        return out
+
 
 class CategoryCount(BaseModel):
     """One category with doc count."""
@@ -60,6 +100,20 @@ class OutlineResponse(BaseModel):
     tiers: list[TierOutline]
     source_commit: str
 
+    def compact_dump(self) -> dict[str, object]:
+        """kb_outline is already a lean tier/category/count tree with no
+        redundant or low-value fields (measured saving from any further trim is
+        below the 5% adopt threshold in issue #65), so compact mode returns the
+        same shape as full. The method exists so every read tool honours the
+        ``verbose`` parameter uniformly."""
+        return self.model_dump()
+
+
+# Compact-mode snippet cap (characters). Measured against the example-bundle:
+# real snippets sit well under this, so the cap is a guard against pathological
+# long snippets, not a routine truncation. See issue #65 / benchmarks/token_compact.py.
+COMPACT_SNIPPET_CHARS = 160
+
 
 class SearchHitModel(BaseModel):
     """One search hit."""
@@ -71,6 +125,29 @@ class SearchHitModel(BaseModel):
     score: float
     status: str = ""
     type: str = ""
+
+    def compact_dump(self) -> dict[str, object]:
+        """Token-lean hit shape (issue #65).
+
+        Drops:
+          - ``path``: redundant with ``id`` (fetch the doc via kb_get(id) to get
+            its path); saved the single largest per-hit token cost.
+          - ``score``: a raw bm25 float (e.g. -4.877023162317077) that mixes
+            incompatible conventions across pipeline paths and is uninterpretable
+            to an agent. Array order already conveys rank.
+        Emits ``status`` only when it deviates from the in-force default (i.e. a
+        superseded/deprecated/rejected hit an agent must NOT treat as current),
+        and ``type`` only when present. ``verbose=True`` restores the full shape.
+        """
+        snippet = self.snippet
+        if len(snippet) > COMPACT_SNIPPET_CHARS:
+            snippet = snippet[:COMPACT_SNIPPET_CHARS] + "…"
+        d: dict[str, object] = {"id": self.id, "title": self.title, "snippet": snippet}
+        if self.status and self.status not in _IN_FORCE_STATUSES:
+            d["status"] = self.status
+        if self.type:
+            d["type"] = self.type
+        return d
 
 
 class SearchResponse(BaseModel):
@@ -97,6 +174,24 @@ class SearchResponse(BaseModel):
         ),
     )
 
+    def compact_dump(self) -> dict[str, object]:
+        """Token-lean search response (issue #65).
+
+        Drops the ``query`` echo (the caller knows what it searched) and shapes
+        each hit via :meth:`SearchHitModel.compact_dump`. Keeps the small,
+        informative envelope (source_commit, total_returned, and the abstain
+        signal when it fired). ``verbose=True`` restores the full JSON shape.
+        """
+        d: dict[str, object] = {
+            "hits": [h.compact_dump() for h in self.hits],
+            "source_commit": self.source_commit,
+            "total_returned": self.total_returned,
+        }
+        if self.abstained:
+            d["abstained"] = True
+            d["abstain_reason"] = self.abstain_reason
+        return d
+
 
 class GetResponse(BaseModel):
     """kb_get response."""
@@ -117,6 +212,37 @@ class GetResponse(BaseModel):
     source_commit: str
     git_remote_url: str | None = None
 
+    def compact_dump(self) -> dict[str, object]:
+        """Token-lean kb_get response (issue #65).
+
+        Keeps the full ``content_markdown`` body by default: agents call kb_get
+        precisely to read the doc, so truncating it would break the primary use.
+        Trims only the low-value envelope fields that the body already implies or
+        that a caller rarely needs inline: ``path`` (derivable from ``id`` /
+        present in the body's own links), ``git_remote_url``,
+        ``last_modified_source``, and ``source_commit``. Omits empty ``status`` /
+        ``type`` / ``applies_when`` / ``description``. ``verbose=True`` restores
+        the full shape.
+        """
+        d: dict[str, object] = {
+            "id": self.id,
+            "title": self.title,
+            "tier": self.tier,
+            "category": self.category,
+        }
+        if self.status:
+            d["status"] = self.status
+        if self.type:
+            d["type"] = self.type
+        d["tags"] = list(self.tags)
+        if self.applies_when:
+            d["applies_when"] = list(self.applies_when)
+        if self.description:
+            d["description"] = self.description
+        d["content_markdown"] = self.content_markdown
+        d["last_modified"] = self.last_modified
+        return d
+
 
 class ListEntry(BaseModel):
     """One entry in kb_list output."""
@@ -124,6 +250,10 @@ class ListEntry(BaseModel):
     id: str
     title: str
     path: str
+
+    def compact_dump(self) -> dict[str, object]:
+        """Drop ``path`` (derivable via kb_get(id)); keep id + title."""
+        return {"id": self.id, "title": self.title}
 
 
 class ListResponse(BaseModel):
@@ -134,6 +264,18 @@ class ListResponse(BaseModel):
     entries: list[ListEntry]
     source_commit: str
     total: int
+
+    def compact_dump(self) -> dict[str, object]:
+        """Token-lean kb_list response (issue #65): per-entry ``path`` dropped
+        (fetch via kb_get(id)). Omits a null ``category``. ``verbose=True``
+        restores the full shape."""
+        d: dict[str, object] = {"tier": self.tier}
+        if self.category is not None:
+            d["category"] = self.category
+        d["entries"] = [e.compact_dump() for e in self.entries]
+        d["source_commit"] = self.source_commit
+        d["total"] = self.total
+        return d
 
 
 class ProposeMemoryRequest(BaseModel):

--- a/src/data_olympus/rest_api.py
+++ b/src/data_olympus/rest_api.py
@@ -24,6 +24,7 @@ from data_olympus.tools_read import (
     kb_list_fn,
     kb_outline_fn,
     kb_search_fn,
+    shape_response,
 )
 
 if TYPE_CHECKING:
@@ -332,7 +333,7 @@ def register_routes(
     """
 
     @app.custom_route("/api/v1/health", methods=["GET"])
-    async def health(_request: Request) -> JSONResponse:
+    async def health(request: Request) -> JSONResponse:
         # Served INLINE, not via _offload(): the readiness probe must never queue
         # behind the shared anyio worker pool it exists to outlive. _build_health
         # reads the cached Index.health() snapshot (memory in steady state; the
@@ -342,15 +343,17 @@ def register_routes(
         # Degraded health responses MUST return 503 so the
         # CLI's --no-stale contract (exit 2 on HTTP 200 or 503 degraded) is meaningful.
         status = 503 if resp.degraded else 200
-        return JSONResponse(resp.model_dump(), status_code=status)
+        verbose = _query_bool(request.query_params.get("verbose"))
+        return JSONResponse(shape_response(resp, verbose=verbose), status_code=status)
 
     @app.custom_route("/api/v1/outline", methods=["GET"])
-    async def outline(_request: Request) -> JSONResponse:
+    async def outline(request: Request) -> JSONResponse:
         h = await _offload(_build_health, state)
         if h.degraded:
             return _degraded_response(h)
+        verbose = _query_bool(request.query_params.get("verbose"))
         resp = await _offload(kb_outline_fn, idx=state.idx)
-        return JSONResponse(resp.model_dump())
+        return JSONResponse(shape_response(resp, verbose=verbose))
 
     @app.custom_route("/api/v1/search", methods=["GET"])
     async def search(request: Request) -> JSONResponse:
@@ -368,11 +371,12 @@ def register_routes(
         category = request.query_params.get("category") or None
         in_force = _query_bool(request.query_params.get("in_force"))
         abstain = _query_bool(request.query_params.get("abstain"))
+        verbose = _query_bool(request.query_params.get("verbose"))
         resp = await _offload(
             kb_search_fn, idx=state.idx, query=q, limit=limit, tier=tier,
             category=category, in_force=in_force, abstain=abstain,
         )
-        return JSONResponse(resp.model_dump())
+        return JSONResponse(shape_response(resp, verbose=verbose))
 
     @app.custom_route("/api/v1/get/{id}", methods=["GET"])
     async def get(request: Request) -> JSONResponse:
@@ -380,11 +384,12 @@ def register_routes(
         if h.degraded:
             return _degraded_response(h)
         id_ = request.path_params["id"]
+        verbose = _query_bool(request.query_params.get("verbose"))
         try:
             resp = await _offload(kb_get_fn, idx=state.idx, id=id_)
         except KbNotFoundError as e:
             return JSONResponse({"error": "not_found", "message": str(e)}, status_code=404)
-        return JSONResponse(resp.model_dump())
+        return JSONResponse(shape_response(resp, verbose=verbose))
 
     @app.custom_route("/api/v1/list", methods=["GET"])
     async def list_(request: Request) -> JSONResponse:
@@ -395,8 +400,9 @@ def register_routes(
         if not tier:
             return JSONResponse({"error": "missing_tier"}, status_code=400)
         category = request.query_params.get("category") or None
+        verbose = _query_bool(request.query_params.get("verbose"))
         resp = await _offload(kb_list_fn, idx=state.idx, tier=tier, category=category)
-        return JSONResponse(resp.model_dump())
+        return JSONResponse(shape_response(resp, verbose=verbose))
 
     if not read_only:
         # Write + enforcement-write REST surface. A read-only replica

--- a/src/data_olympus/server.py
+++ b/src/data_olympus/server.py
@@ -44,7 +44,12 @@ from data_olympus.push_queue import PushQueue
 from data_olympus.query_expansion import default_query_expander
 from data_olympus.rate_limit import SlidingWindowLimiter
 from data_olympus.search_shortcut import make_id_tag_reranker
-from data_olympus.tools_read import kb_health_fn, kb_outline_fn, kb_search_fn
+from data_olympus.tools_read import (
+    kb_health_fn,
+    kb_outline_fn,
+    kb_search_fn,
+    shape_response,
+)
 from data_olympus.worktrees import WorktreeRegistry
 
 log = logging.getLogger("data_olympus")
@@ -411,9 +416,14 @@ def build_app(
     app: FastMCP = FastMCP(name="data-olympus-mcp")
 
     @app.tool()
-    def kb_health() -> dict[str, object]:
+    def kb_health(verbose: bool = False) -> dict[str, object]:
         """Return service health: kb_commit, index_built_at, staleness, degraded flag,
-        and write-side state (pending_count, push_queue_size, last_index_*)."""
+        and write-side state (pending_count, push_queue_size, last_index_*).
+
+        verbose: False (default) returns a token-compact shape that keeps the core
+        snapshot and OMITS diagnostic fields that are null/empty (e.g.
+        last_index_error, remote_head_sha when unset). verbose=True returns every
+        field including the nulls."""
         resp = kb_health_fn(
             idx=state.idx,
             last_git_pull_at=state.last_git_pull_at,
@@ -434,13 +444,16 @@ def build_app(
             remote_head_sha=state.remote_head_sha,
             live_sessions=state.live_session_count(),
         )
-        return resp.model_dump()
+        return shape_response(resp, verbose=verbose)
 
     @app.tool()
-    def kb_outline() -> dict[str, object]:
-        """Return the tree of tiers and categories with doc counts."""
+    def kb_outline(verbose: bool = False) -> dict[str, object]:
+        """Return the tree of tiers and categories with doc counts.
+
+        verbose: kb_outline is already lean, so compact and full modes return the
+        same shape; the parameter exists for interface consistency."""
         resp = kb_outline_fn(idx=state.idx)
-        return resp.model_dump()
+        return shape_response(resp, verbose=verbose)
 
     @app.tool()
     def kb_search(
@@ -452,6 +465,7 @@ def build_app(
         in_force: bool = False,
         doc_type: str | None = None,
         abstain: bool = False,
+        verbose: bool = False,
     ) -> dict[str, object]:
         """Full-text search across the KB.
 
@@ -470,30 +484,46 @@ def build_app(
         `abstain_reason`, instead of surfacing a weak keyword match. A query with
         a real signal retrieves normally. Distinguish `abstained: true` (no
         governing rule) from an ordinary empty result (`abstained: false`).
+
+        verbose: False (default) returns a token-compact shape. Each hit is
+        {id, title, snippet} plus `status` only when a hit is NOT in-force
+        (superseded/deprecated) and `type` when set; the `query` echo, per-hit
+        `path`, and `score` are dropped (fetch a hit's full metadata with
+        kb_get(id); array order conveys rank). verbose=True restores the full
+        legacy shape with query, path, score, status, and type on every hit.
         """
         resp = kb_search_fn(
             idx=state.idx, query=query, limit=limit, tier=tier, category=category,
             status=status, in_force=in_force, doc_type=doc_type, abstain=abstain,
         )
-        return resp.model_dump()
+        return shape_response(resp, verbose=verbose)
 
     @app.tool()
-    def kb_get(id: str) -> dict[str, object]:
+    def kb_get(id: str, verbose: bool = False) -> dict[str, object]:
         """Retrieve a document by id (STD-U-001, ADR-002, T-NNN, etc.).
-        Returns full content markdown plus metadata."""
+        Returns the full content markdown plus metadata.
+
+        verbose: False (default) returns the full `content_markdown` body (kb_get
+        exists to read the doc) with a trimmed envelope: `path`, `git_remote_url`,
+        `last_modified_source`, and `source_commit` are dropped and empty
+        status/type/applies_when/description are omitted. verbose=True returns the
+        full legacy envelope with every field."""
         from data_olympus.tools_read import KbNotFoundError, kb_get_fn
         try:
             resp = kb_get_fn(idx=state.idx, id=id)
         except KbNotFoundError as e:
             return {"error": "not_found", "message": str(e)}
-        return resp.model_dump()
+        return shape_response(resp, verbose=verbose)
 
     @app.tool()
-    def kb_list(tier: str, category: str | None = None) -> dict[str, object]:
-        """List doc ids in the given tier (and optional category), ordered by id."""
+    def kb_list(tier: str, category: str | None = None, verbose: bool = False) -> dict[str, object]:
+        """List doc ids in the given tier (and optional category), ordered by id.
+
+        verbose: False (default) drops per-entry `path` (fetch via kb_get(id)) and
+        omits a null category. verbose=True restores the full shape with paths."""
         from data_olympus.tools_read import kb_list_fn
         resp = kb_list_fn(idx=state.idx, tier=tier, category=category)
-        return resp.model_dump()
+        return shape_response(resp, verbose=verbose)
 
     @app.tool()
     def kb_onboarding_status(

--- a/src/data_olympus/server.py
+++ b/src/data_olympus/server.py
@@ -504,10 +504,11 @@ def build_app(
         Returns the full content markdown plus metadata.
 
         verbose: False (default) returns the full `content_markdown` body (kb_get
-        exists to read the doc) with a trimmed envelope: `path`, `git_remote_url`,
-        `last_modified_source`, and `source_commit` are dropped and empty
-        status/type/applies_when/description are omitted. verbose=True returns the
-        full legacy envelope with every field."""
+        exists to read the doc) with a trimmed envelope: `path`,
+        `git_remote_url`, and `last_modified_source` are dropped and empty
+        status/type/applies_when/description are omitted; `source_commit` and
+        `last_modified` provenance are kept. verbose=True returns the full legacy
+        envelope with every field."""
         from data_olympus.tools_read import KbNotFoundError, kb_get_fn
         try:
             resp = kb_get_fn(idx=state.idx, id=id)

--- a/src/data_olympus/tools_read.py
+++ b/src/data_olympus/tools_read.py
@@ -5,7 +5,7 @@ without instantiating a FastMCP server. The server module wires them in.
 """
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Protocol
 
 from data_olympus.health import snapshot
 from data_olympus.models import (
@@ -22,6 +22,24 @@ from data_olympus.models import (
 
 if TYPE_CHECKING:
     from data_olympus.index import Index
+
+
+class _CompactDumpable(Protocol):
+    def compact_dump(self) -> dict[str, object]: ...
+    def model_dump(self) -> dict[str, object]: ...
+
+
+def shape_response(resp: _CompactDumpable, *, verbose: bool) -> dict[str, object]:
+    """Serialize a read-tool response to the wire dict.
+
+    ``verbose=False`` (the default for every read tool) returns the token-compact
+    shape; ``verbose=True`` returns the full, byte-for-byte legacy JSON shape. The
+    ``verbose`` parameter threads from the MCP tool wrappers in ``server.py`` and
+    the REST handlers in ``rest_api.py`` through here into the per-model
+    ``compact_dump`` / ``model_dump`` methods, so MCP and REST stay consistent.
+    See issue #65.
+    """
+    return resp.model_dump() if verbose else resp.compact_dump()
 
 
 def kb_health_fn(

--- a/tests/test_in_force_and_abstain.py
+++ b/tests/test_in_force_and_abstain.py
@@ -255,9 +255,23 @@ async def test_rest_abstain_threads(tmp_path: Path) -> None:
             "/api/v1/search", params={"q": "widget", "abstain": "true"}
         )
     fired_body = fired.json()
+    # Compact default: the abstain signal is emitted only when it FIRED.
     assert fired_body["abstained"] is True
     assert fired_body["abstain_reason"] == "no_signal_match"
     assert fired_body["hits"] == []
     ok_body = ok.json()
-    assert ok_body["abstained"] is False
+    # A non-abstaining response OMITS the abstain fields in compact mode
+    # (absent == not abstained); a consumer reads them with .get(..., False).
+    assert ok_body.get("abstained", False) is False
     assert ok_body["hits"]
+
+    # verbose=true restores the full shape with abstained present even when False.
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        ok_verbose = await client.get(
+            "/api/v1/search",
+            params={"q": "widget", "abstain": "true", "verbose": "true"},
+        )
+    ok_verbose_body = ok_verbose.json()
+    assert ok_verbose_body["abstained"] is False
+    assert ok_verbose_body["query"] == "widget"
+    assert "path" in ok_verbose_body["hits"][0]

--- a/tests/test_token_compact_budget.py
+++ b/tests/test_token_compact_budget.py
@@ -1,0 +1,71 @@
+"""Tokenizer-based regression guard for the compact read-tool defaults (issue #65).
+
+Runs the committed measurement harness (:func:`benchmarks.token_compact.measure`)
+and asserts the compact default stays under a measured budget WITH HEADROOM, so a
+future change that re-bloats a response (re-adds a dropped field, uncaps snippets)
+fails loudly here. Budgets are set ~15% above the measured compact counts at the
+time of writing; the point is to catch regressions, not to pin exact numbers.
+
+Measured compact totals (simple tokenizer, example-bundle) at authoring time:
+  kb_search(20)=921  kb_search(100)=1451  kb_get(STD-U-004)=533  kb_get(ADR-002)=481
+  kb_get(MEM...)=659  kb_list(T1)=192  kb_outline=369  kb_health=81  aggregate=4687
+The compact aggregate saved 25.1% (simple) / 26.6% (tiktoken cl100k) vs verbose.
+"""
+from __future__ import annotations
+
+from benchmarks.token_compact import measure
+
+# Per-scenario compact budgets (simple tokenizer). ~15% headroom over measured.
+_BUDGETS = {
+    "kb_search (limit 20, 'commit message format')": 1060,
+    "kb_search (limit 100, 'module standard commit secret')": 1670,
+    "kb_get (STD-U-004)": 615,
+    "kb_get (ADR-002)": 555,
+    "kb_get (MEM-2026-06-20-nestjs-module-naming-collision)": 760,
+    "kb_list (T1)": 225,
+    "kb_outline": 425,
+    "kb_health": 95,
+}
+_AGGREGATE_BUDGET = 5400  # ~15% over 4687
+
+
+def test_compact_defaults_under_budget() -> None:
+    report = measure(tokenizer="simple")
+    over = [
+        f"{r.label}: {r.compact_tokens} > {_BUDGETS[r.label]}"
+        for r in report.rows
+        if r.label in _BUDGETS and r.compact_tokens > _BUDGETS[r.label]
+    ]
+    assert not over, "compact response(s) exceed token budget (re-bloat?): " + "; ".join(over)
+    assert report.total_compact <= _AGGREGATE_BUDGET, (
+        f"aggregate compact tokens {report.total_compact} exceed budget {_AGGREGATE_BUDGET}"
+    )
+
+
+def test_compact_saves_meaningfully_vs_verbose() -> None:
+    """The adopt-decision bar from issue #65: kb_search must save >= 25% and the
+    aggregate must save a meaningful fraction. Guards against a change that
+    quietly makes compact ~= verbose (defeating the point)."""
+    report = measure(tokenizer="simple")
+    by_label = {r.label: r for r in report.rows}
+
+    search20 = by_label["kb_search (limit 20, 'commit message format')"]
+    search100 = by_label["kb_search (limit 100, 'module standard commit secret')"]
+    assert search20.pct_saved >= 25.0, f"kb_search(20) only saved {search20.pct_saved:.1f}%"
+    assert search100.pct_saved >= 25.0, f"kb_search(100) only saved {search100.pct_saved:.1f}%"
+
+    assert report.total_pct_saved >= 20.0, (
+        f"aggregate only saved {report.total_pct_saved:.1f}%"
+    )
+
+
+def test_verbose_matches_legacy_model_dump() -> None:
+    """Verbose token counts must equal the pre-compact (model_dump) shape exactly:
+    the harness measures verbose via shape_response(..., verbose=True), which is
+    model_dump. This asserts verbose is never smaller than compact (a sanity floor
+    that the modes are not swapped)."""
+    report = measure(tokenizer="simple")
+    for r in report.rows:
+        assert r.verbose_tokens >= r.compact_tokens, (
+            f"{r.label}: verbose {r.verbose_tokens} < compact {r.compact_tokens} (modes swapped?)"
+        )

--- a/tests/test_token_compact_budget.py
+++ b/tests/test_token_compact_budget.py
@@ -7,11 +7,13 @@ fails loudly here. Budgets are set ~15% above the measured compact counts at the
 time of writing; the point is to catch regressions, not to pin exact numbers.
 
 Measured compact totals (simple tokenizer, example-bundle) at authoring time:
-  kb_search(20)=921  kb_search(100)=1451  kb_get(STD-U-004)=533  kb_get(ADR-002)=481
-  kb_get(MEM...)=659  kb_list(T1)=192  kb_outline=369  kb_health=81  aggregate=4687
-The compact aggregate saved 25.1% (simple) / 26.6% (tiktoken cl100k) vs verbose.
+  kb_search(20)=921  kb_search(100)=1451  kb_get(STD-U-004)=541  kb_get(ADR-002)=489
+  kb_get(MEM...)=667  kb_list(T1)=192  kb_outline=369  kb_health=81  aggregate=4711
+The compact aggregate saved 24.7% (simple) / 26.1% (tiktoken cl100k) vs verbose.
 """
 from __future__ import annotations
+
+import pytest
 
 from benchmarks.token_compact import measure
 
@@ -19,14 +21,14 @@ from benchmarks.token_compact import measure
 _BUDGETS = {
     "kb_search (limit 20, 'commit message format')": 1060,
     "kb_search (limit 100, 'module standard commit secret')": 1670,
-    "kb_get (STD-U-004)": 615,
-    "kb_get (ADR-002)": 555,
-    "kb_get (MEM-2026-06-20-nestjs-module-naming-collision)": 760,
+    "kb_get (STD-U-004)": 625,
+    "kb_get (ADR-002)": 565,
+    "kb_get (MEM-2026-06-20-nestjs-module-naming-collision)": 770,
     "kb_list (T1)": 225,
     "kb_outline": 425,
     "kb_health": 95,
 }
-_AGGREGATE_BUDGET = 5400  # ~15% over 4687
+_AGGREGATE_BUDGET = 5420  # ~15% over 4711
 
 
 def test_compact_defaults_under_budget() -> None:
@@ -56,6 +58,32 @@ def test_compact_saves_meaningfully_vs_verbose() -> None:
 
     assert report.total_pct_saved >= 20.0, (
         f"aggregate only saved {report.total_pct_saved:.1f}%"
+    )
+
+
+def _tiktoken_available() -> bool:
+    try:
+        import tiktoken  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+@pytest.mark.skipif(not _tiktoken_available(), reason="tiktoken not installed")
+def test_tiktoken_aggregate_savings_hold() -> None:
+    """Real-tokenizer (tiktoken cl100k) guard for the headline PR/CHANGELOG claim.
+
+    The changelog quotes tiktoken-cl100k percentages; this asserts they do not
+    silently regress (the simple-tokenizer budget above could pass while the real
+    model-token savings evaporate). Skipped with a clear reason when tiktoken is
+    absent so it never blocks a dependency-free environment."""
+    report = measure(tokenizer="tiktoken")
+    assert report.tokenizer_name == "tiktoken-cl100k"
+    by_label = {r.label: r for r in report.rows}
+    assert by_label["kb_search (limit 20, 'commit message format')"].pct_saved >= 30.0
+    assert by_label["kb_search (limit 100, 'module standard commit secret')"].pct_saved >= 30.0
+    assert report.total_pct_saved >= 20.0, (
+        f"tiktoken aggregate only saved {report.total_pct_saved:.1f}%"
     )
 
 

--- a/tests/test_token_compact_shapes.py
+++ b/tests/test_token_compact_shapes.py
@@ -99,8 +99,11 @@ def test_get_compact_keeps_full_body_trims_envelope(
     compact = shape_response(resp, verbose=False)
 
     assert compact["content_markdown"] == resp.content_markdown, "full body preserved"
-    for dropped in ("path", "git_remote_url", "last_modified_source", "source_commit"):
+    for dropped in ("path", "git_remote_url", "last_modified_source"):
         assert dropped not in compact
+    # Provenance a direct caller needs is retained.
+    assert compact["source_commit"] == resp.source_commit
+    assert compact["last_modified"] == resp.last_modified
     assert compact["id"] == "STD-U-001"
     assert compact["tier"] == resp.tier
 

--- a/tests/test_token_compact_shapes.py
+++ b/tests/test_token_compact_shapes.py
@@ -1,0 +1,278 @@
+"""Compact-vs-verbose shape tests for the read tools (issue #65).
+
+Two axes are covered:
+  - Model level: SearchResponse/GetResponse/ListResponse/OutlineResponse/
+    HealthResponse ``compact_dump`` drops exactly the intended fields, keeps the
+    payload, and surfaces deviating status; ``verbose`` (model_dump) reproduces
+    today's exact shape.
+  - Wire level: the MCP tool wrappers (via an in-memory FastMCP Client) and the
+    REST handlers (via httpx ASGI) honour ``verbose`` consistently. Compact is
+    the default; ``verbose=True`` restores the full shape on both surfaces.
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import httpx
+import pytest
+from fastmcp import Client
+
+from data_olympus.index import Index
+from data_olympus.server import build_app
+from data_olympus.tools_read import (
+    kb_get_fn,
+    kb_health_fn,
+    kb_list_fn,
+    kb_outline_fn,
+    kb_search_fn,
+    shape_response,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+# --------------------------------------------------------------------------
+# Model-level compact/verbose shape
+# --------------------------------------------------------------------------
+
+
+def test_search_compact_drops_query_path_score(status_kb: Path, tmp_index_path: Path) -> None:
+    idx = Index(tmp_index_path)
+    idx.build(status_kb, source_commit="x")
+    resp = kb_search_fn(idx=idx, query="caching")
+    compact = shape_response(resp, verbose=False)
+
+    assert "query" not in compact, "compact drops the query echo"
+    assert compact["source_commit"] == "x"
+    assert compact["total_returned"] == len(resp.hits)
+    for hit in compact["hits"]:
+        assert set(hit) <= {"id", "title", "snippet", "status", "type"}
+        assert "path" not in hit, "compact drops per-hit path (fetch via kb_get)"
+        assert "score" not in hit, "compact drops the raw bm25 score"
+
+
+def test_search_compact_surfaces_only_deviating_status(
+    status_kb: Path, tmp_index_path: Path
+) -> None:
+    """In-force hits omit status; a superseded hit KEEPS it (the signal an agent
+    must act on)."""
+    idx = Index(tmp_index_path)
+    idx.build(status_kb, source_commit="x")
+    resp = kb_search_fn(idx=idx, query="caching", limit=100)
+    compact = shape_response(resp, verbose=False)
+    by_id = {h["id"]: h for h in compact["hits"]}
+
+    assert by_id["STD-NEW"].get("status") is None, "active status omitted"
+    assert by_id["DEC-1"].get("status") is None, "accepted (in-force) status omitted"
+    assert by_id["STD-OLD"]["status"] == "superseded", "deviating status surfaced"
+
+
+def test_search_verbose_reproduces_full_shape(status_kb: Path, tmp_index_path: Path) -> None:
+    idx = Index(tmp_index_path)
+    idx.build(status_kb, source_commit="x")
+    resp = kb_search_fn(idx=idx, query="caching")
+    verbose = shape_response(resp, verbose=True)
+
+    assert verbose == resp.model_dump(), "verbose is byte-for-byte the legacy shape"
+    assert verbose["query"] == "caching"
+    for hit in verbose["hits"]:
+        assert {"id", "path", "title", "snippet", "score", "status", "type"} <= set(hit)
+
+
+def test_search_compact_caps_snippet() -> None:
+    from data_olympus.models import COMPACT_SNIPPET_CHARS, SearchHitModel
+
+    long = "x" * (COMPACT_SNIPPET_CHARS + 500)
+    hit = SearchHitModel(id="A", path="a.md", title="A", snippet=long, score=-1.0)
+    compact = hit.compact_dump()
+    assert len(str(compact["snippet"])) == COMPACT_SNIPPET_CHARS + 1  # +1 for the ellipsis
+    assert str(compact["snippet"]).endswith("…")
+
+
+def test_get_compact_keeps_full_body_trims_envelope(
+    tmp_kb: Path, tmp_index_path: Path
+) -> None:
+    idx = Index(tmp_index_path)
+    idx.build(tmp_kb, source_commit="abc")
+    resp = kb_get_fn(idx=idx, id="STD-U-001")
+    compact = shape_response(resp, verbose=False)
+
+    assert compact["content_markdown"] == resp.content_markdown, "full body preserved"
+    for dropped in ("path", "git_remote_url", "last_modified_source", "source_commit"):
+        assert dropped not in compact
+    assert compact["id"] == "STD-U-001"
+    assert compact["tier"] == resp.tier
+
+
+def test_get_verbose_reproduces_full_shape(tmp_kb: Path, tmp_index_path: Path) -> None:
+    idx = Index(tmp_index_path)
+    idx.build(tmp_kb, source_commit="abc")
+    resp = kb_get_fn(idx=idx, id="STD-U-001")
+    assert shape_response(resp, verbose=True) == resp.model_dump()
+
+
+def test_list_compact_drops_path(tmp_kb: Path, tmp_index_path: Path) -> None:
+    idx = Index(tmp_index_path)
+    idx.build(tmp_kb, source_commit="x")
+    resp = kb_list_fn(idx=idx, tier="T1")
+    compact = shape_response(resp, verbose=False)
+
+    assert "category" not in compact, "null category omitted"
+    for entry in compact["entries"]:
+        assert set(entry) == {"id", "title"}
+    assert compact["total"] == len(resp.entries)
+
+
+def test_list_verbose_reproduces_full_shape(tmp_kb: Path, tmp_index_path: Path) -> None:
+    idx = Index(tmp_index_path)
+    idx.build(tmp_kb, source_commit="x")
+    resp = kb_list_fn(idx=idx, tier="T1", category="foundation")
+    verbose = shape_response(resp, verbose=True)
+    assert verbose == resp.model_dump()
+    assert verbose["category"] == "foundation"
+    for entry in verbose["entries"]:
+        assert "path" in entry
+
+
+def test_outline_compact_equals_verbose(tmp_kb: Path, tmp_index_path: Path) -> None:
+    """kb_outline is already lean: compact and verbose are the same shape."""
+    idx = Index(tmp_index_path)
+    idx.build(tmp_kb, source_commit="x")
+    resp = kb_outline_fn(idx=idx)
+    assert shape_response(resp, verbose=False) == shape_response(resp, verbose=True)
+    assert shape_response(resp, verbose=True) == resp.model_dump()
+
+
+def test_health_compact_omits_nulls_keeps_core(tmp_kb: Path, tmp_index_path: Path) -> None:
+    idx = Index(tmp_index_path)
+    idx.build(tmp_kb, source_commit="x")
+    resp = kb_health_fn(idx=idx, last_git_pull_at=None, staleness_degraded_sec=600)
+    compact = shape_response(resp, verbose=False)
+
+    # Core fields a consumer always branches on are present even when falsy.
+    for core in ("kb_commit", "total_rules", "degraded", "db_size_bytes"):
+        assert core in compact
+    # Null diagnostics are omitted.
+    assert "last_index_error" not in compact
+    assert "remote_head_sha" not in compact
+    assert "last_git_pull_at" not in compact  # None -> omitted
+
+
+def test_health_verbose_reproduces_full_shape(tmp_kb: Path, tmp_index_path: Path) -> None:
+    idx = Index(tmp_index_path)
+    idx.build(tmp_kb, source_commit="x")
+    resp = kb_health_fn(idx=idx, last_git_pull_at=None, staleness_degraded_sec=600)
+    verbose = shape_response(resp, verbose=True)
+    assert verbose == resp.model_dump()
+    assert "last_index_error" in verbose  # present as null in verbose
+
+
+def test_health_compact_keeps_populated_diagnostic() -> None:
+    """A populated diagnostic (a real error) survives the null filter."""
+    from data_olympus.models import HealthResponse
+
+    h = HealthResponse(
+        kb_commit="c", index_built_at=1.0, total_rules=3, last_git_pull_at=None,
+        staleness_seconds=None, degraded=True, db_size_bytes=10,
+        last_index_build_status="failed", last_index_error="dup id",
+    )
+    compact = h.compact_dump()
+    assert compact["last_index_build_status"] == "failed"
+    assert compact["last_index_error"] == "dup id"
+
+
+# --------------------------------------------------------------------------
+# Wire level: MCP tool wrappers
+# --------------------------------------------------------------------------
+
+
+def _app(tmp_kb: Path, tmp_path: Path):
+    return build_app(
+        kb_main_path=tmp_kb,
+        kb_index_path=tmp_path / "idx.db",
+        sync_interval_sec=60,
+        staleness_degraded_sec=600,
+        bootstrap_now=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_mcp_search_compact_default_and_verbose(tmp_kb: Path, tmp_path: Path) -> None:
+    app = _app(tmp_kb, tmp_path)
+    async with Client(app) as client:
+        compact = (await client.call_tool("kb_search", {"query": "worktree"})).data
+        verbose = (
+            await client.call_tool("kb_search", {"query": "worktree", "verbose": True})
+        ).data
+
+    assert "query" not in compact
+    assert all("path" not in h and "score" not in h for h in compact["hits"])
+    assert verbose["query"] == "worktree"
+    assert all("path" in h and "score" in h for h in verbose["hits"])
+
+
+@pytest.mark.asyncio
+async def test_mcp_get_compact_default_and_verbose(tmp_kb: Path, tmp_path: Path) -> None:
+    app = _app(tmp_kb, tmp_path)
+    async with Client(app) as client:
+        compact = (await client.call_tool("kb_get", {"id": "STD-U-001"})).data
+        verbose = (
+            await client.call_tool("kb_get", {"id": "STD-U-001", "verbose": True})
+        ).data
+
+    assert "path" not in compact
+    assert compact["content_markdown"]  # body kept
+    assert "path" in verbose and "source_commit" in verbose
+
+
+@pytest.mark.asyncio
+async def test_mcp_list_and_health_compact_default(tmp_kb: Path, tmp_path: Path) -> None:
+    app = _app(tmp_kb, tmp_path)
+    async with Client(app) as client:
+        lst = (await client.call_tool("kb_list", {"tier": "T1"})).data
+        health = (await client.call_tool("kb_health", {})).data
+        health_v = (await client.call_tool("kb_health", {"verbose": True})).data
+
+    assert all("path" not in e for e in lst["entries"])
+    assert "last_index_error" not in health
+    assert "last_index_error" in health_v
+
+
+# --------------------------------------------------------------------------
+# Wire level: REST handlers
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_rest_read_tools_honour_verbose(tmp_kb: Path, tmp_path: Path) -> None:
+    app = _app(tmp_kb, tmp_path)
+    transport = httpx.ASGITransport(app=app.http_app())
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        s_compact = (await client.get("/api/v1/search", params={"q": "worktree"})).json()
+        s_verbose = (
+            await client.get("/api/v1/search", params={"q": "worktree", "verbose": "true"})
+        ).json()
+        g_compact = (await client.get("/api/v1/get/STD-U-001")).json()
+        g_verbose = (
+            await client.get("/api/v1/get/STD-U-001", params={"verbose": "true"})
+        ).json()
+        l_compact = (await client.get("/api/v1/list", params={"tier": "T1"})).json()
+        l_verbose = (
+            await client.get("/api/v1/list", params={"tier": "T1", "verbose": "true"})
+        ).json()
+        h_compact = (await client.get("/api/v1/health")).json()
+        h_verbose = (await client.get("/api/v1/health", params={"verbose": "true"})).json()
+
+    assert "query" not in s_compact and s_verbose["query"] == "worktree"
+    assert all("path" not in h for h in s_compact["hits"])
+    assert all("path" in h for h in s_verbose["hits"])
+
+    assert "path" not in g_compact and "path" in g_verbose
+    assert g_compact["content_markdown"]
+
+    assert all("path" not in e for e in l_compact["entries"])
+    assert all("path" in e for e in l_verbose["entries"])
+
+    assert "last_index_error" not in h_compact
+    assert "last_index_error" in h_verbose


### PR DESCRIPTION
## Summary

Makes the read tools (`kb_search`, `kb_get`, `kb_list`, `kb_outline`, `kb_health`) return a **token-compact** representation **by default**, with a `verbose` opt-out that restores the exact legacy JSON shape byte-for-byte. The consumer of these responses is almost always an LLM paying for every token, so a leaner default cuts the recurring context/cost tax on every MCP call. Per issue #65, this shipped only after measuring: the cuts below are the ones the numbers justify.

Closes #65.

## Measured token savings (before/after)

Reproduce: `python -m benchmarks.token_compact --tokenizer tiktoken` (or omit the flag for the dependency-free `simple` splitter). Corpus is the committed `example-bundle` (13 content docs incl. supersession/memory/reference).

**Real tokenizer — tiktoken cl100k:**

| Tool scenario | Verbose | Compact | Saved | % |
|---|---:|---:|---:|---:|
| kb_search (limit 20, "commit message format") | 1110 | 699 | 411 | 37.0% |
| kb_search (limit 100, "module standard commit secret") | 1796 | 1118 | 678 | 37.8% |
| kb_get (STD-U-004) | 509 | 477 | 32 | 6.3% |
| kb_get (ADR-002) | 501 | 464 | 37 | 7.4% |
| kb_get (MEM-2026-06-20-nestjs-module-naming-collision) | 648 | 609 | 39 | 6.0% |
| kb_list (T1) | 243 | 140 | 103 | 42.4% |
| kb_outline | 278 | 278 | 0 | 0.0% |
| kb_health | 182 | 107 | 75 | 41.2% |
| **Aggregate** | **5267** | **3892** | **1375** | **26.1%** |

**Dependency-free `simple` splitter (used by the regression budget):** aggregate 6260 → 4711 = **24.7%**; kb_search 33-35%, kb_list 43%, kb_health 43%, kb_get 6-7%.

## Decisions on each candidate cut

- **`kb_search`** (37% real): drop the `query` echo (caller knows it); drop per-hit `path` (redundant with `id` — fetch full metadata via `kb_get(id)`); drop the raw bm25 `score` (a high-entropy float like `-4.877023162317077` that mixes incompatible conventions across pipeline paths and is uninterpretable to an agent — array order already conveys rank); **surface `status` only when a hit deviates from the in-force class** (superseded/deprecated — the signal an agent must act on) and omit it for active/accepted; keep `type` when set; cap snippets at 160 chars (guard against pathological snippets; no truncation on this corpus).
- **`kb_get`** (6-7% real): keep the full `content_markdown` body (agents call kb_get to read the doc) **and** `source_commit`/`last_modified` provenance; drop only `path` (recoverable via `verbose=true`), `git_remote_url` (null for most docs), and `last_modified_source` (a provenance label, not the timestamp); omit empty status/type/applies_when/description. Above the 5% adopt bar, and verbose restores everything.
- **`kb_list`** (42% real): drop per-entry `path`; omit null `category`.
- **`kb_health`** (41% real): keep the core snapshot a consumer branches on; omit diagnostic fields that are null/empty (a no-error steady state stops emitting a run of nulls). Generic filter, so a field a concurrent package (WP3a) adds flows through and appears only when populated — **additive, WP3a-safe**.
- **`kb_outline`** (0%): already lean; no cut clears the 5% bar without complicating clients, so **left verbose-equivalent** and documented as such (per issue #65's "leave it verbose and say so" rule).

## Compatibility

Behavioral change to default response shapes (prominent CHANGELOG note under `### Changed`). Opt out with `verbose=true` (REST query param / MCP tool arg), which reproduces the pre-#65 shape byte-for-byte. In-repo consumers updated: the `kb` CLI requests `verbose=true` automatically (plain output unaffected; the local fallback already emits the full shape); tests and the quickstart doc updated; MCP tool descriptions document the compact shape.

## Threading

`verbose` flows from the `server.py` MCP tool wrappers and `rest_api.py` REST handlers through `tools_read.shape_response` into per-model `compact_dump`/`model_dump`, so MCP and REST stay consistent.

## Test evidence

- New `tests/test_token_compact_shapes.py` (17 tests): compact + verbose shape of every read tool at the model level, the MCP wire level (in-memory FastMCP client), and the REST wire level (httpx ASGI). Verbose asserted equal to `model_dump()`.
- New `tests/test_token_compact_budget.py`: tokenizer-based regression — `simple` per-tool + aggregate budgets with ~15% headroom, a `>=25%` kb_search savings floor, and a **tiktoken aggregate-savings guard** (skipped when tiktoken absent) so the real-tokenizer claim is guarded.
- New `benchmarks/token_compact.py` measurement harness (committed, deterministic).
- Full suite green (1 unrelated skip: optional `sentence_transformers`), `ruff check .` clean, `mypy src` clean, `bats tests/test_kb_cli.bats` 12/12, `check_changelog` / `check_doc_consistency` / `check_benchmark_docs` all ok.

## Peer review (codex)

**Verdict: No Blockers; 2 Concerns, both addressed.**

- *Concern — headline tiktoken numbers vs the documented reproduction command.* The changelog cited tiktoken numbers while the committed command and regression test used `simple`. Fixed: documented `--tokenizer tiktoken` for the cl100k numbers and added a tiktoken aggregate-savings regression test.
- *Concern — kb_get dropped non-derivable provenance.* `source_commit` is not derivable from the compact payload and matters for auditability. Fixed: compact kb_get now retains `source_commit`/`last_modified`; corrected the docstring (path is recoverable via verbose, not derivable from id).

Codex confirmed verbose routes through `model_dump()` and matches `origin/release/0.3.0`, bin/kb appends `verbose=true`, and MCP descriptions document both shapes.
