### PR TITLE
chore(release): v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,44 +12,7 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-### Changed
-
-- **BREAKING (default response shape): token-compact read-tool responses (#65).**
-  The read tools `kb_search`, `kb_get`, `kb_list`, `kb_outline`, and `kb_health`
-  now return a **token-compact** representation **by default**, because their
-  consumer is almost always an LLM paying for every token. Measured against the
-  example-bundle with a real tokenizer (tiktoken cl100k; reproduce with
-  `python -m benchmarks.token_compact --tokenizer tiktoken`) this saves ~37% of
-  tokens on `kb_search`, ~42% on `kb_list`, ~41% on `kb_health`, and ~6-7% on
-  `kb_get` (which keeps its full body and provenance); 26.1% aggregate. What
-  changed in the default shape:
-  - `kb_search`: each hit is `{id, title, snippet}` plus `status` **only when the
-    hit is not currently in force** (e.g. `superseded`/`deprecated`) and `type`
-    when set. The `query` echo, the per-hit `path`, and the raw bm25 `score` are
-    dropped; snippets are capped at 160 chars. Array order still conveys rank; to
-    read a hit in full, call `kb_get(id)`.
-  - `kb_get`: keeps the full `content_markdown` body (unchanged) plus
-    `source_commit`/`last_modified` provenance, and trims the envelope: `path`,
-    `git_remote_url`, and `last_modified_source` are dropped, and empty
-    `status`/`type`/`applies_when`/`description` are omitted.
-  - `kb_list`: drops per-entry `path`; omits a null `category`.
-  - `kb_health`: keeps the core snapshot and omits diagnostic fields that are
-    null/empty (a no-error steady state no longer emits a run of nulls).
-  - `kb_outline`: already lean; its shape is unchanged.
-
-  **Opt out** with `verbose=true` (a REST query parameter, or the `verbose`
-  argument on each MCP tool), which restores the exact pre-#65 JSON shape
-  byte-for-byte. The bundled `kb` CLI requests `verbose=true` automatically, so
-  its output is unaffected. Any first-party or third-party consumer that parsed
-  the dropped fields (`query`, per-hit `path`/`score`, the full health envelope)
-  must either adopt the compact shape or pass `verbose=true`. A committed
-  measurement harness (`benchmarks/token_compact.py`) reproduces the per-tool
-  token table under either tokenizer (`python -m benchmarks.token_compact`
-  defaults to the dependency-free `simple` splitter; add `--tokenizer tiktoken`
-  for the cl100k numbers quoted above), and a tokenizer-based regression test
-  (`tests/test_token_compact_budget.py`, with both a `simple` budget and a
-  `tiktoken` aggregate-savings guard) fails loudly if a future change re-bloats
-  the compact default.
+## [0.3.0] - 2026-07-03
 
 ### Added
 
@@ -164,64 +127,6 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
     `main()` as a fallback) now set a default `GIT_AUTHOR_*`/`GIT_COMMITTER_*`
     identity (overridable via `KB_GIT_AUTHOR_NAME` / `KB_GIT_AUTHOR_EMAIL`) so a
     commit inside a fresh container no longer fails with "who are you".
