### PR TITLE
fix(mcp): stop SSE session churn for long-lived clients (opencode web)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,25 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- **MCP streamable-HTTP session churn under long-lived clients.** A persistent
+  client (notably `opencode serve`) that holds the `GET /mcp` SSE stream open was
+  being forced to reconnect on a cycle, piling up abandoned transports on the
+  server and leaking event listeners on the client until it degraded. Two causes
+  addressed:
+  - The activity middleware now keeps a session non-idle for as long as its SSE
+    stream is actually open (re-stamping every `KB_SESSION_TOUCH_INTERVAL_SEC`,
+    default 30s, clamped to a third of the idle window), so the reaper evicts a
+    session only after its stream has genuinely closed. With that safety in
+    place, the idle-reap default (`KB_SESSION_IDLE_TIMEOUT_SEC`) drops from 1800s
+    to 300s, so an abandoned handshake is cleared in minutes instead of half an
+    hour.
+  - The shipped ingress manifest (`deploy/k8s/ingress.yaml`) now sets a long
+    `proxy-read-timeout`/`proxy-send-timeout` and disables buffering, so a proxy
+    with a short default idle timeout (nginx: 60s) no longer closes the SSE
+    stream and triggers the reconnect loop. See `docs/serving.md`.
+
 ## [0.3.2] - 2026-07-05
 
 ### Fixed

--- a/deploy/k8s/ingress.yaml
+++ b/deploy/k8s/ingress.yaml
@@ -13,7 +13,17 @@ kind: Ingress
 metadata:
   name: data-olympus-mcp
   namespace: data-olympus
-  # annotations:
+  annotations:
+    # The MCP streamable-HTTP transport holds a long-lived Server-Sent-Events
+    # stream (GET /mcp). An ingress/proxy whose read timeout is short (nginx's
+    # default is 60s) closes that idle stream, forcing clients to reconnect on
+    # that cadence; a persistent client like `opencode serve` then piles up
+    # transports server-side and leaks listeners client-side. Give the stream a
+    # long read timeout and disable response buffering so SSE events are flushed
+    # immediately. Adjust the annotation prefix for your ingress controller.
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-buffering: "off"
   #   cert-manager.io/cluster-issuer: letsencrypt-prod
 spec:
   # tls:

--- a/docs/serving.md
+++ b/docs/serving.md
@@ -23,6 +23,27 @@ each run their own stdio MCP process against the same git working tree, they
 race each other's worktrees and lock state. Streamable HTTP eliminates that
 race.
 
+### The long-lived SSE stream (proxy and session tuning)
+
+Each MCP client holds a long-lived `GET /mcp` Server-Sent-Events stream to
+receive server-to-client messages. Two things must be configured so that stream
+does not churn:
+
+- **Ingress/proxy read timeout.** A proxy that closes the idle stream (nginx's
+  default is 60s) forces the client to reconnect on that cadence. Each reconnect
+  creates a new transport server-side and, in a persistent client like
+  `opencode serve`, leaks event listeners. Set a long read timeout and disable
+  response buffering on the `/mcp` path (see `deploy/k8s/ingress.yaml` for the
+  nginx annotations).
+- **Session reaping.** FastMCP does not reap the transport a client leaves behind
+  when it disconnects without sending `DELETE`. The server runs its own reaper
+  (`session_metrics`): the activity middleware keeps a session non-idle for as
+  long as its SSE stream is open, and `KB_SESSION_IDLE_TIMEOUT_SEC` (default
+  `300`) terminates a session only after its stream has actually closed.
+  `KB_SESSION_TOUCH_INTERVAL_SEC` (default `30`, clamped to a third of the idle
+  window) sets how often an in-flight stream is re-stamped. `kb_health` /
+  `/api/v1/health` and a periodic log surface the live session count.
+
 ## Core configuration reference
 
 A few server-wide settings, beyond the feature-specific env vars documented in

--- a/src/data_olympus/config.py
+++ b/src/data_olympus/config.py
@@ -65,8 +65,15 @@ class Config:
     # Streamable-http session reaping: terminate transports idle beyond this many
     # seconds to bound _server_instances (see session_metrics). 0 disables the
     # reaper (observability-only). The scan runs every session_reap_interval_sec.
-    session_idle_timeout_sec: int = 1800
+    # An in-flight GET SSE stream is kept non-idle by the activity middleware, so
+    # this window only clears sessions whose stream has actually closed (an
+    # abandoned handshake); 5 minutes keeps those from piling up.
+    session_idle_timeout_sec: int = 300
     session_reap_interval_sec: int = 60
