### PR TITLE
chore(release): v0.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,37 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.3.4] - 2026-07-05
+
+### Fixed
+
+- **Enforcement gate false-positives on prose that merely mentions a governed
+  keyword, for tool calls with a known file path.** `IntentClassifier.classify`
+  scanned `action_diff` (the raw Write/Edit content or Bash command text, up
+  to 4000 chars) for free-text keywords like `auth`, `rls`, `tenant`, `secret`
+  in addition to `intent`, for every tool call. A scratch write whose text
+  simply discussed one of those words as a topic - not an actual governed
+  action - tripped the pre-tool gate regardless of the real (ungoverned)
+  write target, and a fresh `kb_consult` call did not clear it because the
+  consult's own classification (`intent`-only) and the gate's classification
+  (`intent + action_diff`) disagreed on whether the action was governed.
+  Keyword matching on `action_diff` now only applies when the tool call
+  carries no `action_path` (Bash commands and OpenCode's `patch`, whose
+  content is the only signal available); when an `action_path` is present
+  (Write/Edit/MultiEdit), classification uses the path globs and dependency
+  command patterns, unchanged, so this keeps full detection for real governed
+  edits (a patch touching `package.json`) without flagging unrelated prose in
+  files the path globs don't consider governed. Found via a company-knowledge
+  KB audit session that reproduced it live (a scratch `.txt` file containing
+  "RLS tenant boundaries auth trust model" was blocked with no governed path
+  or command in sight); independently reviewed via `codex exec` before
+  release.
+  - The audit's other finding (CX1: the pre-tool gate and the pre-commit
+    `report --staged` gate resolving two different workspace keys) was
+    already fixed in v0.2.0 (#64, worktree-invariant workspace key); no
+    further change needed. It was still visible in that audit only because
+    it predated the deployed kn-dev redeploy.
+
 ## [0.3.3] - 2026-07-05
 
 ### Fixed

--- a/docs/releases/v0.3.4.md
+++ b/docs/releases/v0.3.4.md
@@ -1,0 +1,13 @@
+# v0.3.4
+
+## Fixed
+
+- Fixed a bug where the governance gate could block a file write or command
+  just because its text happened to mention a sensitive-sounding word (like
+  "auth" or "tenant"), even when nothing about the actual change needed
+  review. This was making the gate feel unpredictable: a harmless scratch
+  note could get blocked while the real target file was never at risk. The
+  gate still catches every case it's meant to (dependency changes, schema and
+  migration files, install commands, and shell/patch actions that have no
+  file name to check), it just no longer trips on unrelated prose in ordinary
+  files. Everything else is unchanged from 0.3.3.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "data-olympus"
-version = "0.3.3"
+version = "0.3.4"
 description = "Governance-grade knowledge-base format (OKF-compatible) plus CLI and single-writer MCP server"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/data_olympus/enforce_policy.py
+++ b/src/data_olympus/enforce_policy.py
@@ -81,7 +81,21 @@ class IntentClassifier:
         action_diff: str = "",
     ) -> ClassifyResult:
         signals: list[str] = []
-        text = f"{intent} {action_diff}".lower()
+        # Free-text keyword signals always scan `intent` (a short, deliberate
+        # statement of what the agent is about to do - kb_consult's argument -
+        # so a keyword there is a real signal). They scan `action_diff` too,
+        # but ONLY when there is no `action_path`: `action_diff` is arbitrary
+        # write/command CONTENT up to 4000 chars (Write.content, Edit.new_string,
+        # Bash.command, OpenCode patch text), and when a concrete action_path is
+        # already given, path-glob matching below is the intended signal for
+        # that action - layering the free-text net on top blocked benign writes
+        # to ungoverned files that merely discussed a keyword as a topic (a
+        # scratch file quoting "RLS"/"auth" from a security standard). Bash
+        # commands and OpenCode's `patch` tool carry no action_path at all
+        # (their action_diff IS the only content available), so the free-text
+        # net still applies there - dropping it entirely would silently lose
+        # the only governed-decision signal for those two tool shapes.
+        text = intent.lower() if action_path else f"{intent} {action_diff}".lower()
         for kw, rx in self._keyword_res:
             if rx.search(text):
                 signals.append(f"keyword:{kw}")

