### PR TITLE
ci: fix startup failure of PyPI dry-run on pull requests

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -48,6 +48,16 @@ jobs:
       upload: false
     permissions:
       contents: read
+      # id-token: write is NOT used on this path (upload=false skips the only
+      # job with an OIDC step) but must be granted anyway: GitHub validates a
+      # called workflow's job-level permission requests against the caller's
+      # grant statically at startup, BEFORE `if:` conditions are evaluated, so
+      # omitting it startup-fails every pull_request run. Exposure is bounded:
+      # the reusable `build` job runs with contents: read only, the `upload`
+      # job (the only OIDC consumer) is gated off by `if: inputs.upload`, and
+      # a real PyPI exchange additionally requires the `pypi` environment
+      # (deployment policy: main + v* tags) and a matching Trusted Publisher.
+      id-token: write
 
   release:
     if: github.event_name == 'push' && github.ref_type == 'tag'


### PR DESCRIPTION
## Summary

Every `pull_request` run of the "Publish to PyPI" workflow has died with `startup_failure` since the workflow shipped (see e.g. run 28919949847 and the run history of the workflow: 8/8 recent PR runs failed the same way). No dry-run build/twine-check ever executed on a packaging PR.

Root cause: the `dry-run` caller job grants `permissions: contents: read`, while the called reusable workflow (`publish-pypi-reusable.yml`) contains an `upload` job requesting `id-token: write`. GitHub validates a called workflow's job-level permission requests against the caller's grant statically at run startup, BEFORE `if:` conditions are evaluated, so the run fails even though `upload: false` would skip that job. The tag-push and manual-dispatch caller jobs already grant `id-token: write`, which is why only PR runs failed.

Fix: grant `id-token: write` on the `dry-run` caller job, with an in-file comment documenting why and the bounded exposure: the reusable `build` job runs with `contents: read` only, the `upload` job (the only OIDC consumer) is gated off by `if: inputs.upload`, and a real PyPI exchange additionally requires the `pypi` environment (deployment policy: main + v* tags) and a matching Trusted Publisher.

Alternative considered and rejected for this slice: splitting build and upload into separate reusable workflows would keep `id-token` off PR callers entirely but gives up the single-reusable-workflow shape; noted in review as the stricter least-privilege design if the workflow is ever restructured.

## Test evidence

- `python -c "yaml.safe_load(...)"` parses the workflow.
- `actionlint` clean (run during companion review).
- The definitive check is the PR's own run of this workflow: with this change the dry-run must start and execute build + twine check on this very PR (it touches `.github/workflows/publish-pypi*.yml`, which is in the dry-run path filter).

## Companion review (codex)

Verdict: **GO, no blockers.** Diagnosis confirmed against GitHub's reusable-workflow permission model (permissions can only be maintained or reduced through a call chain, validated statically). One concern raised: the original comment overstated the safety claim ("risk is nil", fork-OIDC reasoning); reworded per the review to the bounded-exposure explanation above. actionlint and git diff --check run by the reviewer passed.