-
-### Changed
-
-- **MCP/REST write-surface parity (deferred WP0b items).** The MCP
-  `kb_resolve_pending` tool now applies the `KB_MAX_POSTIMAGE_BYTES` `edited_text`
-  cap (REST already did), and the MCP `kb_consult` / `kb_gate_check` /
-  `kb_cleanup_plan` tools now apply the shared rate limiter consistently with their
-  REST counterparts.
-
-### Security
-
-- Hardened the write and enforcement surface (issue #74). Ten fixes, each with
-  regression tests:
-  - **Request body caps.** The resolve, consult, gate/check, and audit/event REST
-    routes read the body with an uncapped `request.json()`; they now go through the
-    same `KB_MAX_BODY_BYTES` streaming cap as propose/bootstrap and return 413 on
-    oversize input.
-  - **`resolve.edited_text` cap.** Operator-supplied `edited_text` on approve
-    became the committed postimage with no size check; it is now bounded by
-    `KB_MAX_POSTIMAGE_BYTES` and rejected with a distinct
-    `rejected_edited_text_too_large` status, leaving the pending entry in place.
-  - **YAML frontmatter injection.** Memory frontmatter was string-concatenated, so
-    a `tags` / `agent_identity` value containing a newline or `]` could forge
-    reserved keys (`id` / `status` / `supersedes`); a forged duplicate `id` breaks
-    every index rebuild. Frontmatter is now serialized with `yaml.safe_dump`, and
-    the size cap counts the full rendered postimage (frontmatter + body), not just
-    the body.
-  - **Backslash / control-char path bypass.** `decisions\x.md` validated as
-    `decisions/x.md` but wrote a literal root-level file outside every indexed
-    prefix and invisible to `KB_WRITE_BLOCK_PATHS`. Path normalization now returns
-    the canonical form and every downstream operation (classification, blocklist,
-    join, `git add`, pending record) uses it; control characters (newline, CR, tab,
-    NUL) in a target path are rejected. The same canonical-path handling and safe
-    YAML frontmatter (with the size cap applied after remote-URL injection) now
-    also cover the onboarding bootstrap path.
-  - **Enforcement-plane auth + rate limiting.** `/consult`, `/gate/check`, and
-    `/onboarding/cleanup-plan` were anonymous-allowed even when auth was configured
-    and were unthrottled. They now require an authenticated principal when auth is
-    configured (no-auth deployments are unchanged) and are subject to the shared
-    rate limiter. `kb_cleanup_plan` is added to the MCP auth-required tool set so
-    the MCP enforcement plane matches REST.
-  - **Viewer HTML injection.** A doc body containing `</script>` could break out of
-    the embedded `<script>` block and run arbitrary JS; `</` is now escaped to
-    `<\/`. Fixed a substitution-ordering bug where a body containing the literal
-    `__DISPLAY_NAME__` was mangled (both placeholders are now substituted in a
-    single pass).
-  - **Search limit clamp.** `kb_search` clamped only the upper bound, so
-    `limit=-1` reached SQLite as `LIMIT -1` (unlimited full-corpus dump); it is now
-    clamped to 1..100.
-  - **Actionable status codes.** Malformed `since` / `limit` query params on
-    `/audit` and `/compliance` now return 400 instead of an opaque 500, and resolve
-    of an unknown/expired `pending_id` returns 404 (with path-traversal-shaped ids
-    rejected).
-  - **Rate-limiter hygiene.** The sliding-window limiter now evicts empty bucket
-    keys (bounding memory under varying identities) and guards its read-modify-write
-    with a lock (correct under the threadpool the REST handlers run on).
-
-### Added
 
 - **PyPI distribution + `data-olympus setup` wizard** (issue #70). The package is
   now installable from PyPI (`uvx data-olympus`, `uv tool install data-olympus`),
@@ -389,24 +294,51 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   session's `kb-session/<safe_id>` branch, so a returning session can create its
   worktree again instead of hitting a fatal "branch already exists" error.
 
-### Documentation
-
-- Reworded OKF-compatibility claims for honesty (WP4c, 0.3.0). `README.md`,
-  `SPEC.md`, `WHY.md`, and `docs/comparison.md` asserted "OKF-compatible" /
-  "any OKF consumer can read a data-olympus bundle unchanged" / "every
-  data-olympus bundle is a valid OKF bundle" with zero executable backing: no
-  test runs a real OKF reference consumer/producer against a data-olympus
-  bundle. The strongest claims are now worded as design intent ("designed to
-  be readable by OKF consumers") backed by the shared structure that does
-  exist by construction (directory layout, frontmatter conventions, reserved
-  filenames, link model), with formal conformance testing tracked in
-  [issue #82](https://github.com/knaisoma/data-olympus/issues/82). A cheap,
-  non-behavioral structural floor (non-empty `id`/`type` on every example-bundle
-  concept doc, `okf_version` on the bundle-root index) was added as
-  `tests/test_okf_minimal_fields.py`; its docstring is explicit that this
-  proves frontmatter shape, not that any OKF tool can read the bundle.
 
 ### Changed
+
+- **BREAKING (default response shape): token-compact read-tool responses (#65).**
+  The read tools `kb_search`, `kb_get`, `kb_list`, `kb_outline`, and `kb_health`
+  now return a **token-compact** representation **by default**, because their
+  consumer is almost always an LLM paying for every token. Measured against the
+  example-bundle with a real tokenizer (tiktoken cl100k; reproduce with
+  `python -m benchmarks.token_compact --tokenizer tiktoken`) this saves ~37% of
+  tokens on `kb_search`, ~42% on `kb_list`, ~41% on `kb_health`, and ~6-7% on
+  `kb_get` (which keeps its full body and provenance); 26.1% aggregate. What
+  changed in the default shape:
+  - `kb_search`: each hit is `{id, title, snippet}` plus `status` **only when the
+    hit is not currently in force** (e.g. `superseded`/`deprecated`) and `type`
+    when set. The `query` echo, the per-hit `path`, and the raw bm25 `score` are
+    dropped; snippets are capped at 160 chars. Array order still conveys rank; to
+    read a hit in full, call `kb_get(id)`.
+  - `kb_get`: keeps the full `content_markdown` body (unchanged) plus
+    `source_commit`/`last_modified` provenance, and trims the envelope: `path`,
+    `git_remote_url`, and `last_modified_source` are dropped, and empty
+    `status`/`type`/`applies_when`/`description` are omitted.
+  - `kb_list`: drops per-entry `path`; omits a null `category`.
+  - `kb_health`: keeps the core snapshot and omits diagnostic fields that are
+    null/empty (a no-error steady state no longer emits a run of nulls).
+  - `kb_outline`: already lean; its shape is unchanged.
+
+  **Opt out** with `verbose=true` (a REST query parameter, or the `verbose`
+  argument on each MCP tool), which restores the exact pre-#65 JSON shape
+  byte-for-byte. The bundled `kb` CLI requests `verbose=true` automatically, so
+  its output is unaffected. Any first-party or third-party consumer that parsed
+  the dropped fields (`query`, per-hit `path`/`score`, the full health envelope)
+  must either adopt the compact shape or pass `verbose=true`. A committed
+  measurement harness (`benchmarks/token_compact.py`) reproduces the per-tool
+  token table under either tokenizer (`python -m benchmarks.token_compact`
+  defaults to the dependency-free `simple` splitter; add `--tokenizer tiktoken`
+  for the cl100k numbers quoted above), and a tokenizer-based regression test
+  (`tests/test_token_compact_budget.py`, with both a `simple` budget and a
+  `tiktoken` aggregate-savings guard) fails loudly if a future change re-bloats
+  the compact default.
+
+- **MCP/REST write-surface parity (deferred WP0b items).** The MCP
+  `kb_resolve_pending` tool now applies the `KB_MAX_POSTIMAGE_BYTES` `edited_text`
+  cap (REST already did), and the MCP `kb_consult` / `kb_gate_check` /
+  `kb_cleanup_plan` tools now apply the shared rate limiter consistently with their
+  REST counterparts.
 
 - **BREAKING (auth):** A `KB_AUTH_PRINCIPALS` entry that omits an explicit
   `capabilities` list now defaults to least privilege (`read`, `propose`) instead
@@ -481,6 +413,8 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 > Scope note: this wave makes write-path failures **visible** and recovers
 > orphaned commits. It does **not** fix the non-fast-forward publication stall
 > itself (rebase-retry redesign); that is tracked separately as Wave 1.
+
+
 ### Fixed
 
 - Search pipeline hardening (WP2b, epic #75), bug + perf fixes:
@@ -576,7 +510,72 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   tooling, so `index.md`, `log.md`, and `template.md` are consistently
   reserved everywhere.
 
+
+### Security
+
+- Hardened the write and enforcement surface (issue #74). Ten fixes, each with
+  regression tests:
+  - **Request body caps.** The resolve, consult, gate/check, and audit/event REST
+    routes read the body with an uncapped `request.json()`; they now go through the
+    same `KB_MAX_BODY_BYTES` streaming cap as propose/bootstrap and return 413 on
+    oversize input.
+  - **`resolve.edited_text` cap.** Operator-supplied `edited_text` on approve
+    became the committed postimage with no size check; it is now bounded by
+    `KB_MAX_POSTIMAGE_BYTES` and rejected with a distinct
+    `rejected_edited_text_too_large` status, leaving the pending entry in place.
+  - **YAML frontmatter injection.** Memory frontmatter was string-concatenated, so
+    a `tags` / `agent_identity` value containing a newline or `]` could forge
+    reserved keys (`id` / `status` / `supersedes`); a forged duplicate `id` breaks
+    every index rebuild. Frontmatter is now serialized with `yaml.safe_dump`, and
+    the size cap counts the full rendered postimage (frontmatter + body), not just
+    the body.
+  - **Backslash / control-char path bypass.** `decisions\x.md` validated as
+    `decisions/x.md` but wrote a literal root-level file outside every indexed
+    prefix and invisible to `KB_WRITE_BLOCK_PATHS`. Path normalization now returns
+    the canonical form and every downstream operation (classification, blocklist,
+    join, `git add`, pending record) uses it; control characters (newline, CR, tab,
+    NUL) in a target path are rejected. The same canonical-path handling and safe
+    YAML frontmatter (with the size cap applied after remote-URL injection) now
+    also cover the onboarding bootstrap path.
+  - **Enforcement-plane auth + rate limiting.** `/consult`, `/gate/check`, and
+    `/onboarding/cleanup-plan` were anonymous-allowed even when auth was configured
+    and were unthrottled. They now require an authenticated principal when auth is
+    configured (no-auth deployments are unchanged) and are subject to the shared
+    rate limiter. `kb_cleanup_plan` is added to the MCP auth-required tool set so
+    the MCP enforcement plane matches REST.
+  - **Viewer HTML injection.** A doc body containing `</script>` could break out of
+    the embedded `<script>` block and run arbitrary JS; `</` is now escaped to
+    `<\/`. Fixed a substitution-ordering bug where a body containing the literal
+    `__DISPLAY_NAME__` was mangled (both placeholders are now substituted in a
+    single pass).
+  - **Search limit clamp.** `kb_search` clamped only the upper bound, so
+    `limit=-1` reached SQLite as `LIMIT -1` (unlimited full-corpus dump); it is now
+    clamped to 1..100.
+  - **Actionable status codes.** Malformed `since` / `limit` query params on
+    `/audit` and `/compliance` now return 400 instead of an opaque 500, and resolve
+    of an unknown/expired `pending_id` returns 404 (with path-traversal-shaped ids
+    rejected).
+  - **Rate-limiter hygiene.** The sliding-window limiter now evicts empty bucket
+    keys (bounding memory under varying identities) and guards its read-modify-write
+    with a lock (correct under the threadpool the REST handlers run on).
+
+
 ### Documentation
+
+- Reworded OKF-compatibility claims for honesty (WP4c, 0.3.0). `README.md`,
+  `SPEC.md`, `WHY.md`, and `docs/comparison.md` asserted "OKF-compatible" /
+  "any OKF consumer can read a data-olympus bundle unchanged" / "every
+  data-olympus bundle is a valid OKF bundle" with zero executable backing: no
+  test runs a real OKF reference consumer/producer against a data-olympus
+  bundle. The strongest claims are now worded as design intent ("designed to
+  be readable by OKF consumers") backed by the shared structure that does
+  exist by construction (directory layout, frontmatter conventions, reserved
+  filenames, link model), with formal conformance testing tracked in
+  [issue #82](https://github.com/knaisoma/data-olympus/issues/82). A cheap,
+  non-behavioral structural floor (non-empty `id`/`type` on every example-bundle
+  concept doc, `okf_version` on the bundle-root index) was added as
+  `tests/test_okf_minimal_fields.py`; its docstring is explicit that this
+  proves frontmatter shape, not that any OKF tool can read the bundle.
 
 - Corrected several stale or inaccurate claims ahead of 0.3.0: `docs/adoption.md`
   now describes the actual `KB_MAIN_PATH`-ignoring behaviour of
@@ -979,7 +978,8 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `docs/adoption.md`: bring-your-own-KB guide (author, lint, index, serve, wire an agent).
 - `docs/comparison.md`: how data-olympus relates to OKF, enterprise catalogs, markdown KB tools, agent-context conventions, RAG, and ADR tooling.
 
-[Unreleased]: https://github.com/knaisoma/data-olympus/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/knaisoma/data-olympus/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/knaisoma/data-olympus/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/knaisoma/data-olympus/compare/v0.1.1...v0.2.0
 [0.1.1]: https://github.com/knaisoma/data-olympus/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/knaisoma/data-olympus/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ data-olympus is a governance-grade knowledge-base format and server for agent wo
 
 It governs *decisions*, not code. When an agent is about to make a choice (a library, a pattern, a migration), data-olympus surfaces the established standard or decision that should govern that choice. It is deliberately **not** a code-search, reference-finding, or "where is X used" tool: LSP, grep, and Sourcegraph already do that well. The retrieval task it targets is coding-intent to governing-rule, and it helps where current model interaction during vibe-coding is weakest: keeping the model aligned to patterns the team has already established as correct.
 
-**Status: pre-release (v0.2.0 shipped; v0.3.0 in progress).**
+**Status: pre-release (v0.3.0 shipped).**
 
 ## Why
 

--- a/docs/releases/v0.3.0.md
+++ b/docs/releases/v0.3.0.md
@@ -2,20 +2,26 @@
 
 ## New features
 
-- Search that never hands back a retired rule and can honestly say "no rule
-  applies." A new strict mode excludes superseded or deprecated guidance
-  entirely instead of just ranking it lower, and a separate signal catches
-  queries that do not match anything meaningful, so the assistant gets a clear
-  "nothing applies here" instead of a stretch of unrelated results.
+- A stricter search option that can guarantee it never hands back a retired
+  rule, plus an honest "no rule applies" answer. By default, search still
+  favors current guidance but can still return an older, superseded document
+  lower in the list; the new strict mode excludes superseded or deprecated
+  guidance entirely instead of just ranking it lower. A separate signal
+  catches queries that do not match anything meaningful, so the assistant
+  gets a clear "nothing applies here" instead of a stretch of unrelated
+  results.
 - An import command for teams that already have a pile of agent rules. Point
   it at an existing CLAUDE.md, AGENTS.md, cursorrules file, or a folder of
   architecture decision records and it produces a draft set of governed
   documents, ready for a person to review before anything is committed.
-- Install straight from PyPI, with a guided setup wizard. The wizard checks
-  the server is reachable, finds which coding assistants are installed on the
-  machine, registers the knowledge base with each one, and offers to turn on
-  the mandatory-consultation safeguard, all with automatic backups of
-  anything it changes.
+- The groundwork to install straight from PyPI, with a guided setup wizard.
+  The release chain is now wired to publish the package once the operator
+  finishes a one-time PyPI publishing setup; from then on, every release
+  becomes installable with a single command. The wizard checks the server is
+  reachable, finds which coding assistants are installed on the machine,
+  registers the knowledge base with each one, and offers to turn on the
+  mandatory-consultation safeguard, all with automatic backups of anything
+  it changes.
 - Noticeably leaner responses. The everyday search and lookup calls now
   return a trimmed-down shape by default, cutting the tokens an assistant
   pays for by about 26 percent overall, with the full, original shape still
@@ -35,10 +41,10 @@
   assistant actually needs instead of full access by default.
 - Rechecked, honestly reported benchmark numbers, so the quality claims this
   project makes about its own search are ones it can stand behind.
-- A written runbook for operators, a health check that no longer flags a
-  service as broken just because it is briefly out of sync with its source,
-  and an audit trail that now rotates in the background while still proving
-  nothing in it was tampered with.
+- A written runbook for operators, a separate readiness check that no longer
+  flags a service as broken just because it is briefly out of sync with its
+  source, and an audit trail that can now rotate to a fresh file as it grows
+  (an opt-in setting) while still proving nothing in it was tampered with.
 - A refreshed example knowledge base showing off supersession, memories, and
   reference documents, plus documentation for a field that helps search match
   a task to the right rule.

--- a/docs/releases/v0.3.0.md
+++ b/docs/releases/v0.3.0.md
@@ -1,0 +1,57 @@
+# v0.3.0
+
+## New features
+
+- Search that never hands back a retired rule and can honestly say "no rule
+  applies." A new strict mode excludes superseded or deprecated guidance
+  entirely instead of just ranking it lower, and a separate signal catches
+  queries that do not match anything meaningful, so the assistant gets a clear
+  "nothing applies here" instead of a stretch of unrelated results.
+- An import command for teams that already have a pile of agent rules. Point
+  it at an existing CLAUDE.md, AGENTS.md, cursorrules file, or a folder of
+  architecture decision records and it produces a draft set of governed
+  documents, ready for a person to review before anything is committed.
+- Install straight from PyPI, with a guided setup wizard. The wizard checks
+  the server is reachable, finds which coding assistants are installed on the
+  machine, registers the knowledge base with each one, and offers to turn on
+  the mandatory-consultation safeguard, all with automatic backups of
+  anything it changes.
+- Noticeably leaner responses. The everyday search and lookup calls now
+  return a trimmed-down shape by default, cutting the tokens an assistant
+  pays for by about 26 percent overall, with the full, original shape still
+  available on request.
+- A write pipeline that can no longer lose or clobber someone else's work.
+  Concurrent changes are now serialized and locked per file, conflicting
+  updates are recovered automatically or handed to a person to resolve, and
+  every incoming change is checked for valid formatting before it is
+  committed, so a malformed or duplicate entry can no longer break the
+  knowledge base for everyone.
+- A mandatory-consultation gate that actually verifies a real check happened,
+  and tells a blocked assistant exactly how to unblock itself, including the
+  precise command to run.
+- Hardened security across the board: limits on oversized requests, fixes for
+  several ways a crafted document or request could have injected content or
+  escaped its intended folder, and tokens that grant only the access an
+  assistant actually needs instead of full access by default.
+- Rechecked, honestly reported benchmark numbers, so the quality claims this
+  project makes about its own search are ones it can stand behind.
+- A written runbook for operators, a health check that no longer flags a
+  service as broken just because it is briefly out of sync with its source,
+  and an audit trail that now rotates in the background while still proving
+  nothing in it was tampered with.
+- A refreshed example knowledge base showing off supersession, memories, and
+  reference documents, plus documentation for a field that helps search match
+  a task to the right rule.
+
+## Fixed
+
+- A local development script that could silently delete a folder you pointed
+  it at now refuses to touch anything it does not own.
+- The guide for adopting this project into a new codebase was teaching a
+  document format that did not match what the software actually expects; it
+  now matches.
+- A placeholder template file was mistakenly being treated as real content in
+  places, which could pollute generated indexes and diagrams; it is now
+  consistently ignored everywhere.
+- Health metrics that were supposed to show queue activity always read zero;
+  they now reflect what is actually happening.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "data-olympus"
-version = "0.2.0"
+version = "0.3.0"
 description = "Governance-grade knowledge-base format (OKF-compatible) plus CLI and single-writer MCP server"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -465,7 +465,7 @@ wheels = [
 
 [[package]]
 name = "data-olympus"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Summary

Final release-cut package for the v0.3.0 program (15 PRs already merged into `release/0.3.0`: #76-#81, #83-#91).

- Bumps `pyproject.toml` version 0.2.0 -> 0.3.0 (the single version source of truth per STD-U-810 section 11.4; `deploy/k8s/statefulset.yaml` was already bumped to `v0.3.0` in #91, and `src/data_olympus/__init__.py` reads installed distribution metadata so it needed no edit).
- Rolls `CHANGELOG.md`: renames `[Unreleased]` to `[0.3.0] - 2026-07-03`, opens a fresh empty `[Unreleased]` block above it per the file's own convention comment, merges the duplicated `Added`/`Changed`/`Documentation` section headings that accumulated from parallel PR merges (content kept byte-for-byte verbatim at the entry level; only headings consolidated into Added/Changed/Fixed/Security/Documentation order), and fixes the compare links (`[0.3.0]: v0.2.0...v0.3.0`, `[Unreleased]: v0.3.0...HEAD`).
- Adds `docs/releases/v0.3.0.md`, the user-facing GitHub Release body (New features / Fixed, non-technical reader), following `docs/releases/README.md` and the style of `v0.2.0.md`.
- Updates the `README.md` status line.

### Version bump sanity check

`.rules/versioning.md` (STD-U-810 pre-1.0 features-as-minor mapping, adopted by this project) says a `feat:` commit drives a MINOR bump pre-1.0. `python scripts/compute_release.py` confirms this mechanically against the actual commits since `v0.2.0`:

```
{
  "releasable": true,
  "bump": "minor",
  "current_version": "0.2.0",
  "next_version": "0.3.0",
  "functional_changed": true,
  "changes": { "features": [8 feat commits], "fixes": [7 fix commits], "breaking": [] }
}
```

8 `feat:` commits (#80, #84, #86, #87, #88, #89, #90, #91) with no breaking-major override needed pre-1.0 confirms minor is correct.

## Verification

- `uv run pytest -q`: all green (2 skipped: optional `sentence_transformers`/`tiktoken` extras not installed).
- `uv run ruff check .`: all checks passed.
- `uv run mypy src`: no issues found (61 source files).
- `python scripts/check_changelog.py`: ok.
- `python scripts/check_doc_consistency.py`: ok.
- `python scripts/check_benchmark_docs.py`: ok.
- `uv run data-olympus lint example-bundle`: 0 errors across 0 files (13 linted).
- `uv build`: sdist + wheel built successfully as `data_olympus-0.3.0`.
- `uvx twine check dist/*`: both artifacts PASSED.

## Peer review (codex)

Ran `codex exec --sandbox read-only` against `git diff origin/release/0.3.0...HEAD`. First pass found:

- **Blocker**: release notes claimed search "never hands back a retired rule" without scoping to the new strict (`in_force`) mode; default search still soft-reranks and can return superseded docs. Fixed.
- **Concern**: "Install straight from PyPI" overstated readiness; publishing is inert until the operator completes the one-time PyPI Trusted Publishing setup. Reworded as release-chain groundwork. Fixed.
- **Concern**: conflated the `/readyz` staleness-decoupling with `/api/v1/health` (which keeps its degraded/503 contract), and stated audit-log rotation as on-by-default when it is opt-in (`KB_AUDIT_MAX_BYTES`). Split and corrected. Fixed.
- Verified independently: version bump, changelog link correctness, verbatim entry-level preservation of the CHANGELOG roll (40 old entries / 40 new entries, exact multiset match), honest token-savings/abstain framing, ruff/mypy green.

All three findings were fixed in a follow-up commit and re-pushed; no outstanding Blockers or Concerns.

## Deviations

None from the task brief.