### PR TITLE
chore(release): v0.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,34 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.3.5] - 2026-07-06
+
+### Fixed
+
+- **Ambiguous rejection reason for writes outside the deployment's indexed
+  prefixes.** `kb_propose_edit` (and `kb_propose_memory`) rejected a
+  well-formed, non-malicious path outside `KB_INDEXED_PREFIXES` with the same
+  opaque reason string (`traversal_or_excluded` / `not_md_or_excluded`) used
+  for an actual traversal or control-character attempt. A syntactically fine
+  path outside the configured prefixes is an ordinary deployment-configuration
+  fact, not a structural or security rejection - conflating the two sent an
+  operator hunting for a nonexistent traversal bug during a company-knowledge
+  KB audit session (`operator/laptop.md`, readable and indexed for search,
+  came back rejected on write with no indication it was simply outside the
+  deployment's writable-prefix allowlist). `rejected_path_not_indexable`
+  responses (and audit events) now carry a specific reason:
+  `structurally_invalid` (empty/control-chars/absolute/traversal/excluded
+  segment), `not_markdown`, or `not_in_indexed_prefixes`.
+- Investigated the same session's second report (a `rejected_stale_base`
+  resolve appearing to "leak" its path lock) and confirmed it is **not a
+  bug**: `restore_resolve` deliberately keeps the path lock held after a
+  gate rejection so the operator's still-pending proposal can't be clobbered
+  by a concurrent write to the same path (documented behavior, hardened
+  across multiple rounds of review). `reject`ing the stale entry (which does
+  release the lock) and re-proposing fresh, exactly what that session did, is
+  the correct and only intended recovery for a pending entry with a
+  permanently-wrong base marker - there was nothing to fix.
+
 ## [0.3.4] - 2026-07-05
 
 ### Fixed

--- a/docs/releases/v0.3.5.md
+++ b/docs/releases/v0.3.5.md
@@ -1,0 +1,11 @@
+# v0.3.5
+
+## Fixed
+
+- Fixed a confusing error when a write was rejected for being outside the
+  deployment's configured writable folders. It used to look identical to a
+  security rejection (like a path-traversal attempt), so a perfectly normal,
+  well-formed request could send someone hunting for a bug that wasn't there.
+  The rejection now says specifically whether the path just isn't in the
+  writable list, isn't a markdown file, or is genuinely malformed. Everything
+  else is unchanged from 0.3.4.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "data-olympus"
-version = "0.3.4"
+version = "0.3.5"
 description = "Governance-grade knowledge-base format (OKF-compatible) plus CLI and single-writer MCP server"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/data_olympus/auth.py
+++ b/src/data_olympus/auth.py
@@ -95,6 +95,32 @@ def is_writable_path(target_path: str) -> bool:
     return any(canonical.startswith(p) for p in indexed_prefixes())
 
 
