### PR TITLE
fix(release): copy bin/ into Docker build context (wheel force-include)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -419,10 +419,11 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - **Release delivery for 0.3.0.** Two release-pipeline bugs surfaced on the first
   0.3.0 run and are fixed so the tag, image, and PyPI package publish together: the
-  Docker image build now copies `README.md`, `LICENSE`, and `NOTICE` (referenced by
-  `pyproject.toml`) into the build context before the project-installing `uv sync`;
-  and the PyPI publish runs inline in `tag-release.yml` rather than through a
-  reusable workflow, which PyPI trusted publishing does not reliably match through.
+  Docker image build now copies everything `pyproject.toml` references into the
+  build context before the project-installing `uv sync` (`README.md`, `LICENSE`,
+  `NOTICE`, and the `bin/` machinery force-included into the wheel); and the PyPI
+  publish runs inline in `tag-release.yml` rather than through a reusable workflow,
+  which PyPI trusted publishing does not reliably match through.
 - **Stale auto-commit path locks are reclaimed.** A hard kill while an auto-commit
   held a per-path advisory lock left the lock on the `/state` volume with no
   in-process holder to release it, wedging that path (`rejected_path_lock_busy`)

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -38,11 +38,16 @@ WORKDIR /app
 COPY pyproject.toml uv.lock ./
 RUN uv sync --frozen --no-dev --no-install-project
 
-# README.md, LICENSE, and NOTICE are referenced by pyproject.toml
-# (readme = "README.md", license-files = ["LICENSE", "NOTICE"]); the build
-# backend reads them when it builds the project in the sync below, so they must
-# be in the build context before this step (not just at wheel-publish time).
+# The project build (the `uv sync` below, which builds + installs the wheel via
+# hatchling) needs everything pyproject.toml references at build time:
+#   - readme = "README.md" and license-files = ["LICENSE", "NOTICE"];
+#   - [tool.hatch.build.targets.wheel] packages = src/data_olympus;
+#   - [tool.hatch.build.targets.wheel.force-include] the bin/ enforcement
+#     machinery shipped inside the wheel at data_olympus/_bin/.
+# All of these must be in the build context before the sync, not just at
+# wheel-publish time.
 COPY README.md LICENSE NOTICE ./
+COPY bin/ ./bin/
 COPY src/ ./src/
 RUN uv sync --frozen --no-dev
 


### PR DESCRIPTION
Third and final piece of the v0.3.0 image-build fix. PyPI 0.3.0 published successfully on the re-drive; the image build progressed past the README/LICENSE fix (PR #97) but then failed on `FileNotFoundError: Forced include not found` because `[tool.hatch.build.targets.wheel.force-include]` ships the six `bin/` enforcement files inside the wheel, and the Dockerfile never copied `bin/` before the project-installing `uv sync`.

Fix: `COPY bin/ ./bin/` before that sync. The build context now has everything pyproject references (src, README, LICENSE, NOTICE, bin), so the wheel build completes.

Verified the six force-include targets exist under bin/. Docker isn't installed on the maintainer laptop; CI's image-build job on the re-drive is the authoritative check. changelog guard green.