### PR TITLE
feat(cli): add init bundle scaffold subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,20 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **`data-olympus init <dir>` bundle scaffold command** (issue #66). Creates a
+  new knowledge bundle: the tier directories (`--tiers`, default `universal,
+  tech-stacks,projects,decisions,workflows,tooling`), a root `index.md`
+  carrying the `spec_version`/`okf_version` frontmatter, a `template.md`
+  authoring scaffold, and one example concept document per SPEC-supported
+  `type` (`standard`, `decision`, `workflow`, `project`, `memory`,
+  `reference`), including a real `superseded`/`superseded_by`/`supersedes`
+  pair and `applies_when` trigger metadata. The generated bundle passes
+  `data-olympus lint` with zero errors and zero warnings and builds cleanly
+  under `data-olympus index`. Refuses to scaffold into a non-empty directory
+  (no `--force` in this slice).
+
 ## [0.3.5] - 2026-07-06
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,17 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   under `data-olympus index`. Refuses to scaffold into a non-empty directory
   (no `--force` in this slice).
 
+### Fixed
+
+- **`data-olympus index` silently regenerated zero indexes for a bundle whose
+  absolute path passes through a skip-named ancestor** (found in companion
+  review of the `init` scaffold). `regenerate_indexes` matched skip-directory
+  names (`.git`, `.venv`, `node_modules`, ...) against the bundle's absolute
+  path components instead of the bundle-relative ones, so a bundle located
+  under e.g. a `.venv/` or `node_modules/` parent produced "wrote 0 index.md
+  file(s)" with no error. Skip matching is now relative to the bundle root,
+  matching `discover_bundle_files` in the lint pipeline.
+
 ## [0.3.5] - 2026-07-06
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -31,11 +31,14 @@ uv venv && uv pip install -e '.[dev]'
 # Lint the example bundle
 uv run data-olympus lint example-bundle
 
+# ...or scaffold your own bundle instead of copying example-bundle/
+uv run data-olympus init my-kb
+
 # Start the MCP server against the example bundle
 ./scripts/run-local.sh
 ```
 
-See `docs/quickstart.md` for the full local-run walkthrough, including curl and `kb` CLI queries.
+See `docs/quickstart.md` for the full local-run walkthrough, including curl and `kb` CLI queries. See `docs/adoption.md` for the full bundle-authoring guide.
 
 ## Documentation
 

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -21,6 +21,25 @@ command in this guide works with either approach; the examples below use
 A bundle is a directory of markdown files with YAML frontmatter. The layout
 mirrors `example-bundle/` in this repo.
 
+### Scaffolding a fresh bundle
+
+Instead of copying `example-bundle/` by hand, scaffold a new bundle with:
+
+```bash
+uv run data-olympus init <dir>
+```
+
+This creates the tier directories (`--tiers`, default `universal,tech-stacks,
+projects,decisions,workflows,tooling`), a root `index.md` carrying the
+`spec_version`/`okf_version` frontmatter, a `template.md` authoring scaffold,
+and one example document per supported `type` (`standard`, `decision`,
+`workflow`, `project`, `memory`, `reference`) — including a real
+`superseded`/`superseded_by`/`supersedes` pair and `applies_when` trigger
+metadata, so `data-olympus lint`, `data-olympus index`, and `kb search` all
+have something to demo against immediately. The command refuses to write into
+a non-empty directory. Scaffold a subset of tiers with, for example,
+`--tiers decisions,workflows`.
+
 ### Required frontmatter fields
 
 Every concept file (every `.md` file that is not `index.md`, `log.md`, or

--- a/src/data_olympus/cli/indexgen.py
+++ b/src/data_olympus/cli/indexgen.py
@@ -13,7 +13,13 @@ _SKIP = {".git", "__pycache__", ".venv", ".pytest_cache", ".ruff_cache", "node_m
 def _dirs_with_markdown(root: Path) -> list[Path]:
     dirs: set[Path] = set()
     for md in root.rglob("*.md"):
-        if any(part in _SKIP for part in md.parts):
+        # Match skip-dirs only among components INSIDE the bundle. Matching
+        # the absolute path would silently skip the whole bundle whenever an
+        # ancestor directory happens to be named like a skip-dir (e.g. a
+        # bundle scaffolded under a `.venv/` or `node_modules/` parent),
+        # regenerating zero indexes. Same discipline as
+        # `discover_bundle_files` in format/lint.py.
+        if any(part in _SKIP for part in md.relative_to(root).parts):
             continue
         if md.name in _RESERVED:
             continue

--- a/src/data_olympus/cli/init_cmd.py
+++ b/src/data_olympus/cli/init_cmd.py
@@ -1,0 +1,44 @@
+"""`data-olympus init <dir>`: scaffold a new knowledge bundle (issue #66)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from data_olympus.scaffold import ALL_TIERS, ScaffoldError, scaffold_bundle
+
+if TYPE_CHECKING:
+    import argparse
+
+
+def _cmd_init(args: argparse.Namespace) -> int:
+    tiers = args.tiers.split(",") if args.tiers else None
+    try:
+        result = scaffold_bundle(Path(args.dir), tiers=tiers)
+    except ScaffoldError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    print(
+        f"scaffolded {result.root} "
+        f"(tiers: {', '.join(result.tiers)}; "
+        f"{len(result.files_written)} file(s) written, "
+        f"{len(result.indexes_written)} index(es) generated)"
+    )
+    return 0
+
+
+def add_init_subparser(sub: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
+    """Register the ``init`` subcommand on the CLI's subparser action."""
+    p = sub.add_parser(
+        "init",
+        help="scaffold a new knowledge bundle: tier directories, root index.md, "
+        "template.md, and one example document per supported concept type",
+    )
+    p.add_argument("dir", help="bundle directory to create (created if missing)")
+    p.add_argument(
+        "--tiers", default=None,
+        help="comma-separated subset of tier directories to scaffold "
+        f"(default: all of {', '.join(ALL_TIERS)})",
+    )
+    p.set_defaults(func=_cmd_init)

--- a/src/data_olympus/cli/main.py
+++ b/src/data_olympus/cli/main.py
@@ -137,6 +137,8 @@ def build_parser() -> argparse.ArgumentParser:
     p_report.set_defaults(func=_cmd_report)
     from data_olympus.cli.import_cmd import add_import_subparser
     add_import_subparser(sub)
+    from data_olympus.cli.init_cmd import add_init_subparser
+    add_init_subparser(sub)
     return parser
 
 

--- a/src/data_olympus/scaffold.py
+++ b/src/data_olympus/scaffold.py
@@ -1,0 +1,386 @@
+"""`data-olympus init`: scaffold a new knowledge bundle (issue #66).
+
+Generates the tier directories, a root ``index.md`` carrying the format-version
+frontmatter, an authoring ``template.md``, and one example concept document per
+SPEC-supported ``type`` (including ``memory`` and ``reference``, which the
+hand-authored ``example-bundle/`` historically lacked). The generated
+supersession pair and ``applies_when`` metadata are real, not decorative: they
+are exactly what `SPEC.md` section 4.2 documents and what `kb search` demos
+depend on, so a freshly scaffolded bundle demonstrates those features without
+any hand-authoring.
+
+The generated bundle is lint-clean by construction (see `format/validate.py`):
+every concept document carries all four required fields plus every
+recommended field, so `data-olympus lint` reports zero errors and zero
+warnings on a fresh scaffold.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from data_olympus.cli.indexgen import regenerate_indexes
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+SPEC_VERSION = "0.1"
+OKF_VERSION = "0.1"
+
+# The six top-level tier directories `--tiers` selects among (issue #66's
+# sketch). Order is both the CLI default and the order tiers are scaffolded
+# and listed in the root index.
+ALL_TIERS: tuple[str, ...] = (
+    "universal", "tech-stacks", "projects", "decisions", "workflows", "tooling",
+)
+DEFAULT_TIERS: tuple[str, ...] = ALL_TIERS
+
+
+class ScaffoldError(Exception):
+    """Raised for a refused or invalid `init` invocation. Message is user-facing."""
+
+
+@dataclass(frozen=True)
+class ScaffoldResult:
+    root: Path
+    tiers: tuple[str, ...]
+    files_written: tuple[Path, ...]
+    indexes_written: tuple[Path, ...]
+
+
+def _validate_tiers(tiers: Sequence[str] | None) -> tuple[str, ...]:
+    if tiers is None:
+        return DEFAULT_TIERS
+    selected: list[str] = []
+    for raw in tiers:
+        name = raw.strip()
+        if not name:
+            continue
+        if name not in ALL_TIERS:
+            raise ScaffoldError(
+                f"unknown tier '{name}' (allowed: {', '.join(ALL_TIERS)})"
+            )
+        if name not in selected:
+            selected.append(name)
+    if not selected:
+        raise ScaffoldError("--tiers produced an empty tier list")
+    return tuple(selected)
+
+
+def _prepare_dest(dest: Path) -> None:
+    if dest.exists():
+        if not dest.is_dir():
+            raise ScaffoldError(f"{dest} exists and is not a directory")
+        if any(dest.iterdir()):
+            raise ScaffoldError(
+                f"{dest} is not empty; refusing to scaffold into an existing "
+                "directory (no --force in this slice)"
+            )
+    else:
+        dest.mkdir(parents=True)
+
+
+def _write(path: Path, content: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def _doc(
+    *,
+    id_: str,
+    type_: str,
+    status: str,
+    tier: str,
+    title: str,
+    description: str,
+    tags: list[str],
+    timestamp: str,
+    body: str,
+    applies_when: list[str] | None = None,
+    supersedes: list[str] | None = None,
+    superseded_by: str | None = None,
+) -> str:
+    lines = [
+        "---",
+        f"id: {id_}",
+        f"type: {type_}",
+        f"status: {status}",
+        f"tier: {tier}",
+        f"title: {title}",
+        f"description: {description}",
+        f"tags: [{', '.join(tags)}]",
+        f'timestamp: "{timestamp}"',
+    ]
+    if supersedes:
+        lines.append(f"supersedes: [{', '.join(supersedes)}]")
+    if superseded_by:
+        lines.append(f"superseded_by: {superseded_by}")
+    if applies_when:
+        lines.append("applies_when:")
+        lines.extend(f'  - "{phrase}"' for phrase in applies_when)
+    lines.append("---")
+    return "\n".join(lines) + "\n" + body.rstrip() + "\n"
+
+
+def _root_index(selected: tuple[str, ...]) -> str:
+    tier_lines = "\n".join(f"- `{t}/`" for t in selected)
+    return (
+        "---\n"
+        f'spec_version: "{SPEC_VERSION}"\n'
+        f'okf_version: "{OKF_VERSION}"\n'
+        "---\n"
+        "# Knowledge bundle\n\n"
+        "Scaffolded by `data-olympus init`. This bundle demonstrates every "
+        "SPEC-supported concept `type` (`standard`, `decision`, `workflow`, "
+        "`project`, `memory`, `reference`), a real `superseded` / "
+        "`superseded_by` / `supersedes` chain, and `applies_when` retrieval "
+        "trigger metadata, so `kb search` and `kb lint` both have something "
+        "to demo against out of the box. Replace the example documents with "
+        "your own content; delete the ones you don't need.\n\n"
+        "Run `data-olympus lint .` after editing, and `data-olympus index .` "
+        "to regenerate the per-directory `index.md` navigation files.\n\n"
+        "## Tier directories in this bundle\n\n"
+        f"{tier_lines}\n\n"
+        "See [template.md](template.md) for the frontmatter fields a new "
+        "concept document needs, and `SPEC.md` in the data-olympus repo for "
+        "the full format specification.\n"
+    )
+
+
+def _template_doc() -> str:
+    # template.md is a reserved filename (format/validate.py RESERVED): it is
+    # exempt from the concept schema, so the placeholder values below are
+    # never linted. It exists purely as an authoring aid.
+    return (
+        "---\n"
+        "id: <STABLE-ID>                # e.g. STD-U-001, ADR-007; decoupled from path\n"
+        "type: <standard|decision|workflow|project|memory|reference>\n"
+        "status: <draft|active|deprecated|superseded|proposed|accepted|rejected>\n"
+        "tier: <T1|T2|T3|T4|meta>\n"
+        "title: <short human-readable name>\n"
+        "description: <one or two sentences; used in generated indexes and search>\n"
+        "tags: [<lowercase>, <keywords>]\n"
+        'timestamp: "<YYYY-MM-DD>"\n'
+        "applies_when:                  # recommended for standard/decision docs\n"
+        '  - "<coding intent this document governs, e.g. writing a migration>"\n'
+        "# supersedes: [<ID>]           # optional: IDs this document replaces\n"
+        "# superseded_by: <ID>          # optional: set when status is superseded\n"
+        "# owner: <team-or-individual>  # optional\n"
+        "---\n\n"
+        "# <Title>\n\n"
+        "## Purpose\n\n"
+        "What this concept governs and why it exists.\n\n"
+        "## Rule / Content\n\n"
+        "The actual guidance, decision, workflow steps, or reference material.\n\n"
+        "## See also\n\n"
+        "Links to related concepts, using bundle-relative paths.\n"
+    )
+
+
+def _write_universal_tier(dest: Path) -> list[Path]:
+    base = dest / "universal" / "foundation"
+    old = _doc(
+        id_="STD-INIT-001", type_="standard", status="superseded", tier="T1",
+        title="Example Standard (superseded)",
+        description=(
+            "Placeholder standard superseded by STD-INIT-002. Demonstrates the "
+            "superseded/superseded_by chain; replace with your own content."
+        ),
+        tags=["example", "superseded"], timestamp="2026-01-01",
+        superseded_by="STD-INIT-002",
+        body=(
+            "# Example superseded standard\n\n"
+            "This document demonstrates the `superseded` / `superseded_by` chain "
+            "`data-olympus` tracks (see `SPEC.md` section 4.2). It is superseded "
+            "by [STD-INIT-002](STD-INIT-002-example-standard.md).\n\n"
+            "Replace both documents with your own standards once you have real "
+            "ones to record, or delete them.\n"
+        ),
+    )
+    new = _doc(
+        id_="STD-INIT-002", type_="standard", status="active", tier="T1",
+        title="Example Standard (current)",
+        description=(
+            "Placeholder active standard that supersedes STD-INIT-001. "
+            "Demonstrates applies_when trigger metadata; replace with your own content."
+        ),
+        tags=["example"], timestamp="2026-01-01",
+        supersedes=["STD-INIT-001"],
+        applies_when=[
+            "writing a new standard or policy document",
+            "deciding whether to supersede an existing standard",
+        ],
+        body=(
+            "# Example active standard\n\n"
+            "This document supersedes "
+            "[STD-INIT-001](STD-INIT-001-example-standard.md) and demonstrates "
+            "`applies_when`, the highest-weight indexed field in full-text "
+            "search (see `SPEC.md` section 4.2). Replace this content with "
+            "your team's actual standard.\n"
+        ),
+    )
+    return [
+        _write(base / "STD-INIT-001-example-standard.md", old),
+        _write(base / "STD-INIT-002-example-standard.md", new),
+    ]
+
+
+def _write_tech_stacks_tier(dest: Path) -> list[Path]:
+    base = dest / "tech-stacks" / "example-stack"
+    doc = _doc(
+        id_="STD-INIT-STACK-001", type_="standard", status="active", tier="T2",
+        title="Example Stack Convention",
+        description=(
+            "Placeholder stack-specific convention; replace with a real "
+            "tech-stack standard."
+        ),
+        tags=["example", "tech-stack"], timestamp="2026-01-01",
+        body=(
+            "# Example stack convention\n\n"
+            "Stack-specific standards (tier `T2`) live under `tech-stacks/"
+            "<stack-name>/`, one directory per stack. Replace this file with "
+            "your stack's actual conventions.\n"
+        ),
+    )
+    return [_write(base / "STD-INIT-STACK-001-example-convention.md", doc)]
+
+
+def _write_projects_tier(dest: Path) -> list[Path]:
+    base = dest / "projects" / "example-project"
+    doc = _doc(
+        id_="PROJ-INIT-example-project", type_="project", status="active", tier="T3",
+        title="Example Project",
+        description=(
+            "Placeholder project-scoped concept; replace with your actual "
+            "project's knowledge."
+        ),
+        tags=["example", "project"], timestamp="2026-01-01",
+        body=(
+            "# Example project\n\n"
+            "Project-scoped concepts (tier `T3`) live under `projects/"
+            "<project-name>/`; component-scoped concepts (tier `T4`) live under "
+            "`projects/<project-name>/components/<component-name>/`. Replace "
+            "this file with your actual project overview.\n"
+        ),
+    )
+    return [_write(base / "README.md", doc)]
+
+
+def _write_decisions_tier(dest: Path) -> list[Path]:
+    base = dest / "decisions"
+    doc = _doc(
+        id_="ADR-INIT-001", type_="decision", status="accepted", tier="meta",
+        title="Example Architectural Decision",
+        description="Placeholder decision record; replace with a real ADR.",
+        tags=["example", "architecture"], timestamp="2026-01-01",
+        body=(
+            "# Context\n\n"
+            "Describe the problem that prompted this decision.\n\n"
+            "# Decision\n\n"
+            "State the decision made.\n\n"
+            "# Consequences\n\n"
+            "Describe the tradeoffs accepted. Replace this placeholder with a "
+            "real ADR.\n"
+        ),
+    )
+    return [_write(base / "ADR-INIT-001-example-decision.md", doc)]
+
+
+def _write_workflows_tier(dest: Path) -> list[Path]:
+    base = dest / "workflows"
+    doc = _doc(
+        id_="WF-INIT-001", type_="workflow", status="active", tier="meta",
+        title="Example Workflow",
+        description="Placeholder step-by-step process; replace with a real workflow.",
+        tags=["example", "workflow"], timestamp="2026-01-01",
+        body=(
+            "# Purpose\n\n"
+            "Describe what this workflow accomplishes.\n\n"
+            "# Steps\n\n"
+            "1. Replace this with the first real step.\n"
+            "2. Add as many steps as needed.\n"
+        ),
+    )
+    return [_write(base / "WF-INIT-001-example-workflow.md", doc)]
+
+
+def _write_tooling_tier(dest: Path) -> list[Path]:
+    base = dest / "tooling"
+    reference = _doc(
+        id_="REF-INIT-001", type_="reference", status="active", tier="meta",
+        title="Example Reference",
+        description=(
+            "Placeholder lookup reference (current-state facts, not a governing "
+            "rule); replace with real reference material."
+        ),
+        tags=["example", "reference"], timestamp="2026-01-01",
+        body=(
+            "# Example reference\n\n"
+            "A `reference` document describes current state for lookup, not a "
+            "rule that governs future work (contrast with `standard`). Replace "
+            "this with a real lookup table, endpoint list, or similar.\n"
+        ),
+    )
+    memory = _doc(
+        id_="MEM-INIT-001", type_="memory", status="active", tier="meta",
+        title="Example Memory",
+        description=(
+            "Placeholder recorded incident or one-off learning, not a general "
+            "standard; replace with a real memory entry or delete it."
+        ),
+        tags=["example", "memory"], timestamp="2026-01-01",
+        body=(
+            "# What happened\n\n"
+            "Record a specific incident or one-off learning here.\n\n"
+            "# Why this is memory, not a standard\n\n"
+            "A `memory` document records something true about one situation, "
+            "not a general rule every project needs. If the same issue recurs "
+            "across multiple contexts, promote it into a `standard` instead.\n"
+        ),
+    )
+    return [
+        _write(base / "REF-INIT-001-example-reference.md", reference),
+        _write(base / "MEM-INIT-001-example-memory.md", memory),
+    ]
+
+
+_TIER_WRITERS = {
+    "universal": _write_universal_tier,
+    "tech-stacks": _write_tech_stacks_tier,
+    "projects": _write_projects_tier,
+    "decisions": _write_decisions_tier,
+    "workflows": _write_workflows_tier,
+    "tooling": _write_tooling_tier,
+}
+
+
+def scaffold_bundle(dest: Path, tiers: Sequence[str] | None = None) -> ScaffoldResult:
+    """Scaffold a new knowledge bundle at `dest`.
+
+    `dest` is created if it does not exist. Raises `ScaffoldError` if `dest`
+    exists and is non-empty, if `dest` exists and is not a directory, or if
+    `tiers` names an unknown tier. `tiers` defaults to `DEFAULT_TIERS` (all
+    six tier directories).
+    """
+    dest = Path(dest)
+    selected = _validate_tiers(tiers)
+    _prepare_dest(dest)
+
+    written: list[Path] = [
+        _write(dest / "index.md", _root_index(selected)),
+        _write(dest / "template.md", _template_doc()),
+    ]
+    for tier in selected:
+        written.extend(_TIER_WRITERS[tier](dest))
+
+    indexes = regenerate_indexes(dest)
+
+    return ScaffoldResult(
+        root=dest,
+        tiers=selected,
+        files_written=tuple(written),
+        indexes_written=tuple(indexes),
+    )

