### PR TITLE
fix(release): repair v0.3.0 image build + PyPI trusted publishing

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -69,22 +69,50 @@ jobs:
   # pushed with GITHUB_TOKEN, which does NOT trigger publish-pypi.yml's `on: push
   # tags`, so we call the reusable workflow here (exactly as build-image does).
   #
-  # INERT UNTIL OPERATOR SETUP: until the pypi.org Trusted Publisher exists, the
-  # upload STEP inside the reusable workflow no-ops on failure (that step carries
-  # continue-on-error, which is only valid on a step, not on a `uses:` job like
-  # this one). So this job still succeeds pre-setup and does not block the GitHub
-  # Release; once the publisher is configured the upload succeeds for real. See
-  # docs/releases/pypi-trusted-publishing.md.
+  # Publish sdist + wheel to PyPI via Trusted Publishing (OIDC, no token). The
+  # steps run INLINE here (not via a reusable workflow) on purpose: PyPI's OIDC
+  # exchange does not reliably match a publisher when the publishing step runs
+  # inside a called reusable workflow (the gh-action-pypi-publish action itself
+  # warns against reusable workflows). Running inline makes the entry workflow
+  # (tag-release.yml) the publishing workflow, matching the registered pypi.org
+  # Trusted Publisher (workflow=tag-release.yml, environment=pypi). Runs off the
+  # SAME decided tag as build-image. Does not gate the GitHub Release (which needs
+  # only build-image), so a PyPI hiccup surfaces as a failed job without blocking
+  # the tag/image/release. See docs/releases/pypi-trusted-publishing.md.
   publish-pypi:
     needs: decide
     if: needs.decide.outputs.tag != ''
-    uses: ./.github/workflows/publish-pypi-reusable.yml
-    with:
-      ref: ${{ needs.decide.outputs.tag }}
-      upload: true
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/data-olympus
     permissions:
       contents: read
