### PR TITLE
fix(enforce): separate rate-limit ceiling for gate/check (default off)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,20 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- **`gate/check` no longer self-DoSes multi-agent fleets with 429s.** The
+  enforcement hook calls `POST /api/v1/gate/check` (and `kb_gate_check`) once per
+  gated tool action for every agent, but it shared the write/consult quota
+  (`KB_RATE_LIMIT_PER_HOUR`, default 100). Behind an ingress with no auth, all
+  clients collapse to a single limiter bucket, so a few active agents exhausted
+  the hourly quota in minutes and everything after got `429 Too Many Requests`.
+  gate-check now has its own ceiling, `KB_GATE_CHECK_RATE_LIMIT_PER_HOUR`,
+  defaulting to `0` (unthrottled, consistent with the read routes) since it is a
+  mandatory per-action probe that does only cheap classification and no writes.
+  Set a positive value for an explicit backstop. `consult` and
+  `onboarding/cleanup-plan` stay throttled by `KB_RATE_LIMIT_PER_HOUR`.
+
 ## [0.3.1] - 2026-07-05
 
 ### Fixed

--- a/docs/serving.md
+++ b/docs/serving.md
@@ -537,6 +537,25 @@ Set `KB_TRUSTED_PROXIES` to the proxy address(es) (comma-separated) to fix this:
   and only the ingress can connect). Otherwise a direct client could forge the
   header.
 
+### The gate-check route (`KB_GATE_CHECK_RATE_LIMIT_PER_HOUR`)
+
+`POST /api/v1/gate/check` (and the `kb_gate_check` MCP tool) is the enforcement
+hook's freshness probe, called **once per gated tool action** by every agent. It
+therefore must not share the write/consult quota (`KB_RATE_LIMIT_PER_HOUR`): with
+several agents active, and all clients collapsing to one limiter bucket behind an
+ingress, a fixed hourly quota self-throttles the whole fleet with `429`s. So
+gate-check has its own ceiling:
+
+- **`KB_GATE_CHECK_RATE_LIMIT_PER_HOUR=0` (default)** — gate-check is **not**
+  rate-limited. It does only cheap classification plus a freshness lookup and no
+  writes, so this matches the read routes, which are also unthrottled.
+- **A positive value** — an explicit per-(address, principal) backstop just for
+  gate-check, independent of the write/consult limiter. Size it above your fleet's
+  real per-hour tool-call volume, not near it, or you reintroduce the self-DoS.
+
+The `consult` and `onboarding/cleanup-plan` routes remain throttled by
+`KB_RATE_LIMIT_PER_HOUR` (they write to the ledger or are CPU-heavy).
+
 ## Audit-log rotation (`KB_AUDIT_MAX_BYTES`)
 
 The JSONL audit log (`KB_AUDIT_LOG_PATH`, default `/state/audit/events.log`) grows

--- a/src/data_olympus/config.py
+++ b/src/data_olympus/config.py
@@ -28,6 +28,14 @@ class Config:
     write_block_paths: list[str] = field(default_factory=list)
     rate_limit_per_hour: int = 100
     rate_limit_per_ip_per_hour: int = 0
+    # Separate ceiling for the high-frequency /api/v1/gate/check route (the
+    # enforcement hook's per-tool-action freshness probe). 0 (default) disables
+    # throttling for that route: it is a mandatory, once-per-tool-call, read-only
+    # probe, so any fixed hourly quota self-DoSes an active multi-agent fleet
+    # (behind ingress all clients collapse to one limiter bucket). Reads are
+    # already unthrottled; this keeps gate/check consistent with them. Set a
+    # positive value only if you want an explicit backstop.
+    gate_check_rate_limit_per_hour: int = 0
     max_text_bytes: int = 262144
     max_postimage_bytes: int = 1048576
     max_body_bytes: int = 2097152
@@ -155,6 +163,7 @@ def load_config() -> Config:
     write_block_paths = _split_csv(os.getenv("KB_WRITE_BLOCK_PATHS", ""))
     rate_limit_per_hour = int(os.getenv("KB_RATE_LIMIT_PER_HOUR", "100"))
     rate_limit_per_ip_per_hour = int(os.getenv("KB_RATE_LIMIT_PER_IP_PER_HOUR", "0"))
