### PR TITLE
test(setup): harden pypi URL assertions against substring sanitization

### DIFF
--- a/tests/test_setup_wizard.py
+++ b/tests/test_setup_wizard.py
@@ -10,6 +10,7 @@ import io
 import json
 import subprocess
 from typing import TYPE_CHECKING
+from urllib.parse import urlsplit
 
 from data_olympus import setup_wizard as w
 
@@ -321,7 +322,7 @@ def test_install_enforcement_missing_script_skips(monkeypatch, tmp_path: Path):
 # --------------------------------------------------------------------------- #
 def test_latest_version_from_pypi():
     def fetch(url, timeout):  # noqa: ARG001
-        assert "pypi.org" in url
+        assert urlsplit(url).hostname == "pypi.org"
         return json.dumps({"info": {"version": "9.9.9"}}).encode()
 
     info = w.latest_version(fetcher=fetch)
@@ -331,7 +332,7 @@ def test_latest_version_from_pypi():
 
 def test_latest_version_falls_back_to_github():
     def fetch(url, timeout):  # noqa: ARG001
-        if "pypi.org" in url:
+        if urlsplit(url).hostname == "pypi.org":
             raise OSError("no pypi yet")
         return json.dumps({"tag_name": "v1.2.3"}).encode()
 


### PR DESCRIPTION
Fixes the 2 high-severity CodeQL alerts blocking PR #93 (rule py/incomplete-url-substring-sanitization, tests/test_setup_wizard.py:324,334).

The wizard version-check test doubles asserted `"pypi.org" in url`, which CodeQL correctly flags because the marker can appear anywhere in a hostile URL (e.g. https://pypi.org.evil.com/). Replaced both with a hostname comparison via urlsplit(url).hostname == "pypi.org", which is the canonical robust check and a strictly stronger assertion of the wizard's actual behavior.

Test-only change. Full suite green (2 optional-dep skips), ruff clean, changelog guard ok (no functional path touched). Unblocks the v0.3.0 release.