### PR TITLE
fix(write): reclaim stale auto-commit path locks; release-gate doc fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -417,6 +417,22 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **Stale auto-commit path locks are reclaimed.** A hard kill while an auto-commit
+  held a per-path advisory lock left the lock on the `/state` volume with no
+  in-process holder to release it, wedging that path (`rejected_path_lock_busy`)
+  until manual cleanup. Locks now record an `owner_kind`; crash-orphaned
+  auto-commit locks are reclaimed unconditionally at server startup (a fresh
+  process holds none) and, while running, once older than
+  `KB_AUTO_COMMIT_LOCK_TTL_SEC` (default 600s, far above a seconds-long commit
+  critical section). The periodic reclaim runs under the same process-wide write
+  serializer that `path_lock` acquire/release runs under, so a stalled holder that
+  resumes cannot free the path (and let a successor re-acquire it) mid-reclaim;
+  the delete is additionally inode + timestamp ownership-checked as defense in
+  depth. Pre-fix legacy auto-commit locks (no `owner_kind`, `auto-commit:`
+  `pending_id` prefix) are recognised too, so an upgrade on a persistent `/state`
+  volume frees any old wedged path. Pending-proposal locks are never TTL-reclaimed
+  (they legitimately live until the operator resolves or the entry expires).
+
 - Search pipeline hardening (WP2b, epic #75), bug + perf fixes:
   - `Index.search` could return MORE than `limit` hits when embeddings were
     configured but no reranker was set (finding h): the dense union widened the

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ data-olympus is a governance-grade knowledge-base format and server for agent wo
 
 It governs *decisions*, not code. When an agent is about to make a choice (a library, a pattern, a migration), data-olympus surfaces the established standard or decision that should govern that choice. It is deliberately **not** a code-search, reference-finding, or "where is X used" tool: LSP, grep, and Sourcegraph already do that well. The retrieval task it targets is coding-intent to governing-rule, and it helps where current model interaction during vibe-coding is weakest: keeping the model aligned to patterns the team has already established as correct.
 
-**Status: pre-release (v0.3.0 shipped).**
+**Status: pre-1.0 beta. Latest release: v0.3.0.**
 
 ## Why
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -70,6 +70,8 @@ Authentication is resolved from the `Authorization: Bearer <token>` header again
 
   A principal with `propose` but not `auto_commit` may propose, but its proposals are always parked as pending (the confidence clamp).
 
+  **Breaking change in v0.3.0:** a `KB_AUTH_PRINCIPALS` entry that omits the `capabilities` field now defaults to least privilege (`{read, propose}`) instead of all capabilities; grant `resolve`, `auto_commit`, `bootstrap`, or `record_event` by listing them explicitly. This prevents an agent token from silently gaining self-approval (`resolve` + `auto_commit`).
+
 Tokens are compared with `hmac.compare_digest` (constant time).
 
 **Coverage is REST and MCP.** Unlike earlier releases where the token guarded REST routes only, an MCP-transport middleware enforces the same capabilities on the MCP write tools (`kb_propose_*`, `kb_resolve_pending`, `kb_bootstrap_project`, `kb_record_event`). The observability/enforcement tools (`kb_list_pending`, `kb_audit`, `kb_consult`, `kb_gate_check`, `kb_compliance`) likewise require an authenticated principal over MCP when auth is configured, matching the REST gating. A token-less MCP client can no longer call write or observability tools when auth is configured.

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,8 +1,8 @@
 # data-olympus Knowledge Format
 
-**Version:** 0.1 (draft)
-**Date:** 2026-06-24
-**Status:** Draft
+**Version:** 0.1
+**Date:** 2026-07-03
+**Status:** Stable (shipped with data-olympus v0.3.0; the format is versioned independently of the package, see section 10)
 
 ---
 
@@ -237,6 +237,8 @@ The single-replica invariant applies only to the write-enabled server. Deploymen
 
 The serving transport MUST be streamable HTTP (not stdio). The MCP endpoint is `/mcp` by convention.
 
+**Readiness probes MUST NOT target `/api/v1/health`.** A load balancer or orchestrator readiness check MUST use `GET /readyz` (200 once the process is up and the index is loaded, independent of data staleness). `/api/v1/health` keeps a 503-on-degraded contract for data-freshness alerting; wiring it as a readiness probe would eject a healthy single replica from its Service on a transient git-remote staleness. See [`docs/serving.md`](docs/serving.md).
+
 **Enforcement endpoints.** A server MAY expose an enforcement surface that turns the advisory KB into a gated consultation proxy for code and architectural decisions. The endpoints are:
 
 - `POST /api/v1/consult`: record a consultation for a `(source_session, workspace)` pair and return the governing rules for the supplied intent.
@@ -244,6 +246,8 @@ The serving transport MUST be streamable HTTP (not stdio). The MCP endpoint is `
 - `GET /api/v1/compliance`: return aggregated enforcement-event counts, overall and per agent.
 
 These three are mirrored as the `kb_consult`, `kb_gate_check`, and `kb_compliance` MCP tools. See [`docs/enforcement.md`](docs/enforcement.md) for the request bodies, configuration (`KB_CONSULT_TTL_SEC`, `KB_ENFORCE_FAIL_MODE`), and the Claude Code hook installer.
+
+**Only an explicit-trigger consultation satisfies the gate.** `POST /api/v1/gate/check` returns `allow` only when a fresh `POST /api/v1/consult` is on record for the action's `(session_id, workspace)` pair. A read-only KB search or any other tool call does NOT count as a consultation and does NOT clear the gate; the agent MUST issue an explicit `kb_consult` (or the REST equivalent) whose freshness is bounded by `KB_CONSULT_TTL_SEC`. See [`docs/enforcement.md`](docs/enforcement.md).
 
 ---
 

--- a/WHY.md
+++ b/WHY.md
@@ -210,7 +210,7 @@ keep. It does: on intents whose phrasing is covered by a trigger, it lifts recal
 from 0.667 to 1.000, at roughly half the token cost of the BM25 baseline. And
 because plain keyword search will always return something, even for a question
 that has no governing rule at all, we added an optional abstention mode that drops
-the false-positive rate on those out-of-scope queries from 1.000 to about 0.10
+the false-positive rate on those out-of-scope queries from 1.000 to 0.097
 (a few distractors still share a real word with a rule; we report that residual
 rather than round it away). For a governance tool, abstaining beats confidently
 handing back a rule that does not apply.

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -293,8 +293,23 @@ data-olympus setup
 The wizard probes the endpoint, detects which of Claude Code, Codex, Gemini, and
 OpenCode are installed, writes each agent's MCP registration (with a timestamped
 backup of any file it edits, and idempotent re-runs), optionally installs the
-enforcement hooks, and prints a doctor summary. `data-olympus setup --check` runs
-the same summary read-only and never changes anything.
+enforcement hooks, and prints a doctor summary.
+
+Flags:
+
+- `--endpoint <url>`: server endpoint to wire (default `$KB_ENDPOINT` or
+  `http://localhost:8080`).
+- `--check`: read-only doctor summary (also the update-check path); changes
+  nothing.
+- `-y` / `--yes`: non-interactive; accept defaults (register detected agents,
+  skip hook prompts).
+- `--no-version-check`: skip the PyPI/GitHub latest-version lookup (fully
+  offline).
+
+When you point agents at a server, use `GET /readyz` (not `/api/v1/health`) as
+the readiness probe: it returns 200 once the process is up and the index is
+loaded, independent of data staleness. See `docs/serving.md` for the full
+health/readiness/liveness split.
 
 ### Manual per-agent registration
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -6,9 +6,29 @@ with Python 3.13 and uv.
 
 ## 1. Install
 
-### Install from PyPI (recommended)
+### Install from source
 
-Run the CLI directly with no clone, using `uvx`:
+This is the path that works today, from a clone of the repo:
+
+```bash
+# From the repo root
+uv venv && uv pip install -e '.[dev]'
+```
+
+Or simply use `uv run` (which handles the venv automatically):
+
+```bash
+uv run data-olympus-mcp --help   # confirms the entry point is installed
+```
+
+### Install from PyPI
+
+> The PyPI package is available from v0.3.0 onward, but publishing goes live only
+> after the operator completes the one-time pypi.org Trusted Publishing setup (see
+> `docs/releases/pypi-trusted-publishing.md`). Until that first publish lands the
+> commands below fail; use the from-source path above.
+
+Once the package is published, run the CLI directly with no clone, using `uvx`:
 
 ```bash
 uvx data-olympus --help
@@ -28,24 +48,6 @@ enforcement hooks:
 ```bash
 data-olympus setup          # interactive
 data-olympus setup --check  # read-only doctor summary (also the update check)
-```
-
-> The PyPI package is published by the release chain via Trusted Publishing.
-> Until the one-time pypi.org publisher is configured (see
-> `docs/releases/pypi-trusted-publishing.md`), install from source with the dev
-> path below.
-
-### Install from source (development)
-
-```bash
-# From the repo root
-uv venv && uv pip install -e '.[dev]'
-```
-
-Or simply use `uv run` (which handles the venv automatically):
-
-```bash
-uv run data-olympus-mcp --help   # confirms the entry point is installed
 ```
 
 ## 2. Run the server

--- a/docs/releases/pypi-trusted-publishing.md
+++ b/docs/releases/pypi-trusted-publishing.md
@@ -12,6 +12,25 @@ GitHub Release normally; only the PyPI upload step fails (and it is marked
 `continue-on-error`, so it does not block the release). Once the pending
 publisher exists, the next release uploads to PyPI with no further action.
 
+## After setup: tighten the release chain
+
+Once the publishers are configured and the first release has published to PyPI
+for real, harden the chain so a broken upload can no longer pass silently. Do
+NOT make these edits before setup: pre-setup the upload step fails by design, so
+removing its tolerance would break every release.
+
+Two edits, both post-first-successful-publish:
+
+- In `.github/workflows/publish-pypi-reusable.yml`, remove the
+  `continue-on-error: true` line from the **Publish to PyPI (Trusted
+  Publishing)** step (the `pypa/gh-action-pypi-publish@release/v1` step). A real
+  upload failure then fails the job instead of no-oping.
+- In `.github/workflows/tag-release.yml`, add `publish-pypi` to the `release`
+  job's `needs`, i.e. change `needs: [decide, build-image]` to
+  `needs: [decide, build-image, publish-pypi]`. The GitHub Release is then cut
+  only after the PyPI upload succeeds, so a release never advertises a version
+  that failed to publish.
+
 ## What binds the publisher
 
 Trusted Publishing matches four values exactly. Ours are:

--- a/docs/serving.md
+++ b/docs/serving.md
@@ -23,6 +23,21 @@ each run their own stdio MCP process against the same git working tree, they
 race each other's worktrees and lock state. Streamable HTTP eliminates that
 race.
 
+## Core configuration reference
+
+A few server-wide settings, beyond the feature-specific env vars documented in
+their own sections below (search ranking, synonyms, embeddings, co-occurrence,
+trigram, auth, audit rotation):
+
+- `KB_HTTP_PORT`: TCP port the MCP HTTP server binds (default `8080`).
+- `KB_CONFIDENCE_THRESHOLD`: the auto-commit confidence cutoff, in `[0, 1]`
+  (default `0.85`). A proposal at or above it from a principal holding
+  `auto_commit` is committed; below it (or from a principal without that
+  capability) it is parked as pending. An out-of-range value fails startup loudly.
+- `KB_PENDING_TIMEOUT_SEC`: age after which an unresolved pending proposal is
+  auto-expired by the pending GC loop (default `86400`, i.e. 24h). Each expiry
+  emits an audit event.
+
 ## Read-only mirrors may scale horizontally
 
 Set `KB_READ_ONLY=true` to run an instance as a read-only replica. In this mode
@@ -439,6 +454,46 @@ Cost: build adds one batched local embedding pass over the corpus (seconds for a
 small KB); storage adds `dim x 4` bytes per document in `doc_vectors` (~1.5 KB
 per doc for the 384-dim default). Query-time cost is one query embedding plus a
 cosine over the (bounded) candidate pool.
+
+## Corpus co-occurrence query expansion
+
+A build-time pass mines the corpus for term pairs that co-occur far more often
+than chance (positive pointwise mutual information) and stores the top related
+terms per term. At query time the expander adds those related terms so a query
+reaches documents that use a different-but-associated vocabulary, without a
+hand-curated synonym map. This is **ON by default** and adds no query-time
+network call. It auto-disables on a corpus below the doc floor (too little
+signal), and the O(n^2) pair counting is bounded per document.
+
+Tune it with:
+
+- `KB_COOCCURRENCE_MODE`: `off` disables it (both the build-time table and the
+  query-time expansion); any other value (including unset) leaves it **on**.
+- `KB_COOCCURRENCE_K`: max related terms kept per term (default `5`).
+- `KB_COOCCURRENCE_MIN_COUNT`: minimum raw co-occurrence count for a pair to
+  qualify (default `3`).
+- `KB_COOCCURRENCE_MIN_PMI`: minimum PMI for a pair to qualify (default `0.1`).
+- `KB_COOCCURRENCE_MIN_DOCS`: corpus-size floor below which co-occurrence is
+  auto-disabled (default `50`).
+- `KB_COOCCURRENCE_MAX_DOC_TOKENS`: per-document unique-token cap on the pair
+  counting, bounding the O(n^2) work on large docs (default `400`).
+
+## Trigram fuzzy-match fallback
+
+For typos and partial identifiers, an optional trigram index backfills results
+when the primary FTS query returns few hits. This is **OFF by default** so the
+default deployment pays no trigram build or storage cost; when off, the trigram
+table is neither created nor populated. When on, a primary query returning at or
+below the threshold is backfilled from the trigram index, and the backfill only
+ever appends after the primary hits (never reorders them).
+
+Tune it with:
+
+- `KB_TRIGRAM_MODE`: `on` (case-insensitive) enables it; any other value
+  (including unset) leaves it off.
+- `KB_TRIGRAM_FALLBACK_THRESHOLD`: primary-hit count at or below which the
+  fallback fires (default `3`). A malformed or negative value falls back to the
+  default.
 
 ## Authentication and network security
 

--- a/src/data_olympus/config.py
+++ b/src/data_olympus/config.py
@@ -1,10 +1,13 @@
 """Configuration loading from environment variables."""
 from __future__ import annotations
 
+import logging
 import os
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
+
+_log = logging.getLogger("data_olympus.config")
 
 
 @dataclass(frozen=True, slots=True)
@@ -31,6 +34,13 @@ class Config:
     max_bootstrap_files: int = 50
     pending_timeout_sec: int = 86400
     pending_queue_cap: int = 100
+    # Age (seconds) after which a crash-orphaned AUTO-COMMIT path lock is reclaimed
+    # by pending_gc_loop (KB_AUTO_COMMIT_LOCK_TTL_SEC). An auto-commit critical
+    # section is seconds long, so a lock older than this cannot have a live holder;
+    # the default of 600s (10 min) is a wide safety margin. Pending-proposal locks
+    # are NEVER reclaimed by this TTL (they live until resolve/expiry). Startup
+    # reclaims every auto-commit lock unconditionally (a fresh process holds none).
+    auto_commit_lock_ttl_sec: int = 600
     worktree_idle_sec: int = 3600
     git_key_path: str = "/tmp/git-key"
     audit_log_path: str = "/state/audit/events.log"
@@ -151,6 +161,17 @@ def load_config() -> Config:
     max_bootstrap_files = int(os.getenv("KB_MAX_BOOTSTRAP_FILES", "50"))
     pending_timeout_sec = int(os.getenv("KB_PENDING_TIMEOUT_SEC", "86400"))
     pending_queue_cap = int(os.getenv("KB_PENDING_QUEUE_CAP", "100"))
+    auto_commit_lock_ttl_sec = int(os.getenv("KB_AUTO_COMMIT_LOCK_TTL_SEC", "600"))
+    if auto_commit_lock_ttl_sec <= 0:
+        # A non-positive periodic TTL is unsafe: reclaim treats max_age_sec=0 as the
+        # unconditional (startup) sweep sentinel, so the running loop would reclaim
+        # FRESH auto-commit locks and could free a live one. Clamp to the default.
+        _log.warning(
+            "KB_AUTO_COMMIT_LOCK_TTL_SEC=%s is non-positive; clamping to 600s "
+            "(a non-positive periodic TTL would reclaim live auto-commit locks)",
+            auto_commit_lock_ttl_sec,
+        )
+        auto_commit_lock_ttl_sec = 600
     worktree_idle_sec = int(os.getenv("KB_WORKTREE_IDLE_SEC", "3600"))
     git_key_path = os.getenv("KB_GIT_KEY_PATH", "/tmp/git-key")
     audit_log_path = os.getenv("KB_AUDIT_LOG_PATH", "/state/audit/events.log")
@@ -211,6 +232,7 @@ def load_config() -> Config:
         max_bootstrap_files=max_bootstrap_files,
         pending_timeout_sec=pending_timeout_sec,
         pending_queue_cap=pending_queue_cap,
+        auto_commit_lock_ttl_sec=auto_commit_lock_ttl_sec,
         worktree_idle_sec=worktree_idle_sec,
         git_key_path=git_key_path,
         audit_log_path=audit_log_path,

--- a/src/data_olympus/pending.py
+++ b/src/data_olympus/pending.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING, Any, Literal
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
+    from contextlib import AbstractContextManager
 
 from data_olympus.durable import atomic_remove, atomic_write_json
 
@@ -83,24 +84,95 @@ class PendingQueue:
         ``_root`` attribute."""
         return self._root
 
-    def _acquire_lock(self, target_path: str, pending_id: str) -> None:
+    def _acquire_lock(
+        self,
+        target_path: str,
+        pending_id: str,
+        *,
+        owner_kind: str = "pending",
+    ) -> float:
+        """Create the exclusive lock file for ``target_path``. Returns the
+        ``acquired_at`` timestamp stamped into the file so the caller can hand it
+        back to ``_release_lock`` for an ownership-checked delete."""
         lock_path = os.path.join(self._locks_dir, _path_lock_filename(target_path))
         try:
             fd = os.open(lock_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
         except FileExistsError:
             raise PathLockBusyError(target_path) from None
+        acquired_at = time.time()
         try:
             with os.fdopen(fd, "w") as f:
                 json.dump({"pending_id": pending_id, "target_path": target_path,
-                           "acquired_at": time.time()}, f)
+                           "owner_kind": owner_kind, "acquired_at": acquired_at}, f)
         except Exception:
             os.unlink(lock_path)
             raise
+        return acquired_at
 
-    def _release_lock(self, target_path: str) -> None:
+    def _release_lock(
+        self, target_path: str, *, expected_acquired_at: float | None = None,
+    ) -> bool:
+        """Delete the lock file for ``target_path``. Returns True iff a file was
+        actually unlinked (an ownership-checked call that skips returns False).
+
+        When ``expected_acquired_at`` is given, the delete is ownership-checked so a
+        holder or the reclaimer removes ONLY the lock it acquired/inspected, never a
+        successor's. Two independent guards:
+
+        - **``acquired_at`` is the ownership token.** It is ``time.time()`` at
+          acquisition, unique per acquire to sub-microsecond, so a successor (which
+          re-acquires with its own fresh timestamp) never matches the token of the
+          lock we meant to delete. A file whose on-disk ``acquired_at`` differs is
+          left alone.
+        - **inode re-stat closes this call's own open-to-unlink window.** We open
+          the file, pin its inode, verify ``acquired_at``, then confirm the path
+          still resolves to the SAME inode immediately before ``unlink`` (a
+          successor is a fresh ``O_EXCL`` inode). This stops a delete that raced a
+          concurrent free+re-acquire between our read and our unlink.
+
+        The residual gap between the final re-stat and ``unlink`` is a single
+        syscall and is not closable portably (the stdlib has no ``funlinkat``); it
+        is vanishingly narrow next to the minutes-long staleness that gates a
+        reclaim, and a successor would still need a colliding ``acquired_at`` (which
+        cannot happen) to be wrongly deleted.
+
+        When ``expected_acquired_at`` is ``None`` (the pending queue's own release
+        paths, which hold the lock unbroken from enqueue to resolve and are never
+        TTL-reclaimed) the delete is unconditional, as before."""
         lock_path = os.path.join(self._locks_dir, _path_lock_filename(target_path))
-        with contextlib.suppress(FileNotFoundError):
-            os.unlink(lock_path)
+        if expected_acquired_at is None:
+            try:
+                os.unlink(lock_path)
+            except FileNotFoundError:
+                return False
+            return True
+        # Ownership-checked delete. Open + fstat pins the inode we verify.
+        try:
+            fd = os.open(lock_path, os.O_RDONLY)
+        except FileNotFoundError:
+            return False
+        try:
+            pinned_ino = os.fstat(fd).st_ino
+            try:
+                info = json.load(os.fdopen(os.dup(fd), "r"))
+            except ValueError:
+                return False
+            if info.get("acquired_at") != expected_acquired_at:
+                return False
+            # Confirm the path still resolves to the inode we verified (a successor
+            # would have a different, freshly-created inode) right before unlinking.
+            try:
+                if os.stat(lock_path).st_ino != pinned_ino:
+                    return False
+            except FileNotFoundError:
+                return False
+            try:
+                os.unlink(lock_path)
+            except FileNotFoundError:
+                return False
+            return True
+        finally:
+            os.close(fd)
 
     @contextlib.contextmanager
     def path_lock(self, target_path: str, *, owner: str) -> Iterator[None]:
@@ -112,13 +184,22 @@ class PendingQueue:
         pending proposal in flight (the later approval would clobber it) and two
         auto-commits to the same path cannot interleave. ``owner`` is a marker
         (e.g. ``auto-commit:<sha_or_session>``) recorded in the lock file for
-        operator diagnosis; it is not a pending_id. Raises :class:`PathLockBusyError`
-        when the path is already locked. Releases on exit."""
-        self._acquire_lock(target_path, owner)
+        operator diagnosis; it is not a pending_id. The lock records
+        ``owner_kind="auto_commit"`` so ``reclaim_stale_auto_commit_locks`` can
+        safely free it if a crash orphans it (an auto-commit critical section is
+        seconds long, so a lock older than the TTL cannot have a live holder).
+        Raises :class:`PathLockBusyError` when the path is already locked.
+        Releases on exit."""
+        acquired_at = self._acquire_lock(
+            target_path, owner, owner_kind="auto_commit",
+        )
         try:
             yield
         finally:
-            self._release_lock(target_path)
+            # Ownership-checked release: if the lock was TTL-reclaimed while this
+            # (slow) holder ran and a successor re-acquired the path, the
+            # acquired_at will not match and the successor's lock is left intact.
+            self._release_lock(target_path, expected_acquired_at=acquired_at)
 
     def enqueue(
         self,
@@ -285,12 +366,11 @@ class PendingQueue:
         proposal to that path is rejected ``rejected_path_lock_busy``. Each lock
         file records the ``pending_id`` that holds it; if neither ``<pid>.json``
         nor ``<pid>.claimed`` exists, the lock is orphaned and is removed. Locks
-        held by the shared auto-commit path (``owner`` is not a hex uuid) are
-        left alone: those are held only for the duration of an in-process commit
-        and are never orphaned across a restart (a restart clears the process,
-        and a stale one is released by the ``finally`` of ``path_lock``; but if a
-        hard crash left one, its non-uuid owner means we cannot prove it orphaned,
-        so we conservatively skip it). Returns the number of locks removed."""
+        held by the shared auto-commit path (``owner_kind == "auto_commit"``) are
+        left alone HERE: they have no pending entry to key off, so a hung/crashed
+        auto-commit lock is reclaimed by the age-bounded
+        :meth:`reclaim_stale_auto_commit_locks` instead. Returns the number of
+        locks removed."""
         if not os.path.isdir(self._locks_dir):
             return 0
         removed = 0
@@ -316,6 +396,123 @@ class PendingQueue:
                 os.unlink(lock_path)
                 removed += 1
         return removed
+
+    def reclaim_stale_auto_commit_locks(
+        self,
+        *,
+        max_age_sec: float,
+        serializer: AbstractContextManager[Any] | None = None,
+    ) -> int:
+        """Reclaim auto-commit path locks left behind by a crash.
+
+        An auto-commit takes a per-path lock (``owner_kind == "auto_commit"``) for
+        the duration of its write -> git add -> commit critical section, which is
+        bounded by the process-wide write serializer and completes in seconds. If
+        the process is killed while holding one, the lock file survives on the
+        ``/state`` volume and wedges that path forever
+        (``rejected_path_lock_busy``): unlike a pending-proposal lock, there is no
+        entry to key an orphan-reclaim off, and unlike a clean shutdown the
+        ``finally`` in :meth:`path_lock` never ran.
+
+        A lock is reclaimed only when ALL of these hold:
+
+        - it is an auto-commit lock (``owner_kind == "auto_commit"``, or a pre-fix
+          legacy lock recognised by its ``auto-commit:`` ``pending_id`` prefix so an
+          upgrade on a persistent ``/state`` volume still frees old wedged locks).
+          Pending-proposal locks legitimately live until the operator resolves or
+          the entry expires, so they are NEVER TTL-reclaimed here;
+        - its ``acquired_at`` is older than ``max_age_sec``.
+
+        Concurrency safety. ``serializer`` MUST be the process-wide
+        :class:`~data_olympus.write_gate.WriteSerializer` that
+        :meth:`path_lock` (via ``tools_write``) already runs its acquire/release
+        under. Holding it for the whole reclaim scan makes lock deletion mutually
+        exclusive with every auto-commit acquire/release, which is what closes the
+        two-deleter race: a stale holder that resumes cannot run its own
+        ``path_lock`` release (and no successor can acquire) while the reclaimer is
+        mid-scan, so the reclaimer's ``unlink`` can never land on a successor that
+        replaced the file after an interleaved free. The inode+``acquired_at``
+        ownership check in :meth:`_release_lock` is retained as defense in depth.
+        When ``serializer`` is ``None`` (tests, or the startup sweep where the write
+        loops have not started so nothing contends) the scan runs without it.
+
+        The age bound is the other half: a real auto-commit critical section is
+        seconds long, so any auto-commit lock older than the (minutes-long) TTL
+        cannot have a live holder still inside its section.
+
+        Pass ``max_age_sec=0`` to reclaim EVERY auto-commit lock unconditionally;
+        the server uses this at startup, where a fresh process provably holds none.
+        Returns the number of locks reclaimed."""
+        ctx: AbstractContextManager[Any] = (
+            serializer if serializer is not None else contextlib.nullcontext()
+        )
+        with ctx:
+            return self._reclaim_stale_auto_commit_locks_locked(max_age_sec)
+
+    def _reclaim_stale_auto_commit_locks_locked(self, max_age_sec: float) -> int:
+        if not os.path.isdir(self._locks_dir):
+            return 0
+        now = time.time()
+        removed = 0
+        for name in os.listdir(self._locks_dir):
+            if not name.endswith(".lock"):
+                continue
+            lock_path = os.path.join(self._locks_dir, name)
+            try:
+                with open(lock_path) as f:
+                    info = json.load(f)
+            except (FileNotFoundError, ValueError):
+                continue
+            if not self._is_auto_commit_lock(info):
+                continue
+            target_path = info.get("target_path")
+            if not isinstance(target_path, str):
+                continue
+            acquired_at = info.get("acquired_at")
+            if not isinstance(acquired_at, int | float):
+                # Malformed/legacy lock with no usable timestamp: treat as stale
+                # only in the unconditional (startup) sweep, never on the TTL path.
+                if max_age_sec > 0:
+                    continue
+                if self._lock_still_matches(lock_path, expected=info):
+                    with contextlib.suppress(FileNotFoundError):
+                        os.unlink(lock_path)
+                        removed += 1
+                continue
+            if now - acquired_at <= max_age_sec:
+                continue
+            # Ownership-checked delete (defense in depth under the serializer):
+            # removes ONLY the exact lock we inspected.
+            if self._release_lock(target_path, expected_acquired_at=acquired_at):
+                removed += 1
+        return removed
+
+    @staticmethod
+    def _is_auto_commit_lock(info: dict[str, Any]) -> bool:
+        """Whether a lock file describes an auto-commit hold (vs a pending
+        proposal). New-format locks carry ``owner_kind == "auto_commit"``. Locks
+        written by a PRE-fix build have no ``owner_kind`` and stash the auto-commit
+        marker in ``pending_id`` (``"auto-commit:<...>"``); those are recognised
+        here so an upgrade on a persistent ``/state`` volume still reclaims them.
+        A pending-proposal lock always has a 32-hex-char UUID ``pending_id`` and no
+        ``auto-commit:`` prefix, so it never matches either arm."""
+        if info.get("owner_kind") == "auto_commit":
+            return True
+        if "owner_kind" in info:
+            # A new-format lock that is explicitly some other kind: not ours.
+            return False
+        holder = info.get("pending_id", "")
+        return isinstance(holder, str) and holder.startswith("auto-commit:")
+
+    def _lock_still_matches(self, lock_path: str, *, expected: dict[str, Any]) -> bool:
+        """True if the lock file at ``lock_path`` still holds exactly ``expected``
+        (used for the timestamp-less legacy-lock reclaim, where there is no
+        ``acquired_at`` to key an ownership check off)."""
+        try:
+            with open(lock_path) as f:
+                return bool(json.load(f) == expected)
+        except (FileNotFoundError, ValueError):
+            return False
 
     def would_exceed(self, n: int) -> bool:
         """True if enqueuing ``n`` more entries would exceed the cap (0 = unlimited).

--- a/src/data_olympus/refresh.py
+++ b/src/data_olympus/refresh.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Any
 from data_olympus.index import DuplicateIdError, Index
 
 if TYPE_CHECKING:
+    from contextlib import AbstractContextManager
     from pathlib import Path
 
     from data_olympus.audit_log import AuditLog
@@ -257,6 +258,8 @@ async def pending_gc_loop(
     pending: PendingQueue,
     timeout_sec: int,
     interval_sec: int,
+    auto_commit_lock_ttl_sec: float = 600,
+    write_serializer: AbstractContextManager[Any] | None = None,
     audit_log: AuditLog | None = None,
 ) -> None:
     """Periodically expire pending entries older than timeout_sec and reclaim
@@ -272,7 +275,10 @@ async def pending_gc_loop(
 
     Orphaned path locks (a crash between lock create and entry write, scope item
     5) are reclaimed each pass via ``gc_orphan_locks`` so a path is not locked
-    forever with no entry to release it.
+    forever with no entry to release it. Crash-orphaned AUTO-COMMIT locks (held
+    across a seconds-long commit, wedged by a hard kill) are separately reclaimed
+    each pass once older than ``auto_commit_lock_ttl_sec``; pending-proposal locks
+    are never TTL-reclaimed.
     """
     from data_olympus.pending import (
         PendingAlreadyResolvedError,
@@ -305,6 +311,19 @@ async def pending_gc_loop(
             if reclaimed:
                 log.warning("pending_gc reclaimed %d orphaned path lock(s)",
                             reclaimed)
+            # Defense in depth: never pass max_age_sec<=0 from the periodic path,
+            # since 0 is the unconditional (startup) reclaim sentinel and would free
+            # fresh auto-commit locks. Config already clamps this; guard anyway.
+            if auto_commit_lock_ttl_sec > 0:
+                stale_ac = pending.reclaim_stale_auto_commit_locks(
+                    max_age_sec=auto_commit_lock_ttl_sec,
+                    serializer=write_serializer,
+                )
+                if stale_ac:
+                    log.warning(
+                        "pending_gc reclaimed %d stale auto-commit path lock(s) "
+                        "(older than %ss)", stale_ac, auto_commit_lock_ttl_sec,
+                    )
         except Exception:
             log.exception("pending_gc_loop iteration failed")
         await asyncio.sleep(interval_sec)

--- a/src/data_olympus/server.py
+++ b/src/data_olympus/server.py
@@ -1006,6 +1006,25 @@ def main() -> None:
             except Exception:
                 log.exception("startup push recovery failed (continuing)")
 
+        # Startup lock recovery: a hard kill while an auto-commit held a per-path
+        # lock leaves it on the /state volume with no in-process holder to release
+        # it, wedging that path (rejected_path_lock_busy) until manual cleanup. A
+        # fresh process provably holds no auto-commit lock, so reclaim every
+        # auto-commit lock unconditionally (max_age_sec=0). Pending-proposal locks
+        # are untouched: they legitimately outlive a restart.
+        if state.pending is not None:
+            try:
+                reclaimed = state.pending.reclaim_stale_auto_commit_locks(
+                    max_age_sec=0,
+                )
+                if reclaimed > 0:
+                    log.warning(
+                        "startup reclaimed %d stale auto-commit path lock(s)",
+                        reclaimed,
+                    )
+            except Exception:
+                log.exception("startup auto-commit lock reclaim failed (continuing)")
+
         tasks = [
             asyncio.create_task(
                 git_pull_loop(state, config.sync_interval_sec),
@@ -1041,6 +1060,14 @@ def main() -> None:
                     pending=state.pending,
                     timeout_sec=config.pending_timeout_sec,
                     interval_sec=300,
+                    # Crash-orphaned auto-commit path locks older than this are
+                    # reclaimed each pass so a hard kill mid-commit does not wedge
+                    # the path with rejected_path_lock_busy forever.
+                    auto_commit_lock_ttl_sec=config.auto_commit_lock_ttl_sec,
+                    # The reclaim runs under the SAME write serializer that
+                    # path_lock acquire/release runs under, so a stale holder that
+                    # resumes cannot free+let-a-successor-acquire the path mid-scan.
+                    write_serializer=state.write_serializer,
                     # Scope item 7: emit an audit event on each expiry instead of
                     # silently rejecting >24h entries.
                     audit_log=state.audit_log,

--- a/tests/test_pending.py
+++ b/tests/test_pending.py
@@ -2,6 +2,8 @@
 from __future__ import annotations
 
 import json
+import os
+import time
 
 import pytest
 
@@ -9,6 +11,7 @@ from data_olympus.pending import (
     PathLockBusyError,
     PendingQueue,
     PendingQueueFullError,
+    _path_lock_filename,
 )
 
 
@@ -256,3 +259,278 @@ def test_path_lock_shared_context_manager(tmp_path) -> None:
         "universal/foundation/x.md", owner="auto-commit:s",
     ):
         pass
+
+
+def _lock_file(q: PendingQueue, target_path: str) -> str:
+    return os.path.join(q._locks_dir, _path_lock_filename(target_path))  # noqa: SLF001
+
+
+def _backdate_lock(q: PendingQueue, target_path: str, seconds: float) -> None:
+    """Rewrite a lock file's acquired_at to ``seconds`` ago (simulate a crash that
+    left an old lock behind)."""
+    p = _lock_file(q, target_path)
+    with open(p) as f:
+        info = json.load(f)
+    info["acquired_at"] = time.time() - seconds
+    with open(p, "w") as f:
+        json.dump(info, f)
+
+
+def test_reclaim_stale_auto_commit_lock_via_ttl(tmp_path) -> None:
+    """A crash while an auto-commit held a path lock leaves it on disk; once older
+    than the TTL, reclaim_stale_auto_commit_locks frees it so the path is usable."""
+    q = PendingQueue(pending_root=str(tmp_path / "p"))
+    # Simulate the crash: acquire the auto-commit lock but never release it.
+    q._acquire_lock("decisions/a.md", "auto-commit:sess", owner_kind="auto_commit")  # noqa: SLF001
+    assert q.locks_held() == 1
+    # Not yet stale (default TTL far larger than age): NOT reclaimed.
+    assert q.reclaim_stale_auto_commit_locks(max_age_sec=600) == 0
+    assert q.locks_held() == 1
+    # Age it past the TTL: reclaimed.
+    _backdate_lock(q, "decisions/a.md", 700)
+    assert q.reclaim_stale_auto_commit_locks(max_age_sec=600) == 1
+    assert q.locks_held() == 0
+
+
+def test_reclaim_startup_frees_auto_commit_locks_unconditionally(tmp_path) -> None:
+    """max_age_sec=0 (the startup sweep) reclaims a FRESH auto-commit lock: a fresh
+    process provably holds none, so any present lock is a crash orphan."""
+    q = PendingQueue(pending_root=str(tmp_path / "p"))
+    q._acquire_lock("decisions/b.md", "auto-commit:sess", owner_kind="auto_commit")  # noqa: SLF001
+    assert q.locks_held() == 1
+    assert q.reclaim_stale_auto_commit_locks(max_age_sec=0) == 1
+    assert q.locks_held() == 0
+
+
+def test_reclaim_does_not_touch_fresh_auto_commit_lock(tmp_path) -> None:
+    """A currently-held (fresh) auto-commit lock is NOT reclaimed by the TTL path."""
+    q = PendingQueue(pending_root=str(tmp_path / "p"))
+    with q.path_lock("decisions/c.md", owner="auto-commit:live"):
+        # While the lock is genuinely held, the TTL reclaim must leave it alone.
+        assert q.reclaim_stale_auto_commit_locks(max_age_sec=600) == 0
+        assert q.locks_held() == 1
+    # Released cleanly on exit.
+    assert q.locks_held() == 0
+
+
+def test_reclaim_never_touches_pending_proposal_locks(tmp_path) -> None:
+    """Pending-proposal locks live until resolve/expiry: neither the TTL sweep nor
+    the unconditional startup sweep may reclaim them, even when very old."""
+    q = PendingQueue(pending_root=str(tmp_path / "p"))
+    q.enqueue(
+        proposal_type="edit", target_path="decisions/pending.md",
+        postimage="x", base_commit="c", base_blob_sha=None, target_file_hash=None,
+        meta={},
+    )
+    assert q.locks_held() == 1
+    # Even if the pending lock is ancient, it is not an auto-commit lock.
+    _backdate_lock(q, "decisions/pending.md", 10_000)
+    assert q.reclaim_stale_auto_commit_locks(max_age_sec=600) == 0
+    assert q.reclaim_stale_auto_commit_locks(max_age_sec=0) == 0
+    assert q.locks_held() == 1
+
+
+def test_reclaimed_lock_release_does_not_delete_successor(tmp_path) -> None:
+    """The reclaim race: a stale auto-commit holder is reclaimed, a successor grabs
+    the path, then the stale holder finally releases. The ownership-checked release
+    must NOT delete the successor's lock (acquired_at differs)."""
+    q = PendingQueue(pending_root=str(tmp_path / "p"))
+    target = "decisions/race.md"
+    stale_acquired = q._acquire_lock(  # noqa: SLF001
+        target, "auto-commit:stale", owner_kind="auto_commit",
+    )
+    # Reclaim it (as if TTL-expired).
+    _backdate_lock(q, target, 700)
+    assert q.reclaim_stale_auto_commit_locks(max_age_sec=600) == 1
+    # Successor grabs the freed path.
+    q._acquire_lock(target, "auto-commit:successor", owner_kind="auto_commit")  # noqa: SLF001
+    assert q.locks_held() == 1
+    # The stale holder resumes and releases with ITS acquired_at: must be a no-op.
+    q._release_lock(target, expected_acquired_at=stale_acquired)  # noqa: SLF001
+    assert q.locks_held() == 1
+    with open(_lock_file(q, target)) as f:
+        assert json.load(f)["pending_id"] == "auto-commit:successor"
+
+
+def test_reclaimer_check_to_delete_race_spares_successor(tmp_path) -> None:
+    """The reclaimer's OWN check-to-delete window: reclaim reads a stale lock and
+    passes the age check, then a successor replaces the file before the unlink. The
+    ownership-checked delete must remove ONLY the exact lock inspected, so the
+    successor's lock survives. Simulated by swapping the file in during the
+    reclaim's _release_lock call."""
+    target = "decisions/reclaim-race.md"
+
+    class RacyQueue(PendingQueue):
+        def _release_lock(self, tp, *, expected_acquired_at=None):  # noqa: ANN001, ANN204
+            # Simulate the successor grabbing the freed path in the race window,
+            # AFTER reclaim decided this lock is stale but BEFORE it deletes.
+            if expected_acquired_at is not None and not getattr(
+                self, "_raced", False,
+            ):
+                self._raced = True
+                lock_path = _lock_file(self, tp)
+                with open(lock_path, "w") as f:
+                    json.dump(
+                        {"pending_id": "auto-commit:successor",
+                         "target_path": tp, "owner_kind": "auto_commit",
+                         "acquired_at": time.time()}, f,
+                    )
+            super()._release_lock(tp, expected_acquired_at=expected_acquired_at)
+
+    q = RacyQueue(pending_root=str(tmp_path / "p"))
+    q._acquire_lock(target, "auto-commit:stale", owner_kind="auto_commit")  # noqa: SLF001
+    _backdate_lock(q, target, 700)
+    reclaimed = q.reclaim_stale_auto_commit_locks(max_age_sec=600)
+    # The stale lock was NOT actually removed (its acquired_at no longer matches the
+    # successor's), so the ownership-checked release is a no-op and the successor
+    # lock survives.
+    assert reclaimed == 0
+    assert q.locks_held() == 1
+    with open(_lock_file(q, target)) as f:
+        assert json.load(f)["pending_id"] == "auto-commit:successor"
+
+
+def test_release_lock_spares_successor_with_different_timestamp(tmp_path) -> None:
+    """A real successor acquires with its own time.time() acquired_at (distinct to
+    sub-microsecond), so the ownership check's content compare rejects it: the
+    release is a no-op and reports no removal. This is the physically reachable
+    case (a colliding acquired_at cannot occur: each acquire stamps a fresh now)."""
+    q = PendingQueue(pending_root=str(tmp_path / "p"))
+    target = "decisions/inode.md"
+    stale_acquired = q._acquire_lock(  # noqa: SLF001
+        target, "auto-commit:stale", owner_kind="auto_commit",
+    )
+    lock_path = _lock_file(q, target)
+    # Successor replaces the file (fresh inode, fresh timestamp), as a real acquire
+    # would after the stale lock was freed.
+    os.unlink(lock_path)
+    successor_acquired = q._acquire_lock(  # noqa: SLF001
+        target, "auto-commit:successor", owner_kind="auto_commit",
+    )
+    assert successor_acquired != stale_acquired
+    # A release keyed to the STALE token must not touch the successor.
+    assert q._release_lock(  # noqa: SLF001
+        target, expected_acquired_at=stale_acquired,
+    ) is False
+    assert q.locks_held() == 1
+    with open(lock_path) as f:
+        assert json.load(f)["pending_id"] == "auto-commit:successor"
+
+
+def test_release_lock_returns_true_on_own_lock(tmp_path) -> None:
+    """The ownership-checked release removes and reports True for the exact lock the
+    caller acquired."""
+    q = PendingQueue(pending_root=str(tmp_path / "p"))
+    acquired = q._acquire_lock("decisions/mine.md", "auto-commit:me",  # noqa: SLF001
+                               owner_kind="auto_commit")
+    assert q._release_lock("decisions/mine.md",  # noqa: SLF001
+                           expected_acquired_at=acquired) is True
+    assert q.locks_held() == 0
+
+
+def test_config_clamps_nonpositive_auto_commit_lock_ttl(monkeypatch) -> None:
+    """A non-positive KB_AUTO_COMMIT_LOCK_TTL_SEC is clamped to the 600s default so
+    the periodic loop never receives the max_age_sec=0 startup sentinel."""
+    from data_olympus.config import load_config
+
+    for bad in ("0", "-5"):
+        monkeypatch.setenv("KB_AUTO_COMMIT_LOCK_TTL_SEC", bad)
+        monkeypatch.setenv("KB_HTTP_PORT", "8080")
+        cfg = load_config()
+        assert cfg.auto_commit_lock_ttl_sec == 600
+
+
+def test_reclaim_under_serializer_never_deletes_successor(tmp_path) -> None:
+    """The two-deleter race is closed by running the reclaim under the SAME
+    serializer path_lock uses: reclaim (delete) and a holder's release+reacquire
+    (the two deleters) can no longer interleave, so the reclaimer's unlink can
+    never land on a successor that a holder freed the path for mid-scan.
+
+    Whichever of {reclaimer, holder} wins the serializer, the INVARIANT holds: the
+    successor lock is never deleted. If the reclaimer runs first it removes the
+    genuinely-stale lock (reclaimed==1) and the holder then reacquires; if the
+    holder runs first the stale lock is already gone and the reclaimer removes
+    nothing (reclaimed==0). Random jitter before each side's serializer acquire is
+    used to shake out both orderings; we assert both orderings actually occur so
+    the test cannot silently degrade to exercising one schedule."""
+    import random
+    import threading
+
+    outcomes: set[int] = set()
+    for trial in range(60):
+        q = PendingQueue(pending_root=str(tmp_path / f"p{trial}"))
+        target = "decisions/serialized.md"
+        q._acquire_lock(  # noqa: SLF001
+            target, "auto-commit:stale", owner_kind="auto_commit",
+        )
+        _backdate_lock(q, target, 700)
+        serializer = threading.RLock()
+
+        def holder(q=q, target=target, serializer=serializer) -> None:
+            # Mimic tools_write: the whole acquire..release runs UNDER the
+            # serializer. This holder resumes, releases the (stale) lock it held,
+            # and a successor acquires the freed path, all atomically vs reclaim.
+            time.sleep(random.uniform(0, 0.002))  # noqa: S311
+            with serializer:
+                q._release_lock(target)  # noqa: SLF001
+                q._acquire_lock(  # noqa: SLF001
+                    target, "auto-commit:successor", owner_kind="auto_commit",
+                )
+
+        reclaimed_box: list[int] = []
+
+        def reclaimer(q=q, serializer=serializer, box=reclaimed_box) -> None:
+            time.sleep(random.uniform(0, 0.002))  # noqa: S311
+            box.append(q.reclaim_stale_auto_commit_locks(
+                max_age_sec=600, serializer=serializer,
+            ))
+
+        th = threading.Thread(target=holder)
+        rt = threading.Thread(target=reclaimer)
+        th.start()
+        rt.start()
+        th.join()
+        rt.join()
+
+        # Invariant across every ordering: successor present, never deleted.
+        assert q.locks_held() == 1
+        with open(_lock_file(q, target)) as f:
+            assert json.load(f)["pending_id"] == "auto-commit:successor"
+        assert reclaimed_box[0] in (0, 1)
+        outcomes.add(reclaimed_box[0])
+    # Both orderings were actually hit (reclaimer-first removes 1; holder-first
+    # removes 0). If jitter ever fails to produce both, the invariant above is
+    # what really matters, but this guards against a silently one-sided schedule.
+    assert outcomes == {0, 1}
+
+
+def test_reclaim_recognises_legacy_pre_fix_auto_commit_lock(tmp_path) -> None:
+    """A lock written by a PRE-fix build has no owner_kind and stashes the
+    auto-commit marker in pending_id ("auto-commit:..."). After upgrade on a
+    persistent /state volume, the reclaimer must still recognise and free it (once
+    stale) so an old wedged path is not stuck forever. A legacy UUID-holder pending
+    lock must NOT be mistaken for auto-commit."""
+    q = PendingQueue(pending_root=str(tmp_path / "p"))
+    lock_path = _lock_file(q, "decisions/legacy.md")
+    # Hand-write a pre-fix auto-commit lock: pending_id has the prefix, NO owner_kind.
+    fd = os.open(lock_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+    with os.fdopen(fd, "w") as f:
+        json.dump({"pending_id": "auto-commit:oldsess",
+                   "target_path": "decisions/legacy.md",
+                   "acquired_at": time.time() - 700}, f)
+    assert q.locks_held() == 1
+    # Fresh legacy lock (aged 700s) reclaimed under a 600s TTL.
+    assert q.reclaim_stale_auto_commit_locks(max_age_sec=600) == 1
+    assert q.locks_held() == 0
+
+    # A legacy pending lock (UUID holder, no owner_kind) must be left alone.
+    import uuid
+    pending_lock = _lock_file(q, "decisions/legacy-pending.md")
+    fd2 = os.open(pending_lock, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+    with os.fdopen(fd2, "w") as f:
+        json.dump({"pending_id": uuid.uuid4().hex,
+                   "target_path": "decisions/legacy-pending.md",
+                   "acquired_at": time.time() - 10_000}, f)
+    assert q.reclaim_stale_auto_commit_locks(max_age_sec=600) == 0
+    assert q.reclaim_stale_auto_commit_locks(max_age_sec=0) == 0
+    assert q.locks_held() == 1


### PR DESCRIPTION
## Summary

Final small-fix package for the v0.3.0 release, addressing release-gate review findings plus a doc-currency audit of the release branch. One code fix and a set of doc edits. Targets `release/0.3.0`.

**Code (item 1): reclaim stale auto-commit path locks.** The write path takes per-path advisory locks for auto-commit sessions (`owner="auto-commit:<session>"`), but the orphan-lock GC only reclaimed UUID-owner (pending-proposal) locks and skipped auto-commit owners. A hard kill while an auto-commit held one left the lock on the `/state` volume with no in-process holder to release it, wedging that path (`rejected_path_lock_busy`) until manual cleanup.

Fix:
- Lock files now record an `owner_kind`.
- Crash-orphaned auto-commit locks are reclaimed **unconditionally at server startup** (a fresh process provably holds none) and, **while running, once older than `KB_AUTO_COMMIT_LOCK_TTL_SEC`** (default 600s, far above a seconds-long commit critical section; a non-positive value clamps to 600 with a warning, and `pending_gc_loop` guards `ttl>0`).
- Pre-fix legacy auto-commit locks (no `owner_kind`, `auto-commit:` `pending_id` prefix) are recognised too, so an upgrade on a persistent `/state` volume frees any already-wedged path.
- **Pending-proposal locks are never TTL-reclaimed** (they legitimately live until the operator resolves or the entry expires).

## Reclaim safety argument

The delete must never remove a *successor* lock (a fresh acquire on the same path after the stale one was freed). Two independent guards, in order of strength:

1. **Serializer mutual exclusion (the real fix).** The periodic reclaim runs under the *same* process-wide `WriteSerializer` that `path_lock` acquire/release runs under (threaded from `server.py`'s `pending_gc_loop` as `state.write_serializer`). While the reclaimer holds it, no auto-commit acquire/release can run, so a stalled holder cannot free-the-path-and-let-a-successor-acquire mid-reclaim. This closes the two-deleter check-to-delete race raised in review: the only two deleters of a given auto-commit lock (a resuming holder's `path_lock` finally, and the reclaimer) can no longer interleave. Startup reclaim needs no serializer: it runs before the write loops start, so nothing contends.
2. **Ownership check (defense in depth).** `_release_lock(expected_acquired_at=...)` deletes only a file whose `acquired_at` (a per-acquire, sub-microsecond-unique `time.time()` token) still matches, and pins the inode (open + `fstat`, re-`stat` same inode immediately before `unlink`) to close its own internal open-to-unlink window. A successor is a fresh `O_EXCL` inode with a distinct token, so it is never matched.

## Test evidence

`.venv/bin/python -m pytest tests/test_pending.py -q` -> 26 passed. Full suite: all pass (2 skips for optional `sentence_transformers` / `tiktoken` extras). `ruff check .` and `mypy src/` clean. `scripts/check_changelog.py`, `scripts/check_doc_consistency.py`, `scripts/check_benchmark_docs.py` all green.

New/updated regression tests (`tests/test_pending.py`):
- stale auto-commit lock reclaimed via TTL; startup (`max_age_sec=0`) reclaims unconditionally;
- a fresh/held auto-commit lock is NOT reclaimed; pending locks untouched by TTL and startup sweeps;
- ownership-checked release spares a different-timestamp successor; returns True only on the owner's own lock;
- **serializer mutual-exclusion race test**: 60 jittered trials, asserts the successor is never deleted AND that both interleavings (reclaimer-first removes 1, holder-first removes 0) actually occur;
- **legacy pre-fix lock** recognised and reclaimed; a legacy UUID-holder pending lock is left alone;
- config clamps non-positive `KB_AUTO_COMMIT_LOCK_TTL_SEC` to 600.

## Changelog placement

The changelog was rolled for 0.3.0 (PR #92) so `[Unreleased]` is empty. Since this fix ships **in** 0.3.0 via the release branch, the lock-reclaim entry is added to the **`[0.3.0]` block's `Fixed` section**, not `[Unreleased]`. `check_changelog.py` passes.

## Docs

- README: `Status: pre-1.0 beta. Latest release: v0.3.0.`
- `docs/quickstart.md`: reordered install so **from-source is the first working path**; the PyPI/uvx block now sits after it, gated behind the pending-publisher note (the doc previously led with a command that fails until the operator's one-time PyPI setup).
- `docs/releases/pypi-trusted-publishing.md`: an "After setup" note documenting the two edits to tighten the release chain once publishing is live (remove the upload step's `continue-on-error`; add `publish-pypi` to the Release job's `needs`). Documented only, not applied (pre-setup they would break releases).
- `SECURITY.md`: note the **breaking v0.3.0 principals default** — an entry omitting `capabilities` defaults to least privilege `{read, propose}`; `resolve`/`auto_commit`/`bootstrap`/`record_event` must be listed explicitly (verified against `principals.py`).
- `docs/serving.md`: co-occurrence (`KB_COOCCURRENCE_*`) and trigram (`KB_TRIGRAM_*`) env subsections mirroring the synonyms/embeddings style; a core config reference for `KB_HTTP_PORT` / `KB_CONFIDENCE_THRESHOLD` / `KB_PENDING_TIMEOUT_SEC` (defaults from `config.py`).
- `docs/adoption.md`: document all `setup` flags (`--check`, `--endpoint`, `-y`/`--yes`, `--no-version-check` per `cli/main.py`) and a `/readyz` readiness-probe pointer.
- `SPEC.md`: refreshed the stale header; §8 adds two normative notes — readiness MUST NOT target `/api/v1/health` (points to `docs/serving.md`), and only an explicit-trigger consult satisfies the enforcement gate (points to `docs/enforcement.md`).
- `WHY.md`: use the exact committed `0.097` false-positive rate (the sentence promises not to round).

## Peer review (codex)

Reviewed via `codex exec` across three passes on the full diff.

- Pass 1 raised a **Blocker** (reclaimer check-to-delete race) and a **Concern** (`KB_AUTO_COMMIT_LOCK_TTL_SEC<=0` hitting the startup sentinel). Both fixed.
- Pass 2 confirmed the Concern closed; maintained the Blocker on the read-then-unlink window.
- The Blocker was then resolved by moving to **serializer-based mutual exclusion** (the ownership/inode check alone cannot make a path-based `unlink` atomic; serializing the two deleters does).
- **Final pass verdict: No Blockers.** One **Concern** (legacy pre-fix locks left wedged after upgrade) and one **Nit** (serializer-test wording overstated coverage) — both addressed in this PR: legacy-lock predicate added with a regression test; the serializer test now uses jitter and asserts both orderings occur. Codex confirmed all changed doc claims match the code/workflows (principals default, setup flags, `/readyz`, co-occurrence/trigram names+defaults, PyPI post-setup notes, `WHY.md` 0.097).

Codex could not run pytest itself (read-only sandbox has no usable temp dir); all suites were run locally in the worktree venv with the results above.