+    gate_check_rate_limit_per_hour = int(os.getenv("KB_GATE_CHECK_RATE_LIMIT_PER_HOUR", "0"))
     max_text_bytes = int(os.getenv("KB_MAX_TEXT_BYTES", "262144"))
     max_postimage_bytes = int(os.getenv("KB_MAX_POSTIMAGE_BYTES", "1048576"))
     max_body_bytes = int(os.getenv("KB_MAX_BODY_BYTES", "2097152"))
@@ -226,6 +235,7 @@ def load_config() -> Config:
         write_block_paths=write_block_paths,
         rate_limit_per_hour=rate_limit_per_hour,
         rate_limit_per_ip_per_hour=rate_limit_per_ip_per_hour,
+        gate_check_rate_limit_per_hour=gate_check_rate_limit_per_hour,
         max_text_bytes=max_text_bytes,
         max_postimage_bytes=max_postimage_bytes,
         max_body_bytes=max_body_bytes,

--- a/src/data_olympus/rest_api.py
+++ b/src/data_olympus/rest_api.py
@@ -32,6 +32,7 @@ if TYPE_CHECKING:
     from starlette.requests import Request
 
     from data_olympus.models import HealthResponse
+    from data_olympus.rate_limit import SlidingWindowLimiter
     from data_olympus.server import ServerState
 
 
@@ -285,22 +286,33 @@ async def _read_json_capped(
         )
 
 
+_USE_WRITE_LIMITER: Any = object()
+
+
 def _rate_limited(
     state: ServerState, request: Request, principal: Principal,
+    *, limiter: SlidingWindowLimiter | None = _USE_WRITE_LIMITER,
 ) -> JSONResponse | None:
-    """Apply the shared sliding-window limiter to an enforcement-plane route.
+    """Apply a sliding-window limiter to an enforcement-plane route.
 
-    The consult / gate / cleanup-plan routes were previously unthrottled (item 6),
-    so an anonymous or authenticated caller could hammer the classifier and ledger
-    without bound. Reuse the same limiter the write routes use, keyed by
-    (remote_addr, principal name) so a per-principal quota applies. Returns a 429
-    JSONResponse when over quota, else None.
+    The consult / cleanup-plan routes were previously unthrottled (item 6), so an
+    anonymous or authenticated caller could hammer the classifier and ledger
+    without bound. They reuse the write limiter (``state.rate_limiter``), keyed by
+    (remote_addr, principal name). Returns a 429 JSONResponse when over quota, else
+    None.
 