--- a/tests/test_cli_init.py
+++ b/tests/test_cli_init.py
@@ -55,6 +55,37 @@ def test_init_into_nonexistent_dir_creates_conformant_bundle(tmp_path):
     assert index_code == 0
 
 
+def test_init_under_skip_named_ancestor_still_generates_indexes(tmp_path):
+    # Regression (companion review, issue #66 branch): regenerate_indexes
+    # matched skip-dir names against the ABSOLUTE path components, so a
+    # bundle whose ancestor path passed through e.g. `.venv` silently
+    # generated zero per-directory indexes. Skip matching must be relative
+    # to the bundle root, exactly like discover_bundle_files in lint.py.
+    dest = tmp_path / ".venv" / "kb"
+
+    code = main(["init", str(dest)])
+    assert code == 0
+
+    tier_indexes = [p for p in dest.rglob("index.md") if p.parent != dest]
+    assert tier_indexes, "no per-directory index.md was generated"
+    assert (dest / "decisions" / "index.md").is_file()
+    assert (dest / "universal" / "foundation" / "index.md").is_file()
+
+
+def test_index_command_under_skip_named_ancestor_regenerates(tmp_path):
+    # Same root cause, pre-existing `index` subcommand path: `data-olympus
+    # index <dir>` must regenerate indexes even when <dir>'s absolute path
+    # passes through a skip-named ancestor.
+    dest = tmp_path / "node_modules" / "kb"
+    assert main(["init", str(dest)]) == 0
+    for stale in dest.rglob("index.md"):
+        if stale.parent != dest:
+            stale.unlink()
+
+    assert main(["index", str(dest)]) == 0
+    assert (dest / "decisions" / "index.md").is_file()
+
+
 def test_init_into_existing_empty_dir_succeeds(tmp_path):
     dest = tmp_path / "already-here"
     dest.mkdir()

