### PR TITLE
fix(deploy): idempotent prepare-git initContainer (survives pod restarts)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- **`prepare-git` initContainer is now idempotent across pod restarts.** It staged
+  the deploy key with `cp /etc/git-key-mount /state/git-key` then `chmod 0400`.
+  Because `/state` is a PVC, on any pod restart the `0400` (unwritable) key already
+  exists and the plain `cp` fails under `set -e`, leaving the pod stuck in
+  `Init:Error`. The manifest now `rm -f`s the staged key before copying (the
+  `/state` dir is writable to uid 65534 via `fsGroup`). Only the first boot was
+  ever exercised before; a `kubectl rollout restart` or any pod recreation hit it.
+
 ## [0.3.0] - 2026-07-03
 
 ### Added

--- a/deploy/k8s/statefulset.yaml
+++ b/deploy/k8s/statefulset.yaml
@@ -52,7 +52,12 @@ spec:
             - |
               set -e
               # Stage the deploy key with private-key perms on the shared volume.
+              # /state is a PVC, so on a pod RESTART /state/git-key already exists
+              # at 0400 (unwritable) and a plain cp over it fails under `set -e`,
+              # wedging the pod in Init:Error. rm -f first (the /state dir is
+              # writable to the runtime uid via fsGroup) so the copy is repeatable.
               if [ -f /etc/git-key-mount ]; then
+                rm -f /state/git-key
                 cp /etc/git-key-mount /state/git-key
                 chmod 0400 /state/git-key
               fi


### PR DESCRIPTION
## Bug
The v0.3.0 `prepare-git` initContainer (deploy/k8s/statefulset.yaml) stages the deploy key with:
```sh
cp /etc/git-key-mount /state/git-key
chmod 0400 /state/git-key
```
`/state` is a PVC. On the **first** boot this works, but on **any pod restart** `/state/git-key` already exists at `0400` (unwritable), so the plain `cp` fails, `set -e` aborts the init, and the pod is stuck in `Init:Error` and never starts. Any `kubectl rollout restart`, node drain, or pod recreation triggers it. Only the first-boot path was ever exercised.

## Fix
`rm -f /state/git-key` before the copy (the `/state` dir is writable to uid 65534 via `fsGroup`), making the staging repeatable.

## Evidence
Hit live on a real kn-dev deployment during a rolling restart (pod went to Init:Error); fixed on the cluster and verified the pod recovers to Ready. CHANGELOG updated.