+    # How often the activity middleware re-stamps a session while its GET SSE
+    # stream is open, so a quiet-but-connected client is never reaped. Clamped
+    # below session_idle_timeout_sec at wiring time.
+    session_touch_interval_sec: int = 30
     # Optional override for the status-aware reranker's status->weight map
     # (issue #37). None means "use the Index built-in default map". A negative
     # weight boosts an in-force status, a positive one penalizes a retired one.
@@ -191,8 +198,9 @@ def load_config() -> Config:
     auth_principals = parse_principals_env(os.getenv("KB_AUTH_PRINCIPALS", ""))
     consult_ttl_sec = int(os.getenv("KB_CONSULT_TTL_SEC", "300"))
     ledger_path = os.getenv("KB_LEDGER_PATH", "/state/ledger.json")
-    session_idle_timeout_sec = int(os.getenv("KB_SESSION_IDLE_TIMEOUT_SEC", "1800"))
+    session_idle_timeout_sec = int(os.getenv("KB_SESSION_IDLE_TIMEOUT_SEC", "300"))
     session_reap_interval_sec = int(os.getenv("KB_SESSION_REAP_INTERVAL_SEC", "60"))
+    session_touch_interval_sec = int(os.getenv("KB_SESSION_TOUCH_INTERVAL_SEC", "30"))
     status_weights = _load_status_weights(os.getenv("KB_STATUS_WEIGHTS", ""))
     read_only = _env_bool(os.getenv("KB_READ_ONLY", ""))
     from data_olympus.cooccurrence import (
@@ -254,6 +262,7 @@ def load_config() -> Config:
         ledger_path=ledger_path,
         session_idle_timeout_sec=session_idle_timeout_sec,
         session_reap_interval_sec=session_reap_interval_sec,
+        session_touch_interval_sec=session_touch_interval_sec,
         status_weights=status_weights,
         read_only=read_only,
         cooccurrence_enabled=cooc_enabled,

--- a/src/data_olympus/server.py
+++ b/src/data_olympus/server.py
@@ -993,7 +993,9 @@ def main() -> None:
     _idle = config.session_idle_timeout_sec
     _touch_interval = float(config.session_touch_interval_sec)
     if _idle > 0:
-        _touch_interval = max(1.0, min(_touch_interval, _idle / 3))
+        # Always strictly below the idle window (>= 3 touches per window) even for
+        # a tiny idle value; a small positive floor avoids a zero/negative sleep.
+        _touch_interval = max(0.1, min(_touch_interval, _idle / 3))
     http_app = app.http_app(
         transport="streamable-http",
         middleware=[

--- a/src/data_olympus/server.py
+++ b/src/data_olympus/server.py
@@ -251,8 +251,9 @@ def build_app(
     audit_hmac_key: str = "",
     audit_max_bytes: int = 0,
     ledger_path: str | None = None,
-    session_idle_timeout_sec: int = 1800,
+    session_idle_timeout_sec: int = 300,
     session_reap_interval_sec: int = 60,
+    session_touch_interval_sec: int = 30,
     status_weights: dict[str, float] | None = None,
     read_only: bool = False,
     embeddings_enabled: bool = False,
@@ -300,6 +301,7 @@ def build_app(
         audit_max_bytes=audit_max_bytes,
         session_idle_timeout_sec=session_idle_timeout_sec,
         session_reap_interval_sec=session_reap_interval_sec,
+        session_touch_interval_sec=session_touch_interval_sec,
         status_weights=status_weights,
         read_only=read_only,
         embeddings_enabled=embeddings_enabled,
@@ -888,6 +890,7 @@ def build_app_from_config(config: Config, *, bootstrap_now: bool = True) -> Fast
         ledger_path=config.ledger_path,
         session_idle_timeout_sec=config.session_idle_timeout_sec,
         session_reap_interval_sec=config.session_reap_interval_sec,
+        session_touch_interval_sec=config.session_touch_interval_sec,
         status_weights=config.status_weights,
         read_only=config.read_only,
         embeddings_enabled=config.embeddings_enabled,
@@ -983,9 +986,23 @@ def main() -> None:
     )
 
     tracker = SessionActivityTracker()
+    # Re-stamp an in-flight SSE session at least 3x per idle window, so a
+    # quiet-but-connected client is never reaped even if an operator sets a short
+    # idle timeout. Falls back to the configured interval when the idle window is
+    # generous.
+    _idle = config.session_idle_timeout_sec
+    _touch_interval = float(config.session_touch_interval_sec)
+    if _idle > 0:
+        _touch_interval = max(1.0, min(_touch_interval, _idle / 3))
     http_app = app.http_app(
         transport="streamable-http",
-        middleware=[StarletteMiddleware(SessionActivityMiddleware, tracker=tracker)],
+        middleware=[
+            StarletteMiddleware(
+                SessionActivityMiddleware,
+                tracker=tracker,
+                touch_interval_sec=_touch_interval,
+            )
+        ],
     )
     # Health surfaces the live session count; the manager is only reachable once
     # the lifespan has started, so this returns None before then (never raises).

--- a/src/data_olympus/session_metrics.py
+++ b/src/data_olympus/session_metrics.py
@@ -45,6 +45,7 @@ these internals, discovery returns ``None`` and the count is reported as
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 import time
 from typing import TYPE_CHECKING, Any, Protocol
@@ -195,20 +196,61 @@ class SessionActivityTracker:
 
 class SessionActivityMiddleware:
     """ASGI middleware that stamps :class:`SessionActivityTracker` on each request
-    carrying an ``mcp-session-id`` header. Pure pass-through otherwise; adds no
-    latency beyond a header scan."""
+    carrying an ``mcp-session-id`` header.
 
-    def __init__(self, app: ASGIApp, tracker: SessionActivityTracker) -> None:
+    The ``GET /mcp`` Server-Sent-Events stream is a *single* long-lived request
+    that emits no further ASGI events while the session is quiet. Stamping only
+    at request start would let the idle reaper evict a still-connected client
+    after the idle window (forcing a reconnect, the exact churn that piles up
+    transports server-side and leaks listeners in a persistent client like
+    ``opencode serve``). So for an in-flight GET stream this middleware re-stamps
+    the session every ``touch_interval_sec`` for as long as the stream stays open;
+    when the client disconnects the request completes, re-stamping stops, and only
+    then does the session go idle and become reap-eligible. Short GET/POST
+    requests finish before the first tick, so they pay only the initial stamp.
+    """
+
+    def __init__(
+        self,
+        app: ASGIApp,
+        tracker: SessionActivityTracker,
+        *,
+        touch_interval_sec: float = 30.0,
+    ) -> None:
         self.app = app
         self._tracker = tracker
+        self._touch_interval = touch_interval_sec
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
-        if scope.get("type") == "http":
-            for key, value in scope.get("headers", []):
-                if key.lower() == _MCP_SESSION_ID_HEADER and value:
-                    self._tracker.touch(value.decode("latin-1"))
-                    break
-        await self.app(scope, receive, send)
+        if scope.get("type") != "http":
+            await self.app(scope, receive, send)
+            return
+        session_id = ""
+        for key, value in scope.get("headers", []):
+            if key.lower() == _MCP_SESSION_ID_HEADER and value:
+                session_id = value.decode("latin-1")
+                break
+        if not session_id:
+            await self.app(scope, receive, send)
+            return
+        self._tracker.touch(session_id)
+        # Only the long-lived GET SSE stream needs keep-alive re-stamping.
+        if scope.get("method") != "GET":
+            await self.app(scope, receive, send)
+            return
+
+        async def _keep_active() -> None:
+            while True:
+                await asyncio.sleep(self._touch_interval)
+                self._tracker.touch(session_id)
+
+        task = asyncio.create_task(_keep_active())
+        try:
+            await self.app(scope, receive, send)
+        finally:
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                await task
 
 
 async def reap_idle_sessions(

--- a/tests/test_server_config_wiring.py
+++ b/tests/test_server_config_wiring.py
@@ -40,6 +40,7 @@ def test_non_default_config_is_threaded_into_app(
     monkeypatch.setenv("KB_WORKTREE_IDLE_SEC", "999")
     monkeypatch.setenv("KB_SESSION_IDLE_TIMEOUT_SEC", "900")
     monkeypatch.setenv("KB_SESSION_REAP_INTERVAL_SEC", "45")
+    monkeypatch.setenv("KB_SESSION_TOUCH_INTERVAL_SEC", "17")
     monkeypatch.setenv("KB_GIT_KEY_PATH", "/tmp/test-key")
     # No KB_REMOTE_URL: write-pipeline objects are None when no remote is set.
     # We still get the config values threaded into state.config.
@@ -57,6 +58,7 @@ def test_non_default_config_is_threaded_into_app(
     assert cfg.worktree_idle_sec == 999
     assert cfg.session_idle_timeout_sec == 900
     assert cfg.session_reap_interval_sec == 45
+    assert cfg.session_touch_interval_sec == 17
     assert cfg.git_key_path == "/tmp/test-key"
 
     app = server.build_app_from_config(cfg, bootstrap_now=False)
@@ -72,6 +74,7 @@ def test_non_default_config_is_threaded_into_app(
     assert state.config.pending_queue_cap == 25
     assert state.config.worktree_idle_sec == 999
     assert state.config.session_idle_timeout_sec == 900
+    assert state.config.session_touch_interval_sec == 17
     assert state.config.session_reap_interval_sec == 45
     assert state.config.git_key_path == "/tmp/test-key"
     assert state.config.write_block_tiers == ["T1", "T2"]

--- a/tests/test_session_metrics.py
+++ b/tests/test_session_metrics.py
@@ -347,3 +347,69 @@ async def test_reaper_no_manager_is_noop() -> None:
     tracker = SessionActivityTracker()
     assert await reap_idle_sessions(app=None, tracker=tracker, idle_after_sec=30) == 0
     assert await reap_idle_sessions(app=object(), tracker=tracker, idle_after_sec=30) == 0
+
+
+# ---------------------------------------------------------------------------
+# In-flight SSE keep-alive: a quiet-but-connected GET stream must not be reaped
+# ---------------------------------------------------------------------------
+
+
+class _CountingTracker(SessionActivityTracker):
+    """Counts touch() calls so we can assert re-stamping without timing math."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.touch_count = 0
+
+    def touch(self, session_id: str, *, now: float | None = None) -> None:
+        self.touch_count += 1
+        super().touch(session_id, now=now)
+
+
+@pytest.mark.asyncio
+async def test_middleware_restamps_in_flight_get_sse_stream() -> None:
+    """A long-lived GET /mcp SSE request is re-stamped every touch interval while
+    open, so the idle reaper never evicts a still-connected client. Once the
+    stream closes, re-stamping stops."""
+    import asyncio
+
+    released = asyncio.Event()
+
+    class _HoldingApp:
+        async def __call__(self, _scope, _receive, _send) -> None:
+            await released.wait()  # simulate a held-open SSE stream
+
+    tracker = _CountingTracker()
+    mw = SessionActivityMiddleware(_HoldingApp(), tracker, touch_interval_sec=0.02)
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "headers": [(b"mcp-session-id", b"sse-1")],
+    }
+    task = asyncio.create_task(mw(scope, _noop_receive, _noop_send))
+    await asyncio.sleep(0.12)  # ~6 touch intervals
+
+    # Initial stamp plus several periodic re-stamps while the stream is open.
+    assert tracker.touch_count >= 3
+
+    released.set()
+    await task
+    settled = tracker.touch_count
+    await asyncio.sleep(0.06)
+    # No further stamps after the stream closed: the keep-alive task was cancelled.
+    assert tracker.touch_count == settled
+
+
+@pytest.mark.asyncio
+async def test_middleware_short_post_stamps_once_not_periodically() -> None:
+    """A short POST request finishes before the first tick, so it is stamped once
+    and does not spin up a keep-alive loop."""
+    tracker = _CountingTracker()
+    mw = SessionActivityMiddleware(_RecordingApp(), tracker, touch_interval_sec=0.02)
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "headers": [(b"mcp-session-id", b"post-1")],
+    }
+    await mw(scope, _noop_receive, _noop_send)
+    assert tracker.touch_count == 1

--- a/uv.lock
+++ b/uv.lock
@@ -465,7 +465,7 @@ wheels = [
 
 [[package]]
 name = "data-olympus"
-version = "0.3.1"
+version = "0.3.2"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Problem
The persistent `opencode serve` (web) process constantly failed to stay connected to data-olympus. Root cause was MCP streamable-HTTP **session churn**: the long-lived `GET /mcp` SSE stream kept getting closed and reconnected, which (a) piled up abandoned transports server-side and (b) leaked event listeners in the long-running client until it degraded (observed at 170% CPU / 3.3GB RAM, Node MaxListenersExceededWarning). Follow-up to #43, which added the reaper + instrumentation but left two gaps.

## Fixes
1. **In-flight SSE keep-alive.** `SessionActivityMiddleware` re-stamps a session every `KB_SESSION_TOUCH_INTERVAL_SEC` (default 30s, clamped to a third of the idle window) for as long as its GET SSE stream is open, so the idle reaper evicts a session only after its stream has genuinely closed. Previously a quiet-but-connected client was reaped at the idle window, forcing a reconnect.
2. **Shorter idle default.** With (1) protecting live streams, `KB_SESSION_IDLE_TIMEOUT_SEC` default drops 1800 -> 300, clearing abandoned handshakes in minutes.
3. **Ingress SSE keep-alive.** `deploy/k8s/ingress.yaml` sets `proxy-read-timeout`/`proxy-send-timeout=3600` and `proxy-buffering=off`, so an ingress with a short default (nginx 60s) stops closing the stream. Already applied to kn-dev separately.

## Tests
New: in-flight GET stream is re-stamped while open and stops on close; a short POST stamps once and spins up no loop; config parse + wiring for the touch interval through build_app_from_config. Full suite + ruff + mypy + guards green. docs/serving.md documents the proxy + session tuning.

Refs #43.