--- a/tests/test_enforce_classifier_hardening.py
+++ b/tests/test_enforce_classifier_hardening.py
@@ -25,3 +25,38 @@ def test_command_pattern_in_diff_is_governed() -> None:
 def test_plain_command_not_governed() -> None:
     c = IntentClassifier()
     assert c.classify(action_diff="ls -la && cat README.md").is_governed_decision is False
+
+
+def test_keyword_in_action_diff_is_not_governed_when_path_is_known() -> None:
+    """A Write/Edit to a concrete file (action_path present) is classified by
+    the path-glob check, not by free-text keywords in its content. A scratch
+    write whose text merely mentions a keyword (RLS, auth, tenant, ...) as
+    prose, to a file the path globs don't consider governed, must not trip
+    the gate - this was blocked regardless of the actual write target before
+    the fix."""
+    r = IntentClassifier().classify(
+        action_path="/tmp/scratch/bisect-test.txt",
+        action_diff="RLS tenant boundaries auth trust model",
+    )
+    assert r.is_governed_decision is False
+    assert r.signals == []
+
+
+def test_keyword_in_action_diff_still_governs_when_path_is_unknown() -> None:
+    """Bash commands and OpenCode's `patch` tool send no action_path at all -
+    action_diff is the only content available - so the free-text keyword net
+    still applies there; dropping it would silently lose the only signal for
+    those two tool shapes."""
+    r = IntentClassifier().classify(
+        action_diff="RLS tenant boundaries auth trust model"
+    )
+    assert r.is_governed_decision is True
+    assert any(s.startswith("keyword:") for s in r.signals)
+
+
+def test_keyword_in_intent_still_governs_regardless_of_action_diff() -> None:
+    r = IntentClassifier().classify(
+        intent="add a new auth library", action_diff="ls -la"
+    )
+    assert r.is_governed_decision is True
+    assert any(s.startswith("keyword:") for s in r.signals)

--- a/uv.lock
+++ b/uv.lock
@@ -465,7 +465,7 @@ wheels = [
 
 [[package]]
 name = "data-olympus"
-version = "0.3.2"
+version = "0.3.4"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Summary

Patches a data-olympus enforcement-gate bug found live during a company-knowledge KB audit session, and cuts v0.3.4.

- **Fix:** `IntentClassifier.classify` was scanning `action_diff` (raw Write/Edit content or Bash command text, up to 4000 chars) for free-text keywords (`auth`, `rls`, `tenant`, `secret`, ...) on every tool call. A scratch write or shell command that merely *discussed* one of those words as a topic - not an actual governed decision - tripped the pre-tool gate regardless of the real (ungoverned) write target, and a fresh `kb_consult` call could not clear it because consult's classification (`intent`-only) and the gate's classification (`intent + action_diff`) disagreed. Reproduced live: a scratch `.txt` write containing "RLS tenant boundaries auth trust model" was blocked with no governed path or command anywhere in sight.
- **Scope of the fix:** keyword scanning on `action_diff` now only applies when the tool call carries no `action_path` (Bash commands and OpenCode's `patch` tool, whose content is the only signal available). When an `action_path` is present (Write/Edit/MultiEdit), classification uses the existing path-glob and dependency-install command-pattern checks, unchanged - so a real governed edit (a patch touching `package.json`) is still caught, while prose in an ungoverned file no longer is.
- **Also investigated:** the same audit's other finding (the pre-tool gate and the pre-commit `report --staged` gate resolving two different workspace keys) was traced and confirmed already fixed by #64 (worktree-invariant workspace key, merged 2026-07-03); no code change needed there. It was only still visible in that audit because it predated a kn-dev redeploy.
- Independently reviewed via `codex exec` before finalizing (confirmed the #64 finding, flagged that an earlier draft of this fix would have dropped real signal for OpenCode's path-less `patch` tool - the path-aware scoping above addresses that).

## Test plan

- [x] `uv run pytest` - full suite green (2 pre-existing unrelated skips)
- [x] `uv run ruff check .` - clean
- [x] `uv run mypy src` - clean
- [x] `bats -r tests` - all 66 enforcement bats cases pass (1 pre-existing unrelated warning, reproduced identically on `main`)
- [x] New regression tests: keyword-in-content is not governed when a path is known and ungoverned; keyword-in-content still governs when no path is available (Bash/patch)
- [x] Live-verified against the deployed kn-dev gate: consult + commit for this change itself went through the real enforcement gate end-to-end