-    When the limiter is absent (a read-only deployment with no write pipeline
-    configured) throttling is skipped: there is no shared limiter object to
-    consult and these routes are read-mostly there.
+    ``limiter`` overrides which limiter to consult. The high-frequency
+    /api/v1/gate/check route passes ``state.gate_rate_limiter`` (None by default),
+    so it is unthrottled unless an operator sets an explicit ceiling: it is a
+    mandatory once-per-tool-action probe, and any fixed quota shared across a
+    fleet (all clients collapse to one bucket behind ingress) self-DoSes with 429s.
+
+    When the resolved limiter is absent (a read-only deployment, or gate/check with
+    no ceiling configured) throttling is skipped.
     """
-    limiter = state.rate_limiter
+    # Distinguish "no limiter arg" (use the write limiter) from an explicit None
+    # (the gate-check limiter with no ceiling: throttling is genuinely off).
+    limiter = state.rate_limiter if limiter is _USE_WRITE_LIMITER else limiter
     if limiter is None:
         return None
     remote_addr = request.client.host if request.client else "unknown"
@@ -662,7 +674,12 @@ def register_routes(
             principal, denied = _authorize(request, registry)
             if denied is not None:
                 return denied
-            if (throttled := _rate_limited(state, request, principal)) is not None:
+            # gate/check uses its own limiter (unthrottled by default): it is the
+            # hook's once-per-tool-action probe, so it must not share the write /
+            # consult quota (that self-DoSes a fleet, see _rate_limited).
+            if (throttled := _rate_limited(
+                state, request, principal, limiter=state.gate_rate_limiter
+            )) is not None:
                 return throttled
             import time as _time
 

--- a/src/data_olympus/server.py
+++ b/src/data_olympus/server.py
@@ -123,6 +123,7 @@ class ServerState:
         push_queue: PushQueue | None = None,
         pending: PendingQueue | None = None,
         rate_limiter: SlidingWindowLimiter | None = None,
+        gate_rate_limiter: SlidingWindowLimiter | None = None,
         blocklist: PathBlocklist | None = None,
         audit_log: AuditLog | None = None,
         classifier: IntentClassifier | None = None,
@@ -147,6 +148,10 @@ class ServerState:
         self.push_queue: PushQueue | None = push_queue
         self.pending: PendingQueue | None = pending
         self.rate_limiter: SlidingWindowLimiter | None = rate_limiter
+        # Separate limiter for /api/v1/gate/check (None = unthrottled, the default).
+        # Kept distinct from `rate_limiter` so gate-check traffic and the write /
+        # consult / cleanup-plan quota never share a bucket.
+        self.gate_rate_limiter: SlidingWindowLimiter | None = gate_rate_limiter
         self.blocklist: PathBlocklist | None = blocklist
         self.audit_log: AuditLog | None = audit_log
         # Process-wide write serializer (scope item 1): one instance shared by
@@ -232,6 +237,7 @@ def build_app(
     confidence_threshold: float = 0.85,
     rate_limit_per_hour: int = 100,
     rate_limit_per_ip_per_hour: int = 0,
+    gate_check_rate_limit_per_hour: int = 0,
     max_text_bytes: int = 262144,
     max_postimage_bytes: int = 1048576,
     max_body_bytes: int = 2097152,
@@ -279,6 +285,7 @@ def build_app(
         write_block_paths=write_block_paths or [],
         rate_limit_per_hour=rate_limit_per_hour,
         rate_limit_per_ip_per_hour=rate_limit_per_ip_per_hour,
+        gate_check_rate_limit_per_hour=gate_check_rate_limit_per_hour,
         max_text_bytes=max_text_bytes,
         max_postimage_bytes=max_postimage_bytes,
         max_body_bytes=max_body_bytes,
@@ -393,6 +400,13 @@ def build_app(
             max_per_hour=config.rate_limit_per_hour,
             max_per_ip_per_hour=config.rate_limit_per_ip_per_hour,
         )
+        # gate/check gets its own limiter only when a positive ceiling is set;
+        # 0 (default) leaves it unthrottled (see Config.gate_check_rate_limit_per_hour).
+        gate_rate_limiter = (
+            SlidingWindowLimiter(max_per_hour=config.gate_check_rate_limit_per_hour)
+            if config.gate_check_rate_limit_per_hour > 0
+            else None
+        )
         blocklist = PathBlocklist(
             tier_blocks=config.write_block_tiers,
             path_blocks=config.write_block_paths,
@@ -401,6 +415,7 @@ def build_app(
         state.push_queue = push_queue
         state.pending = pending
         state.rate_limiter = rate_limiter
+        state.gate_rate_limiter = gate_rate_limiter
         state.blocklist = blocklist
 
     if config.kb_remote_url and not config.read_only:
@@ -545,17 +560,22 @@ def build_app(
         )
         return resp.model_dump()
 
-    def _mcp_rate_limited() -> dict[str, object] | None:
-        """Apply the shared sliding-window limiter to an MCP enforcement-plane tool
+    def _mcp_rate_limited(*, gate: bool = False) -> dict[str, object] | None:
+        """Apply a sliding-window limiter to an MCP enforcement-plane tool
         (WP0b item (b)).
 
-        The REST consult / gate-check / cleanup-plan routes throttle via
-        ``_rate_limited``; the MCP tool paths did not, so an agent could hammer the
-        classifier/ledger unbounded. Key on the resolved principal (there is no
-        per-request remote addr on the MCP transport, so the limiter's per-agent
-        quota is the meaningful dimension). Returns a rejection dict when over
-        quota, else None. Skipped when no limiter is wired (read-only deploy)."""
-        limiter = state.rate_limiter
+        The REST consult / cleanup-plan routes throttle via ``_rate_limited``; the
+        MCP tool paths did not, so an agent could hammer the classifier/ledger
+        unbounded. Key on the resolved principal (there is no per-request remote
+        addr on the MCP transport, so the limiter's per-agent quota is the
+        meaningful dimension). Returns a rejection dict when over quota, else None.
+
+        ``gate=True`` (kb_gate_check) consults ``state.gate_rate_limiter`` instead
+        of the write limiter; that limiter is None by default, so the
+        high-frequency freshness probe is unthrottled unless explicitly capped,
+        matching the REST /api/v1/gate/check route. Skipped when the resolved
+        limiter is None (read-only deploy, or gate-check with no ceiling set)."""
+        limiter = state.gate_rate_limiter if gate else state.rate_limiter
         if limiter is None:
             return None
         principal_name = _current_principal.get().name
@@ -768,7 +788,7 @@ def build_app(
         ) -> dict[str, object]:
             """Return a verdict (allow | consult_required) for a pending code action.
             Governed actions require a fresh consultation on record."""
-            if (throttled := _mcp_rate_limited()) is not None:
+            if (throttled := _mcp_rate_limited(gate=True)) is not None:
                 return throttled
             import time as _time
 

--- a/src/data_olympus/server.py
+++ b/src/data_olympus/server.py
@@ -872,6 +872,7 @@ def build_app_from_config(config: Config, *, bootstrap_now: bool = True) -> Fast
         confidence_threshold=config.confidence_threshold,
         rate_limit_per_hour=config.rate_limit_per_hour,
         rate_limit_per_ip_per_hour=config.rate_limit_per_ip_per_hour,
+        gate_check_rate_limit_per_hour=config.gate_check_rate_limit_per_hour,
         max_text_bytes=config.max_text_bytes,
         max_postimage_bytes=config.max_postimage_bytes,
         max_body_bytes=config.max_body_bytes,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -105,6 +105,7 @@ def test_config_loads_new_write_env_vars(monkeypatch, tmp_path) -> None:
     monkeypatch.setenv("KB_WRITE_BLOCK_TIERS", "T1,T2")
     monkeypatch.setenv("KB_WRITE_BLOCK_PATHS", "decisions/DEC-008-*.md")
     monkeypatch.setenv("KB_RATE_LIMIT_PER_HOUR", "50")
+    monkeypatch.setenv("KB_GATE_CHECK_RATE_LIMIT_PER_HOUR", "7")
     monkeypatch.setenv("KB_PENDING_TIMEOUT_SEC", "86400")
     monkeypatch.setenv("KB_PENDING_QUEUE_CAP", "100")
     monkeypatch.setenv("KB_WORKTREE_IDLE_SEC", "1800")
@@ -118,6 +119,7 @@ def test_config_loads_new_write_env_vars(monkeypatch, tmp_path) -> None:
     assert cfg.write_block_tiers == ["T1", "T2"]
     assert cfg.write_block_paths == ["decisions/DEC-008-*.md"]
     assert cfg.rate_limit_per_hour == 50
+    assert cfg.gate_check_rate_limit_per_hour == 7
     assert cfg.pending_timeout_sec == 86400
     assert cfg.pending_queue_cap == 100
     assert cfg.worktree_idle_sec == 1800
@@ -128,6 +130,7 @@ def test_config_defaults_for_new_write_vars(monkeypatch, tmp_path) -> None:
     """Empty defaults for the policy blocklist; sensible defaults for the rest."""
     for var in ["KB_WORKTREE_ROOT", "KB_PENDING_ROOT", "KB_PUSH_QUEUE_ROOT",
                 "KB_WRITE_BLOCK_TIERS", "KB_WRITE_BLOCK_PATHS", "KB_RATE_LIMIT_PER_HOUR",
+                "KB_GATE_CHECK_RATE_LIMIT_PER_HOUR",
                 "KB_PENDING_TIMEOUT_SEC", "KB_PENDING_QUEUE_CAP", "KB_WORKTREE_IDLE_SEC",
                 "KB_GIT_KEY_PATH"]:
         monkeypatch.delenv(var, raising=False)
@@ -143,6 +146,7 @@ def test_config_defaults_for_new_write_vars(monkeypatch, tmp_path) -> None:
     assert cfg.write_block_tiers == []
     assert cfg.write_block_paths == []
     assert cfg.rate_limit_per_hour == 100
+    assert cfg.gate_check_rate_limit_per_hour == 0
     assert cfg.pending_timeout_sec == 86400
     assert cfg.pending_queue_cap == 100
     assert cfg.worktree_idle_sec == 3600

--- a/tests/test_mcp_write_wiring.py
+++ b/tests/test_mcp_write_wiring.py
@@ -77,14 +77,41 @@ async def test_mcp_consult_rate_limited(tmp_git_kb: Path, tmp_path: Path) -> Non
 
 
 @pytest.mark.asyncio
-async def test_mcp_gate_check_rate_limited(tmp_git_kb: Path, tmp_path: Path) -> None:
+async def test_mcp_gate_check_not_rate_limited_by_default(
+    tmp_git_kb: Path, tmp_path: Path,
+) -> None:
+    """kb_gate_check must NOT share the write/consult limiter: it is the hook's
+    per-tool-action probe. Even with the write quota exhausted (rate_limit=0) and
+    no gate ceiling configured, gate_check is unthrottled."""
     app = _app_with_pipeline(tmp_git_kb, tmp_path, rate_limit_per_hour=0)
     async with Client(app) as client:
-        res = await client.call_tool("kb_gate_check", {
-            "workspace": "example-project", "session_id": "s",
-            "tool_name": "Edit",
+        for _ in range(3):
+            res = await client.call_tool("kb_gate_check", {
+                "workspace": "example-project", "session_id": "s",
+                "tool_name": "Edit",
+            })
+            assert "rejected_rate_limited" not in str(res)
+
+
+@pytest.mark.asyncio
+async def test_mcp_gate_check_rate_limited_when_ceiling_set(
+    tmp_git_kb: Path, tmp_path: Path,
+) -> None:
+    """With an explicit KB_GATE_CHECK_RATE_LIMIT_PER_HOUR backstop, gate_check
+    throttles at that ceiling (here 1/hour), independent of the write limiter."""
+    app = _app_with_pipeline(
+        tmp_git_kb, tmp_path, rate_limit_per_hour=1000,
+        gate_check_rate_limit_per_hour=1,
+    )
+    async with Client(app) as client:
+        first = await client.call_tool("kb_gate_check", {
+            "workspace": "example-project", "session_id": "s", "tool_name": "Edit",
         })
-        assert "rejected_rate_limited" in str(res)
+        second = await client.call_tool("kb_gate_check", {
+            "workspace": "example-project", "session_id": "s", "tool_name": "Edit",
+        })
+        assert "rejected_rate_limited" not in str(first)
+        assert "rejected_rate_limited" in str(second)
 
 
 @pytest.mark.asyncio

--- a/tests/test_rest_auth.py
+++ b/tests/test_rest_auth.py
@@ -527,6 +527,76 @@ async def test_consult_is_rate_limited(throttled_app) -> None:
     assert r3.json()["error"] == "rate_limited"
 
 
+@pytest.mark.asyncio
+async def test_gate_check_not_rate_limited_by_default(throttled_app) -> None:
+    """gate/check must NOT share the 2/hour write/consult quota: it is the hook's
+    once-per-tool-action probe, so a fixed quota self-DoSes a fleet. With no gate
+    ceiling configured it is unthrottled even well past the base limit."""
+    transport = httpx.ASGITransport(app=throttled_app, raise_app_exceptions=False)
+    payload = {"workspace": "/w", "session_id": "s", "tool_name": "Bash",
+               "action_diff": ""}
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        codes = [
+            (await client.post("/api/v1/gate/check", json=payload)).status_code
+            for _ in range(8)
+        ]
+    assert 429 not in codes, codes
+
+
+@pytest.mark.asyncio
+async def test_consult_still_limited_while_gate_check_is_not(throttled_app) -> None:
+    """The two limiters are independent: unbounded gate/check traffic does not
+    consume the consult quota, and consult is still throttled."""
+    transport = httpx.ASGITransport(app=throttled_app, raise_app_exceptions=False)
+    gate = {"workspace": "/w", "session_id": "s", "tool_name": "Bash", "action_diff": ""}
+    consult = {"workspace": "/w", "source_session": "s"}
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        for _ in range(5):
+            await client.post("/api/v1/gate/check", json=gate)
+        r1 = await client.post("/api/v1/consult", json=consult)
+        r2 = await client.post("/api/v1/consult", json=consult)
+        r3 = await client.post("/api/v1/consult", json=consult)
+    assert r1.status_code != 429
+    assert r2.status_code != 429
+    assert r3.status_code == 429
+
+
+@pytest.mark.asyncio
+async def test_gate_check_rate_limited_when_ceiling_configured(
+    tmp_kb, tmp_index_path, tmp_path
+) -> None:
+    """An operator can still opt into a backstop: with a positive
+    KB_GATE_CHECK_RATE_LIMIT_PER_HOUR, gate/check throttles at that ceiling,
+    independent of the (here generous) write/consult limit."""
+    env = {**os.environ, "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@e.com",
+           "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@e.com"}
+    subprocess.run(["git", "init", "--initial-branch=main"], cwd=tmp_kb, check=True, env=env)
+    subprocess.run(["git", "-C", str(tmp_kb), "add", "-A"], check=True, env=env)
+    subprocess.run(["git", "-C", str(tmp_kb), "commit", "-m", "init"], check=True, env=env)
+    app = build_app(
+        kb_main_path=tmp_kb, kb_index_path=tmp_index_path,
+        sync_interval_sec=60, staleness_degraded_sec=600, bootstrap_now=True,
+        kb_remote_url="dummy",
+        worktree_root=str(tmp_path / "wts"),
+        pending_root=str(tmp_path / "pending"),
+        push_queue_root=str(tmp_path / "pq"),
+        write_block_tiers=[], write_block_paths=[],
+        rate_limit_per_hour=1000,
+        gate_check_rate_limit_per_hour=2,
+    ).http_app()
+    transport = httpx.ASGITransport(app=app, raise_app_exceptions=False)
+    payload = {"workspace": "/w", "session_id": "s", "tool_name": "Bash",
+               "action_diff": ""}
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        r1 = await client.post("/api/v1/gate/check", json=payload)
+        r2 = await client.post("/api/v1/gate/check", json=payload)
+        r3 = await client.post("/api/v1/gate/check", json=payload)
+    assert r1.status_code != 429
+    assert r2.status_code != 429
+    assert r3.status_code == 429
+    assert r3.json()["error"] == "rate_limited"
+
+
 # ---------------------------------------------------------------------------
 # WP0b item 9: 400 on malformed numeric query params; 404 on unknown pending id.
 # ---------------------------------------------------------------------------

--- a/tests/test_server_config_wiring.py
+++ b/tests/test_server_config_wiring.py
@@ -34,6 +34,7 @@ def test_non_default_config_is_threaded_into_app(
     monkeypatch.setenv("KB_WRITE_BLOCK_TIERS", "T1,T2")
     monkeypatch.setenv("KB_WRITE_BLOCK_PATHS", "decisions/DEC-008-*.md")
     monkeypatch.setenv("KB_RATE_LIMIT_PER_HOUR", "42")
+    monkeypatch.setenv("KB_GATE_CHECK_RATE_LIMIT_PER_HOUR", "37")
     monkeypatch.setenv("KB_PENDING_TIMEOUT_SEC", "7200")
     monkeypatch.setenv("KB_PENDING_QUEUE_CAP", "25")
     monkeypatch.setenv("KB_WORKTREE_IDLE_SEC", "999")
@@ -50,6 +51,7 @@ def test_non_default_config_is_threaded_into_app(
     assert cfg.write_block_tiers == ["T1", "T2"]
     assert cfg.write_block_paths == ["decisions/DEC-008-*.md"]
     assert cfg.rate_limit_per_hour == 42
+    assert cfg.gate_check_rate_limit_per_hour == 37
     assert cfg.pending_timeout_sec == 7200
     assert cfg.pending_queue_cap == 25
     assert cfg.worktree_idle_sec == 999
@@ -65,6 +67,7 @@ def test_non_default_config_is_threaded_into_app(
 
     # All other non-default values reach state.config too.
     assert state.config.rate_limit_per_hour == 42
+    assert state.config.gate_check_rate_limit_per_hour == 37
     assert state.config.pending_timeout_sec == 7200
     assert state.config.pending_queue_cap == 25
     assert state.config.worktree_idle_sec == 999
@@ -107,6 +110,32 @@ def test_write_block_tiers_reach_blocklist(
 
     # confidence_threshold is threaded too.
     assert state.config.confidence_threshold == 0.7
+
+
+def test_gate_check_ceiling_reaches_gate_limiter_via_build_app_from_config(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, tmp_git_kb: Path
+) -> None:
+    """Regression: build_app_from_config must forward
+    KB_GATE_CHECK_RATE_LIMIT_PER_HOUR so a positive ceiling actually constructs
+    the separate gate limiter in production (it was dropped on the way to
+    build_app, silently ignoring the opt-in backstop)."""
+    monkeypatch.setenv("KB_MAIN_PATH", str(tmp_git_kb))
+    monkeypatch.setenv("KB_INDEX_PATH", str(tmp_path / "kb.db"))
+    monkeypatch.setenv("KB_REMOTE_URL", "git@github.com:example/repo.git")
+    monkeypatch.setenv("KB_GATE_CHECK_RATE_LIMIT_PER_HOUR", "5")
+    monkeypatch.setenv("KB_WORKTREE_ROOT", str(tmp_path / "worktrees"))
+    monkeypatch.setenv("KB_PENDING_ROOT", str(tmp_path / "pending"))
+    monkeypatch.setenv("KB_PUSH_QUEUE_ROOT", str(tmp_path / "push-queue"))
+
+    cfg = load_config()
+    assert cfg.gate_check_rate_limit_per_hour == 5
+    app = server.build_app_from_config(cfg, bootstrap_now=False)
+    state = app._dolympus_state  # type: ignore[attr-defined]
+
+    # The positive ceiling built a dedicated gate limiter, distinct from the
+    # write limiter (0 default would have left this None).
+    assert state.gate_rate_limiter is not None
+    assert state.gate_rate_limiter is not state.rate_limiter
 
 
 # ---------------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -465,7 +465,7 @@ wheels = [
 
 [[package]]
 name = "data-olympus"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Problem
Under multi-agent load, kn-dev returned sustained `429 Too Many Requests` on `POST /api/v1/gate/check`. That route is the enforcement hook's per-tool-action freshness probe (fires on every gated Edit/Write/Bash for every agent), but it shared the write/consult quota `KB_RATE_LIMIT_PER_HOUR` (default 100). Behind an ingress with no auth, every client collapses to one limiter bucket (ingress IP + `local` principal), so the 100/hour cap became a global fleet throttle and self-DoSed.

## Fix
gate/check (REST route and the `kb_gate_check` MCP tool) gets its own limiter, `KB_GATE_CHECK_RATE_LIMIT_PER_HOUR`, defaulting to **0 = unthrottled** — consistent with the read routes, since it does only cheap classification plus a freshness lookup and no writes. A positive value gives an explicit backstop. `consult` and `onboarding/cleanup-plan` remain throttled by `KB_RATE_LIMIT_PER_HOUR` (they write the ledger or are CPU-heavy).

## Tests
New REST + MCP tests: gate/check unthrottled by default even past the base quota; the two limiters are independent (unbounded gate/check does not consume consult quota); gate/check throttles when a ceiling is set; config parse + default. Updated the old `test_mcp_gate_check_rate_limited` which encoded the previous (buggy) shared-quota behavior. Full suite + ruff + mypy + changelog + doc-consistency green. docs/serving.md documents the new knob.

Note: kn-dev is already unblocked via a configmap bump (KB_RATE_LIMIT_PER_HOUR 100 -> 10000); this is the proper default-correct fix for everyone.