### PR TITLE
docs(rules): merge-method by change granularity

### DIFF
--- a/.rules/versioning.md
+++ b/.rules/versioning.md
@@ -64,5 +64,13 @@ previous rule was squash-only):
   merge commit itself carries no bump-relevant type: `compute_release.py` reads
   the constituent commits, and `tag-release.yml` keys off the `pyproject.toml`
   version bump reaching `main`, so both are unaffected by the merge method.
+  (`compute_release.py` walks `git log --no-merges`, so the merge commit is
+  invisible to the bump computation by construction.)
+- **Do not confuse the two release branch kinds.** The daily release-cutter
+  routine (`.rules/release-routine.md`) opens `chore/release-v<next>` PR
+  branches containing a single version-cut commit; those are one logical
+  change and stay squash-merged. `release/X.Y.Z` integration branches, used
+  when a coordinated program lands many features/fixes together before one
+  gated merge to `main`, are the case the merge-commit rule above exists for.
 - Every functional PR updates the CHANGELOG `[Unreleased]` block (see
   `.rules/changelog-per-release.md`).

--- a/.rules/versioning.md
+++ b/.rules/versioning.md
@@ -47,7 +47,22 @@ The project stays pre-1.0 until `v1.0.0` is cut deliberately. When it reaches
 
 ## PR discipline
 
-- Squash-merge only; the PR title is the one Conventional Commit and is linted by
-  `.github/workflows/pr-title-lint.yml` (STD-U-810 §7.1 equivalent).
+Merge method follows the granularity of the change (amended 2026-07-04; the
+previous rule was squash-only):
+
+- **Feature/fix PRs (one logical change) are squash-merged.** The PR title is
+  the one Conventional Commit and is linted by
+  `.github/workflows/pr-title-lint.yml` (STD-U-810 §7.1 equivalent). This
+  applies equally to PRs targeting `main` and PRs targeting a release branch.
+- **Release/integration branches (`release/X.Y.Z`) merge into `main` with a
+  merge commit, never a squash.** Each constituent commit on the release branch
+  is already one squashed Conventional Commit per feature/fix, so a merge
+  commit preserves one readable commit per change on `main` (blame and bisect
+  keep per-feature granularity), while squashing again would collapse the whole
+  release into a single opaque commit. The release PR title still follows the
+  Conventional format (`chore(release): vX.Y.Z`) for the PR-title lint, but the
+  merge commit itself carries no bump-relevant type: `compute_release.py` reads
+  the constituent commits, and `tag-release.yml` keys off the `pyproject.toml`
+  version bump reaching `main`, so both are unaffected by the merge method.
 - Every functional PR updates the CHANGELOG `[Unreleased]` block (see
   `.rules/changelog-per-release.md`).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,7 +79,10 @@ By contributing you agree to abide by the project's [Code of Conduct](CODE_OF_CO
 
 Releases follow STD-U-810 and are documented in `.rules/versioning.md`. In short:
 
-- Merge PRs with squash-merge; the PR title must be a Conventional Commit.
+- Merge feature/fix PRs with squash-merge; the PR title must be a Conventional
+  Commit. Release branches (`release/X.Y.Z`) merge into `main` with a merge
+  commit instead, so each squashed feature/fix commit survives on `main`; see
+  `.rules/versioning.md`.
 - A daily routine opens a release PR when `main` has releasable changes.
 - Merging the release PR cuts an annotated `vX.Y.Z` tag, a GitHub Release, and
   the Docker image. No tags are cut by hand under normal operation.


### PR DESCRIPTION
Amends the squash-only PR discipline per operator decision (2026-07-04): feature/fix PRs (one logical change, including PRs into a release branch) stay squash-merged with a Conventional Commit title; release/X.Y.Z integration branches merge into main with a merge commit so each constituent squashed feature/fix commit survives on main (readable history, per-feature blame/bisect).

Verified interactions (codex peer review, no Blockers):
- compute_release.py walks git log --no-merges, so the merge commit cannot skew the bump.
- tag-release.yml keys off the pyproject version reaching main; merge-method agnostic.
- pr-title-lint.yml lints PR titles only.
- Codex Concern (branch-kind ambiguity vs .rules/release-routine.md chore/release-v* cut branches) resolved with an explicit distinction in the rule.

Also updates CONTRIBUTING.md's release section. Repo settings updated separately: merge commits are now allowed alongside squash.

## Peer review (codex)
No Blockers. 1 Concern (branch naming ambiguity), fixed in the second commit. Interaction claims verified against compute_release.py, should_tag.py, tag-release.yml, pr-title-lint.yml.