+def path_rejection_reason(raw_target_path: str) -> str:
+    """Why a path fails :func:`is_writable_path`, for a caller that already knows
+    it does. Three distinct causes were previously collapsed into one opaque
+    reason string (``not_md_or_excluded`` / ``traversal_or_excluded``), which
+    reads identically whether the path was a malicious traversal attempt or a
+    perfectly legitimate path outside the deployment's configured
+    ``KB_INDEXED_PREFIXES`` - the latter is an ordinary, expected outcome for any
+    deployment whose repo layout has top-level directories beyond the generic
+    default (see ``indexed_prefixes()``), not a security event, and conflating
+    the two sent at least one operator hunting for a traversal bug that was
+    actually a missing ``KB_INDEXED_PREFIXES`` entry.
+
+    Returns one of: ``structurally_invalid`` (empty/control-chars/absolute/
+    traversal/excluded-segment - :func:`normalize_target_path` rejected it),
+    ``not_markdown``, or ``not_in_indexed_prefixes`` (a syntactically fine path
+    outside every configured prefix - a deployment-configuration gap, not a
+    structural or security rejection).
+    """
+    canonical = normalize_target_path(raw_target_path)
+    if canonical is None:
+        return "structurally_invalid"
+    if not canonical.endswith(".md"):
+        return "not_markdown"
+    return "not_in_indexed_prefixes"
+
+
 def safe_join_under_root(root: str, target_path: str) -> str | None:
     """Join ``target_path`` under ``root`` and return the absolute path only when
     it resolves to exactly that lexical location inside ``root``; else return None.

--- a/src/data_olympus/tools_write.py
+++ b/src/data_olympus/tools_write.py
@@ -15,6 +15,7 @@ from data_olympus.auth import (
     PathBlocklist,
     is_writable_path,
     normalize_target_path,
+    path_rejection_reason,
     safe_join_under_root,
 )
 from data_olympus.format.frontmatter import parse_frontmatter
@@ -486,11 +487,12 @@ def kb_propose_memory_fn(
 
     # 1. Structural rule (cheap).
     if not is_writable_path(target_path):
+        reason = path_rejection_reason(target_path)
         _emit_audit(audit_log, **{**audit_base, "status": "rejected_path_not_indexable",
-                                   "reason": "not_md_or_excluded"})
+                                   "reason": reason})
         return ProposeResponse(
             status="rejected_path_not_indexable",
-            reason="not_md_or_excluded",
+            reason=reason,
             target_path=target_path,
         )
 
@@ -657,9 +659,15 @@ def kb_propose_edit_fn(
     }
     canonical = normalize_target_path(target_path)
     if canonical is None or not is_writable_path(canonical):
-        _emit_audit(audit_log, **{**audit_base, "status": "rejected_path_not_indexable"})
+        # audit_base["reason"] otherwise carries the caller's edit rationale;
+        # for this terminal rejection (nothing is written) it is overwritten
+        # with the machine rejection cause instead, since that is what an
+        # operator reading the audit log needs to see here.
+        rejection_reason = path_rejection_reason(target_path)
+        _emit_audit(audit_log, **{**audit_base, "status": "rejected_path_not_indexable",
+                                   "reason": rejection_reason})
         return ProposeResponse(status="rejected_path_not_indexable",
-                               reason="traversal_or_excluded",
+                               reason=rejection_reason,
                                target_path=target_path)
     # From here on operate ONLY on the canonical path: classification, blocklist,
     # the pending record, the filesystem join, and ``git add`` must all agree with

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -5,6 +5,7 @@ from data_olympus.auth import (
     PathBlocklist,
     is_writable_path,
     normalize_target_path,
+    path_rejection_reason,
 )
 
 # ---- Structural rule (Codex blocker 2 fix: path traversal rejected) ----
@@ -36,6 +37,35 @@ def test_structural_rule_rejects_structurally_excluded_dir() -> None:
 
 def test_structural_rule_rejects_traversal_double_dot() -> None:
     assert is_writable_path("projects/foo/../../memory/x.md") is False
+
+
+# ---- path_rejection_reason: distinguish WHY a path was rejected. Previously a
+# single opaque reason ("not_md_or_excluded" / "traversal_or_excluded") covered
+# both a malicious traversal attempt and a perfectly ordinary path that is just
+# outside this deployment's KB_INDEXED_PREFIXES - the latter is a deployment
+# config gap, not a structural/security rejection, and conflating them misled an
+# operator into diagnosing a nonexistent traversal bug. ----
+
+
+def test_rejection_reason_for_legitimate_path_outside_indexed_prefixes() -> None:
+    # "operator/" is syntactically fine (no traversal, valid .md) but is not one
+    # of the DEFAULT_INDEXED_PREFIXES - a deployment-configuration gap.
+    assert path_rejection_reason("operator/laptop.md") == "not_in_indexed_prefixes"
+
+
+def test_rejection_reason_for_non_markdown() -> None:
+    assert path_rejection_reason("universal/foundation/STD-U-001.txt") == "not_markdown"
+
+
+def test_rejection_reason_for_traversal() -> None:
+    assert (
+        path_rejection_reason("projects/foo/../../memory/x.md")
+        == "structurally_invalid"
+    )
+
+
+def test_rejection_reason_for_absolute_path() -> None:
+    assert path_rejection_reason("/etc/passwd.md") == "structurally_invalid"
 
 
 def test_structural_rule_rejects_absolute_path() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -465,7 +465,7 @@ wheels = [
 
 [[package]]
 name = "data-olympus"
-version = "0.3.4"
+version = "0.3.5"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Summary

Patches a second data-olympus finding from the same company-knowledge KB audit session (v0.3.4 fixed the first), and cuts v0.3.5.

- **Fix:** `kb_propose_edit` and `kb_propose_memory` rejected any path outside the deployment's `KB_INDEXED_PREFIXES` with the same opaque reason string (`traversal_or_excluded` / `not_md_or_excluded`) used for an actual path-traversal or control-character attempt. A syntactically fine path outside the configured prefixes is an ordinary deployment-config fact, not a structural or security rejection - conflating the two sent the audit session hunting for a nonexistent traversal bug when `operator/laptop.md` (a legitimate, readable, indexed-for-search path) came back rejected on write. `rejected_path_not_indexable` responses (and audit events) now carry a specific reason: `structurally_invalid`, `not_markdown`, or `not_in_indexed_prefixes`.
- **Also investigated, confirmed NOT a bug:** the same session reported a `rejected_stale_base` resolve appearing to "leak" its path lock (stuck `path_locks_held: 1` until the pending entry was rejected). Traced to `pending.py`'s `restore_resolve`, which deliberately keeps the path lock held after a gate rejection so the pending proposal can't be clobbered by a concurrent write to the same path - documented behavior, hardened across multiple prior review rounds. Reject-then-repropose (what that session did) is the correct, intended recovery for a permanently-stale base marker. No code change for this one.
- **Root cause of the actual outage the audit hit:** the kn-dev deployment's `KB_INDEXED_PREFIXES` was never set, so it fell back to the generic default (no `operator/`). Already patched live on kn-dev (added `operator/`, `audits/`, `plans/`, `workforce/`, plus `KB_MEMORY_INBOX_PREFIX=operator/memory/inbox/`) and verified `operator/laptop.md` is now writable - this code fix only makes the *next* such deployment-config gap legible instead of looking like a security bug, it doesn't itself fix kn-dev.
- Independently reviewed via `codex exec` before finalizing - confirmed the reason split is correct and complete, confirmed the lock-hold finding is not a defect, and flagged one nit (the audit log's `reason` field switches meaning from "caller's edit rationale" to "rejection cause" on this specific terminal-rejection path) which is now documented with a code comment.

## Test plan

- [x] `uv run pytest` - full suite green (2 pre-existing unrelated skips)
- [x] `uv run ruff check .` - clean
- [x] `uv run mypy src` - clean
- [x] `bats -r tests` - all 66 enforcement bats cases pass (1 pre-existing unrelated warning)
- [x] New regression tests in `tests/test_auth.py` covering all three `path_rejection_reason` outcomes
- [x] Live-verified against the deployed kn-dev gate: `operator/laptop.md` writability confirmed via direct pod exec before and after the ConfigMap patch