--- a/tests/test_cli_init.py
+++ b/tests/test_cli_init.py
@@ -1,0 +1,188 @@
+"""Tests for `data-olympus init <dir>`: bundle scaffold (issue #66).
+
+Covers: conformant scaffold (zero lint errors/warnings, index builds), full
+SPEC type coverage including memory/reference, a symmetric supersession pair
+that `Index.search(in_force=...)` filters correctly, `applies_when` metadata,
+root format-version frontmatter, `template.md`, `--tiers` subsetting, and the
+non-empty-directory refusal.
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from data_olympus.cli.main import main
+from data_olympus.format import Document, discover_bundle_files, lint_files
+from data_olympus.format.validate import TYPES
+from data_olympus.index import Index
+from data_olympus.scaffold import ALL_TIERS
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _lint(root: Path) -> dict:
+    return lint_files(discover_bundle_files(root))
+
+
+def _docs(root: Path) -> list[Document]:
+    return [Document.load(p) for p in discover_bundle_files(root)]
+
+
+# --- scenario 1: empty/nonexistent dir, lint clean, index builds -----------
+
+
+def test_init_into_nonexistent_dir_creates_conformant_bundle(tmp_path):
+    dest = tmp_path / "new-bundle"
+    assert not dest.exists()
+
+    code = main(["init", str(dest)])
+    assert code == 0
+    assert dest.is_dir()
+
+    findings = _lint(dest)
+    all_findings = [f for flist in findings.values() for f in flist]
+    errors = [f for f in all_findings if f.severity == "error"]
+    warnings = [f for f in all_findings if f.severity == "warning"]
+    assert errors == []
+    assert warnings == []
+
+    lint_code = main(["lint", str(dest)])
+    assert lint_code == 0
+
+    index_code = main(["index", str(dest)])
+    assert index_code == 0
+
+
+def test_init_into_existing_empty_dir_succeeds(tmp_path):
+    dest = tmp_path / "already-here"
+    dest.mkdir()
+    code = main(["init", str(dest)])
+    assert code == 0
+    assert main(["lint", str(dest)]) == 0
+
+
+# --- scenario 2: every SPEC type has an example, incl. memory/reference ----
+
+
+def test_init_covers_every_spec_type_including_memory_and_reference(tmp_path):
+    dest = tmp_path / "kb"
+    assert main(["init", str(dest)]) == 0
+
+    docs = _docs(dest)
+    seen_types = {d.type for d in docs}
+    assert seen_types == set(TYPES)
+    assert "memory" in seen_types
+    assert "reference" in seen_types
+
+    for d in docs:
+        assert d.id, d.path
+        assert d.type, d.path
+        assert d.status, d.path
+
+
+# --- scenario 3: symmetric supersession pair + in_force filtering ----------
+
+
+def test_init_supersession_pair_is_symmetric_and_status_consistent(tmp_path):
+    dest = tmp_path / "kb"
+    assert main(["init", str(dest)]) == 0
+
+    docs = _docs(dest)
+    superseded = [d for d in docs if d.status == "superseded"]
+    assert len(superseded) == 1
+    old = superseded[0]
+    successor_id = old.frontmatter.get("superseded_by")
+    assert successor_id
+
+    new = next(d for d in docs if d.id == successor_id)
+    assert new.status == "active"
+    supersedes = new.frontmatter.get("supersedes")
+    assert supersedes is not None
+    supersedes_list = supersedes if isinstance(supersedes, list) else [supersedes]
+    assert old.id in supersedes_list
+
+
+def test_init_in_force_search_excludes_superseded_doc(tmp_path, tmp_index_path):
+    dest = tmp_path / "kb"
+    assert main(["init", str(dest)]) == 0
+
+    idx = Index(tmp_index_path)
+    idx.build(dest, source_commit="test")
+
+    unfiltered = idx.search("example standard", limit=20)
+    unfiltered_ids = {h.id for h in unfiltered}
+    assert "STD-INIT-001" in unfiltered_ids
+    assert "STD-INIT-002" in unfiltered_ids
+
+    in_force = idx.search("example standard", limit=20, in_force=True)
+    in_force_ids = {h.id for h in in_force}
+    assert "STD-INIT-002" in in_force_ids
+    assert "STD-INIT-001" not in in_force_ids
+
+
+# --- scenario 4: applies_when, root version frontmatter, template.md ------
+
+
+def test_init_has_applies_when_root_version_and_template(tmp_path):
+    dest = tmp_path / "kb"
+    assert main(["init", str(dest)]) == 0
+
+    docs = _docs(dest)
+    assert any(d.frontmatter.get("applies_when") for d in docs)
+
+    root_index = Document.load(dest / "index.md")
+    assert root_index.frontmatter.get("spec_version")
+    assert root_index.frontmatter.get("okf_version")
+
+    assert (dest / "template.md").is_file()
+
+
+# --- scenario 5: --tiers subset creates only the selected tier dirs -------
+
+
+def test_init_tiers_subset_creates_only_selected_dirs(tmp_path):
+    dest = tmp_path / "kb"
+    code = main(["init", str(dest), "--tiers", "decisions,workflows"])
+    assert code == 0
+
+    assert (dest / "decisions").is_dir()
+    assert (dest / "workflows").is_dir()
+    for unselected in set(ALL_TIERS) - {"decisions", "workflows"}:
+        assert not (dest / unselected).exists(), unselected
+
+    # still conformant: lint clean over the subset that was generated
+    assert main(["lint", str(dest)]) == 0
+
+
+def test_init_rejects_unknown_tier(tmp_path):
+    dest = tmp_path / "kb"
+    code = main(["init", str(dest), "--tiers", "bogus"])
+    assert code != 0
+    assert not dest.exists()
+
+
+# --- scenario 6: refuses to scaffold into a non-empty directory ----------
+
+
+def test_init_refuses_nonempty_dir_and_changes_nothing(tmp_path, capsys):
+    dest = tmp_path / "kb"
+    dest.mkdir()
+    (dest / "existing-file.txt").write_text("do not touch\n", encoding="utf-8")
+
+    code = main(["init", str(dest)])
+    assert code != 0
+    err = capsys.readouterr().err
+    assert "not empty" in err.lower() or "non-empty" in err.lower()
+
+    entries = sorted(p.name for p in dest.iterdir())
+    assert entries == ["existing-file.txt"]
+    assert (dest / "existing-file.txt").read_text(encoding="utf-8") == "do not touch\n"
+
+
+def test_init_missing_path_argument_returns_nonzero():
+    # argparse itself enforces `dir` is required; keep this in the same
+    # module as the other init error-handling tests for discoverability.
+    with pytest.raises(SystemExit):
+        main(["init"])


### PR DESCRIPTION
## Summary

Implements issue #66: a `data-olympus init <dir> [--tiers ...]` subcommand that scaffolds a new knowledge bundle, replacing the "copy example-bundle/" authoring instruction.

- New `src/data_olympus/scaffold.py` (scaffold engine) and `src/data_olympus/cli/init_cmd.py` (CLI wiring), registered in `cli/main.py`.
- Scaffolds the tier directories (`--tiers`, default `universal,tech-stacks,projects,decisions,workflows,tooling`), a root `index.md` with `spec_version`/`okf_version` frontmatter, a `template.md` authoring scaffold, and one example document per SPEC-supported `type` (`standard`, `decision`, `workflow`, `project`, `memory`, `reference` — the latter two are missing from `example-bundle/`).
- The examples demonstrate the differentiating features: a real, symmetric supersession pair (`STD-INIT-001` `status: superseded` + `superseded_by: STD-INIT-002`; `STD-INIT-002` `status: active` + `supersedes: [STD-INIT-001]`) and `applies_when` trigger metadata. Every generated doc carries an explicit `status` plus all recommended fields, so the bundle passes `data-olympus lint` with zero errors and zero warnings, and `data-olympus index` builds on it.
- Refuses to scaffold into a non-empty directory with a clear error; creates the directory if missing. No `--force` in this slice.
- Docs: README quickstart and `docs/adoption.md` now present `init` as the new-bundle path. CHANGELOG `[Unreleased]` updated.

Also fixes a pre-existing bug the companion review caught: `regenerate_indexes` matched skip-dir names (`.git`, `.venv`, `node_modules`, ...) against the bundle's **absolute** path components, so `data-olympus index` (and `init`) silently generated zero per-directory indexes for a bundle whose ancestor path passes through a skip-named directory. Skip matching is now bundle-relative, mirroring `discover_bundle_files` in the lint pipeline, with regression tests for both CLI paths.

## Test evidence

`tests/test_cli_init.py` (12 tests) covers: scaffold into nonexistent/empty dir with lint zero-errors/zero-warnings and `index` building; full SPEC type coverage including `memory`/`reference` with id/type/status on every doc; symmetric supersession pair; `Index.search(in_force=True)` excluding the superseded doc while unfiltered search finds it; `applies_when` presence, root format-version frontmatter, `template.md`; `--tiers` subsetting and unknown-tier rejection; non-empty-dir refusal with no changes; plus the two skip-named-ancestor regressions.

Full suite (`uv run pytest -q`, exit code 0, 1230 collected):

```
........................................................................ [ 93%]
........................................................................ [ 99%]
......                                                                   [100%]
=========================== short test summary info ============================
SKIPPED [1] tests/test_bench_methods.py:69: could not import 'sentence_transformers': No module named 'sentence_transformers'
SKIPPED [1] tests/test_token_compact_budget.py:72: tiktoken not installed
```

`ruff check` and `mypy --strict` clean on the new/changed files. Manual end-to-end check: `init` -> `lint` (0 errors, 0 warnings, 8 linted) -> `index` (6 indexes) on a fresh directory, and the root `index.md` version frontmatter survives re-indexing.

## Companion review (codex)

Two passes via `codex exec --sandbox read-only` over `origin/release/0.4.0...HEAD`:

1. First pass: **NO-GO** with one blocker — `regenerate_indexes` skip-matching against absolute path components could silently generate zero indexes for bundles under skip-named ancestors. Fixed in `6139765` with regression tests.
2. Re-review after the fix: **GO, no blockers.** "The previous blocker is fixed correctly ... regression coverage is targeted and complete ... Scope, docs, and changelog look aligned with the feature. I did not find security concerns in this diff." Reviewer noted it could not execute pytest itself from the read-only sandbox; the full-suite evidence above is from the primary.