+      # id-token: write mints the OIDC token gh-action-pypi-publish exchanges for
+      # a short-lived upload credential. No secret token exists.
       id-token: write
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.decide.outputs.tag }}
+          fetch-depth: 0
+      - uses: astral-sh/setup-uv@v7
+      - name: Build sdist + wheel
+        run: uv build
+      - name: Verify metadata (twine check)
+        run: uvx twine check --strict dist/*
+      - name: Smoke-test the built wheel
+        run: |
+          uvx --from ./dist/*.whl data-olympus --help
+          uvx --from ./dist/*.whl data-olympus setup --check --no-version-check
+      - name: Publish to PyPI (Trusted Publishing)
+        uses: pypa/gh-action-pypi-publish@release/v1
+        # skip-existing so a partial-failure rerun of an already-uploaded version
+        # is a no-op, not an error (mirrors the idempotent tag/image/release jobs).
+        # No continue-on-error: the publisher is configured, so a real upload
+        # failure must be visible rather than silently swallowed.
+        with:
+          skip-existing: true
 
   release:
     needs: [decide, build-image]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -417,6 +417,12 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **Release delivery for 0.3.0.** Two release-pipeline bugs surfaced on the first
+  0.3.0 run and are fixed so the tag, image, and PyPI package publish together: the
+  Docker image build now copies `README.md`, `LICENSE`, and `NOTICE` (referenced by
+  `pyproject.toml`) into the build context before the project-installing `uv sync`;
+  and the PyPI publish runs inline in `tag-release.yml` rather than through a
+  reusable workflow, which PyPI trusted publishing does not reliably match through.
 - **Stale auto-commit path locks are reclaimed.** A hard kill while an auto-commit
   held a per-path advisory lock left the lock on the `/state` volume with no
   in-process holder to release it, wedging that path (`rejected_path_lock_busy`)

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -38,6 +38,11 @@ WORKDIR /app
 COPY pyproject.toml uv.lock ./
 RUN uv sync --frozen --no-dev --no-install-project
 
+# README.md, LICENSE, and NOTICE are referenced by pyproject.toml
+# (readme = "README.md", license-files = ["LICENSE", "NOTICE"]); the build
+# backend reads them when it builds the project in the sync below, so they must
+# be in the build context before this step (not just at wheel-publish time).
+COPY README.md LICENSE NOTICE ./
 COPY src/ ./src/
 RUN uv sync --frozen --no-dev
 

--- a/tests/test_publish_workflows.py
+++ b/tests/test_publish_workflows.py
@@ -3,7 +3,8 @@
 Keeps the release wiring honest without needing a live GitHub Actions run:
 - the workflow YAML parses;
 - the reusable upload job is trusted-publishing + inert-until-setup shaped;
-- the normal release path (tag-release.yml) calls the reusable publish workflow;
+- the normal release path (tag-release.yml) publishes to PyPI inline (not via the
+  reusable workflow, which PyPI trusted publishing does not match through);
 - the PR dry-run does not upload.
 """
 
@@ -63,14 +64,30 @@ def test_publish_pr_dry_run_does_not_upload():
     assert "pull_request" in dry["if"]
 
 
-def test_tag_release_calls_publish_reusable():
+def test_tag_release_publishes_pypi_inline():
+    """The primary release path publishes to PyPI with the steps INLINE in
+    tag-release.yml, not through a reusable workflow. PyPI trusted publishing does
+    not reliably match a publisher when the upload runs inside a called reusable
+    workflow, so the entry workflow must be the publishing workflow."""
     doc = _load("tag-release.yml")
     pub = doc["jobs"]["publish-pypi"]
-    assert pub["uses"].endswith("publish-pypi-reusable.yml")
-    assert pub["with"]["upload"] is True
+    # Inline job: no `uses:` delegation to a reusable workflow.
+    assert "uses" not in pub
     assert pub["permissions"]["id-token"] == "write"
-    # It keys off the same decided tag as the image build.
-    assert pub["with"]["ref"] == "${{ needs.decide.outputs.tag }}"
+    assert pub["environment"]["name"] == "pypi"
+    # Checks out the same decided tag as the image build.
+    checkout = next(s for s in pub["steps"] if "actions/checkout" in str(s.get("uses", "")))
+    assert checkout["with"]["ref"] == "${{ needs.decide.outputs.tag }}"
+    publish = next(
+        s for s in pub["steps"] if "pypa/gh-action-pypi-publish" in str(s.get("uses", ""))
+    )
+    # Trusted publishing only (no token) + idempotent rerun.
+    assert "password" not in (publish.get("with") or {})
+    assert publish["with"]["skip-existing"] is True
+    # The publisher is configured now, so a real failure must be visible.
+    assert "continue-on-error" not in publish
+    # PyPI publish must not gate the GitHub Release (release needs only build-image).
+    assert "publish-pypi" not in doc["jobs"]["release"]["needs"]
 
 
 def test_publish_step_inert_until_setup():


### PR DESCRIPTION
## Why
The v0.3.0 release chain (tag-release.yml) ran on merge of #93 but **published nothing** — the git tag exists, but PyPI is empty, no container image, no GitHub Release. Two independent CI bugs, both diagnosed from the failed run logs:

1. **Image build failed**: `OSError: Readme file does not exist: README.md` during `uv sync`. `pyproject.toml` declares `readme = "README.md"` and `license-files = ["LICENSE", "NOTICE"]`, but the Dockerfile copied only pyproject/uv.lock/src before the project-installing sync. Fix: copy the three referenced files into the build context first.
2. **PyPI publish failed**: `Trusted publishing exchange failure: invalid-publisher`. The upload ran inside the reusable workflow `publish-pypi-reusable.yml`; PyPI's OIDC match does not work reliably through a reusable workflow (the publish action prints this warning). Fix: inline the build+upload directly into `tag-release.yml`, so the entry workflow IS the publishing workflow and matches the registered pypi.org publisher (`workflow=tag-release.yml`, `environment=pypi`). Also removed `continue-on-error` so a genuine upload failure is no longer swallowed.

## Verification
- `tag-release.yml` valid YAML + actionlint clean.
- Dockerfile fix is definitive (build aborted on the exact missing file; Docker isn't installed on the maintainer laptop, so the authoritative check is the CI image-build job on the re-drive).
- The `ref:` inputs use `needs.decide.outputs.tag` (from should_tag.py / pyproject version), not untrusted event input.

## Re-drive plan (after merge)
Nothing published under v0.3.0, so re-point the tag onto this fixed commit via the primary path (delete the tag, re-run tag-release on this commit). PyPI 0.3.0 is a clean first upload.

## Follow-up (not in this PR)
The manual/fallback path in `publish-pypi.yml` still delegates upload to the reusable workflow and would hit the same OIDC issue; it is not exercised by the primary release flow. Track separately.