### PR TITLE
feat(ops): readiness split, audit-log rotation with chain continuity, proxy config, rootless container, operations runbook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,47 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **Serving/ops hardening (WP3a).** Production-readiness work on the serving path,
+  container, and operator docs:
+  - **Readiness split from data staleness.** New `GET /readyz` (200 when the
+    process is up and the index is loaded, **independent of staleness**) and
+    `GET /livez` (always 200). The Kubernetes readiness probe now targets
+    `/readyz` instead of `/api/v1/health`, so a git-remote outage that makes the
+    KB stale no longer ejects a single-replica pod from the Service and turns
+    "reads are slightly old" into a hard 503. `/api/v1/health` keeps its
+    503-on-degraded contract for the `bin/kb --no-stale` flag; alert on it rather
+    than probing it.
+  - **Audit-log rotation with chain continuity (`KB_AUDIT_MAX_BYTES`).** Size-based
+    rotation that carries the tamper-evident hash chain across files (the first
+    event of a new segment links to the last hash of the previous one), so
+    `verify` validates across the rotation boundary. The read path can include
+    rotated segments for `--since` queries and bounds the reverse scan. Off by
+    default (single-file, backward compatible; old single-file logs still verify).
+  - **Proxy-header configuration (`KB_TRUSTED_PROXIES`).** Enables uvicorn
+    `proxy_headers` + `forwarded_allow_ips` so the rate limiter sees the real
+    client IP behind an ingress instead of collapsing every client into the proxy
+    address. Off by default (X-Forwarded-For ignored) so a direct client cannot
+    spoof its address.
+  - **Rootless container.** The root+`gosu` entrypoint phase is removed. Deploy-key
+    staging and the first-boot `/kb-main` clone move to a non-root `prepare-git`
+    initContainer; the main container and initContainer both run as uid 65534 with
+    `runAsNonRoot: true`, all capabilities dropped, and a read-only root FS, so the
+    manifest passes the **restricted** Pod Security Standard. The base image is
+    digest-pinned, the git SSH host is build-arg + runtime-env configurable
+    (`KB_SSH_KEYSCAN_HOST`), Docker Compose binds `127.0.0.1:8080`, and the Ingress
+    is commented out of the default kustomization (opt-in after auth is set) with a
+    `deploy/k8s/README.md` note.
+  - **`malformed_frontmatter` in health.** The count of docs whose front-matter was
+    present but malformed at the last index build (from WP2b) is surfaced on the
+    health payload. It is a warning signal and deliberately does **not** flip
+    `degraded`.
+  - **Operations runbook.** New `docs/operations.md` (linked from README and
+    `docs/serving.md`) covering backup (git remote plus the audit chain / pending
+    proposals / unpushed commits it does not cover), upgrade (image bump, taxonomy
+    compatibility, index rebuilds), recovery playbooks (degraded/fetch-failed,
+    history rewrite, frozen and rebase-conflict-demoted push entries, orphaned
+    locks), and the health/readiness/alerting model.
+
 - **Write-pipeline integrity core (epic #72).** This wave makes the write-safety
   claims in `SPEC.md` section 8 and `docs/serving.md` actually true; each item
   ships with regression tests, including two integration tests that drive a real

--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ See `docs/quickstart.md` for the full local-run walkthrough, including curl and 
 - [`SPEC.md`](SPEC.md): format specification (bundle layout, frontmatter schema, serving contracts).
 - [`docs/quickstart.md`](docs/quickstart.md): verified local-run procedure.
 - [`docs/adoption.md`](docs/adoption.md): bring-your-own-KB guide (author, lint, index, serve, wire an agent).
-- [`docs/serving.md`](docs/serving.md): single-replica serving model, read-only replicas, git pull loop.
+- [`docs/serving.md`](docs/serving.md): single-replica serving model, read-only replicas, git pull loop, health/readiness/liveness split, proxy headers, audit-log rotation.
+- [`docs/operations.md`](docs/operations.md): production runbook — backup, upgrade, recovery playbooks (degraded/fetch-failed, history rewrite, frozen/demoted push entries, orphaned locks), and the health/alerting model.
 - [`docs/comparison.md`](docs/comparison.md): how data-olympus relates to OKF, enterprise catalogs, markdown KB tools, agent-context conventions, RAG, and ADR tooling.
 - [`docs/enforcement.md`](docs/enforcement.md): turning the KB into a mandatory consultation gate (hooks, `kb enforce`).
 - [`benchmarks/README.md`](benchmarks/README.md): retrieval benchmark methodology and how to reproduce the numbers in `docs/comparison.md`.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -37,7 +37,7 @@ The single-writer write pipeline (propose, pending, resolve) is the primary atta
 - **Payload size caps.** `KB_MAX_TEXT_BYTES` (memory text, default 256 KiB), `KB_MAX_POSTIMAGE_BYTES` (edit/bootstrap file, default 1 MiB), and `KB_MAX_BODY_BYTES` (REST request body, default 2 MiB) reject oversized proposals before any disk write. The body cap is enforced by reading the request stream incrementally and returning `413` once the byte count is exceeded, so it bounds chunked or `Content-Length`-omitting clients, not just honest ones. Set to `0` to disable a given cap.
 - **Aggregate caps.** Onboarding bootstrap rejects requests over `KB_MAX_BOOTSTRAP_FILES` (default 50). The pending queue is bounded by `KB_PENDING_QUEUE_CAP` (default 100); enqueue past the cap is rejected rather than growing unbounded on disk.
 - **Confidence clamp.** Client-supplied `confidence` is advisory. Only a caller whose principal holds the `auto_commit` capability may auto-commit; everyone else has their proposals parked as pending regardless of the asserted confidence (see authentication below).
-- **Rate limiting.** A per-(remote_addr, agent_identity) sliding window (`KB_RATE_LIMIT_PER_HOUR`) plus an optional per-IP cap (`KB_RATE_LIMIT_PER_IP_PER_HOUR`, default disabled) bound write volume.
+- **Rate limiting.** A per-(remote_addr, agent_identity) sliding window (`KB_RATE_LIMIT_PER_HOUR`) plus an optional per-IP cap (`KB_RATE_LIMIT_PER_IP_PER_HOUR`, default disabled) bound write volume. Behind a proxy, set `KB_TRUSTED_PROXIES` so `remote_addr` is the real client IP (off by default; see the network-security section).
 - **Single writer.** The server runs a single writer with advisory locking and a durable push queue. Concurrent write races from multiple agent sessions are serialised rather than silently merged.
 
 ### Audit log
@@ -95,6 +95,14 @@ When neither `KB_AUTH_TOKEN` nor `KB_AUTH_PRINCIPALS` is set (the default), ever
 
 - Deploy on a trusted private network, or behind an authenticating reverse proxy (terminate TLS there).
 - NOT expose the server to untrusted networks.
+
+The default `kubectl apply -k deploy/k8s/` does NOT create the Ingress (it would publish the write routes to the LAN with auth unset by default); it is opt-in after `KB_AUTH_TOKEN` is set. The Docker Compose file binds `127.0.0.1:8080` so the local demo is not LAN-exposed. See `deploy/k8s/README.md`.
+
+**Proxy headers.** Behind a reverse proxy, set `KB_TRUSTED_PROXIES` to the proxy address(es) so the rate limiter sees the real client IP via `X-Forwarded-For`. It is **off by default** (X-Forwarded-For ignored), which prevents a direct client from spoofing its address to evade the per-IP cap. See `docs/serving.md`.
+
+## Container hardening
+
+The Kubernetes pod runs fully rootless: the `prepare-git` initContainer (deploy-key staging + first-boot clone) and the main container both run as uid 65534 with `runAsNonRoot: true`, all Linux capabilities dropped, `allowPrivilegeEscalation: false`, and a read-only root filesystem. The old root+`gosu` entrypoint phase has been removed. The base image is digest-pinned in `deploy/docker/Dockerfile`. Readiness targets `/readyz` (index loaded, independent of data staleness); `/api/v1/health` keeps its 503-on-degraded contract for the CLI `--no-stale` flag and should be **alerted on, not probed**. Operational runbook: `docs/operations.md`.
 
 ## License
 

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -1,10 +1,32 @@
 # syntax=docker/dockerfile:1.7
 
-FROM python:3.13-slim AS runtime
+# Digest-pinned base for reproducible, tamper-resistant builds. This is the
+# multi-arch (linux/amd64, arm64, ...) OCI index digest for python:3.13-slim.
+# To roll the pin forward: resolve the current tag's index digest and replace
+# BOTH the tag comment and the @sha256 below, e.g.
+#   docker buildx imagetools inspect python:3.13-slim   # shows the index digest
+# or via the registry API (no docker needed):
+#   TOKEN=$(curl -s "https://auth.docker.io/token?service=registry.docker.io&scope=repository:library/python:pull" | jq -r .token)
+#   curl -sI -H "Authorization: Bearer $TOKEN" \
+#     -H "Accept: application/vnd.oci.image.index.v1+json" \
+#     https://registry-1.docker.io/v2/library/python/manifests/3.13-slim \
+#     | grep -i docker-content-digest
+FROM python:3.13-slim@sha256:eb43ff125d8d58d7449dcba7d336c23bcac412f526d861db493b9994d8010280 AS runtime
 
-# Install git + ssh + gosu (privilege-drop helper) + ca-certs.
+# SSH host to trust for git over SSH. Defaults to github.com; override at build
+# time (--build-arg KB_SSH_KEYSCAN_HOST=git.example.com) for a non-GitHub remote.
+# The runtime KB_SSH_KEYSCAN_HOST env var (see entrypoint.sh) can add another host
+# at boot without a rebuild.
+ARG KB_SSH_KEYSCAN_HOST=github.com
+
+# Install git + ssh + ca-certs. gosu is intentionally NOT installed: the image
+# runs entirely as the non-root uid 65534 (see USER below), so there is no
+# root->non-root privilege drop to perform. The deploy-key permission fix and the
+# first-boot /kb-main clone that the old root entrypoint did are now handled by a
+# non-root k8s initContainer (see deploy/k8s/statefulset.yaml) writing to shared
+# volumes with an fsGroup, so the runtime container never needs root or gosu.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-        git openssh-client ca-certificates curl gosu \
+        git openssh-client ca-certificates curl \
     && rm -rf /var/lib/apt/lists/*
 
 # Install uv (same version as before)
@@ -23,27 +45,40 @@ RUN uv sync --frozen --no-dev
 RUN mkdir -p /tmp/uv-cache && chmod 0777 /tmp/uv-cache
 ENV UV_CACHE_DIR=/tmp/uv-cache
 
-# Pre-create runtime volume mount points + writable kb-main.
+# Pre-create runtime volume mount points + writable kb-main, owned by the runtime
+# uid so the container can write them when running as non-root (and when a PVC is
+# mounted the fsGroup owns the volume root; these image dirs are the fallback for
+# non-k8s runs like docker compose).
 RUN mkdir -p /kb-main /kb-worktrees /state/pending /state/pending/locks \
              /state/push-queue /state/audit /index \
     && chown -R 65534:65534 /kb-main /kb-worktrees /state /index
 
-# Bake GitHub's current known_hosts; rotate by rebuilding image.
-RUN ssh-keyscan -t ed25519 github.com > /etc/ssh/known_hosts \
+# Bake the git host's current known_hosts; rotate by rebuilding image (or add a
+# host at runtime via KB_SSH_KEYSCAN_HOST, see entrypoint.sh). Written into
+# /etc/ssh (root-owned, world-readable) at build time; the entrypoint appends any
+# runtime host into a user-writable copy so the read-only-root container can still
+# extend it without needing to write /etc/ssh.
+RUN ssh-keyscan -t ed25519,rsa "${KB_SSH_KEYSCAN_HOST}" > /etc/ssh/known_hosts \
     && chmod 0644 /etc/ssh/known_hosts
 
-# Entrypoint runs as root (no USER directive); drops privileges in entrypoint.sh.
+# Entrypoint runs as the non-root runtime user (no privilege drop). It prepares a
+# user-writable known_hosts and the git identity, then execs the server.
 COPY deploy/docker/entrypoint.sh /entrypoint.sh
-RUN chmod +x /entrypoint.sh
+RUN chmod 0755 /entrypoint.sh
 
 ENV KB_MAIN_PATH=/kb-main \
     KB_INDEX_PATH=/index/kb.db \
     KB_PENDING_ROOT=/state/pending \
     KB_PUSH_QUEUE_ROOT=/state/push-queue \
     KB_WORKTREE_ROOT=/kb-worktrees \
-    KB_HTTP_PORT=8080
+    KB_HTTP_PORT=8080 \
+    KB_SSH_KEYSCAN_HOST=${KB_SSH_KEYSCAN_HOST}
 
 EXPOSE 8080
+
+# Run as the non-root nobody uid. Combined with runAsNonRoot:true in k8s this lets
+# the manifest pass the restricted PodSecurity standard.
+USER 65534:65534
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["uv", "run", "--no-sync", "data-olympus-mcp"]

--- a/deploy/docker/compose.yaml
+++ b/deploy/docker/compose.yaml
@@ -5,7 +5,11 @@ services:
       context: ../..
       dockerfile: deploy/docker/Dockerfile
     ports:
-      - "8080:8080"
+      # Bind to loopback only. The write + enforcement REST routes are open when
+      # KB_AUTH_TOKEN is unset (the compose default), so publishing on 0.0.0.0
+      # would expose them to the whole LAN. Loopback keeps the local demo private;
+      # change to "8080:8080" (or a host IP) only behind an authenticating proxy.
+      - "127.0.0.1:8080:8080"
     environment:
       KB_MAIN_PATH: /kb-main
       KB_INDEX_PATH: /index/kb.db

--- a/deploy/docker/entrypoint.sh
+++ b/deploy/docker/entrypoint.sh
@@ -1,8 +1,14 @@
 #!/bin/sh
-# Runs as root. Handles SSH key + (optional) /kb-main bootstrap, then drops to uid 65534.
+# Runs as the NON-ROOT runtime uid (65534). No privilege drop (gosu is gone).
+#
+# In k8s the deploy-key permission fix and the first-boot /kb-main clone are done
+# by a non-root initContainer (see deploy/k8s/statefulset.yaml) before this runs,
+# so here we only prepare the SSH known_hosts + git identity and exec the server.
+# For a plain `docker compose` run (no initContainer) this script also performs
+# the key copy and the clone itself, still entirely as non-root.
 set -e
 
-# --- Git author/committer identity (scope item 10) ---------------------------
+# --- Git author/committer identity -------------------------------------------
 # The shipped image sets no git user, so a commit inside a fresh container fails
 # with "Please tell me who you are". Export a default identity (operator-
 # overridable via KB_GIT_AUTHOR_NAME / KB_GIT_AUTHOR_EMAIL) so the artifact can
@@ -18,38 +24,57 @@ export GIT_COMMITTER_EMAIL="$GIT_EMAIL"
 # --- Writable scratch under a read-only root filesystem ----------------------
 # When the container runs with readOnlyRootFilesystem, /tmp is an emptyDir mount
 # that starts empty (masking the image's pre-created /tmp/uv-cache). Recreate the
-# uv cache dir owned by the runtime user so `uv run` can write there.
+# uv cache dir; we already run as the runtime user, so no chown is needed.
 mkdir -p "${UV_CACHE_DIR:-/tmp/uv-cache}"
-chown 65534:65534 "${UV_CACHE_DIR:-/tmp/uv-cache}" || true
+
+# --- known_hosts (user-writable copy) ----------------------------------------
+# The image bakes /etc/ssh/known_hosts, but /etc is not writable to the non-root
+# user under a read-only root FS, so we cannot append a runtime host there.
+# Maintain a user-writable copy under /tmp and point SSH at it. If
+# KB_SSH_KEYSCAN_HOST names a host not already trusted, add it at boot (lets a
+# non-GitHub remote work without a rebuild).
+KNOWN_HOSTS=/tmp/known_hosts
+if [ -f /state/known_hosts ]; then
+    # k8s: the initContainer already scanned KB_SSH_KEYSCAN_HOST into /state.
+    cp /state/known_hosts "$KNOWN_HOSTS"
+elif [ -f /etc/ssh/known_hosts ]; then
+    cp /etc/ssh/known_hosts "$KNOWN_HOSTS"
+else
+    : > "$KNOWN_HOSTS"
+fi
+if [ -n "${KB_SSH_KEYSCAN_HOST:-}" ] && ! grep -q "^${KB_SSH_KEYSCAN_HOST} " "$KNOWN_HOSTS" 2>/dev/null; then
+    ssh-keyscan -t ed25519,rsa "${KB_SSH_KEYSCAN_HOST}" >> "$KNOWN_HOSTS" 2>/dev/null || \
+        echo "[entrypoint] WARNING: ssh-keyscan for ${KB_SSH_KEYSCAN_HOST} failed"
+fi
+chmod 0644 "$KNOWN_HOSTS"
 
 # --- SSH key for git push/pull -----------------------------------------------
-# Mounted via the K8s Secret -> /etc/git-key-mount (read-only). We copy to
-# /tmp/git-key so we can chown + chmod for the non-root runtime user.
-if [ -f /etc/git-key-mount ]; then
-    cp /etc/git-key-mount /tmp/git-key
-    chown 65534:65534 /tmp/git-key
-    chmod 0400 /tmp/git-key
-    export GIT_SSH_COMMAND="ssh -i /tmp/git-key -o UserKnownHostsFile=/etc/ssh/known_hosts -o StrictHostKeyChecking=yes"
+# In k8s the initContainer copies the deploy key to /state/git-key (0400, owned
+# by the runtime user) so it is ready before we start. For a bare `docker compose`
+# run the Secret is instead mounted read-only at /etc/git-key-mount; copy it to a
+# user-writable path so ssh accepts the perms. Prefer the pre-staged key.
+KEY_PATH="${KB_GIT_KEY_PATH:-/tmp/git-key}"
+if [ -f /state/git-key ]; then
+    KEY_PATH=/state/git-key
+elif [ -f /etc/git-key-mount ]; then
+    cp /etc/git-key-mount "$KEY_PATH"
+    chmod 0400 "$KEY_PATH"
+fi
+if [ -f "$KEY_PATH" ]; then
+    export GIT_SSH_COMMAND="ssh -i $KEY_PATH -o UserKnownHostsFile=$KNOWN_HOSTS -o StrictHostKeyChecking=yes"
 fi
 
-# --- Bootstrap /kb-main on first boot ----------------------------------------
-# On a fresh PVC the /kb-main mount is empty (possibly with a 'lost+found'
-# directory created by the filesystem). The MCP refuses to start under those
-# conditions (no git repo to refresh / search). We clone here once, fix
-# ownership for the non-root user, and leave the directory ready.
-#
-# Idempotent: skipped on subsequent pod restarts because /kb-main is non-empty.
-# Safe: only attempts the clone when KB_GIT_REMOTE_URL is set. If the clone
-# fails (network, key, etc.) the volume stays empty and the MCP reports a
-# degraded health state so the operator notices.
-
+# --- Bootstrap /kb-main on first boot (docker compose path only) -------------
+# In k8s the initContainer already cloned /kb-main. For a bare docker run there is
+# no initContainer, so do it here. Idempotent: skipped when /kb-main is non-empty.
+# Safe: only clones when KB_GIT_REMOTE_URL is set. On clone failure the volume
+# stays empty and the MCP reports degraded so the operator notices.
 if [ -n "${KB_GIT_REMOTE_URL:-}" ] && [ -d /kb-main ]; then
     found_real_files=$(find /kb-main -mindepth 1 -maxdepth 1 \
         ! -name 'lost+found' -print -quit 2>/dev/null || true)
     if [ -z "$found_real_files" ]; then
         echo "[entrypoint] /kb-main is empty; cloning ${KB_GIT_REMOTE_URL}"
         if git clone "$KB_GIT_REMOTE_URL" /kb-main; then
-            chown -R 65534:65534 /kb-main
             echo "[entrypoint] bootstrap complete"
         else
             echo "[entrypoint] WARNING: clone failed; pod will start degraded"
@@ -57,4 +82,4 @@ if [ -n "${KB_GIT_REMOTE_URL:-}" ] && [ -d /kb-main ]; then
     fi
 fi
 
-exec gosu 65534:65534 "$@"
+exec "$@"

--- a/deploy/k8s/README.md
+++ b/deploy/k8s/README.md
@@ -1,0 +1,59 @@
+# data-olympus Kubernetes manifests
+
+Base stack for the single-writer MCP server: namespace, configmap, Service,
+NetworkPolicy, and the writer StatefulSet. Apply with kustomize:
+
+```bash
+# 1. Apply the SOPS-encrypted Secret (kustomize can't decrypt SOPS in-flow):
+sops exec-file secret.sops.yaml 'kubectl apply -f {}'
+# 2. Apply the base stack:
+kubectl apply -k .
+```
+
+## Two resources are intentionally excluded from the default apply
+
+Both are opt-in because applying them by default would be unsafe:
+
+- **`secret.sops.yaml`** — SOPS-encrypted, applied separately (step 1 above) so
+  the plaintext key never lands on disk.
+- **`ingress.yaml`** — the Ingress publishes **all** routes, including the write
+  and enforcement REST routes (`/api/v1/propose/*`, `/api/v1/resolve/*`,
+  `/api/v1/onboarding/bootstrap`, `/api/v1/consult`, `/api/v1/gate/check`). With
+  `KB_AUTH_TOKEN` unset that is an **unauthenticated write surface reachable from
+  wherever the ingress controller is** (the LAN, by default). The default
+  `kubectl apply -k .` therefore exposes only the in-cluster `Service`.
+
+### Enabling the Ingress (after you have set auth)
+
+1. Set `KB_AUTH_TOKEN` (and optionally `KB_AUTH_PRINCIPALS`) in the Secret so the
+   write + enforcement routes require a bearer token. Read routes stay open by
+   design; if reads must be confidential too, also restrict to a trusted network
+   or front the Ingress with an authenticating reverse proxy.
+2. Edit `ingress.yaml`: replace the `host`, and uncomment the TLS block +
+   cert-manager annotation so write routes are never served over plaintext.
+3. Uncomment `- ingress.yaml` in `kustomization.yaml`.
+4. Re-apply: `kubectl apply -k .`.
+
+See the repository `SECURITY.md` for the full threat model.
+
+## Security posture
+
+- **Rootless containers.** Both the `prepare-git` initContainer and the main
+  container run as the non-root uid `65534` with `runAsNonRoot: true`, all
+  Linux capabilities dropped, `allowPrivilegeEscalation: false`, and a read-only
+  root filesystem. `fsGroup: 65534` gives the non-root process write access to the
+  PVCs and read access to the deploy-key Secret. The manifest passes the
+  **restricted** Pod Security Standard.
+- **Deploy-key flow.** The old root+`gosu` entrypoint is gone. The initContainer
+  stages the SSH deploy key to `/state/git-key` (mode `0400`) on the shared state
+  volume and performs the first-boot `/kb-main` clone, all as non-root.
+- **Probes.** Readiness targets `/readyz` (process up + index loaded, independent
+  of data staleness) so a stale-KB pod is not ejected from the Service. Liveness
+  is a `tcpSocket` check (an HTTP `/livez` route also exists). `/api/v1/health`
+  keeps its 503-on-degraded contract for the CLI `--no-stale` flag; alert on it,
+  do not probe it. See `../../docs/operations.md` for the full alerting model.
+
+## Read replicas
+
+`read-replica/` holds an overlay of N read-only replicas (a Deployment, not the
+writer StatefulSet). See `../../docs/serving.md`.

--- a/deploy/k8s/kustomization.yaml
+++ b/deploy/k8s/kustomization.yaml
@@ -5,9 +5,17 @@ resources:
   - namespace.yaml
   - configmap.yaml
   - service.yaml
-  - ingress.yaml
   - networkpolicy.yaml
   - statefulset.yaml
+  # ingress.yaml is DELIBERATELY NOT in resources. The Ingress publishes ALL
+  # routes, including the write + enforcement routes, to whatever the ingress
+  # controller is reachable from (the LAN, by default). With KB_AUTH_TOKEN unset
+  # that is an unauthenticated write surface. So the default `kubectl apply -k`
+  # exposes only the in-cluster Service; you opt into external exposure explicitly
+  # AFTER setting auth. Uncomment the line above (and edit ingress.yaml's host/TLS)
+  # to enable it, exactly as you separately apply the secret below. See README.md.
+  # - ingress.yaml
+  #
   # secret.sops.yaml NOT in resources because kustomize can't decrypt SOPS in
   # its base flow. The deploy script applies it separately via:
   #   sops exec-file secret.sops.yaml 'kubectl apply -f {}'

--- a/deploy/k8s/statefulset.yaml
+++ b/deploy/k8s/statefulset.yaml
@@ -32,7 +32,10 @@ spec:
       # transition anywhere in the pod.
       initContainers:
         - name: prepare-git
-          image: ghcr.io/knaisoma/data-olympus:v0.1.1  # keep in sync with the main container tag
+          # Must be >= v0.3.0: the rootless deploy-key staging (/state/git-key) and
+          # the /readyz probe below only exist from that release. Keep in sync with
+          # the main container tag.
+          image: ghcr.io/knaisoma/data-olympus:v0.3.0  # replace with your registry/tag or digest
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -94,7 +97,10 @@ spec:
           # For opt-in auto-update, switch to a mutable channel tag (e.g.
           # ghcr.io/knaisoma/data-olympus:stable) with imagePullPolicy: Always and
           # a scheduled `kubectl rollout restart` or an image-update controller.
-          image: ghcr.io/knaisoma/data-olympus:v0.1.1  # replace with your registry/tag or digest
+          # Must be >= v0.3.0: this manifest's /readyz probe and rootless
+          # /state/git-key entrypoint flow only exist from that release; an older
+          # image would stay NotReady and could not find the staged deploy key.
+          image: ghcr.io/knaisoma/data-olympus:v0.3.0  # replace with your registry/tag or digest
           imagePullPolicy: IfNotPresent
           # Fully non-root: the deploy-key staging + first-boot clone moved to the
           # non-root initContainer above, so the main container needs no root, no

--- a/deploy/k8s/statefulset.yaml
+++ b/deploy/k8s/statefulset.yaml
@@ -14,9 +14,80 @@ spec:
       labels:
         app.kubernetes.io/name: data-olympus-mcp
     spec:
+      # Pod runs entirely as the non-root nobody uid. fsGroup makes the mounted
+      # PVCs and the Secret group-owned by 65534 so the non-root process can write
+      # /state, /kb-main, etc. and read the deploy key. This lets the manifest pass
+      # the restricted PodSecurity standard (no root, no added caps).
       securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+        fsGroup: 65534
         seccompProfile:
           type: RuntimeDefault
+      # initContainer (WP3a): the root+gosu entrypoint phase is gone. This
+      # non-root init step stages the deploy key onto the shared /state volume at
+      # 0400 (SSH refuses a group/world-readable key) and clones /kb-main on first
+      # boot. Running it as the same uid as the main container means no privilege
+      # transition anywhere in the pod.
+      initContainers:
+        - name: prepare-git
+          image: ghcr.io/knaisoma/data-olympus:v0.1.1  # keep in sync with the main container tag
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 65534
+            runAsGroup: 65534
+            capabilities:
+              drop: ["ALL"]
+            seccompProfile:
+              type: RuntimeDefault
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -e
+              # Stage the deploy key with private-key perms on the shared volume.
+              if [ -f /etc/git-key-mount ]; then
+                cp /etc/git-key-mount /state/git-key
+                chmod 0400 /state/git-key
+              fi
+              # Trust the git SSH host into a writable known_hosts on /state.
+              HOST="${KB_SSH_KEYSCAN_HOST:-github.com}"
+              ssh-keyscan -t ed25519,rsa "$HOST" > /state/known_hosts 2>/dev/null || true
+              chmod 0644 /state/known_hosts
+              # First-boot clone of /kb-main (idempotent; skipped when non-empty).
+              if [ -n "${KB_GIT_REMOTE_URL:-}" ] && [ -d /kb-main ]; then
+                real=$(find /kb-main -mindepth 1 -maxdepth 1 ! -name 'lost+found' -print -quit 2>/dev/null || true)
+                if [ -z "$real" ]; then
+                  echo "[init] /kb-main empty; cloning $KB_GIT_REMOTE_URL"
+                  GIT_SSH_COMMAND="ssh -i /state/git-key -o UserKnownHostsFile=/state/known_hosts -o StrictHostKeyChecking=yes" \
+                    git clone "$KB_GIT_REMOTE_URL" /kb-main \
+                    && echo "[init] bootstrap complete" \
+                    || echo "[init] WARNING: clone failed; pod starts degraded"
+                fi
+              fi
+          env:
+            - name: KB_GIT_REMOTE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: data-olympus-mcp
+                  key: KB_GIT_REMOTE_URL
+          envFrom:
+            - configMapRef:
+                name: data-olympus-mcp
+          volumeMounts:
+            - name: kb-main
+              mountPath: /kb-main
+            - name: kb-state
+              mountPath: /state
+            - name: tmp
+              mountPath: /tmp
+            - name: git-key
+              mountPath: /etc/git-key-mount
+              subPath: git-key
+              readOnly: true
       containers:
         - name: data-olympus-mcp
           # Reproducible default: pin an immutable released tag (or a digest).
@@ -25,17 +96,18 @@ spec:
           # a scheduled `kubectl rollout restart` or an image-update controller.
           image: ghcr.io/knaisoma/data-olympus:v0.1.1  # replace with your registry/tag or digest
           imagePullPolicy: IfNotPresent
-          # The entrypoint starts as root to copy/chown the deploy key and bootstrap
-          # /kb-main, then drops to uid 65534 via gosu. So we cannot runAsNonRoot at
-          # the pod level, but we still drop all caps except those the entrypoint
-          # needs, forbid privilege escalation, and run a read-only root filesystem
-          # (writes go to the PVCs below and the /tmp emptyDir).
+          # Fully non-root: the deploy-key staging + first-boot clone moved to the
+          # non-root initContainer above, so the main container needs no root, no
+          # gosu, and no added capabilities. Drop ALL caps, forbid privilege
+          # escalation, read-only root FS (writes go to the PVCs and /tmp emptyDir).
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 65534
+            runAsGroup: 65534
             capabilities:
               drop: ["ALL"]
-              add: ["CHOWN", "DAC_OVERRIDE", "FOWNER", "SETGID", "SETUID"]
             seccompProfile:
               type: RuntimeDefault
           ports:
@@ -66,13 +138,20 @@ spec:
               mountPath: /index
             - name: tmp
               mountPath: /tmp
-            - name: git-key
-              mountPath: /etc/git-key-mount
-              subPath: git-key
-              readOnly: true
+            # No git-key mount here: the initContainer staged the key to
+            # /state/git-key (0400) on the shared kb-state volume, which the
+            # entrypoint reads. Only the initContainer touches the raw Secret.
           readinessProbe:
+            # /readyz reports ready == process up AND index loaded, INDEPENDENT of
+            # data staleness. Previously this probed /api/v1/health, which returns
+            # 503 when the KB is stale (a >KB_STALENESS_DEGRADED_SEC git-remote
+            # outage): that ejected a perfectly serviceable pod from the Service
+            # and turned "reads are a bit old" into a hard 503 with zero endpoints.
+            # /api/v1/health keeps its 503-on-degraded contract for the CLI
+            # --no-stale flag; alert on it (not the probe) for staleness. See
+            # docs/operations.md and docs/serving.md.
             httpGet:
-              path: /api/v1/health
+              path: /readyz
               port: 8080
             initialDelaySeconds: 10
             periodSeconds: 10

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1,0 +1,352 @@
+# Operations runbook
+
+Operational procedures for running data-olympus in production: backup, upgrade,
+recovery playbooks, and the health/readiness/alerting model. For the architecture
+of the serving path (write serialization, push queue, session lifecycle) see
+`docs/serving.md`; for the security posture see `SECURITY.md`.
+
+Throughout, the Kubernetes examples target a single-writer StatefulSet pod
+`data-olympus-mcp-0` in namespace `data-olympus`. Adjust for your deployment.
+
+---
+
+## 1. Health, readiness, and alerting model
+
+Three endpoints answer three different questions (full table in
+`docs/serving.md`):
+
+- **`GET /readyz`** — *Can this pod serve reads now?* 200 when the process is up
+  and the index is loaded and the last build succeeded; 503 otherwise.
+  **Independent of data staleness.** This is the Kubernetes readiness-probe
+  target.
+- **`GET /livez`** — *Is the process responsive?* Always 200 if it answers at all.
+  (The default liveness probe is a `tcpSocket` check; `/livez` is the HTTP
+  equivalent.)
+- **`GET /api/v1/health`** — *Is the data fresh and the write path healthy?*
+  Returns 503 with `degraded: true` when stale, when no pull has succeeded, when
+  the index is empty, or when the last build failed. **This is the alerting
+  surface, not a probe target.**
+
+### What to alert on
+
+Poll `GET /api/v1/health` from your monitoring system and alert on:
+
+| Condition | Meaning | Severity |
+|---|---|---|
+| `degraded == true` | KB is stale or the last index build failed | page if sustained > a few minutes |
+| `last_git_fetch_status in (fetch_failed, ff_failed)` | git remote unreachable or history diverged | investigate; see §4.1 |
+| `staleness_seconds` climbing past `KB_STALENESS_DEGRADED_SEC` | pulls not landing | investigate; see §4.1 |
+| `push_queue_frozen > 0` | writes stuck, need manual unfreeze | investigate; see §4.4 |
+| `pending_count` growing unbounded | proposals not being resolved by an operator | review the pending queue |
+| `last_index_build_status == failed` | a rebuild left the last-good index in place (e.g. duplicate id) | investigate `last_index_conflicts`; see §4.2 |
+| `malformed_frontmatter > 0` | one or more docs silently lost governance metadata (`type`/`status`/`tier`) | fix the offending doc(s); **warning**, not a service failure |
+
+Why `malformed_frontmatter` does NOT flip `degraded`: it is an authoring-quality
+issue, not a serviceability failure. Flipping `degraded` would 503 every read (via
+the CLI `--no-stale` contract) for one bad document. Alert on it separately and
+fix the front-matter; the index still serves every well-formed doc.
+
+Do **not** point the Kubernetes readiness probe at `/api/v1/health`. On a stale
+KB it returns 503, which would eject the (single-replica) pod from the Service and
+turn "reads are slightly old" into a hard outage with zero endpoints. The probe
+targets `/readyz` for exactly this reason.
+
+### Verify tamper-evidence of the audit chain
+
+```bash
+curl -s http://<host>/api/v1/audit/verify   # {"ok": true, "first_broken_index": -1}
+```
+
+`ok: false` means the hash chain is broken at `first_broken_index` (counted across
+all rotated segments + the live file, chronologically). Investigate before trusting
+recent audit records. See §2.2 and §4.5.
+
+---
+
+## 2. Backup
+
+The KB **content** is a git repo, so `origin/main` is the primary backup: every
+committed document is on the remote. But three pieces of state live only on the
+pod's PVCs and are **not** covered by the git remote. Back these up separately.
+
+### 2.1 What the git remote does NOT cover
+
+1. **The audit chain** (`/state/audit/`) — the tamper-evident JSONL log and its
+   rotated segments. Lost audit history cannot be reconstructed from git.
+2. **Pending proposals** (`/state/pending/`) — low-confidence writes awaiting
+   operator approval. These have not been committed, so they are not on the
+   remote; losing the volume drops them.
+3. **Unpushed worktree commits** (`/kb-worktrees/`, `/state/push-queue/`) —
+   commits that were made on a session branch but not yet pushed (including frozen
+   or demoted push-queue entries). Until they reach `origin/main` they exist only
+   on the pod.
+
+### 2.2 Backing up the audit chain
+
+```bash
+# Snapshot every audit segment (live + rotated) out of the pod.
+kubectl -n data-olympus exec data-olympus-mcp-0 -- \
+    tar -czf - -C /state audit > audit-$(date +%Y%m%d).tar.gz
+
+# Verify integrity of the running chain first, so you know the snapshot is clean:
+curl -s http://<host>/api/v1/audit/verify
+```
+
+Because rotation carries the hash chain across files (see `docs/serving.md`), a
+backup that includes **all** `events*.log` files verifies end-to-end. Do not back
+up only the live `events.log` if rotation is enabled — the chain would be
+incomplete.
+
+If you rotate manually instead of via `KB_AUDIT_MAX_BYTES`, do it while the
+process is running so the in-memory last-hash carries forward:
+
+```bash
+kubectl -n data-olympus exec data-olympus-mcp-0 -- sh -c \
+  'mv /state/audit/events.log /state/audit/events-$(date +%Y%m%dT%H%M%S).log'
+# The next append starts a fresh live file linked to the prior tail hash.
+```
+
+Prefer `KB_AUDIT_MAX_BYTES` (automatic rotation) so the boundary link is always
+written by the server itself.
+
+### 2.3 Backing up pending proposals + unpushed commits
+
+```bash
+# Pending queue and push queue (small; safe to snapshot live).
+kubectl -n data-olympus exec data-olympus-mcp-0 -- \
+    tar -czf - -C /state pending push-queue > state-queues-$(date +%Y%m%d).tar.gz
+
+# Detect unpushed session commits before decommissioning a pod:
+kubectl -n data-olympus exec data-olympus-mcp-0 -- \
+    sh -c 'cd /kb-main && git fetch -q origin && \
+           for wt in /kb-worktrees/*/; do \
+             [ -d "$wt/.git" ] || [ -f "$wt/.git" ] || continue; \
+             git -C "$wt" log --oneline origin/main..HEAD 2>/dev/null; \
+           done'
+```
+
+If that last command prints commits, they are **not** on the remote. Let the push
+queue drain (watch `push_queue_size` reach 0) before deleting the pod or its PVCs,
+or the commits are lost. A restart re-runs startup recovery, which re-enqueues
+orphaned commits reachable from a session HEAD but not from `origin/main`.
+
+### 2.4 Full-volume backup (belt and braces)
+
+The PVCs are `ReadWriteOnce`. For a cold full backup, scale the writer to 0 (so no
+in-flight writes), snapshot the volumes with your storage layer's snapshot feature
+(or `tar` each mount), then scale back to 1:
+
+```bash
+kubectl -n data-olympus scale statefulset/data-olympus-mcp --replicas=0
+# ... snapshot kb-main / kb-state / kb-worktrees / kb-index PVCs ...
+kubectl -n data-olympus scale statefulset/data-olympus-mcp --replicas=1
+```
+
+`kb-index` is disposable: the index rebuilds from `/kb-main` on startup, so it need
+not be backed up (see §3.3).
+
+---
+
+## 3. Upgrade
+
+### 3.1 Bump the image tag
+
+Edit the image reference in `deploy/k8s/statefulset.yaml` (BOTH the `prepare-git`
+initContainer and the main container — keep them on the same tag) and re-apply:
+
+```bash
+kubectl apply -k deploy/k8s/
+kubectl -n data-olympus rollout status statefulset/data-olympus-mcp
+```
+
+Pin to an immutable released tag or a digest for reproducibility. For opt-in
+auto-update, use a mutable channel tag with `imagePullPolicy: Always` and a
+scheduled `kubectl rollout restart`.
+
+### 3.2 Taxonomy / indexed-prefix compatibility (from the 0.2.0 changelog)
+
+The taxonomy and the set of writable prefixes are configurable at deploy time with
+no code change. If you set any of these, they must stay **consistent across an
+upgrade** or the index will classify/accept documents differently:
+
+- `KB_TAXONOMY_PATH` — JSON file of the tier/category taxonomy.
+- `KB_INDEXED_PREFIXES` — comma-separated writable top-level prefixes that
+  **replace** the default set. A prefix removed here makes previously-indexed docs
+  under it invisible after the next rebuild.
+- `KB_MEMORY_INBOX_PREFIX` — directory new memory proposals are written under.
+
+Before upgrading, diff the new release's default taxonomy against yours; if the
+release changes defaults and you rely on them (rather than setting the env vars
+explicitly), pin the values in the ConfigMap so the upgrade does not silently move
+documents between categories.
+
+### 3.3 Index schema rebuilds
+
+The index (`kb-index` PVC) rebuilds automatically on startup and on every git
+refresh that changes the source commit; a schema-version bump in a new release
+triggers a full rebuild transparently. You do **not** need to migrate the index
+across upgrades.
+
+To force a rebuild (e.g. after manually editing `/kb-main`, or to clear a
+suspected corrupt index):
+
+```bash
+# Delete the DB and restart; the server rebuilds from /kb-main on boot.
+kubectl -n data-olympus exec data-olympus-mcp-0 -- rm -f /index/kb.db
+kubectl -n data-olympus rollout restart statefulset/data-olympus-mcp
+```
+
+The rebuild uses an atomic swap: if it fails (e.g. a duplicate id), the previous
+index is preserved and `last_index_build_status` goes `failed` rather than serving
+an empty index.
+
+---
+
+## 4. Recovery playbooks
+
+### 4.1 Degraded / `fetch_failed`
+
+**Symptom:** `/api/v1/health` returns `degraded: true`; `last_git_fetch_status` is
+`fetch_failed` or `ff_failed`; `staleness_seconds` climbing. `/readyz` stays 200
+(reads still work off the last-good index).
+
+**Cause:** the git remote is unreachable (network, auth, deploy-key), or
+`origin/main` diverged from the local `/kb-main` so a fast-forward is impossible.
+
+**Recovery:**
+
+1. Check the deploy key and remote reachability from inside the pod:
+   ```bash
+   kubectl -n data-olympus exec data-olympus-mcp-0 -- \
+     sh -c 'cd /kb-main && GIT_SSH_COMMAND="ssh -i /state/git-key -o UserKnownHostsFile=/state/known_hosts" git fetch -v origin'
+   ```
+2. `fetch_failed` → fix networking / the deploy key (rotate the Secret and restart
+   if the key is revoked). See `SECURITY.md` for the key flow.
+3. `ff_failed` → local `/kb-main` diverged from `origin/main`. This usually means a
+   history rewrite on the remote (see §4.3) or a local commit that never pushed.
+   Resolve per §4.3.
+
+Once the remote is reachable again the pull loop advances `last_git_pull_at`,
+staleness resets, and `degraded` clears on the next interval.
+
+### 4.2 Index build failed (`last_index_build_status: failed`)
+
+**Symptom:** `last_index_build_status == failed`; `last_index_conflicts` lists
+duplicate ids. The last-good index is still served (atomic swap), so `/readyz`
+stays 200, but new content is not indexed.
+
+**Cause:** two docs share a governance `id`, or another build-time validation
+failure.
+
+**Recovery:** fix the offending documents on the remote (the conflict list names
+the ids and paths), let the pull loop pick up the fix, and the next rebuild
+succeeds. Do not delete the index to "retry" — that would drop the last-good index
+and leave nothing to serve until the source is fixed.
+
+### 4.3 Force-push / history rewrite on `origin/main`
+
+**Symptom:** after someone force-pushed or rewrote `origin/main`, the pod's
+`/kb-main` cannot fast-forward (`ff_failed`); worktrees may hold commits based on
+the old history.
+
+**Recovery (destructive; do it deliberately):**
+
+1. Quiesce writes: `kubectl -n data-olympus scale statefulset/data-olympus-mcp --replicas=0`.
+   (Confirm the push queue is empty first, or you will lose unpushed commits — see
+   §2.3. If you need to preserve them, `git format-patch`/`bundle` them out of the
+   worktrees before proceeding.)
+2. Scale back up. On boot, hard-reset `/kb-main` to the rewritten remote and clear
+   stale worktrees + session branches so sessions re-checkout cleanly:
+   ```bash
+   kubectl -n data-olympus scale statefulset/data-olympus-mcp --replicas=1
+   kubectl -n data-olympus exec data-olympus-mcp-0 -- sh -c '
+     cd /kb-main &&
+     GIT_SSH_COMMAND="ssh -i /state/git-key -o UserKnownHostsFile=/state/known_hosts" git fetch -q origin &&
+     git reset --hard origin/main &&
+     git worktree prune'
+   # Remove per-session worktrees and their kb-session/* branches so a returning
+   # session recreates them against the new history:
+   kubectl -n data-olympus exec data-olympus-mcp-0 -- sh -c '
+     rm -rf /kb-worktrees/* &&
+     cd /kb-main && for b in $(git branch --list "kb-session/*" | tr -d " *"); do git branch -D "$b"; done'
+   kubectl -n data-olympus rollout restart statefulset/data-olympus-mcp
+   ```
+3. Force a fresh index rebuild if needed (§3.3).
+
+The worktree GC would eventually reconcile some of this on its own, but after a
+history rewrite an explicit reset is the safe, fast path.
+
+### 4.4 Frozen push-queue entries
+
+**Symptom:** `push_queue_frozen > 0`. An entry hit the retry cap (a persistent
+push failure the non-FF rebase recovery could not handle — typically auth,
+network, or a remote-side rejection) and the retry loop stopped retrying it.
+
+**Recovery (file-level; there is no unfreeze API):** fix the underlying push
+failure, then edit the entry on the push-queue volume (`KB_PUSH_QUEUE_ROOT`,
+default `/state/push-queue`):
+
+- **Requeue:** in the entry's `<sha>.json`, set `"frozen": false` and `"attempts": 0`
+  (or delete the file and let startup recovery re-enqueue the commit), then the
+  retry loop picks it up on its next pass.
+- **Drop:** delete the entry's `<sha>.json`. The commit stays on its session
+  worktree branch but is never published.
+
+### 4.5 Rebase-conflict demotions (PR #89)
+
+**Symptom:** a `push_conflict_demoted` audit event; a new **pending** entry appears
+in `kb_list_pending` that the agent did not create; `pending_count` rose without a
+new low-confidence proposal.
+
+**Cause (this is normal, not a fault):** a second overlapping session moved
+`origin/main` between a session's commit and its push, the push was rejected
+non-fast-forward, and the automatic rebase **conflicted** (both sessions edited the
+same lines). Rather than retry forever, the push loop **demoted** the commit to a
+pending proposal for operator resolution: it re-proposed the postimage as a pending
+edit (carrying the base the commit sat on), removed the push-queue entry, and
+recorded the audit event. Pure repeated contention (a non-conflicting non-FF that
+keeps losing the race) is retried in-line for a bounded number of passes and then
+demoted the same way instead of being counted toward the freeze cap.
+
+**Recovery:** resolve the demoted pending entry like any other. Approving re-applies
+the change on the current base, subject to the CAS / content-validation gates:
+
+```bash
+kb pending                                  # find the demoted entry's id
+kb resolve <pending_id> --decision approve  # re-apply on current origin/main
+# or --decision reject to abandon it.
+```
+
+If approval returns `rejected_stale_base`, the target moved again; re-fetch the
+current content, reconcile the change by hand, and re-propose.
+
+### 4.6 Orphaned advisory path locks
+
+**Symptom:** writes to a specific path return `rejected_path_lock_busy` /
+`rejected_path_locked` even though no proposal for that path is in flight;
+`path_locks_held` in health is non-zero with no matching pending entry.
+
+**Cause:** a crash between acquiring the per-path advisory lock and writing the
+pending entry left a lock with no owner.
+
+**Recovery:** the pending GC loop reclaims orphaned locks automatically each pass
+(every 5 minutes), logging `pending_gc reclaimed N orphaned path lock(s)`. If you
+cannot wait, remove the stale lock file under `KB_PENDING_ROOT/locks` (default
+`/state/pending/locks`) for the affected path, then retry the write. Only do this
+after confirming no operator is mid-resolve on that path.
+
+---
+
+## 5. Quick reference
+
+| Task | Command |
+|---|---|
+| Health / alerting | `curl -s http://<host>/api/v1/health` |
+| Readiness (probe) | `curl -s http://<host>/readyz` |
+| Verify audit chain | `curl -s http://<host>/api/v1/audit/verify` |
+| Force index rebuild | `kubectl -n data-olympus exec data-olympus-mcp-0 -- rm -f /index/kb.db && kubectl -n data-olympus rollout restart statefulset/data-olympus-mcp` |
+| Upgrade | bump image tag in `statefulset.yaml`, `kubectl apply -k deploy/k8s/` |
+| Backup audit | `kubectl -n data-olympus exec data-olympus-mcp-0 -- tar -czf - -C /state audit > audit.tar.gz` |
+| Enable audit rotation | set `KB_AUDIT_MAX_BYTES` in the ConfigMap |
+| Enable proxy headers | set `KB_TRUSTED_PROXIES` in the ConfigMap |
+| Enable Ingress | set `KB_AUTH_TOKEN`, uncomment `- ingress.yaml` in `kustomization.yaml` (see `deploy/k8s/README.md`) |

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -59,7 +59,10 @@ curl -s http://<host>/api/v1/audit/verify   # {"ok": true, "first_broken_index":
 
 `ok: false` means the hash chain is broken at `first_broken_index` (counted across
 all rotated segments + the live file, chronologically). Investigate before trusting
-recent audit records. See §2.2 and §4.5.
+recent audit records: someone edited, deleted, reordered, or (if `KB_AUDIT_HMAC_KEY`
+is set) forged a record, or a rotated segment was hand-edited (see §2.2). Preserve
+the current `/state/audit/` for forensics before any further writes; a clean backup
+(§2.2) taken while `verify` was `ok` is the recovery baseline.
 
 ---
 
@@ -292,21 +295,32 @@ default `/state/push-queue`):
 - **Drop:** delete the entry's `<sha>.json`. The commit stays on its session
   worktree branch but is never published.
 
-### 4.5 Rebase-conflict demotions (PR #89)
+### 4.5 Push-queue demotions to pending (PR #89)
 
 **Symptom:** a `push_conflict_demoted` audit event; a new **pending** entry appears
 in `kb_list_pending` that the agent did not create; `pending_count` rose without a
 new low-confidence proposal.
 
 **Cause (this is normal, not a fault):** a second overlapping session moved
-`origin/main` between a session's commit and its push, the push was rejected
-non-fast-forward, and the automatic rebase **conflicted** (both sessions edited the
-same lines). Rather than retry forever, the push loop **demoted** the commit to a
-pending proposal for operator resolution: it re-proposed the postimage as a pending
-edit (carrying the base the commit sat on), removed the push-queue entry, and
-recorded the audit event. Pure repeated contention (a non-conflicting non-FF that
-keeps losing the race) is retried in-line for a bounded number of passes and then
-demoted the same way instead of being counted toward the freeze cap.
+`origin/main` between a session's commit and its push and the push was rejected
+non-fast-forward. Rather than retry forever, the push loop **demoted** the commit
+to a pending proposal for operator resolution: it re-proposed the postimage as a
+pending edit (carrying the base the commit sat on), removed the push-queue entry,
+and recorded a `push_conflict_demoted` audit event (status `demoted_to_pending`).
+Two situations reach this same demotion path and emit the same audit
+event_type/status:
+
+- **Rebase conflict** — the automatic fetch+rebase could not re-apply the commit
+  because both sessions edited the same lines.
+- **Persistent contention** — a non-conflicting non-FF that kept losing the race
+  is retried in-line for a bounded number of passes, then demoted the same way
+  instead of counting toward the freeze cap.
+
+Both surface identically (one `push_conflict_demoted` status; the pending entry's
+`reason` is a generic "demoted from push queue after rebase conflict"), so do not
+rely on the audit record to tell the two apart. To confirm which occurred, inspect
+the push loop logs around the demotion timestamp: a rebase conflict logs the
+conflicting paths, whereas contention logs repeated non-FF retry passes.
 
 **Recovery:** resolve the demoted pending entry like any other. Approving re-applies
 the change on the current base, subject to the CAS / content-validation gates:

--- a/docs/serving.md
+++ b/docs/serving.md
@@ -62,6 +62,41 @@ reports `degraded: true` only when the index has not been rebuilt within
 For a local read-only demo with no remote, set `KB_REMOTE_URL=""`. The server
 stays healthy as long as the index builds successfully on startup.
 
+## Health, readiness, and liveness (three distinct signals)
+
+The server exposes three endpoints that answer three different questions. They
+are deliberately split so a data-freshness problem does not eject a pod that can
+still serve reads:
+
+| Endpoint | Question | 200 when | 503 when |
+|---|---|---|---|
+| `GET /api/v1/health` | Is the data fresh? | index built, fresh, last build ok | **degraded**: staleness > `KB_STALENESS_DEGRADED_SEC`, no successful pull, empty index, or last build failed |
+| `GET /readyz` | Can this pod serve reads now? | process up **and** index loaded **and** last build ok | no index built yet, or the last index build failed |
+| `GET /livez` | Is the process responsive? | always (if the handler runs, the loop is alive) | never |
+
+Key point: **`/readyz` is independent of data staleness.** A git-remote outage
+makes the KB stale (so `/api/v1/health` returns 503 with `degraded: true`), but
+the last-good index still answers reads perfectly, so `/readyz` stays 200 and the
+pod stays in the Service. The Kubernetes **readiness probe targets `/readyz`**
+(see `deploy/k8s/statefulset.yaml`); if it targeted `/api/v1/health` a stale
+single-replica pod would be ejected from the Service and a "reads are a bit old"
+condition would become a hard 503 with zero endpoints.
+
+`/api/v1/health` keeps its 503-on-degraded contract because the `bin/kb` CLI
+`--no-stale` flag relies on it (exit 2 when the endpoint reports `degraded: true`,
+whether over HTTP 200 or 503). **Alert on `/api/v1/health` degraded** (and on the
+`last_git_fetch_status` / `staleness_seconds` fields it carries) rather than
+wiring it to a probe. The liveness probe is a `tcpSocket` check by default; the
+HTTP `/livez` route is offered for operators who prefer an explicit route. See
+`docs/operations.md` for the full alerting and recovery model.
+
+The health payload also carries `malformed_frontmatter`: the count of docs whose
+front-matter was present but malformed at the last index build. A non-zero value
+means a doc silently lost its governance metadata (`type`/`status`/`tier`), so it
+will not be governed or filtered correctly. It is a **warning** signal and does
+**not** flip `degraded` (that would 503 every read for an authoring mistake);
+alert on `malformed_frontmatter > 0` separately.
+
 ## Write serialization and integrity gates
 
 Every write (`kb_propose_memory`, `kb_propose_edit`, `kb_resolve_pending`, and
@@ -426,6 +461,52 @@ reverse proxy (terminate TLS there). See `SECURITY.md` for the full threat model
 the route/capability table, payload limits, the tamper-evident audit log, and the
 git sync-failure health fields.
 
+### Proxy headers and the rate limiter (`KB_TRUSTED_PROXIES`)
+
+The rate limiter keys on the client remote address (plus principal). Behind an
+ingress or reverse proxy, uvicorn by default sees the **proxy's** address as the
+peer, so every client collapses into one `remote_addr` and the per-IP cap
+(`KB_RATE_LIMIT_PER_IP_PER_HOUR`) throttles all clients as if they were one.
+
+Set `KB_TRUSTED_PROXIES` to the proxy address(es) (comma-separated) to fix this:
+
+- **Unset (default)** — uvicorn runs with `proxy_headers` **off**. `X-Forwarded-For`
+  is ignored and `remote_addr` is the immediate peer. This is the safe default: a
+  direct client cannot spoof its address to dodge the limiter.
+- **Set to the proxy IP(s)** — uvicorn enables `proxy_headers` and restricts
+  `forwarded_allow_ips` to those addresses, so it rewrites `remote_addr` from
+  `X-Forwarded-For` **only** when the immediate peer is a trusted proxy. The
+  limiter then sees the true client IP.
+- **`*`** — trust `X-Forwarded-For` from any peer. Only safe when nothing
+  untrusted can reach the port directly (e.g. the port is bound to the pod network
+  and only the ingress can connect). Otherwise a direct client could forge the
+  header.
+
+## Audit-log rotation (`KB_AUDIT_MAX_BYTES`)
+
+The JSONL audit log (`KB_AUDIT_LOG_PATH`, default `/state/audit/events.log`) grows
+without bound by default. Set `KB_AUDIT_MAX_BYTES` to a byte threshold to enable
+size-based rotation: when the live file passes the threshold, the next append
+first renames it to `events-<UTC-timestamp>.log` and starts a fresh live file.
+
+- **Chain continuity.** The tamper-evident hash chain carries **across** the
+  rotation boundary: the first event of the new file links to the last hash of the
+  rotated file, so `GET /api/v1/audit/verify` (and the `kb audit`/`verify` logic)
+  validates the whole history, rotated segments included, in chronological order.
+  A break at the boundary is caught like any other.
+- **Backward compatible.** With `KB_AUDIT_MAX_BYTES` unset (0), nothing rotates:
+  the log stays a single file exactly as before, and an existing single-file log
+  still verifies unchanged when opened by a rotation-aware build.
+- **Reads.** `kb audit` reads the live file by default (cheap, most-recent-first).
+  A `--since` query also walks rotated segments so history that has rotated out of
+  the live file is still visible; the reverse scan is bounded so a large archive
+  cannot turn one query into an unbounded read.
+
+Manual `mv`-based rotation (documented in the operator runbook) no longer breaks
+the chain when the process keeps running, because the in-memory last-hash carries
+forward; but prefer `KB_AUDIT_MAX_BYTES` so rotation is automatic and the boundary
+link is always written. See `docs/operations.md` for backup/verify procedures.
+
 ## Git commit identity
 
 Every write commits to the KB repo, so git needs an author/committer identity.
@@ -461,6 +542,20 @@ sops exec-file deploy/k8s/secret.sops.yaml 'kubectl apply -f {}'
 The `deploy/k8s/secret.template.yaml` file shows the expected secret shape.
 Fill in your git remote URL and deploy key, then encrypt with SOPS before
 committing. Never commit the unencrypted secret.
+
+The default `kubectl apply -k deploy/k8s/` deliberately does **not** create the
+Ingress: it publishes all routes (including the unauthenticated-by-default write
+routes) to the LAN. The Ingress is opt-in and enabled only after you set
+`KB_AUTH_TOKEN`; see `deploy/k8s/README.md` for the enablement steps.
+
+The pod is fully rootless: both the `prepare-git` initContainer (which stages the
+deploy key and does the first-boot `/kb-main` clone) and the main container run as
+uid 65534 with `runAsNonRoot: true`, all capabilities dropped, and a read-only
+root filesystem, so the manifest passes the **restricted** Pod Security Standard.
+The base image is digest-pinned in `deploy/docker/Dockerfile`; the git SSH host is
+build-arg + runtime-env configurable (`KB_SSH_KEYSCAN_HOST`) for non-GitHub
+remotes. Operational procedures (backup, upgrade, recovery playbooks) live in
+`docs/operations.md`.
 
 ## Running with Docker Compose
 

--- a/src/data_olympus/audit_log.py
+++ b/src/data_olympus/audit_log.py
@@ -8,14 +8,28 @@ keyed HMAC-SHA256, so an attacker who can write the log file still cannot forge 
 valid chain without the key. Legacy lines without a ``hash`` are tolerated: the
 chain validates the hashed lines in order and ignores unhashed ones, so enabling
 the feature on an existing log does not retroactively flag it.
+
+Rotation (WP3a). When the live file grows past ``max_bytes`` a fresh append
+rotates it: the live file is renamed to ``<stem>-<UTC-timestamp><suffix>`` and a
+new live file is started. The hash chain carries across the boundary because
+``_last_hash`` is retained in memory across the rename, so the first event of the
+new file links to the last hash of the rotated one. :meth:`verify` replays every
+rotated segment in chronological order followed by the live file, so an intact
+chain validates across rotations and any break at the boundary is caught. Reads
+(:meth:`iter_filtered`) default to the live file only (cheap, matches the pre-
+rotation behaviour) but can walk rotated segments newest-first when
+``include_rotated=True`` so a ``since``-filtered query still sees history that has
+rotated out of the live file.
 """
 from __future__ import annotations
 
+import glob
 import hashlib
 import hmac
 import json
 import os
 import threading
+import time
 import uuid
 from typing import TYPE_CHECKING, Any
 
@@ -26,9 +40,15 @@ GENESIS = ""
 
 
 class AuditLog:
-    def __init__(self, *, log_path: str, hmac_key: str = "") -> None:
+    def __init__(
+        self, *, log_path: str, hmac_key: str = "", max_bytes: int = 0,
+    ) -> None:
         self._path = log_path
         self._hmac_key = hmac_key or ""
+        # Size-based rotation threshold in bytes. 0 (the default) disables
+        # rotation entirely, so an operator who never sets KB_AUDIT_MAX_BYTES keeps
+        # the single-file behaviour and existing logs are untouched.
+        self._max_bytes = max_bytes if max_bytes and max_bytes > 0 else 0
         # append() is a read-modify-write on _last_hash plus a file write. Once
         # handlers are offloaded to the anyio threadpool, appends can run
         # concurrently; without this lock two threads read the same _last_hash
@@ -52,21 +72,68 @@ class AuditLog:
         return json.dumps(body, sort_keys=True, ensure_ascii=False)
 
     def _load_last_hash(self) -> str:
-        if not os.path.exists(self._path):
-            return GENESIS
+        """The last chained hash across ALL segments (rotated + live).
+
+        Reads rotated segments in chronological order then the live file so a
+        process that restarts after a rotation still chains its first append to
+        the true tail of the chain rather than to the (now-rotated-out) live
+        file's older content.
+        """
         last = GENESIS
-        with open(self._path, encoding="utf-8") as f:
-            for line in f:
-                line = line.strip()
-                if not line:
-                    continue
-                try:
-                    ev = json.loads(line)
-                except json.JSONDecodeError:
-                    continue
-                if isinstance(ev, dict) and ev.get("hash"):
-                    last = ev["hash"]
+        for path in [*self._rotated_paths(), self._path]:
+            if not os.path.exists(path):
+                continue
+            with open(path, encoding="utf-8") as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        ev = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    if isinstance(ev, dict) and ev.get("hash"):
+                        last = ev["hash"]
         return last
+
+    # --- rotation helpers --------------------------------------------------
+    def _rotated_paths(self) -> list[str]:
+        """Rotated segment paths, oldest-first.
+
+        Rotated files are named ``<stem>-<UTC-timestamp><suffix>`` next to the
+        live file. Sorting the glob lexically orders them chronologically because
+        the timestamp is fixed-width ``YYYYmmddTHHMMSSffffff``. The live file
+        itself is excluded (its name has no timestamp segment)."""
+        stem, suffix = os.path.splitext(self._path)
+        pattern = f"{glob.escape(stem)}-*{suffix}"
+        return sorted(p for p in glob.glob(pattern) if p != self._path)
+
+    def _rotated_path_for(self, when: float) -> str:
+        stem, suffix = os.path.splitext(self._path)
+        ts = time.strftime("%Y%m%dT%H%M%S", time.gmtime(when))
+        micros = int((when % 1) * 1_000_000)
+        candidate = f"{stem}-{ts}{micros:06d}{suffix}"
+        # Extremely unlikely, but never clobber an existing rotated segment.
+        n = 1
+        while os.path.exists(candidate):
+            candidate = f"{stem}-{ts}{micros:06d}-{n}{suffix}"
+            n += 1
+        return candidate
+
+    def _maybe_rotate_locked(self) -> None:
+        """Rotate the live file when it exceeds the size threshold. Caller holds
+        the lock. The in-memory ``_last_hash`` is deliberately NOT reset, so the
+        first event written to the fresh live file links to the last hash of the
+        rotated segment and the chain is continuous across the boundary."""
+        if self._max_bytes <= 0 or not os.path.exists(self._path):
+            return
+        try:
+            size = os.path.getsize(self._path)
+        except OSError:  # pragma: no cover - defensive
+            return
+        if size < self._max_bytes:
+            return
+        os.rename(self._path, self._rotated_path_for(time.time()))
 
     # --- public API --------------------------------------------------------
     def append(self, event: dict[str, Any]) -> None:
@@ -74,10 +141,13 @@ class AuditLog:
 
         The parent directory is created lazily on first append so that
         constructing an AuditLog with an unwritable default path (e.g. macOS
-        tests that never trigger a write) does not crash startup.
+        tests that never trigger a write) does not crash startup. When rotation
+        is enabled and the live file has passed the size threshold, it is rotated
+        BEFORE this event is written so the new event starts the fresh segment.
         """
         os.makedirs(os.path.dirname(self._path) or ".", exist_ok=True)
         with self._lock:
+            self._maybe_rotate_locked()
             chained = dict(event)
             chained["event_id"] = uuid.uuid4().hex
             chained["prev_hash"] = self._last_hash
@@ -88,10 +158,15 @@ class AuditLog:
             self._last_hash = chained["hash"]
 
     def verify(self) -> tuple[bool, int]:
-        """Recompute the hash chain over the log.
+        """Recompute the hash chain over the whole log (all rotated segments +
+        the live file, in chronological order).
 
         Returns ``(True, -1)`` when intact (or empty / all-legacy), else
-        ``(False, line_index)`` for the 0-based index of the first offending line.
+        ``(False, line_index)`` for the 0-based index of the first offending line
+        counted across the concatenation of all segments (rotated oldest-first,
+        then live). So a single-file log verifies exactly as before, and a
+        rotated log verifies across the boundary: the first event of a new segment
+        must carry the last hash of the previous segment as its ``prev_hash``.
 
         Unhashed legacy lines are tolerated ONLY as a prefix before the first
         hashed event (the pre-chaining migration window). Once the chain has
@@ -99,32 +174,40 @@ class AuditLog:
         verification, so an attacker cannot append a legacy-shaped record to forge
         an event while keeping verify green.
         """
-        if not os.path.exists(self._path):
-            return (True, -1)
-        # Snapshot the file under the lock (short hold), then verify in memory so
-        # a concurrent append cannot make us read a torn final line as tampering.
-        with self._lock, open(self._path, encoding="utf-8") as f:
-            raw_lines = f.readlines()
+        # Snapshot every segment under the lock (short hold), then verify in
+        # memory so a concurrent append cannot make us read a torn final line as
+        # tampering.
+        with self._lock:
+            segments: list[list[str]] = []
+            for path in [*self._rotated_paths(), self._path]:
+                if not os.path.exists(path):
+                    continue
+                with open(path, encoding="utf-8") as f:
+                    segments.append(f.readlines())
         prev = GENESIS
         seen_hashed = False
-        for i, raw in enumerate(raw_lines):
-            raw = raw.strip()
-            if not raw:
-                continue
-            try:
-                ev = json.loads(raw)
-            except json.JSONDecodeError:
-                return (False, i)
-            if not (isinstance(ev, dict) and ev.get("hash")):
-                if seen_hashed:
-                    return (False, i)  # unhashed line after the chain started
-                continue  # legacy prefix, tolerated
-            if ev.get("prev_hash") != prev:
-                return (False, i)
-            if self._digest(self._canonical(ev)) != ev["hash"]:
-                return (False, i)
-            prev = ev["hash"]
-            seen_hashed = True
+        global_index = 0
+        for raw_lines in segments:
+            for raw in raw_lines:
+                i = global_index
+                global_index += 1
+                raw = raw.strip()
+                if not raw:
+                    continue
+                try:
+                    ev = json.loads(raw)
+                except json.JSONDecodeError:
+                    return (False, i)
+                if not (isinstance(ev, dict) and ev.get("hash")):
+                    if seen_hashed:
+                        return (False, i)  # unhashed line after the chain started
+                    continue  # legacy prefix, tolerated
+                if ev.get("prev_hash") != prev:
+                    return (False, i)
+                if self._digest(self._canonical(ev)) != ev["hash"]:
+                    return (False, i)
+                prev = ev["hash"]
+                seen_hashed = True
         return (True, -1)
 
     def iter_filtered(
@@ -133,27 +216,60 @@ class AuditLog:
         since: float | None = None,
         agent: str | None = None,
         status: str | None = None,
+        include_rotated: bool = False,
+        max_scan_events: int | None = None,
     ) -> Iterator[dict[str, Any]]:
-        """Yield events matching the filters, most-recent first."""
-        if not os.path.exists(self._path):
-            return
-        # Read under the lock so we never see a torn append, then yield from the
-        # in-memory snapshot (holding the lock across yields would block appends
-        # for as long as the caller iterates).
-        with self._lock, open(self._path, encoding="utf-8") as f:
-            lines = f.readlines()
-        for line in reversed(lines):
-            line = line.strip()
-            if not line:
+        """Yield events matching the filters, most-recent first.
+
+        By default only the live file is read (cheap; matches the pre-rotation
+        behaviour). When ``include_rotated`` is True the rotated segments are also
+        walked, newest-first, AFTER the live file so results stay strictly most-
+        recent-first across the rotation boundary. Callers that pass a ``since``
+        filter should set ``include_rotated=True`` to see history that has already
+        rotated out of the live file.
+
+        ``max_scan_events`` bounds the reverse scan: once that many raw events
+        have been examined (across all scanned segments) iteration stops even if
+        more match. This caps the memory/time cost of a query against a large
+        rotated history; callers that only need "the most recent N" pass their N
+        so the scan does not walk the entire archive.
+        """
+        scanned = 0
+        # Live file first (newest events live here), then rotated newest-first.
+        paths = [self._path]
+        if include_rotated:
+            paths.extend(reversed(self._rotated_paths()))
+        for path in paths:
+            if not os.path.exists(path):
                 continue
-            try:
-                ev = json.loads(line)
-            except json.JSONDecodeError:
-                continue
-            if since is not None and float(ev.get("ts", 0)) < since:
-                continue
-            if agent is not None and ev.get("agent_identity") != agent:
-                continue
-            if status is not None and ev.get("status") != status:
-                continue
-            yield ev
+            # Read under the lock so we never see a torn append, then yield from
+            # the in-memory snapshot (holding the lock across yields would block
+            # appends for as long as the caller iterates).
+            with self._lock, open(path, encoding="utf-8") as f:
+                lines = f.readlines()
+            for line in reversed(lines):
+                if max_scan_events is not None and scanned >= max_scan_events:
+                    return
+                line = line.strip()
+                if not line:
+                    continue
+                scanned += 1
+                try:
+                    ev = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if since is not None and float(ev.get("ts", 0)) < since:
+                    # Events are appended in time order, so within a segment a
+                    # reverse scan that reaches an older-than-``since`` event has
+                    # no newer matches left below it; and every rotated segment is
+                    # strictly older than the live file we scan first. So the first
+                    # sub-floor event ends the whole scan. (A clock that ran
+                    # backwards mid-run could in theory hide a straggler; the audit
+                    # ts is server wall-clock and this is a best-effort recency
+                    # query, so the bound is worth the rare miss.)
+                    return
+                if agent is not None and ev.get("agent_identity") != agent:
+                    continue
+                if status is not None and ev.get("status") != status:
+                    continue
+                yield ev

--- a/src/data_olympus/config.py
+++ b/src/data_olympus/config.py
@@ -35,6 +35,11 @@ class Config:
     git_key_path: str = "/tmp/git-key"
     audit_log_path: str = "/state/audit/events.log"
     audit_hmac_key: str = ""
+    # Size-based audit-log rotation threshold in bytes (KB_AUDIT_MAX_BYTES). 0
+    # (default) disables rotation: the log stays a single file (backward
+    # compatible). When set, a fresh append rotates the live file once it exceeds
+    # this size; the tamper-evident hash chain carries across the boundary.
+    audit_max_bytes: int = 0
     auth_token: str = ""
     auth_principals: list[dict[str, Any]] = field(default_factory=list)
     consult_ttl_sec: int = 300
@@ -85,6 +90,14 @@ class Config:
     embeddings_enabled: bool = False
     embeddings_weight: float = 0.35
     embeddings_model: str = "BAAI/bge-small-en-v1.5"
+    # Trusted reverse-proxy addresses for X-Forwarded-For handling
+    # (KB_TRUSTED_PROXIES, comma-separated). Empty (default) means uvicorn runs
+    # with proxy_headers OFF: X-Forwarded-For is ignored and the real remote_addr
+    # is the immediate peer, so a client cannot spoof its address to dodge the
+    # per-IP rate limiter. Set to the ingress/proxy IP(s) (or ``*`` to trust any
+    # peer, ONLY safe when nothing untrusted can reach the port directly) to make
+    # the rate limiter see the true client IP behind the proxy. See docs/serving.md.
+    trusted_proxies: list[str] = field(default_factory=list)
 
 
 def _split_csv(raw: str) -> list[str]:
@@ -142,6 +155,7 @@ def load_config() -> Config:
     git_key_path = os.getenv("KB_GIT_KEY_PATH", "/tmp/git-key")
     audit_log_path = os.getenv("KB_AUDIT_LOG_PATH", "/state/audit/events.log")
     audit_hmac_key = os.getenv("KB_AUDIT_HMAC_KEY", "")
+    audit_max_bytes = int(os.getenv("KB_AUDIT_MAX_BYTES", "0"))
     auth_token = os.getenv("KB_AUTH_TOKEN", "")
     from data_olympus.principals import parse_principals_env
     auth_principals = parse_principals_env(os.getenv("KB_AUTH_PRINCIPALS", ""))
@@ -175,6 +189,7 @@ def load_config() -> Config:
     )
     emb_enabled = _embeddings_enabled()
     emb_cfg = _embeddings_config()
+    trusted_proxies = _split_csv(os.getenv("KB_TRUSTED_PROXIES", ""))
     return Config(
         kb_main_path=Path(os.environ.get("KB_MAIN_PATH", "/kb-main")),
         kb_index_path=Path(os.environ.get("KB_INDEX_PATH", "/index/kb.db")),
@@ -200,6 +215,7 @@ def load_config() -> Config:
         git_key_path=git_key_path,
         audit_log_path=audit_log_path,
         audit_hmac_key=audit_hmac_key,
+        audit_max_bytes=audit_max_bytes,
         auth_token=auth_token,
         auth_principals=auth_principals,
         consult_ttl_sec=consult_ttl_sec,
@@ -219,4 +235,5 @@ def load_config() -> Config:
         embeddings_enabled=emb_enabled,
         embeddings_weight=emb_cfg.weight,
         embeddings_model=emb_cfg.model_name,
+        trusted_proxies=trusted_proxies,
     )

--- a/src/data_olympus/health.py
+++ b/src/data_olympus/health.py
@@ -37,6 +37,12 @@ class HealthState:
     last_successful_refresh_at: float | None = None
     remote_head_sha: str | None = None
     live_sessions: int | None = None
+    # Count of docs whose front-matter was present but malformed at the last index
+    # build (WP2b finding (j)). A non-zero value means a doc silently lost its
+    # governance metadata (type/status/tier), so it will not be governed or
+    # filtered correctly. Surfaced as a WARNING signal; it does NOT flip
+    # ``degraded`` (see snapshot()).
+    malformed_frontmatter: int = 0
 
 
 def snapshot(
@@ -68,12 +74,20 @@ def snapshot(
     h = idx.health()
     now = time.time()
     staleness = (now - last_git_pull_at) if last_git_pull_at is not None else None
+    # malformed_frontmatter deliberately does NOT contribute to ``degraded``: a
+    # doc losing its governance metadata is a data-quality WARNING, not a
+    # service-health failure. Flipping degraded would (a) 503 every read via the
+    # CLI --no-stale contract and (b) tie the readiness/health signal to author
+    # error rather than serviceability. Alert on a non-zero count instead (see
+    # docs/operations.md).
     degraded = (
         last_git_pull_at is None
         or (staleness is not None and staleness > staleness_degraded_sec)
         or h["total_docs"] == 0
         or last_index_build_status != "ok"
     )
+    _mf = h.get("malformed_frontmatter")
+    malformed_frontmatter = _mf if isinstance(_mf, int) else 0
     return HealthState(
         kb_commit=str(h["source_commit"]),
         index_built_at=h["index_built_at"] if isinstance(h["index_built_at"], float) else None,
@@ -96,4 +110,5 @@ def snapshot(
         last_successful_refresh_at=last_successful_refresh_at,
         remote_head_sha=remote_head_sha,
         live_sessions=live_sessions,
+        malformed_frontmatter=malformed_frontmatter,
     )

--- a/src/data_olympus/models.py
+++ b/src/data_olympus/models.py
@@ -46,6 +46,10 @@ class HealthResponse(BaseModel):
     # observed (e.g. before the HTTP app's lifespan starts, or in-memory tests).
     # Surfaced so session accumulation is diagnosable in production (issue #43).
     live_sessions: int | None = None
+    # Docs with present-but-malformed front-matter at the last index build (WP2b).
+    # A non-zero value means a doc silently lost its governance metadata. WARNING
+    # signal only: it does NOT flip ``degraded`` (alert on it separately).
+    malformed_frontmatter: int = 0
 
     # Health fields always present in compact mode even when falsy, because a
     # consumer branches on them (bin/kb and the REST 503 path read ``degraded``;

--- a/src/data_olympus/rest_api.py
+++ b/src/data_olympus/rest_api.py
@@ -342,9 +342,50 @@ def register_routes(
         resp = _build_health(state)
         # Degraded health responses MUST return 503 so the
         # CLI's --no-stale contract (exit 2 on HTTP 200 or 503 degraded) is meaningful.
+        # NOTE: /api/v1/health is DELIBERATELY not the k8s readiness probe target
+        # (that is /readyz). Data staleness (a >KB_STALENESS_DEGRADED_SEC git-remote
+        # outage) flips degraded here, and if this route drove readiness a stale-but-
+        # serviceable single pod would be ejected from the Service, turning "reads are
+        # a bit old" into a hard 503. Alert on this route's degraded flag instead
+        # (see docs/operations.md). The CLI --no-stale contract still depends on the
+        # 503-on-degraded behaviour, so it stays here.
         status = 503 if resp.degraded else 200
         verbose = _query_bool(request.query_params.get("verbose"))
         return JSONResponse(shape_response(resp, verbose=verbose), status_code=status)
+
+    @app.custom_route("/readyz", methods=["GET"])
+    async def readyz(_request: Request) -> JSONResponse:
+        # Kubernetes READINESS probe target. Ready == the process is up and the
+        # index is loaded and serviceable, INDEPENDENT of data staleness. This is
+        # the split from /api/v1/health: a git-remote outage makes the KB stale
+        # (health degraded -> 503) but the last-good index still answers reads
+        # perfectly, so readiness must stay 200 and keep the pod in the Service.
+        # We report NOT-ready only when reads genuinely cannot be served: no index
+        # built yet (cold start / never-successful build) or the last index build
+        # failed (a corrupt/duplicate-id rebuild left no swap-in). Served inline
+        # (like /api/v1/health) so the probe never queues behind the worker pool.
+        resp = _build_health(state)
+        ready = resp.index_built_at is not None and resp.last_index_build_status == "ok"
+        body = {
+            "ready": ready,
+            "index_built_at": resp.index_built_at,
+            "total_rules": resp.total_rules,
+            "last_index_build_status": resp.last_index_build_status,
+        }
+        if not ready:
+            body["error"] = "not_ready"
+        return JSONResponse(body, status_code=200 if ready else 503)
+
+    @app.custom_route("/livez", methods=["GET"])
+    async def livez(_request: Request) -> JSONResponse:
+        # Kubernetes LIVENESS probe target. Liveness answers "is the process
+        # responsive?" only: if this handler runs at all, the event loop is alive,
+        # so it is always 200. Deliberately independent of index/git/staleness
+        # state so a degraded-but-running pod is NOT killed and restarted (a
+        # restart cannot fix an upstream git-remote outage and only drops the
+        # last-good index). The existing tcpSocket liveness probe is equivalent;
+        # this HTTP variant is offered for operators who prefer an explicit route.
+        return JSONResponse({"alive": True}, status_code=200)
 
     @app.custom_route("/api/v1/outline", methods=["GET"])
     async def outline(request: Request) -> JSONResponse:

--- a/src/data_olympus/server.py
+++ b/src/data_olympus/server.py
@@ -243,6 +243,7 @@ def build_app(
     auth_token: str = "",
     auth_principals: list[dict[str, Any]] | None = None,
     audit_hmac_key: str = "",
+    audit_max_bytes: int = 0,
     ledger_path: str | None = None,
     session_idle_timeout_sec: int = 1800,
     session_reap_interval_sec: int = 60,
@@ -289,6 +290,7 @@ def build_app(
         auth_token=auth_token,
         auth_principals=auth_principals or [],
         audit_hmac_key=audit_hmac_key,
+        audit_max_bytes=audit_max_bytes,
         session_idle_timeout_sec=session_idle_timeout_sec,
         session_reap_interval_sec=session_reap_interval_sec,
         status_weights=status_weights,
@@ -405,6 +407,7 @@ def build_app(
         audit_log = AuditLog(
             log_path=audit_log_path or config.audit_log_path,
             hmac_key=config.audit_hmac_key,
+            max_bytes=config.audit_max_bytes,
         )
         state.audit_log = audit_log
 
@@ -860,6 +863,7 @@ def build_app_from_config(config: Config, *, bootstrap_now: bool = True) -> Fast
         auth_token=config.auth_token,
         auth_principals=list(config.auth_principals),
         audit_hmac_key=config.audit_hmac_key,
+        audit_max_bytes=config.audit_max_bytes,
         ledger_path=config.ledger_path,
         session_idle_timeout_sec=config.session_idle_timeout_sec,
         session_reap_interval_sec=config.session_reap_interval_sec,
@@ -869,6 +873,26 @@ def build_app_from_config(config: Config, *, bootstrap_now: bool = True) -> Fast
         embeddings_weight=config.embeddings_weight,
         embeddings_model=config.embeddings_model,
     )
+
+
+def _uvicorn_proxy_kwargs(trusted_proxies: list[str]) -> dict[str, Any]:
+    """Build the uvicorn proxy-header kwargs from the trusted-proxy list.
+
+    Empty list -> ``{"proxy_headers": False}``: X-Forwarded-For is ignored and
+    ``request.client.host`` is the immediate peer, so a client cannot spoof its
+    address to evade the per-IP rate limiter. This is the safe default.
+
+    Non-empty -> enable ``proxy_headers`` and set ``forwarded_allow_ips`` to the
+    trusted set so uvicorn rewrites ``remote_addr`` from XFF ONLY when the peer is
+    one of those proxies. ``["*"]`` trusts any peer (only safe when nothing
+    untrusted can reach the port directly). uvicorn expects a comma-separated
+    string for ``forwarded_allow_ips``."""
+    if not trusted_proxies:
+        return {"proxy_headers": False}
+    return {
+        "proxy_headers": True,
+        "forwarded_allow_ips": ",".join(trusted_proxies),
+    }
 
 
 def _ensure_git_identity() -> None:
@@ -1033,9 +1057,19 @@ def main() -> None:
                 ),
                 name="session_reaper_loop",
             ))
+        # Proxy-header handling (WP3a item 3). By default uvicorn ignores
+        # X-Forwarded-For, so behind an ingress every client collapses to the
+        # proxy's address and the per-IP rate limiter throttles all clients as
+        # one. When KB_TRUSTED_PROXIES is set we enable proxy_headers and restrict
+        # forwarded_allow_ips to those proxies, so uvicorn rewrites remote_addr
+        # from XFF ONLY when the immediate peer is trusted (a direct client cannot
+        # then spoof its IP). Empty (default) keeps proxy_headers OFF: safe by
+        # default, no spoofing surface.
+        uvicorn_kwargs = _uvicorn_proxy_kwargs(config.trusted_proxies)
         server = uvicorn.Server(
             uvicorn.Config(
-                http_app, host="0.0.0.0", port=config.http_port, log_level="info"
+                http_app, host="0.0.0.0", port=config.http_port, log_level="info",
+                **uvicorn_kwargs,
             )
         )
         try:

--- a/src/data_olympus/tools_audit.py
+++ b/src/data_olympus/tools_audit.py
@@ -9,6 +9,12 @@ if TYPE_CHECKING:
     from data_olympus.audit_log import AuditLog
 
 
+# Cap the reverse scan at a generous multiple of the requested limit so a
+# heavily-filtered query (e.g. one rare agent) still walks enough history to fill
+# the page without slurping an entire rotated archive when few rows match.
+_SCAN_MULTIPLE = 50
+
+
 def kb_audit_fn(
     *,
     audit_log: AuditLog,
@@ -17,8 +23,18 @@ def kb_audit_fn(
     status: str | None = None,
     limit: int = 100,
 ) -> AuditResponse:
+    # A ``since`` filter is a request for history over a window, which may reach
+    # back past the live file into rotated segments, so include them. Without a
+    # ``since`` the query is "most recent N", answerable from the live file alone
+    # (cheaper, and matches the pre-rotation behaviour). The scan is bounded so a
+    # large rotated archive cannot turn one query into an unbounded read.
+    include_rotated = since is not None
+    max_scan = max(1, limit) * _SCAN_MULTIPLE
     events: list[AuditEvent] = []
-    for ev in audit_log.iter_filtered(since=since, agent=agent, status=status):
+    for ev in audit_log.iter_filtered(
+        since=since, agent=agent, status=status,
+        include_rotated=include_rotated, max_scan_events=max_scan,
+    ):
         events.append(AuditEvent(**ev))
         if len(events) >= limit:
             break

--- a/src/data_olympus/tools_enforce.py
+++ b/src/data_olympus/tools_enforce.py
@@ -155,7 +155,13 @@ def kb_compliance_fn(
     counts. Ignores non-enforcement audit events."""
     counts: dict[str, int] = {}
     by_agent: dict[str, dict[str, int]] = {}
-    for ev in audit_log.iter_filtered(since=since, agent=agent):
+    # A ``since`` window may reach into rotated segments; include them so the
+    # aggregate is complete over the requested window (the ``since`` floor bounds
+    # the scan). Without ``since`` the aggregate is over the live file only,
+    # matching the pre-rotation behaviour.
+    for ev in audit_log.iter_filtered(
+        since=since, agent=agent, include_rotated=since is not None,
+    ):
         et = ev.get("event_type", "")
         if et not in ENFORCE_EVENT_TYPES:
             continue

--- a/src/data_olympus/tools_read.py
+++ b/src/data_olympus/tools_read.py
@@ -105,6 +105,7 @@ def kb_health_fn(
         last_successful_refresh_at=state.last_successful_refresh_at,
         remote_head_sha=state.remote_head_sha,
         live_sessions=state.live_sessions,
+        malformed_frontmatter=state.malformed_frontmatter,
     )
 
 

--- a/tests/test_audit_log.py
+++ b/tests/test_audit_log.py
@@ -148,3 +148,139 @@ def test_verify_rejects_unhashed_line_after_chain_started(tmp_path) -> None:
     ok, idx = AuditLog(log_path=str(path)).verify()
     assert ok is False
     assert idx == 2
+
+
+# --- size-based rotation with chain continuity ----------------------------
+
+def _rotated(tmp_path) -> list:
+    return sorted(p for p in tmp_path.glob("events-*.log"))
+
+
+def test_no_rotation_when_disabled(tmp_path) -> None:
+    """max_bytes=0 (default) never rotates: single file, backward compatible."""
+    path = tmp_path / "events.log"
+    al = AuditLog(log_path=str(path))
+    for i in range(50):
+        al.append({"ts": float(i), "status": "committed", "blob": "x" * 200})
+    assert _rotated(tmp_path) == []
+    assert al.verify() == (True, -1)
+
+
+def test_rotation_creates_segment_and_keeps_live_file(tmp_path) -> None:
+    path = tmp_path / "events.log"
+    al = AuditLog(log_path=str(path), max_bytes=400)
+    for i in range(20):
+        al.append({"ts": float(i), "status": "committed", "blob": "y" * 100})
+    rotated = _rotated(tmp_path)
+    assert rotated, "expected at least one rotated segment"
+    assert path.exists(), "live file must still exist after rotation"
+
+
+def test_chain_continuity_across_rotation(tmp_path) -> None:
+    """The first event of a new segment links to the last hash of the previous
+    segment, so verify() validates across the boundary."""
+    path = tmp_path / "events.log"
+    al = AuditLog(log_path=str(path), max_bytes=300)
+    for i in range(30):
+        al.append({"ts": float(i), "status": "committed", "blob": "z" * 80})
+    rotated = _rotated(tmp_path)
+    assert len(rotated) >= 1
+    # The live file's first hashed event must chain to the last hash of the most
+    # recent rotated segment.
+    last_rotated_lines = [
+        json.loads(x) for x in rotated[-1].read_text().splitlines() if x.strip()
+    ]
+    live_lines = [
+        json.loads(x) for x in path.read_text().splitlines() if x.strip()
+    ]
+    assert live_lines[0]["prev_hash"] == last_rotated_lines[-1]["hash"]
+    # Full chain across every segment validates.
+    assert al.verify() == (True, -1)
+    # A fresh reader (new process) sees the same intact chain.
+    assert AuditLog(log_path=str(path), max_bytes=300).verify() == (True, -1)
+
+
+def test_rotation_survives_process_restart(tmp_path) -> None:
+    """After rotation, a fresh AuditLog resumes the chain from the true tail
+    (live file's last hash), not a rotated segment's."""
+    path = tmp_path / "events.log"
+    al = AuditLog(log_path=str(path), max_bytes=300)
+    for i in range(30):
+        al.append({"ts": float(i), "status": "committed", "blob": "z" * 80})
+    live_last = [
+        json.loads(x) for x in path.read_text().splitlines() if x.strip()
+    ][-1]["hash"]
+    al2 = AuditLog(log_path=str(path), max_bytes=300)
+    al2.append({"ts": 999.0, "status": "committed"})
+    new_first = [
+        json.loads(x) for x in path.read_text().splitlines() if x.strip()
+    ][-1]
+    assert new_first["prev_hash"] == live_last
+    assert al2.verify() == (True, -1)
+
+
+def test_verify_detects_tamper_in_rotated_segment(tmp_path) -> None:
+    path = tmp_path / "events.log"
+    al = AuditLog(log_path=str(path), max_bytes=300)
+    for i in range(30):
+        al.append({"ts": float(i), "status": "committed", "blob": "z" * 80})
+    rotated = _rotated(tmp_path)
+    assert rotated
+    # Tamper with a line inside the oldest rotated segment.
+    seg = rotated[0]
+    lines = seg.read_text().splitlines()
+    ev = json.loads(lines[0])
+    ev["status"] = "FORGED"
+    lines[0] = json.dumps(ev)
+    seg.write_text("\n".join(lines) + "\n")
+    ok, _idx = AuditLog(log_path=str(path), max_bytes=300).verify()
+    assert ok is False
+
+
+def test_iter_includes_rotated_with_since(tmp_path) -> None:
+    """A since-filtered read walks rotated segments so history that rotated out of
+    the live file is still visible."""
+    path = tmp_path / "events.log"
+    al = AuditLog(log_path=str(path), max_bytes=300)
+    for i in range(40):
+        al.append({"ts": float(i), "status": "committed", "blob": "q" * 80})
+    assert _rotated(tmp_path), "test needs at least one rotation"
+    # Without rotated segments the live file alone would miss early ts.
+    all_ts = [
+        ev["ts"] for ev in al.iter_filtered(since=0.0, include_rotated=True)
+    ]
+    assert min(all_ts) == 0.0
+    assert max(all_ts) == 39.0
+    assert len(all_ts) == 40
+    # Most-recent-first ordering preserved across the boundary.
+    assert all_ts == sorted(all_ts, reverse=True)
+
+
+def test_iter_default_reads_live_file_only(tmp_path) -> None:
+    path = tmp_path / "events.log"
+    al = AuditLog(log_path=str(path), max_bytes=300)
+    for i in range(40):
+        al.append({"ts": float(i), "status": "committed", "blob": "q" * 80})
+    live_only = list(al.iter_filtered())
+    all_events = list(al.iter_filtered(include_rotated=True))
+    assert len(live_only) < len(all_events)
+
+
+def test_iter_bounded_scan(tmp_path) -> None:
+    path = tmp_path / "events.log"
+    al = AuditLog(log_path=str(path))
+    for i in range(100):
+        al.append({"ts": float(i), "status": "committed"})
+    bounded = list(al.iter_filtered(max_scan_events=10))
+    assert len(bounded) == 10
+
+
+def test_old_single_file_still_verifies(tmp_path) -> None:
+    """An existing single-file log (written before rotation existed) verifies
+    unchanged when opened by a rotation-aware AuditLog."""
+    path = tmp_path / "events.log"
+    writer = AuditLog(log_path=str(path))  # no max_bytes: single file
+    for i in range(10):
+        writer.append({"ts": float(i), "status": "committed"})
+    # Reader with rotation enabled sees the same intact single-file chain.
+    assert AuditLog(log_path=str(path), max_bytes=1_000_000).verify() == (True, -1)

--- a/tests/test_deploy_manifests.py
+++ b/tests/test_deploy_manifests.py
@@ -116,6 +116,27 @@ def test_readiness_probe_points_at_readyz() -> None:
     assert container["readinessProbe"]["httpGet"]["path"] == "/readyz"
 
 
+def test_image_tag_supports_readyz_and_rootless_flow() -> None:
+    """The manifest now depends on /readyz and the rootless /state/git-key flow,
+    both introduced in v0.3.0. Applying it against an older image (e.g. the old
+    placeholder v0.1.1) would leave the pod NotReady and break the deploy key, so
+    both containers must reference a tag >= v0.3.0 and share the same tag."""
+    sts = _statefulset()
+    spec = sts["spec"]["template"]["spec"]
+    main_img = spec["containers"][0]["image"]
+    init_img = spec["initContainers"][0]["image"]
+    # Both point at the same image (init prepares state the main container reads).
+    assert main_img == init_img, (main_img, init_img)
+    # Must not be a pre-/readyz tag. Guard against the specific stale placeholder
+    # and, generically, any v0.1.x / v0.2.x tag.
+    for img in (main_img, init_img):
+        tag = img.rsplit(":", 1)[-1]
+        assert tag != "v0.1.1", f"stale placeholder image tag: {img}"
+        assert not tag.startswith(("v0.1.", "v0.2.")), (
+            f"image tag {tag} predates /readyz + rootless flow (need >= v0.3.0)"
+        )
+
+
 def test_dockerfile_is_digest_pinned_and_rootless() -> None:
     text = (DOCKER_DIR / "Dockerfile").read_text()
     assert "python:3.13-slim@sha256:" in text  # digest-pinned base

--- a/tests/test_deploy_manifests.py
+++ b/tests/test_deploy_manifests.py
@@ -1,0 +1,146 @@
+"""Sanity checks on the deploy manifests (WP3a container hardening + probe split).
+
+Prefers a real ``kubectl kustomize`` build when the binary is available so the
+kustomization actually renders; otherwise falls back to parsing the individual
+YAML documents. Both paths assert the security posture is what WP3a set out to
+achieve: rootless containers, no gosu/added caps, Ingress excluded from the
+default apply, and the readiness probe pointed at /readyz.
+"""
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import yaml
+
+K8S_DIR = Path(__file__).resolve().parents[1] / "deploy" / "k8s"
+DOCKER_DIR = Path(__file__).resolve().parents[1] / "deploy" / "docker"
+
+
+def _load_all(path: Path) -> list[dict]:
+    return [d for d in yaml.safe_load_all(path.read_text()) if isinstance(d, dict)]
+
+
+def _kustomize_build() -> list[dict] | None:
+    """Render `kubectl kustomize deploy/k8s` if kubectl is available, else None."""
+    kubectl = shutil.which("kubectl")
+    if not kubectl:
+        return None
+    try:
+        out = subprocess.run(
+            [kubectl, "kustomize", str(K8S_DIR)],
+            capture_output=True, text=True, timeout=60,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if out.returncode != 0:
+        return None
+    return [d for d in yaml.safe_load_all(out.stdout) if isinstance(d, dict)]
+
+
+def _rendered_docs() -> list[dict]:
+    docs = _kustomize_build()
+    if docs is not None:
+        return docs
+    # Fallback: parse the resources listed in kustomization.yaml directly.
+    kz = yaml.safe_load((K8S_DIR / "kustomization.yaml").read_text())
+    docs = []
+    for res in kz.get("resources", []):
+        docs.extend(_load_all(K8S_DIR / res))
+    return docs
+
+
+def _statefulset() -> dict:
+    for d in _rendered_docs():
+        if d.get("kind") == "StatefulSet":
+            return d
+    raise AssertionError("StatefulSet not found in rendered manifests")
+
+
+def test_kustomization_yaml_parses() -> None:
+    kz = yaml.safe_load((K8S_DIR / "kustomization.yaml").read_text())
+    assert kz["kind"] == "Kustomization"
+    assert "statefulset.yaml" in kz["resources"]
+
+
+def test_ingress_excluded_from_default_kustomization() -> None:
+    """The default apply must NOT include the Ingress (unauthenticated write
+    surface). It is opt-in, mirroring how the secret is applied separately."""
+    kz = yaml.safe_load((K8S_DIR / "kustomization.yaml").read_text())
+    assert "ingress.yaml" not in kz.get("resources", [])
+    kinds = {d.get("kind") for d in _rendered_docs()}
+    assert "Ingress" not in kinds
+    # But the file still exists for opt-in enablement.
+    assert (K8S_DIR / "ingress.yaml").exists()
+
+
+def test_pod_runs_as_nonroot() -> None:
+    sts = _statefulset()
+    pod_sc = sts["spec"]["template"]["spec"]["securityContext"]
+    assert pod_sc["runAsNonRoot"] is True
+    assert pod_sc["runAsUser"] == 65534
+    assert pod_sc["fsGroup"] == 65534
+
+
+def test_main_container_drops_all_caps_no_adds() -> None:
+    sts = _statefulset()
+    container = sts["spec"]["template"]["spec"]["containers"][0]
+    sc = container["securityContext"]
+    assert sc["runAsNonRoot"] is True
+    assert sc["allowPrivilegeEscalation"] is False
+    assert sc["readOnlyRootFilesystem"] is True
+    caps = sc["capabilities"]
+    assert caps["drop"] == ["ALL"]
+    # The old manifest added CHOWN/DAC_OVERRIDE/FOWNER/SETGID/SETUID for the
+    # root+gosu phase. That phase is gone; no caps may be added back.
+    assert "add" not in caps or caps["add"] == []
+
+
+def test_initcontainer_stages_key_and_clones() -> None:
+    sts = _statefulset()
+    inits = sts["spec"]["template"]["spec"].get("initContainers", [])
+    assert inits, "expected a prepare-git initContainer"
+    init = inits[0]
+    assert init["name"] == "prepare-git"
+    assert init["securityContext"]["runAsNonRoot"] is True
+    assert init["securityContext"]["capabilities"]["drop"] == ["ALL"]
+    script = " ".join(init.get("args", []))
+    assert "/state/git-key" in script  # stages the key
+    assert "git clone" in script       # first-boot clone
+
+
+def test_readiness_probe_points_at_readyz() -> None:
+    sts = _statefulset()
+    container = sts["spec"]["template"]["spec"]["containers"][0]
+    assert container["readinessProbe"]["httpGet"]["path"] == "/readyz"
+
+
+def test_dockerfile_is_digest_pinned_and_rootless() -> None:
+    text = (DOCKER_DIR / "Dockerfile").read_text()
+    assert "python:3.13-slim@sha256:" in text  # digest-pinned base
+    assert "USER 65534:65534" in text          # runs non-root
+    assert "KB_SSH_KEYSCAN_HOST" in text       # keyscan host configurable
+    # gosu must not be installed or exec'd (a comment may mention it by name to
+    # explain its removal, so only inspect non-comment directive lines).
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("#") or not stripped:
+            continue
+        assert "gosu" not in stripped, f"gosu referenced in directive: {line}"
+
+
+def test_entrypoint_has_no_gosu_or_chown() -> None:
+    text = (DOCKER_DIR / "entrypoint.sh").read_text()
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("#") or not stripped:
+            continue
+        assert "gosu" not in stripped, f"gosu in entrypoint: {line}"
+        # No chown: we run as the target uid already, nothing to re-own.
+        assert "chown" not in stripped, f"chown in entrypoint: {line}"
+
+
+def test_compose_binds_loopback() -> None:
+    text = (DOCKER_DIR / "compose.yaml").read_text()
+    assert "127.0.0.1:8080:8080" in text

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -95,6 +95,44 @@ def test_health_response_includes_path_locks_held(tmp_kb, tmp_index_path):
     assert resp.path_locks_held == 2
 
 
+def test_snapshot_surfaces_malformed_frontmatter(tmp_kb, tmp_path):
+    """malformed_frontmatter from Index.health() is threaded onto the snapshot and
+    does NOT flip degraded (it is a warning signal)."""
+    idx = Index(tmp_path / "idx.db")
+    idx.build(tmp_kb, source_commit="x")
+    state = snapshot(idx=idx, last_git_pull_at=time.time(), staleness_degraded_sec=600)
+    # Clean corpus: zero malformed, healthy.
+    assert state.malformed_frontmatter == 0
+    assert state.degraded is False
+
+
+def test_malformed_frontmatter_does_not_flip_degraded(tmp_path, monkeypatch):
+    """Even with a non-zero malformed count, degraded stays driven by staleness /
+    build status only."""
+    idx = Index(tmp_path / "idx.db")
+
+    def fake_health() -> dict[str, object]:
+        return {
+            "source_commit": "c", "index_built_at": 1.0, "total_docs": 5,
+            "db_size_bytes": 100, "malformed_frontmatter": 3,
+        }
+
+    monkeypatch.setattr(idx, "health", fake_health)
+    state = snapshot(idx=idx, last_git_pull_at=time.time(), staleness_degraded_sec=600)
+    assert state.malformed_frontmatter == 3
+    assert state.degraded is False
+
+
+def test_health_response_surfaces_malformed_frontmatter(tmp_kb, tmp_index_path):
+    from data_olympus.index import Index
+    from data_olympus.tools_read import kb_health_fn
+
+    idx = Index(tmp_index_path)
+    idx.build(tmp_kb, source_commit="x")
+    resp = kb_health_fn(idx=idx, last_git_pull_at=None, staleness_degraded_sec=600)
+    assert resp.malformed_frontmatter == 0
+
+
 def test_snapshot_threads_push_queue_frozen(tmp_kb, tmp_path):
     idx = Index(tmp_path / "idx.db")
     idx.build(tmp_kb, source_commit="x")

--- a/tests/test_rest_api.py
+++ b/tests/test_rest_api.py
@@ -39,6 +39,82 @@ async def test_rest_health_returns_200(http_app) -> None:
 
 
 @pytest.mark.asyncio
+async def test_readyz_ready_when_index_built(http_app) -> None:
+    """/readyz is 200 when the index is loaded and the last build was ok."""
+    transport = httpx.ASGITransport(app=http_app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/readyz")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["ready"] is True
+    assert body["index_built_at"] is not None
+
+
+@pytest.mark.asyncio
+async def test_readyz_ready_even_when_health_degraded(tmp_kb: Path, tmp_path: Path) -> None:
+    """The readiness split: a stale KB makes /api/v1/health 503 (degraded) but
+    /readyz stays 200 because the last-good index still serves reads. This is the
+    whole point of pointing the k8s readiness probe at /readyz not /api/v1/health."""
+    app = build_app(
+        kb_main_path=tmp_kb,
+        kb_index_path=tmp_path / "idx.db",
+        sync_interval_sec=60,
+        staleness_degraded_sec=600,
+        bootstrap_now=True,
+    )
+    state = app._dolympus_state  # type: ignore[attr-defined]
+    # Force staleness: last pull was long ago -> health degraded.
+    import time as _t
+    state.last_git_pull_at = _t.time() - 10_000
+    http_app = app.http_app()
+    transport = httpx.ASGITransport(app=http_app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        health = await client.get("/api/v1/health")
+        ready = await client.get("/readyz")
+    assert health.status_code == 503  # degraded (CLI --no-stale contract preserved)
+    assert health.json()["degraded"] is True
+    assert ready.status_code == 200  # but still ready to serve reads
+    assert ready.json()["ready"] is True
+
+
+@pytest.mark.asyncio
+async def test_readyz_not_ready_when_index_never_built(tmp_kb: Path, tmp_path: Path) -> None:
+    """No index built (cold start / never-successful build) -> /readyz 503."""
+    app = build_app(
+        kb_main_path=tmp_kb,
+        kb_index_path=tmp_path / "idx.db",
+        sync_interval_sec=60,
+        staleness_degraded_sec=600,
+        bootstrap_now=False,  # index never built
+    )
+    http_app = app.http_app()
+    transport = httpx.ASGITransport(app=http_app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/readyz")
+    assert resp.status_code == 503
+    assert resp.json()["ready"] is False
+
+
+@pytest.mark.asyncio
+async def test_livez_always_200(http_app) -> None:
+    transport = httpx.ASGITransport(app=http_app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/livez")
+    assert resp.status_code == 200
+    assert resp.json()["alive"] is True
+
+
+@pytest.mark.asyncio
+async def test_health_payload_includes_malformed_frontmatter(http_app) -> None:
+    transport = httpx.ASGITransport(app=http_app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/api/v1/health")
+    body = resp.json()
+    assert "malformed_frontmatter" in body
+    assert body["malformed_frontmatter"] == 0
+
+
+@pytest.mark.asyncio
 async def test_rest_outline_returns_200(http_app) -> None:
     transport = httpx.ASGITransport(app=http_app)
     async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:

--- a/tests/test_server_proxy_headers.py
+++ b/tests/test_server_proxy_headers.py
@@ -1,0 +1,61 @@
+"""Tests for uvicorn proxy-header configuration (WP3a item 3).
+
+The rate limiter keys on the client remote_addr. Behind an ingress, uvicorn must
+be told to trust X-Forwarded-For ONLY from configured proxies, otherwise either
+(a) every client collapses to the proxy IP (proxy_headers off) or (b) a direct
+client can spoof its IP (forwarded_allow_ips too broad). These tests pin the
+off-by-default-safe behaviour and the configured behaviour.
+"""
+from __future__ import annotations
+
+from data_olympus.config import load_config
+from data_olympus.server import _uvicorn_proxy_kwargs
+
+
+def test_proxy_headers_off_by_default() -> None:
+    kwargs = _uvicorn_proxy_kwargs([])
+    assert kwargs == {"proxy_headers": False}
+
+
+def test_proxy_headers_enabled_for_trusted_proxies() -> None:
+    kwargs = _uvicorn_proxy_kwargs(["10.0.0.1", "10.0.0.2"])
+    assert kwargs["proxy_headers"] is True
+    # uvicorn wants a comma-separated string, not a list.
+    assert kwargs["forwarded_allow_ips"] == "10.0.0.1,10.0.0.2"
+
+
+def test_proxy_headers_wildcard() -> None:
+    kwargs = _uvicorn_proxy_kwargs(["*"])
+    assert kwargs["proxy_headers"] is True
+    assert kwargs["forwarded_allow_ips"] == "*"
+
+
+def test_trusted_proxies_config_default_empty(monkeypatch, tmp_path) -> None:
+    kb = tmp_path / "kb"
+    kb.mkdir()
+    monkeypatch.setenv("KB_MAIN_PATH", str(kb))
+    monkeypatch.setenv("KB_INDEX_PATH", str(tmp_path / "kb.db"))
+    monkeypatch.delenv("KB_TRUSTED_PROXIES", raising=False)
+    cfg = load_config()
+    assert cfg.trusted_proxies == []
+    assert _uvicorn_proxy_kwargs(cfg.trusted_proxies) == {"proxy_headers": False}
+
+
+def test_trusted_proxies_config_parsed(monkeypatch, tmp_path) -> None:
+    kb = tmp_path / "kb"
+    kb.mkdir()
+    monkeypatch.setenv("KB_MAIN_PATH", str(kb))
+    monkeypatch.setenv("KB_INDEX_PATH", str(tmp_path / "kb.db"))
+    monkeypatch.setenv("KB_TRUSTED_PROXIES", "192.168.1.10, 192.168.1.11")
+    cfg = load_config()
+    assert cfg.trusted_proxies == ["192.168.1.10", "192.168.1.11"]
+
+
+def test_audit_max_bytes_config(monkeypatch, tmp_path) -> None:
+    kb = tmp_path / "kb"
+    kb.mkdir()
+    monkeypatch.setenv("KB_MAIN_PATH", str(kb))
+    monkeypatch.setenv("KB_INDEX_PATH", str(tmp_path / "kb.db"))
+    monkeypatch.setenv("KB_AUDIT_MAX_BYTES", "1048576")
+    cfg = load_config()
+    assert cfg.audit_max_bytes == 1048576


### PR DESCRIPTION
## Summary

WP3a of the 0.3.0 release program: serving/ops hardening. Builds on Wave 1 (#89) and the visibility work (#77).

1. **Readiness split from data staleness.** New `GET /readyz` (200 when the process is up and the index is loaded, **independent of staleness**) and `GET /livez` (always 200). The k8s readiness probe now targets `/readyz` (was `/api/v1/health`), so a >10min git-remote outage no longer ejects a serviceable single-replica pod from the Service. `/api/v1/health` keeps its 503-on-degraded contract for the CLI `--no-stale` flag; docs direct operators to **alert** on it rather than probe it.
2. **Audit-log rotation with chain continuity (`KB_AUDIT_MAX_BYTES`).** Size-based rotation that carries the tamper-evident hash chain across files (first event of a new segment links to the last hash of the previous). `verify()` validates across the boundary; the read path can include rotated segments for `--since` queries and bounds the reverse scan. Off by default; old single-file logs still verify.
3. **Proxy correctness (`KB_TRUSTED_PROXIES`).** Enables uvicorn `proxy_headers` + `forwarded_allow_ips` so the rate limiter sees the real client IP behind an ingress. Off by default (X-Forwarded-For ignored → no spoofing surface).
4. **Rootless container.** Removed root+`gosu`; deploy-key staging + first-boot clone moved to a non-root `prepare-git` initContainer. Both containers run as uid 65534 with `runAsNonRoot: true`, all caps dropped, read-only root FS → passes the **restricted** Pod Security Standard. Base image digest-pinned; `KB_SSH_KEYSCAN_HOST` build-arg + runtime env for non-GitHub remotes; Compose binds `127.0.0.1:8080`; Ingress commented out of the default kustomization (opt-in after auth) with a `deploy/k8s/README.md` note.
5. **Operations runbook.** New `docs/operations.md` (linked from README + serving.md): backup, upgrade (incl. the taxonomy compatibility note + forced index rebuild), recovery playbooks (degraded/fetch-failed, history rewrite, frozen + PR #89 demotion states, orphaned locks), and the health/readiness/alerting model.
6. **`malformed_frontmatter` in health** (WP2b follow-up). Surfaced on the health payload; warning signal, does **not** flip `degraded` (documented).

Stayed out of Wave-1 write logic (`tools_write.py`/`write_gate.py`/`pending.py`/`push_queue.py`) and WP4e read shapes; the only `models.py`/`tools_read.py` touch is the additive `malformed_frontmatter` health field.

## Test evidence

- Full suite green: `pytest -q` → all pass (2 skips: optional `sentence_transformers`/`tiktoken`).
- `ruff check .` → All checks passed. `mypy src/` → no issues in 61 files.
- New tests: `test_audit_log.py` (rotation + cross-boundary verify + backward compat + bounded reads), `test_rest_api.py` (readyz/livez semantics vs degraded health, malformed_frontmatter payload), `test_health.py` (malformed_frontmatter snapshot/response, does-not-flip-degraded), `test_server_proxy_headers.py` (proxy kwargs on/off, config parsing), `test_deploy_manifests.py` (rootless securityContext, no gosu/added-caps, initContainer flow, Ingress excluded, `/readyz` probe, digest-pin, loopback bind, image tag >= 0.3.0).
- `kubectl kustomize deploy/k8s` builds cleanly (no Ingress, no gosu/added caps); `sh -n` + `shellcheck` clean on entrypoint.sh.
- `python scripts/check_changelog.py` → ok.
- Rebased onto latest `origin/release/0.3.0` (picked up WP4e compact_dump); the additive health field flows through the generic compact filter unchanged.

## Peer review (codex)

Verdict: **1 Blocker, 1 Concern, 1 Nit**, all addressed.

- **Blocker** — statefulset still pinned `v0.1.1`, which predates `/readyz` + the rootless `/state/git-key` flow → pod would stay NotReady and lose git auth. **Fixed:** bumped both image refs to `v0.3.0` and added a manifest test that fails on any `v0.1.x`/`v0.2.x` tag or mismatched init/main tags.
- **Concern** — rebase-conflict and persistent-contention demotions share one audit record, but the runbook implied distinct states. `push_queue.py` demotion logic is out of scope for this WP, so **fixed by doc accuracy**: `docs/operations.md` §4.5 now documents the single `push_conflict_demoted`/`demoted_to_pending` record both causes emit and how to tell them apart via the push-loop logs.
- **Nit** — audit-verify section cross-referenced the push-queue playbook. **Fixed:** now points at forensics/backup guidance.

Codex confirmed: readiness split preserves the CLI 503 contract; audit rotation carries the chain across segments and stays off-by-default/backward-compatible; proxy headers off-by-default-safe.
