### PR TITLE
chore(release): v0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.3.2] - 2026-07-05
+
 ### Fixed
 
 - **`gate/check` no longer self-DoSes multi-agent fleets with 429s.** The
@@ -1027,7 +1029,8 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `docs/adoption.md`: bring-your-own-KB guide (author, lint, index, serve, wire an agent).
 - `docs/comparison.md`: how data-olympus relates to OKF, enterprise catalogs, markdown KB tools, agent-context conventions, RAG, and ADR tooling.
 
-[Unreleased]: https://github.com/knaisoma/data-olympus/compare/v0.3.1...HEAD
+[Unreleased]: https://github.com/knaisoma/data-olympus/compare/v0.3.2...HEAD
+[0.3.2]: https://github.com/knaisoma/data-olympus/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/knaisoma/data-olympus/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/knaisoma/data-olympus/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/knaisoma/data-olympus/compare/v0.1.1...v0.2.0

--- a/docs/releases/v0.3.2.md
+++ b/docs/releases/v0.3.2.md
@@ -1,0 +1,13 @@
+# v0.3.2
+
+## Fixed
+
+- Fixed a problem where the enforcement gate could return "too many requests"
+  (HTTP 429) once several coding agents were working against the same server at
+  once. The per-tool-action check that the gate runs shared a single hourly
+  budget with the heavier write operations, and behind a shared ingress every
+  agent drew from the same bucket, so a few busy agents could exhaust it in
+  minutes. That check now has its own budget, unlimited by default (matching the
+  read endpoints, since it does only light work and never writes), with an
+  optional cap for operators who want one. Everything else is unchanged from
+  0.3.1.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "data-olympus"
-version = "0.3.1"
+version = "0.3.2"
 description = "Governance-grade knowledge-base format (OKF-compatible) plus CLI and single-writer MCP server"
 readme = "README.md"
 requires-python = ">=3.13"


### PR DESCRIPTION
Patch release. Contains the single fix merged since v0.3.1:

- **gate/check no longer self-DoSes multi-agent fleets with 429s** (#101) — the enforcement hook's per-tool-action freshness probe shared the write/consult rate-limit quota; behind an ingress with no auth all agents collapsed to one bucket, so a low quota returned sustained 429s under multi-agent load. gate/check now has its own ceiling (KB_GATE_CHECK_RATE_LIMIT_PER_HOUR), unthrottled by default.

compute_release confirms: patch, next_version 0.3.2. CHANGELOG rolled, docs/releases/v0.3.2.md added, compare links updated. Merging tags v0.3.2 and runs the release chain (image + PyPI + GitHub Release).