### PR TITLE
chore(release): v0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.3.3] - 2026-07-05
+
 ### Fixed
 
 - **MCP streamable-HTTP session churn under long-lived clients.** A persistent
@@ -1048,7 +1050,8 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `docs/adoption.md`: bring-your-own-KB guide (author, lint, index, serve, wire an agent).
 - `docs/comparison.md`: how data-olympus relates to OKF, enterprise catalogs, markdown KB tools, agent-context conventions, RAG, and ADR tooling.
 
-[Unreleased]: https://github.com/knaisoma/data-olympus/compare/v0.3.2...HEAD
+[Unreleased]: https://github.com/knaisoma/data-olympus/compare/v0.3.3...HEAD
+[0.3.3]: https://github.com/knaisoma/data-olympus/compare/v0.3.2...v0.3.3
 [0.3.2]: https://github.com/knaisoma/data-olympus/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/knaisoma/data-olympus/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/knaisoma/data-olympus/compare/v0.2.0...v0.3.0

--- a/docs/releases/v0.3.3.md
+++ b/docs/releases/v0.3.3.md
@@ -1,0 +1,11 @@
+# v0.3.3
+
+## Fixed
+
+- Fixed a problem where a long-running client (such as the OpenCode web service)
+  would repeatedly drop and re-open its connection to the server, slowly
+  degrading over time until it failed to stay connected. The server now keeps a
+  session marked active for as long as its live stream is open, so it only cleans
+  up connections that have genuinely gone away, and it does so promptly. The
+  shipped Kubernetes ingress also now keeps the long-lived stream open instead of
+  timing it out every minute. Everything else is unchanged from 0.3.2.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "data-olympus"
-version = "0.3.2"
+version = "0.3.3"
 description = "Governance-grade knowledge-base format (OKF-compatible) plus CLI and single-writer MCP server"
 readme = "README.md"
 requires-python = ">=3.13"


### PR DESCRIPTION
Patch release. Contains the single fix merged since v0.3.2:

- **MCP SSE session churn fixed** (#103) — long-lived clients (e.g. the OpenCode web service) no longer drop/reconnect on a cycle: the activity middleware keeps a session non-idle while its SSE stream is open (reaper evicts only genuinely-closed sessions; idle default 1800s->300s), and the shipped ingress keeps the stream open (proxy timeouts + buffering off). Refs #43.

compute_release confirms: patch, next_version 0.3.3. CHANGELOG rolled, docs/releases/v0.3.3.md added, compare links updated.