### PR TITLE
chore(release): v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.3.1] - 2026-07-05
+
 ### Fixed
 
 - **`prepare-git` initContainer is now idempotent across pod restarts.** It staged
@@ -1011,7 +1013,8 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `docs/adoption.md`: bring-your-own-KB guide (author, lint, index, serve, wire an agent).
 - `docs/comparison.md`: how data-olympus relates to OKF, enterprise catalogs, markdown KB tools, agent-context conventions, RAG, and ADR tooling.
 
-[Unreleased]: https://github.com/knaisoma/data-olympus/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/knaisoma/data-olympus/compare/v0.3.1...HEAD
+[0.3.1]: https://github.com/knaisoma/data-olympus/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/knaisoma/data-olympus/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/knaisoma/data-olympus/compare/v0.1.1...v0.2.0
 [0.1.1]: https://github.com/knaisoma/data-olympus/compare/v0.1.0...v0.1.1

--- a/docs/releases/v0.3.1.md
+++ b/docs/releases/v0.3.1.md
@@ -1,0 +1,11 @@
+# v0.3.1
+
+## Fixed
+
+- The Kubernetes deployment now survives pod restarts. In 0.3.0 the small
+  setup step that prepares the git deploy key only worked the very first time a
+  pod started: on any later restart it tried to overwrite a file it had made
+  read-only and failed, leaving the pod stuck and unable to start. It now clears
+  the staged key before rewriting it, so restarts, node moves, and rollouts come
+  back up cleanly. This only affects the container deployment; the format, CLI,
+  and server behaviour are unchanged from 0.3.0.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "data-olympus"
-version = "0.3.0"
+version = "0.3.1"
 description = "Governance-grade knowledge-base format (OKF-compatible) plus CLI and single-writer MCP server"
 readme = "README.md"
 requires-python = ">=3.13"


### PR DESCRIPTION
Patch release. Contains the single fix merged since v0.3.0:

- **Idempotent prepare-git initContainer** (#99) — the v0.3.0 Kubernetes initContainer could not re-stage the deploy key on a pod restart (0400 file on the persistent /state volume, plain cp fails under set -e), wedging the pod in Init:Error. Found live on kn-dev during a rolling restart. Now rm -f before copy.

Version-only image change from 0.3.0 (the fix is in deploy/k8s/statefulset.yaml, not src). `compute_release.py` confirms: patch, next_version 0.3.1. CHANGELOG rolled, docs/releases/v0.3.1.md added, compare links updated.

Merging tags v0.3.1 and runs the (now-repaired) release chain: image + PyPI + GitHub Release.