### PR TITLE
feat(ops): maintenance ledger with pending-actions surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,33 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **Maintenance ledger: committed corpus-state audit + `pending_actions` CTA
+  surface (issue #113).** A frontmatter-only markdown doc (default
+  `tooling/maintenance-ledger.md`, `KB_MAINTENANCE_LEDGER_PATH`) is now
+  computed at every index build: whether `status` is present on every
+  indexed document (except reserved filenames), plus a capped list (50 paths
+  + a total count) of the ones missing it — the migration vehicle for making
+  `status` mandatory — and, consuming issue #107 validity data, documents
+  that recently expired or are expiring soon within configurable windows
+  (`KB_MAINTENANCE_RECENTLY_EXPIRED_DAYS` / `KB_MAINTENANCE_EXPIRING_SOON_DAYS`,
+  both default 30 days), each capped the same way. When the computed state
+  changes since the last committed copy, the ledger is committed through the
+  same serialized write/commit machinery every other write uses (system
+  agent identity `data-olympus-system`, a normal `maintenance_ledger` audit
+  event); a commit failure is logged/audited and never breaks index refresh
+  or serving. The ledger doc is excluded from its own audit and always
+  carries valid concept frontmatter, so it lints clean on its own merits
+  rather than relying on reserved-filename semantics. The same computed state
+  drives a new `pending_actions` field (a list of `{kind, message, count}`
+  items) on `kb_consult` and `kb_health` responses — deliberately never
+  `kb_search` — present only while the corpus is dirty; both tool
+  descriptions now instruct the model to surface open items to the operator
+  and act on them only with operator confirmation. `kb health`'s plain-text
+  CLI summary displays any open items. Silencing is automatic: remediate,
+  the next index build flips the flag, the next ledger commit records it,
+  and `pending_actions` disappears with no manual acking. See
+  `docs/operations.md` §5.
+
 - **Validity/freshness frontmatter metadata with hard expiry semantics**
   (issue #107, format `0.2`). Concept documents may now declare an optional
   nested `validity` object: `valid_from`, `valid_until`, `last_verified`,

--- a/bin/kb
+++ b/bin/kb
@@ -782,6 +782,9 @@ do_curl() {
 }
 
 # Helper: emit a plain-text human-readable summary of a health JSON body.
+# Appends a `pending_actions` section (issue #113: the maintenance-ledger CTA
+# surface) only when the field is present and non-empty, so a clean corpus'
+# report is unchanged.
 format_plain_health() {
   if command -v jq >/dev/null 2>&1; then
     echo "$REST_BODY" | jq -r '
@@ -791,7 +794,10 @@ degraded: \(.degraded)
 last_pull_at: \(.last_git_pull_at // "never")
 staleness_seconds: \(.staleness_seconds // "n/a")
 index_build_status: \(.last_index_build_status)
-pending: \(.pending_count) | push_queue: \(.push_queue_size)"
+pending: \(.pending_count) | push_queue: \(.push_queue_size)" +
+      (if ((.pending_actions // []) | length) > 0 then
+        "\npending_actions:\n" + ((.pending_actions // []) | map("  - [" + .kind + "] " + .message + " (count=" + (.count | tostring) + ")") | join("\n"))
+      else "" end)
     '
   else
     echo "$REST_BODY"

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -371,10 +371,17 @@ since the last committed copy, it is committed through the same serialized
 write/commit machinery every other write uses (system agent identity
 `data-olympus-system`, a normal `maintenance_ledger` audit event). A commit
 failure is logged and audited but never breaks index refresh or serving; it is
-retried on the next index build that recomputes a changed state. Recomputation
-is checked on every `git_pull_loop` tick, not only when a new remote commit
-arrives, so a fresh deployment gets its first ledger commit promptly even
-before anyone else ever pushes to the KB.
+retried on the next `git_pull_loop` tick. Recomputation is checked on every
+tick, not only when a new remote commit arrives, so a fresh deployment gets
+its first ledger commit promptly even before anyone else ever pushes to the
+KB. Duplicate commits are guarded three ways, all comparing the structured
+state (never the rendered markdown, whose `computed_at` timestamp changes
+every render): an in-process last-committed memo, the ledger copy in the live
+index, and the system worktree's HEAD copy (which survives restarts), so a
+slow push or short sync interval can never re-commit an unchanged state. A
+`KB_MAINTENANCE_LEDGER_PATH` outside the configured indexed prefixes is
+refused with a `skipped_bad_path` audit event instead of committing a doc the
+index would never serve.
 
 The same computed state also drives a `pending_actions` field on `kb_consult`
 and `kb_health` responses (never `kb_search` — per-hit noise trains agents to

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -351,7 +351,57 @@ after confirming no operator is mid-resolve on that path.
 
 ---
 
-## 5. Quick reference
+## 5. Maintenance ledger
+
+A committed, frontmatter-only markdown doc (default path
+`tooling/maintenance-ledger.md`, `KB_MAINTENANCE_LEDGER_PATH`) records a
+corpus-state audit computed at every index build:
+
+- `status_present_in_all_kb_entries` — whether every indexed document (except
+  reserved filenames — `index.md`/`log.md`/`template.md`) carries a `status`
+  field, plus a capped list (50 paths + a total count) of the ones that don't.
+  This is the migration vehicle for making `status` mandatory.
+- `recently_expired` / `expiring_soon` — documents whose `valid_until`
+  (issue #107 validity metadata) fell in the last `KB_MAINTENANCE_RECENTLY_EXPIRED_DAYS`
+  days (default 30), or falls within the next `KB_MAINTENANCE_EXPIRING_SOON_DAYS`
+  days (default 30), each capped at 50 items + a total count.
+
+The ledger is server-side and best-effort: when the computed state CHANGES
+since the last committed copy, it is committed through the same serialized
+write/commit machinery every other write uses (system agent identity
+`data-olympus-system`, a normal `maintenance_ledger` audit event). A commit
+failure is logged and audited but never breaks index refresh or serving; it is
+retried on the next index build that recomputes a changed state. Recomputation
+is checked on every `git_pull_loop` tick, not only when a new remote commit
+arrives, so a fresh deployment gets its first ledger commit promptly even
+before anyone else ever pushes to the KB.
+
+The same computed state also drives a `pending_actions` field on `kb_consult`
+and `kb_health` responses (never `kb_search` — per-hit noise trains agents to
+ignore it): a list of `{kind, message, count}` items, present only while the
+corpus is dirty. An agent seeing `pending_actions` should surface it to the
+operator and act on it only with operator confirmation. Silencing is
+automatic: fix the underlying doc(s), the next index build flips the flag, the
+next ledger commit records it, and `pending_actions` disappears — no manual
+acking.
+
+A private deployment using a custom `KB_TAXONOMY_PATH` (rather than the
+built-in default taxonomy) must make sure `KB_MAINTENANCE_LEDGER_PATH` still
+resolves inside an INDEXED prefix, or the ledger is committed but never
+searchable/gettable via `kb_search`/`kb_get`.
+
+`kb health` (the CLI) shows any open `pending_actions` in its plain-text
+(`-o plain`) summary; `-o json` passes the field through unchanged.
+
+Relevant environment variables:
+
+| Variable | Default | Meaning |
+|---|---|---|
+| `KB_MAINTENANCE_LEDGER_PATH` | `tooling/maintenance-ledger.md` | Committed ledger doc path (must resolve inside an indexed prefix) |
+| `KB_MAINTENANCE_RECENTLY_EXPIRED_DAYS` | `30` | Window (days) for the "recently expired" bucket |
+| `KB_MAINTENANCE_EXPIRING_SOON_DAYS` | `30` | Window (days) for the "expiring soon" bucket |
+
+## 6. Quick reference
 
 | Task | Command |
 |---|---|
@@ -364,3 +414,4 @@ after confirming no operator is mid-resolve on that path.
 | Enable audit rotation | set `KB_AUDIT_MAX_BYTES` in the ConfigMap |
 | Enable proxy headers | set `KB_TRUSTED_PROXIES` in the ConfigMap |
 | Enable Ingress | set `KB_AUTH_TOKEN`, uncomment `- ingress.yaml` in `kustomization.yaml` (see `deploy/k8s/README.md`) |
+| View maintenance-ledger state | `curl -s 'http://<host>/api/v1/health?verbose=true' \| jq .pending_actions` |

--- a/src/data_olympus/config.py
+++ b/src/data_olympus/config.py
@@ -62,6 +62,19 @@ class Config:
     auth_principals: list[dict[str, Any]] = field(default_factory=list)
     consult_ttl_sec: int = 300
     ledger_path: str = "/state/ledger.json"
+    # Maintenance ledger (issue #113): committed frontmatter-only markdown doc
+    # recording corpus-state audit flags (missing `status`, recently-expired /
+    # expiring-soon docs per #107 validity data), refreshed on every index
+    # build when the computed state changes. The default lives under the
+    # generic `tooling/` taxonomy prefix (index._DEFAULT_PATH_RULES maps it to
+    # tier "tooling"); a deployment using a custom KB_TAXONOMY_PATH must make
+    # sure this path still resolves inside an INDEXED prefix, or the ledger is
+    # committed but never searchable/gettable. Not to be confused with
+    # ``ledger_path`` above (the unrelated ConsultationLedger JSON state file).
+    maintenance_ledger_path: str = "tooling/maintenance-ledger.md"
+    # Window sizes (days) for the "recently expired" / "expiring soon" buckets.
+    maintenance_recently_expired_days: int = 30
+    maintenance_expiring_soon_days: int = 30
     # Streamable-http session reaping: terminate transports idle beyond this many
     # seconds to bound _server_instances (see session_metrics). 0 disables the
     # reaper (observability-only). The scan runs every session_reap_interval_sec.
@@ -198,6 +211,15 @@ def load_config() -> Config:
     auth_principals = parse_principals_env(os.getenv("KB_AUTH_PRINCIPALS", ""))
     consult_ttl_sec = int(os.getenv("KB_CONSULT_TTL_SEC", "300"))
     ledger_path = os.getenv("KB_LEDGER_PATH", "/state/ledger.json")
+    maintenance_ledger_path = os.getenv(
+        "KB_MAINTENANCE_LEDGER_PATH", "tooling/maintenance-ledger.md"
+    )
+    maintenance_recently_expired_days = int(
+        os.getenv("KB_MAINTENANCE_RECENTLY_EXPIRED_DAYS", "30")
+    )
+    maintenance_expiring_soon_days = int(
+        os.getenv("KB_MAINTENANCE_EXPIRING_SOON_DAYS", "30")
+    )
     session_idle_timeout_sec = int(os.getenv("KB_SESSION_IDLE_TIMEOUT_SEC", "300"))
     session_reap_interval_sec = int(os.getenv("KB_SESSION_REAP_INTERVAL_SEC", "60"))
     session_touch_interval_sec = int(os.getenv("KB_SESSION_TOUCH_INTERVAL_SEC", "30"))
@@ -260,6 +282,9 @@ def load_config() -> Config:
         auth_principals=auth_principals,
         consult_ttl_sec=consult_ttl_sec,
         ledger_path=ledger_path,
+        maintenance_ledger_path=maintenance_ledger_path,
+        maintenance_recently_expired_days=maintenance_recently_expired_days,
+        maintenance_expiring_soon_days=maintenance_expiring_soon_days,
         session_idle_timeout_sec=session_idle_timeout_sec,
         session_reap_interval_sec=session_reap_interval_sec,
         session_touch_interval_sec=session_touch_interval_sec,

--- a/src/data_olympus/index.py
+++ b/src/data_olympus/index.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import datetime
+import json
 import logging
 import os
 import sqlite3
@@ -35,9 +36,18 @@ from data_olympus.embeddings import (
 )
 from data_olympus.format.validate import (
     IN_FORCE_STATUSES,
+    RESERVED,
     in_force_sql_fragment,
     not_expired_sql_fragment,
     today_iso,
+)
+from data_olympus.maintenance import (
+    DEFAULT_EXPIRING_SOON_DAYS,
+    DEFAULT_LEDGER_PATH,
+    DEFAULT_RECENTLY_EXPIRED_DAYS,
+    DocAuditRow,
+    MaintenanceState,
+    compute_maintenance_state,
 )
 from data_olympus.markdown_parse import ParsedDoc, parse_text_checked
 from data_olympus.trigram import (
@@ -520,6 +530,9 @@ class Index:
         embedder: Embedder | None = None,
         dense_candidate_count: int = DEFAULT_DENSE_CANDIDATE_COUNT,
         dense_min_cosine: float = DEFAULT_DENSE_MIN_COSINE,
+        maintenance_ledger_path: str = DEFAULT_LEDGER_PATH,
+        maintenance_recently_expired_days: int = DEFAULT_RECENTLY_EXPIRED_DAYS,
+        maintenance_expiring_soon_days: int = DEFAULT_EXPIRING_SOON_DAYS,
     ) -> None:
         self._db_path = db_path
         # Embeddings (issue #42) are threaded in from Config, NOT re-read from env
@@ -600,6 +613,21 @@ class Index:
         # malformed at the last build (issue #107). Updated by build(); surfaced
         # via health() and the ``malformed_validity_count`` property.
         self._malformed_validity_count = 0
+        # Maintenance ledger (issue #113): the corpus-state audit computed at
+        # the LAST build, cached here so kb_health/kb_consult and the
+        # ledger-commit hook can read it without touching SQLite. None before
+        # the first build() call. ``_maintenance_ledger_path`` is excluded from
+        # its own audit (see maintenance.compute_maintenance_state).
+        self._maintenance_ledger_path = maintenance_ledger_path
+        self._maintenance_recently_expired_days = maintenance_recently_expired_days
+        self._maintenance_expiring_soon_days = maintenance_expiring_soon_days
+        self._maintenance_state: MaintenanceState | None = None
+
+    @property
+    def maintenance_state(self) -> MaintenanceState | None:
+        """The corpus-state audit computed at the last build(), or None before
+        the first build (see data_olympus.maintenance.MaintenanceState)."""
+        return self._maintenance_state
 
     @property
     def malformed_frontmatter_count(self) -> int:
@@ -745,8 +773,15 @@ class Index:
             "mtime",
         )
 
-    def build(self, kb_root: Path, *, source_commit: str) -> IndexBuildResult:
-        """Walk kb_root for .md files and (re)build the FTS index using atomic swap."""
+    def build(
+        self, kb_root: Path, *, source_commit: str, today: str | None = None,
+    ) -> IndexBuildResult:
+        """Walk kb_root for .md files and (re)build the FTS index using atomic swap.
+
+        ``today`` (ISO ``YYYY-MM-DD``) drives the maintenance-ledger expiry
+        window computation (issue #113); defaults to :func:`today_iso` (the
+        real wall clock) but is injectable so tests are deterministic.
+        """
         if not kb_root.is_dir():
             raise NotADirectoryError(f"KB root not a directory: {kb_root}")
 
@@ -841,6 +876,10 @@ class Index:
             # counter), but tracked separately since a doc can have valid
             # front matter overall yet a malformed ``validity`` sub-block.
             malformed_validity = 0
+            # Maintenance-ledger audit rows (issue #113), gathered during this
+            # SAME single pass over the corpus so the audit is nearly free (no
+            # extra walk/query). Computed into a MaintenanceState after the loop.
+            maintenance_rows: list[DocAuditRow] = []
             for pf in parsed:
                 rel = pf.rel
                 doc = pf.doc
@@ -861,6 +900,13 @@ class Index:
                         "block was treated as absent for this doc",
                         rel,
                     )
+                maintenance_rows.append(
+                    DocAuditRow(
+                        path=str(rel), id=doc_id, status=doc.status,
+                        valid_until=doc.valid_until,
+                        is_reserved=rel.name in RESERVED,
+                    )
+                )
                 path_tier, path_category = _classify_by_path(str(rel), path_rules)
                 final_tier = doc.tier or path_tier
                 final_category = doc.category or path_category
@@ -975,6 +1021,16 @@ class Index:
                 )
                 write_cooccurrence_table(conn, table)
             now = time.time()
+            # Maintenance ledger (issue #113): computed from the SAME corpus
+            # walk above, so the audit is nearly free. ``today`` is injectable
+            # for deterministic tests; defaults to the real wall clock.
+            maintenance_state = compute_maintenance_state(
+                maintenance_rows,
+                today=today if today is not None else today_iso(),
+                ledger_path=self._maintenance_ledger_path,
+                recently_expired_days=self._maintenance_recently_expired_days,
+                expiring_soon_days=self._maintenance_expiring_soon_days,
+            )
             conn.execute(
                 "INSERT OR REPLACE INTO meta (key, value) VALUES ('source_commit', ?)",
                 (source_commit,),
@@ -1005,6 +1061,14 @@ class Index:
                 "VALUES ('malformed_validity', ?)",
                 (str(malformed_validity),),
             )
+            # Maintenance-ledger state (issue #113): persisted as JSON so it
+            # survives a process restart that reads the swapped index, same
+            # rationale as the counters above.
+            conn.execute(
+                "INSERT OR REPLACE INTO meta (key, value) "
+                "VALUES ('maintenance_state', ?)",
+                (json.dumps(maintenance_state.to_dict()),),
+            )
             # Integrity check before swap
             check = conn.execute("PRAGMA integrity_check").fetchone()
             if check[0] != "ok":
@@ -1030,6 +1094,7 @@ class Index:
         # (finding (j)); the persisted meta row covers a fresh process.
         self._malformed_frontmatter_count = malformed_frontmatter
         self._malformed_validity_count = malformed_validity
+        self._maintenance_state = maintenance_state
         # Invalidate the health cache so the next health() reflects the rebuild
         # immediately rather than serving the pre-swap commit for up to the TTL.
         with self._health_lock:

--- a/src/data_olympus/index.py
+++ b/src/data_olympus/index.py
@@ -622,6 +622,17 @@ class Index:
         self._maintenance_recently_expired_days = maintenance_recently_expired_days
         self._maintenance_expiring_soon_days = maintenance_expiring_soon_days
         self._maintenance_state: MaintenanceState | None = None
+        # In-process memo of the last MaintenanceState the maintenance-ledger
+        # commit hook successfully committed (set by
+        # maintenance.maybe_update_ledger, never by build()). This is the loop
+        # guard for the window between a ledger commit and its publication
+        # (push -> merge to main -> re-index): during that window the INDEX
+        # still holds the pre-commit ledger copy, so without this memo every
+        # pull-loop tick would look like "state changed" and commit a
+        # duplicate. Not persisted: after a restart the system worktree's HEAD
+        # (which survives restarts; unpushed commits block its GC) covers the
+        # same window (see maybe_update_ledger's worktree check).
+        self.maintenance_last_committed_state: MaintenanceState | None = None
 
     @property
     def maintenance_state(self) -> MaintenanceState | None:

--- a/src/data_olympus/maintenance.py
+++ b/src/data_olympus/maintenance.py
@@ -372,6 +372,29 @@ def pending_actions_for(
     return items
 
 
+def _last_committed_in_worktree(
+    worktrees: WorktreeRegistry, ledger_path: str,
+) -> str | None:
+    """The ledger doc's content at the system worktree's HEAD, or None.
+
+    The system worktree is where every ledger commit lands, so its HEAD is the
+    authoritative last-committed copy even BEFORE that commit is pushed,
+    merged to main, and re-indexed. Consulted as the restart-safe half of the
+    duplicate-commit guard (the in-process memo covers the common case without
+    a git call; this covers a fresh process whose memo is empty). Best-effort:
+    any error reads as "nothing committed yet"."""
+    try:
+        wt = worktrees.get_or_create(
+            source_session=_MAINTENANCE_SOURCE_SESSION,
+            agent_identity=_MAINTENANCE_AGENT_IDENTITY,
+        )
+        return worktrees.git.file_at_commit(
+            "HEAD", ledger_path, worktree_path=wt.path,
+        )
+    except Exception:  # noqa: BLE001 - guard read must never break the caller
+        return None
+
+
 def maybe_update_ledger(
     *,
     idx: Index,
@@ -388,19 +411,65 @@ def maybe_update_ledger(
     last committed copy. Returns the new commit sha, or None when no commit was
     needed or attempted.
 
+    Duplicate-commit guard: a freshly committed ledger is not visible in the
+    INDEX until it is pushed, merged to main, and re-indexed, so comparing
+    against the index alone would re-commit the same state on every pull-loop
+    tick during that window. Three checks, cheapest first, all comparing the
+    STRUCTURED state (never the rendered markdown, whose ``computed_at``
+    timestamp changes every render):
+
+    1. ``idx.maintenance_last_committed_state`` -- the in-process memo set
+       after each successful commit.
+    2. The state parsed from the ledger doc in the live index.
+    3. The state parsed from the system worktree's HEAD copy -- the worktree
+       survives process restarts (unpushed commits block its GC), so this
+       closes the restart window the memo cannot.
+
     NEVER raises: a commit failure (gate rejection, lock contention, git
     error, ...) is logged (and audited, best-effort) and swallowed, so a
     maintenance-ledger hiccup can never break index refresh or serving
-    (issue #113). Reuses the SAME serialized write/commit machinery every other
-    write goes through (``tools_write.commit_multifile_in_worktree``) rather
-    than forking a second git-writing path.
+    (issue #113); the memo is NOT set on failure, so the next tick retries.
+    Reuses the SAME serialized write/commit machinery every other write goes
+    through (``tools_write.commit_multifile_in_worktree``) rather than forking
+    a second git-writing path.
     """
     state = idx.maintenance_state
     if state is None:
         return None
+    # Guard 1: in-process memo (no I/O).
+    if idx.maintenance_last_committed_state == state:
+        return None
+    # Guard 2: the indexed ledger copy.
     existing = idx.get(LEDGER_ID)
     old_state = parse_ledger_state(existing.content_markdown if existing is not None else None)
     if old_state == state:
+        idx.maintenance_last_committed_state = state
+        return None
+    # Structural path check: the ledger must land inside an indexed prefix or
+    # it is committed but never served; a misconfigured
+    # KB_MAINTENANCE_LEDGER_PATH is refused loudly instead.
+    from data_olympus.auth import is_writable_path, path_rejection_reason
+    if not is_writable_path(ledger_path):
+        reason = path_rejection_reason(ledger_path)
+        _log.warning(
+            "maintenance ledger path %r is not a writable indexed path (%s); "
+            "skipping the ledger commit -- fix KB_MAINTENANCE_LEDGER_PATH "
+            "(and KB_INDEXED_PREFIXES if using a custom taxonomy)",
+            ledger_path, reason,
+        )
+        if audit_log is not None:
+            with contextlib.suppress(Exception):
+                audit_log.append({
+                    "ts": _time.time(), "event_type": "maintenance_ledger",
+                    "status": "skipped_bad_path", "target_path": ledger_path,
+                    "agent_identity": _MAINTENANCE_AGENT_IDENTITY,
+                    "reason": reason,
+                })
+        return None
+    # Guard 3: the system worktree's HEAD copy (restart-safe).
+    wt_state = parse_ledger_state(_last_committed_in_worktree(worktrees, ledger_path))
+    if wt_state == state:
+        idx.maintenance_last_committed_state = state
         return None
     computed_at = datetime.datetime.fromtimestamp(
         now if now is not None else _time.time(), tz=datetime.UTC
@@ -426,10 +495,10 @@ def maybe_update_ledger(
                        "agent_identity": _MAINTENANCE_AGENT_IDENTITY},
         )
     except Exception as exc:  # noqa: BLE001 - best-effort; never break refresh/serving
-        _log.warning(
-            "maintenance ledger commit failed (will retry once a future index "
-            "build recomputes a changed state): %s", exc,
-        )
+        # The memo is deliberately NOT set here, so the next pull-loop tick
+        # retries the commit while the state still differs from the last
+        # committed copy.
+        _log.warning("maintenance ledger commit failed (retried next tick): %s", exc)
         if audit_log is not None:
             with contextlib.suppress(Exception):
                 audit_log.append({
@@ -439,6 +508,9 @@ def maybe_update_ledger(
                     "reason": str(exc)[:400],
                 })
         return None
+    # Commit landed: arm the in-process memo so subsequent ticks are no-ops
+    # until the state genuinely changes again.
+    idx.maintenance_last_committed_state = state
     if audit_log is not None:
         with contextlib.suppress(Exception):
             audit_log.append({

--- a/src/data_olympus/maintenance.py
+++ b/src/data_olympus/maintenance.py
@@ -1,0 +1,451 @@
+"""Maintenance ledger: corpus-state audit + committed status doc (issue #113).
+
+Computed at every index build (the build already walks the corpus, so this is
+nearly free): which docs are missing a ``status`` field (the migration vehicle
+for making ``status`` mandatory), and which docs have recently expired or are
+expiring soon (issue #107 validity data). The computed :class:`MaintenanceState`
+is cached on the ``Index`` instance (``Index.maintenance_state``) and consumed
+two ways:
+
+- :func:`pending_actions_for` turns it into the ``pending_actions`` CTA
+  envelope surfaced on ``kb_consult`` and ``kb_health`` responses (deliberately
+  NEVER ``kb_search`` -- per-hit noise trains agents to ignore it).
+- :func:`maybe_update_ledger` commits a frontmatter-only markdown doc recording
+  the state through the SAME serialized write machinery every other write uses
+  (``tools_write.commit_multifile_in_worktree``), and only when the state
+  actually changed since the last committed copy (idempotence / no commit
+  loop): the comparison is over the STRUCTURED state, never the rendered
+  markdown text, so the volatile ``computed_at`` timestamp can never itself
+  trigger a spurious re-commit.
+
+This module has no import-time dependency on ``Index`` or the write pipeline
+(only under ``TYPE_CHECKING`` / lazy function-local imports), so a caller that
+only wants the pure computation (e.g. ``kb_consult_fn``) does not pull in the
+git-writing machinery.
+"""
+from __future__ import annotations
+
+import contextlib
+import datetime
+import logging
+import time as _time
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from data_olympus.audit_log import AuditLog
+    from data_olympus.index import Index
+    from data_olympus.pending import PendingQueue
+    from data_olympus.push_queue import PushQueue
+    from data_olympus.worktrees import WorktreeRegistry
+    from data_olympus.write_gate import WriteSerializer
+
+_log = logging.getLogger("data_olympus.maintenance")
+
+# Default committed location, consistent with the generic path taxonomy
+# (index._DEFAULT_PATH_RULES maps "tooling/" -> tier "tooling"): a real
+# deployment's tooling/ directory is exactly where an ops runbook like this one
+# lives (mirrors e.g. a real KB's tooling/data-olympus.md). A private
+# deployment using a custom KB_TAXONOMY_PATH must make sure this path still
+# resolves inside an INDEXED prefix, or the ledger is committed but never
+# searchable/gettable; see docs/operations.md.
+DEFAULT_LEDGER_PATH = "tooling/maintenance-ledger.md"
+DEFAULT_RECENTLY_EXPIRED_DAYS = 30
+DEFAULT_EXPIRING_SOON_DAYS = 30
+
+# Stable id for the committed ledger doc. Excluded by PATH from its own
+# missing-status/expiry audit (belt), and always rendered with full, valid
+# concept front matter (suspenders) so it also lints clean on its own merits
+# rather than relying on the RESERVED-filename exemption (issue #113 design
+# note: avoid reserved-filename semantics when a plain doc will do).
+LEDGER_ID = "maintenance-ledger"
+
+# Cap applied to every list surfaced in the ledger doc / pending_actions
+# envelope: a full corpus scan can be thousands of paths; a bounded sample plus
+# a total count is enough for an operator to act on without inflating every
+# kb_health / kb_consult response or the committed ledger file itself.
+CAP = 50
+
+# System writer identity for the ledger's own commits (server-side, never
+# attributable to an agent session). Kept distinct from any real agent
+# identity so an audit event or commit trailer is unambiguous about its
+# origin.
+_MAINTENANCE_SOURCE_SESSION = "system:maintenance-ledger"
+_MAINTENANCE_AGENT_IDENTITY = "data-olympus-system"
+
+
+@dataclass(frozen=True, slots=True)
+class DocAuditRow:
+    """One document's audit-relevant fields, gathered during the index build's
+    single corpus walk (see ``Index.build``)."""
+
+    path: str
+    id: str
+    status: str
+    valid_until: str
+    is_reserved: bool
+
+
+@dataclass(frozen=True, slots=True)
+class ExpiryItem:
+    """One document surfaced in a recently-expired / expiring-soon bucket."""
+
+    id: str
+    path: str
+    valid_until: str
+
+    def to_dict(self) -> dict[str, str]:
+        return {"id": self.id, "path": self.path, "valid_until": self.valid_until}
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ExpiryItem:
+        return cls(
+            id=str(data.get("id", "")),
+            path=str(data.get("path", "")),
+            valid_until=str(data.get("valid_until", "")),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class MaintenanceState:
+    """Corpus-state audit computed at index build time.
+
+    A plain frozen dataclass: equality is by VALUE, which is exactly what lets
+    :func:`maybe_update_ledger` compare a freshly computed state against the
+    state parsed back out of the last committed ledger doc to decide whether a
+    new commit is needed. Deliberately carries no ``computed_at`` timestamp --
+    that lives only in the rendered markdown (see :func:`render_ledger_markdown`),
+    never in this struct, so recomputing an unchanged corpus can never itself
+    look "different" and trigger a spurious commit.
+    """
+
+    status_present_in_all_kb_entries: bool
+    missing_status_paths: tuple[str, ...] = ()
+    missing_status_count: int = 0
+    recently_expired: tuple[ExpiryItem, ...] = ()
+    recently_expired_count: int = 0
+    expiring_soon: tuple[ExpiryItem, ...] = ()
+    expiring_soon_count: int = 0
+
+    @property
+    def is_dirty(self) -> bool:
+        """True when there is at least one open maintenance item to surface."""
+        return (
+            not self.status_present_in_all_kb_entries
+            or self.recently_expired_count > 0
+            or self.expiring_soon_count > 0
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "status_present_in_all_kb_entries": self.status_present_in_all_kb_entries,
+            "missing_status": {
+                "count": self.missing_status_count,
+                "paths": list(self.missing_status_paths),
+            },
+            "recently_expired": {
+                "count": self.recently_expired_count,
+                "items": [i.to_dict() for i in self.recently_expired],
+            },
+            "expiring_soon": {
+                "count": self.expiring_soon_count,
+                "items": [i.to_dict() for i in self.expiring_soon],
+            },
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> MaintenanceState:
+        missing = data.get("missing_status") or {}
+        recently = data.get("recently_expired") or {}
+        soon = data.get("expiring_soon") or {}
+        return cls(
+            status_present_in_all_kb_entries=bool(
+                data.get("status_present_in_all_kb_entries", True)
+            ),
+            missing_status_paths=tuple(str(p) for p in missing.get("paths", [])),
+            missing_status_count=int(missing.get("count", 0)),
+            recently_expired=tuple(
+                ExpiryItem.from_dict(i) for i in recently.get("items", [])
+            ),
+            recently_expired_count=int(recently.get("count", 0)),
+            expiring_soon=tuple(
+                ExpiryItem.from_dict(i) for i in soon.get("items", [])
+            ),
+            expiring_soon_count=int(soon.get("count", 0)),
+        )
+
+
+def _add_days(today: str, days: int) -> str:
+    """Return ``today`` (ISO YYYY-MM-DD) plus ``days`` calendar days, as ISO."""
+    return (datetime.date.fromisoformat(today) + datetime.timedelta(days=days)).isoformat()
+
+
+def compute_maintenance_state(
+    rows: Iterable[DocAuditRow],
+    *,
+    today: str,
+    ledger_path: str,
+    recently_expired_days: int = DEFAULT_RECENTLY_EXPIRED_DAYS,
+    expiring_soon_days: int = DEFAULT_EXPIRING_SOON_DAYS,
+    cap: int = CAP,
+) -> MaintenanceState:
+    """Pure computation over a corpus snapshot (issue #113).
+
+    ``ledger_path`` is excluded from every bucket: the ledger doc audits the
+    REST of the corpus, never itself (it always carries valid frontmatter
+    anyway, but this is an explicit belt-and-suspenders guard against a commit
+    loop). A reserved filename (index.md/log.md/template.md,
+    ``format.validate.RESERVED``) is exempt from the missing-status check only,
+    matching the same exemption ``validate_document`` grants those files from
+    the full concept schema.
+
+    Windows are inclusive of the boundary day: "recently expired" is
+    ``valid_until`` strictly before ``today`` (expired) AND on/after
+    ``today - recently_expired_days``; "expiring soon" is ``valid_until`` on/
+    after ``today`` (not yet expired) AND on/before ``today +
+    expiring_soon_days``.
+    """
+    from data_olympus.format.validate import is_expired
+
+    missing_status: list[str] = []
+    recently_expired: list[ExpiryItem] = []
+    expiring_soon: list[ExpiryItem] = []
+    recently_cutoff = _add_days(today, -recently_expired_days)
+    soon_cutoff = _add_days(today, expiring_soon_days)
+    for row in rows:
+        if row.path == ledger_path:
+            continue
+        if not row.is_reserved and not row.status:
+            missing_status.append(row.path)
+        if not row.valid_until:
+            continue
+        if is_expired(row.valid_until, today):
+            if row.valid_until >= recently_cutoff:
+                recently_expired.append(
+                    ExpiryItem(id=row.id, path=row.path, valid_until=row.valid_until)
+                )
+        elif row.valid_until <= soon_cutoff:
+            expiring_soon.append(
+                ExpiryItem(id=row.id, path=row.path, valid_until=row.valid_until)
+            )
+    missing_status.sort()
+    recently_expired.sort(key=lambda i: (i.valid_until, i.path))
+    expiring_soon.sort(key=lambda i: (i.valid_until, i.path))
+    return MaintenanceState(
+        status_present_in_all_kb_entries=not missing_status,
+        missing_status_paths=tuple(missing_status[:cap]),
+        missing_status_count=len(missing_status),
+        recently_expired=tuple(recently_expired[:cap]),
+        recently_expired_count=len(recently_expired),
+        expiring_soon=tuple(expiring_soon[:cap]),
+        expiring_soon_count=len(expiring_soon),
+    )
+
+
+def render_ledger_markdown(
+    state: MaintenanceState, *, computed_at_iso: str,
+) -> str:
+    """Render the committed ledger doc: full, valid concept frontmatter (so it
+    lints clean and is never itself flagged missing-status) plus the
+    structured ``maintenance`` block the state round-trips through, and a short
+    human-readable body."""
+    import yaml
+
+    fm: dict[str, Any] = {
+        "id": LEDGER_ID,
+        "type": "reference",
+        "status": "active",
+        "tier": "meta",
+        "title": "Data Olympus Maintenance Ledger",
+        "description": (
+            "Auto-generated corpus maintenance ledger, regenerated on every "
+            "index build when the computed state changes. Do not edit by hand."
+        ),
+        "tags": ["maintenance", "auto-generated"],
+        "maintenance": {
+            "computed_at": computed_at_iso,
+            **state.to_dict(),
+        },
+    }
+    dumped = yaml.safe_dump(
+        fm, sort_keys=False, default_flow_style=False, allow_unicode=True
+    )
+    lines = [
+        "# Data Olympus Maintenance Ledger",
+        "",
+        "Auto-generated by data-olympus at every index build; do not edit by "
+        "hand (edits are overwritten the next time the computed state "
+        "changes). See docs/operations.md.",
+        "",
+    ]
+    if state.status_present_in_all_kb_entries:
+        lines.append("- `status` is present on every indexed document.")
+    else:
+        lines.append(
+            f"- {state.missing_status_count} document(s) are missing a "
+            f"`status` field (showing up to {len(state.missing_status_paths)})."
+        )
+    if state.recently_expired_count:
+        lines.append(f"- {state.recently_expired_count} document(s) recently expired.")
+    if state.expiring_soon_count:
+        lines.append(f"- {state.expiring_soon_count} document(s) are expiring soon.")
+    if state.is_dirty:
+        lines.append("")
+        lines.append(
+            "Run an audit session to review and remediate the open item(s) above."
+        )
+    return "---\n" + dumped + "---\n\n" + "\n".join(lines) + "\n"
+
+
+def parse_ledger_state(content_markdown: str | None) -> MaintenanceState | None:
+    """Parse a previously-committed ledger doc's frontmatter back into a
+    MaintenanceState, for the idempotence check in :func:`maybe_update_ledger`.
+
+    Returns None when there is no content, or the ``maintenance`` block is
+    absent / unparseable (a fresh deployment with no ledger yet, or a
+    hand-edited ledger) -- treated as "no prior state", so the caller commits a
+    fresh one rather than crashing.
+    """
+    if not content_markdown:
+        return None
+    from data_olympus.format.frontmatter import parse_frontmatter
+
+    try:
+        fm, _body = parse_frontmatter(content_markdown)
+    except ValueError:
+        return None
+    maintenance = fm.get("maintenance") if isinstance(fm, dict) else None
+    if not isinstance(maintenance, dict):
+        return None
+    try:
+        return MaintenanceState.from_dict(maintenance)
+    except Exception:  # noqa: BLE001 - a corrupt/hand-edited block must never crash a build
+        return None
+
+
+def pending_actions_for(
+    state: MaintenanceState | None,
+) -> list[dict[str, object]] | None:
+    """Build the ``pending_actions`` CTA envelope from a MaintenanceState.
+
+    Returns None (the field is OMITTED entirely -- token discipline) when there
+    is no state yet, or the state is clean. Each item is a short structured
+    ``{kind, message, count}`` dict; the message instructs the model to surface
+    the item to the operator and act only on operator confirmation (mirrored in
+    the kb_consult / kb_health tool descriptions). Never attached to kb_search.
+    """
+    if state is None or not state.is_dirty:
+        return None
+    items: list[dict[str, object]] = []
+    if not state.status_present_in_all_kb_entries:
+        items.append({
+            "kind": "missing_status",
+            "message": (
+                f"{state.missing_status_count} document(s) are missing a "
+                f"'status' field. Surface this to the operator; act only on "
+                f"operator confirmation."
+            ),
+            "count": state.missing_status_count,
+        })
+    if state.recently_expired_count:
+        items.append({
+            "kind": "recently_expired",
+            "message": (
+                f"{state.recently_expired_count} document(s) recently expired. "
+                f"Surface this to the operator and suggest running an audit "
+                f"session; act only on operator confirmation."
+            ),
+            "count": state.recently_expired_count,
+        })
+    if state.expiring_soon_count:
+        items.append({
+            "kind": "expiring_soon",
+            "message": (
+                f"{state.expiring_soon_count} document(s) are expiring soon. "
+                f"Surface this to the operator and suggest running an audit "
+                f"session; act only on operator confirmation."
+            ),
+            "count": state.expiring_soon_count,
+        })
+    return items
+
+
+def maybe_update_ledger(
+    *,
+    idx: Index,
+    worktrees: WorktreeRegistry,
+    push_queue: PushQueue,
+    pending: PendingQueue,
+    serializer: WriteSerializer,
+    ledger_path: str,
+    audit_log: AuditLog | None = None,
+    now: float | None = None,
+) -> str | None:
+    """Best-effort: commit the maintenance ledger doc when the freshly computed
+    state (``idx.maintenance_state``) differs from the state recorded in the
+    last committed copy. Returns the new commit sha, or None when no commit was
+    needed or attempted.
+
+    NEVER raises: a commit failure (gate rejection, lock contention, git
+    error, ...) is logged (and audited, best-effort) and swallowed, so a
+    maintenance-ledger hiccup can never break index refresh or serving
+    (issue #113). Reuses the SAME serialized write/commit machinery every other
+    write goes through (``tools_write.commit_multifile_in_worktree``) rather
+    than forking a second git-writing path.
+    """
+    state = idx.maintenance_state
+    if state is None:
+        return None
+    existing = idx.get(LEDGER_ID)
+    old_state = parse_ledger_state(existing.content_markdown if existing is not None else None)
+    if old_state == state:
+        return None
+    computed_at = datetime.datetime.fromtimestamp(
+        now if now is not None else _time.time(), tz=datetime.UTC
+    ).isoformat()
+    postimage = render_ledger_markdown(state, computed_at_iso=computed_at)
+
+    from data_olympus.index import _classify_by_path
+    target_tier, _ = _classify_by_path(ledger_path)
+
+    try:
+        from data_olympus.tools_write import commit_multifile_in_worktree
+        sha, push_state = commit_multifile_in_worktree(
+            worktrees=worktrees, push_queue=push_queue, pending=pending,
+            serializer=serializer, idx=idx,
+            source_session=_MAINTENANCE_SOURCE_SESSION,
+            agent_identity=_MAINTENANCE_AGENT_IDENTITY,
+            files=[{"target_path": ledger_path, "postimage": postimage}],
+            subject="chore(maintenance): update maintenance ledger",
+            target_tier=target_tier,
+            target_path_for_msg=ledger_path,
+            confidence=1.0,
+            push_meta={"source_session": _MAINTENANCE_SOURCE_SESSION,
+                       "agent_identity": _MAINTENANCE_AGENT_IDENTITY},
+        )
+    except Exception as exc:  # noqa: BLE001 - best-effort; never break refresh/serving
+        _log.warning(
+            "maintenance ledger commit failed (will retry once a future index "
+            "build recomputes a changed state): %s", exc,
+        )
+        if audit_log is not None:
+            with contextlib.suppress(Exception):
+                audit_log.append({
+                    "ts": _time.time(), "event_type": "maintenance_ledger",
+                    "status": "commit_failed", "target_path": ledger_path,
+                    "agent_identity": _MAINTENANCE_AGENT_IDENTITY,
+                    "reason": str(exc)[:400],
+                })
+        return None
+    if audit_log is not None:
+        with contextlib.suppress(Exception):
+            audit_log.append({
+                "ts": _time.time(), "event_type": "maintenance_ledger",
+                "status": "committed", "target_path": ledger_path,
+                "agent_identity": _MAINTENANCE_AGENT_IDENTITY,
+                "commit_sha": sha,
+            })
+    _log.info("maintenance ledger updated: %s (push_state=%s)", sha, push_state)
+    return sha

--- a/src/data_olympus/models.py
+++ b/src/data_olympus/models.py
@@ -53,6 +53,11 @@ class HealthResponse(BaseModel):
     # Docs with a present-but-malformed ``validity`` block at the last index
     # build (issue #107). Same WARNING-only rationale as malformed_frontmatter.
     malformed_validity: int = 0
+    # Maintenance-ledger CTA (issue #113): short structured items
+    # ({kind, message, count}) an agent should surface to the operator and act
+    # on only with operator confirmation. None (field omitted in compact mode)
+    # when the computed maintenance state is clean -- token discipline.
+    pending_actions: list[dict[str, object]] | None = None
 
     # Health fields always present in compact mode even when falsy, because a
     # consumer branches on them (bin/kb and the REST 503 path read ``degraded``;
@@ -436,6 +441,11 @@ class ConsultResponse(BaseModel):
     rules: list[SearchHitModel] = []
     consulted_at: float
     ttl_seconds: int
+    # Maintenance-ledger CTA (issue #113). See HealthResponse.pending_actions;
+    # omitted (None) when the computed maintenance state is clean. Callers
+    # serialize this response with ``exclude_none=True`` so a clean state
+    # drops the field entirely rather than emitting a null.
+    pending_actions: list[dict[str, object]] | None = None
 
 
 class GateCheckResponse(BaseModel):

--- a/src/data_olympus/refresh.py
+++ b/src/data_olympus/refresh.py
@@ -107,6 +107,33 @@ async def git_pull_loop(state: ServerState, interval_sec: int) -> None:
                 state.last_index_error_at = None
                 state.last_index_conflicts = []
                 log.info("kb refreshed to %s", outcome.get("sha"))
+            # Maintenance ledger (issue #113): checked on EVERY tick, not only
+            # a "rebuilt" outcome. A fresh deployment whose remote never
+            # changes would otherwise get "no_change" forever and the ledger
+            # would never be created. maybe_update_ledger is a cheap no-op
+            # comparison when the state has not changed (idx.maintenance_state
+            # vs. the state parsed back out of the currently-indexed ledger
+            # doc), so checking every tick is inexpensive. Only attempted when
+            # the write pipeline is initialised (not a read-only replica /
+            # no remote configured); best-effort, never raises.
+            if (
+                state.worktrees is not None
+                and state.push_queue is not None
+                and state.pending is not None
+            ):
+                from data_olympus.maintenance import maybe_update_ledger
+                try:
+                    fn2 = functools.partial(
+                        maybe_update_ledger,
+                        idx=state.idx, worktrees=state.worktrees,
+                        push_queue=state.push_queue, pending=state.pending,
+                        serializer=state.write_serializer,
+                        audit_log=state.audit_log,
+                        ledger_path=state.config.maintenance_ledger_path,
+                    )
+                    await asyncio.get_event_loop().run_in_executor(None, fn2)
+                except Exception:
+                    log.exception("maintenance ledger update failed")
         except asyncio.CancelledError:
             log.info("git_pull_loop cancelled")
             raise

--- a/src/data_olympus/rest_api.py
+++ b/src/data_olympus/rest_api.py
@@ -680,7 +680,7 @@ def register_routes(
                 # clients are real agent calls).
                 trigger=body.get("trigger", "explicit"),
             )
-            return JSONResponse(resp.model_dump())
+            return JSONResponse(resp.model_dump(exclude_none=True))
 
         @app.custom_route("/api/v1/gate/check", methods=["POST"])
         async def gate_check(request: Request) -> JSONResponse:

--- a/src/data_olympus/server.py
+++ b/src/data_olympus/server.py
@@ -259,6 +259,9 @@ def build_app(
     embeddings_enabled: bool = False,
     embeddings_weight: float = 0.35,
     embeddings_model: str = "BAAI/bge-small-en-v1.5",
+    maintenance_ledger_path: str = "tooling/maintenance-ledger.md",
+    maintenance_recently_expired_days: int = 30,
+    maintenance_expiring_soon_days: int = 30,
 ) -> FastMCP:
     """Construct a FastMCP app with the read tools registered.
 
@@ -307,6 +310,9 @@ def build_app(
         embeddings_enabled=embeddings_enabled,
         embeddings_weight=embeddings_weight,
         embeddings_model=embeddings_model,
+        maintenance_ledger_path=maintenance_ledger_path,
+        maintenance_recently_expired_days=maintenance_recently_expired_days,
+        maintenance_expiring_soon_days=maintenance_expiring_soon_days,
     )
     if audit_log_path is not None:
         config_kwargs["audit_log_path"] = audit_log_path
@@ -343,6 +349,9 @@ def build_app(
         trigram_fallback_threshold=config.trigram_fallback_threshold,
         embeddings=emb_config,
         embedder=embedder,
+        maintenance_ledger_path=config.maintenance_ledger_path,
+        maintenance_recently_expired_days=config.maintenance_recently_expired_days,
+        maintenance_expiring_soon_days=config.maintenance_expiring_soon_days,
     )
     synonym_expander = default_query_expander()
     cooc_expander = idx.cooccurrence_expander() if cooccurrence_enabled() else None
@@ -443,7 +452,12 @@ def build_app(
         verbose: False (default) returns a token-compact shape that keeps the core
         snapshot and OMITS diagnostic fields that are null/empty (e.g.
         last_index_error, remote_head_sha when unset). verbose=True returns every
-        field including the nulls."""
+        field including the nulls.
+
+        pending_actions, when present, lists open maintenance items (missing
+        `status` fields, recently-expired/expiring-soon docs) computed at the
+        last index build; it is omitted when the corpus is clean. Surface it
+        to the operator and act on it only with operator confirmation."""
         resp = kb_health_fn(
             idx=state.idx,
             last_git_pull_at=state.last_git_pull_at,
@@ -798,7 +812,12 @@ def build_app(
             """Record a consultation for (source_session, workspace) and return the
             governing rules for the intent. Call before code/architectural work.
             trigger is 'explicit' (default: a deliberate consult, clears the gate)
-            or 'prompt_hook' (an installer auto-consult: audited, never clears)."""
+            or 'prompt_hook' (an installer auto-consult: audited, never clears).
+
+            pending_actions, when present, lists open maintenance items (missing
+            `status` fields, recently-expired/expiring-soon docs); omitted when
+            the corpus is clean. Surface it to the operator and act on it only
+            with operator confirmation."""
             if (throttled := _mcp_rate_limited()) is not None:
                 return throttled
             import time as _time
@@ -811,7 +830,7 @@ def build_app(
                 ttl_sec=state.config.consult_ttl_sec, now=_time.time(),
                 audit_log=state.audit_log, trigger=trigger,
             )
-            return resp.model_dump()
+            return resp.model_dump(exclude_none=True)
 
         @app.tool()
         def kb_gate_check(
@@ -926,6 +945,9 @@ def build_app_from_config(config: Config, *, bootstrap_now: bool = True) -> Fast
         embeddings_enabled=config.embeddings_enabled,
         embeddings_weight=config.embeddings_weight,
         embeddings_model=config.embeddings_model,
+        maintenance_ledger_path=config.maintenance_ledger_path,
+        maintenance_recently_expired_days=config.maintenance_recently_expired_days,
+        maintenance_expiring_soon_days=config.maintenance_expiring_soon_days,
     )
 
 

--- a/src/data_olympus/tools_enforce.py
+++ b/src/data_olympus/tools_enforce.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from data_olympus.enforce_policy import EXPLICIT_TRIGGER, PROMPT_HOOK_TRIGGER
+from data_olympus.maintenance import pending_actions_for
 from data_olympus.models import (
     ComplianceResponse,
     ConsultResponse,
@@ -63,7 +64,15 @@ def kb_consult_fn(
     default, which clears the gate) from an installer prompt-hook auto-consult
     (PROMPT_HOOK_TRIGGER, recorded for audit/compliance but never gate-clearing).
     Old clients that omit the field are treated as explicit, since a bare consult
-    call is always a real agent action."""
+    call is always a real agent action.
+
+    The response's ``pending_actions`` (issue #113) surfaces open maintenance
+    items (missing ``status`` fields, recently-expired/expiring-soon docs)
+    ONLY when the computed corpus state is dirty; it is omitted entirely on a
+    clean corpus. When present, surface it to the operator and act on it only
+    with operator confirmation -- do not silently start remediating the
+    corpus.
+    """
     trigger = trigger if trigger in _TRIGGERS else EXPLICIT_TRIGGER
     result = classifier.classify(intent=intent)
     rules = []
@@ -86,6 +95,7 @@ def kb_consult_fn(
     return ConsultResponse(
         is_governed_decision=result.is_governed_decision,
         rules=rules, consulted_at=now, ttl_seconds=int(ttl_sec),
+        pending_actions=pending_actions_for(getattr(idx, "maintenance_state", None)),
     )
 
 

--- a/src/data_olympus/tools_read.py
+++ b/src/data_olympus/tools_read.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Protocol
 
 from data_olympus.health import snapshot
+from data_olympus.maintenance import pending_actions_for
 from data_olympus.models import (
     CategoryCount,
     GetResponse,
@@ -107,6 +108,7 @@ def kb_health_fn(
         live_sessions=state.live_sessions,
         malformed_frontmatter=state.malformed_frontmatter,
         malformed_validity=state.malformed_validity,
+        pending_actions=pending_actions_for(getattr(idx, "maintenance_state", None)),
     )
 
 

--- a/tests/test_config_maintenance.py
+++ b/tests/test_config_maintenance.py
@@ -1,0 +1,24 @@
+"""Config fields for the maintenance ledger (issue #113)."""
+from __future__ import annotations
+
+from data_olympus.config import load_config
+
+
+def test_maintenance_defaults(monkeypatch) -> None:
+    monkeypatch.delenv("KB_MAINTENANCE_LEDGER_PATH", raising=False)
+    monkeypatch.delenv("KB_MAINTENANCE_RECENTLY_EXPIRED_DAYS", raising=False)
+    monkeypatch.delenv("KB_MAINTENANCE_EXPIRING_SOON_DAYS", raising=False)
+    cfg = load_config()
+    assert cfg.maintenance_ledger_path == "tooling/maintenance-ledger.md"
+    assert cfg.maintenance_recently_expired_days == 30
+    assert cfg.maintenance_expiring_soon_days == 30
+
+
+def test_maintenance_from_env(monkeypatch) -> None:
+    monkeypatch.setenv("KB_MAINTENANCE_LEDGER_PATH", "ops/kb-ledger.md")
+    monkeypatch.setenv("KB_MAINTENANCE_RECENTLY_EXPIRED_DAYS", "14")
+    monkeypatch.setenv("KB_MAINTENANCE_EXPIRING_SOON_DAYS", "45")
+    cfg = load_config()
+    assert cfg.maintenance_ledger_path == "ops/kb-ledger.md"
+    assert cfg.maintenance_recently_expired_days == 14
+    assert cfg.maintenance_expiring_soon_days == 45

--- a/tests/test_maintenance.py
+++ b/tests/test_maintenance.py
@@ -1,0 +1,214 @@
+"""Tests for the maintenance-ledger corpus-state audit (issue #113)."""
+from __future__ import annotations
+
+from data_olympus.maintenance import (
+    CAP,
+    DocAuditRow,
+    ExpiryItem,
+    MaintenanceState,
+    compute_maintenance_state,
+    parse_ledger_state,
+    pending_actions_for,
+    render_ledger_markdown,
+)
+
+LEDGER_PATH = "tooling/maintenance-ledger.md"
+
+
+def _row(path: str, *, status: str = "active", valid_until: str = "",
+         is_reserved: bool = False, doc_id: str | None = None) -> DocAuditRow:
+    return DocAuditRow(
+        path=path, id=doc_id or path, status=status,
+        valid_until=valid_until, is_reserved=is_reserved,
+    )
+
+
+# --- scenario 1: all statuses present -----------------------------------
+
+
+def test_all_statuses_present_flags_true_no_missing_list() -> None:
+    rows = [_row("a.md"), _row("b.md"), _row("c.md")]
+    state = compute_maintenance_state(rows, today="2026-07-08", ledger_path=LEDGER_PATH)
+    assert state.status_present_in_all_kb_entries is True
+    assert state.missing_status_paths == ()
+    assert state.missing_status_count == 0
+    assert state.is_dirty is False
+
+
+# --- scenario 2: >50 status-less files -----------------------------------
+
+
+def test_more_than_cap_missing_status_is_capped_with_total_count() -> None:
+    n = 73
+    rows = [_row(f"doc-{i:03d}.md", status="") for i in range(n)]
+    state = compute_maintenance_state(rows, today="2026-07-08", ledger_path=LEDGER_PATH)
+    assert state.status_present_in_all_kb_entries is False
+    assert len(state.missing_status_paths) == CAP
+    assert state.missing_status_count == n
+    assert state.is_dirty is True
+
+
+def test_reserved_filenames_are_exempt_from_missing_status() -> None:
+    rows = [
+        _row("index.md", status="", is_reserved=True),
+        _row("log.md", status="", is_reserved=True),
+        _row("real-doc.md", status="active"),
+    ]
+    state = compute_maintenance_state(rows, today="2026-07-08", ledger_path=LEDGER_PATH)
+    assert state.status_present_in_all_kb_entries is True
+    assert state.missing_status_count == 0
+
+
+# --- scenario 3: expiry windows -------------------------------------------
+
+
+def test_expiry_windows_bucket_correctly() -> None:
+    today = "2026-07-08"
+    rows = [
+        # expired 10 days ago -> recently_expired
+        _row("expired-10.md", valid_until="2026-06-28", doc_id="EXP-10"),
+        # expiring in 10 days -> expiring_soon
+        _row("expiring-10.md", valid_until="2026-07-18", doc_id="EXP-SOON-10"),
+        # expired 60 days ago -> outside the 30-day window, excluded entirely
+        _row("expired-60.md", valid_until="2026-05-09", doc_id="EXP-60"),
+        # no validity at all -> excluded from both buckets
+        _row("no-validity.md"),
+    ]
+    state = compute_maintenance_state(
+        rows, today=today, ledger_path=LEDGER_PATH,
+        recently_expired_days=30, expiring_soon_days=30,
+    )
+    assert [i.id for i in state.recently_expired] == ["EXP-10"]
+    assert state.recently_expired_count == 1
+    assert [i.id for i in state.expiring_soon] == ["EXP-SOON-10"]
+    assert state.expiring_soon_count == 1
+    assert state.is_dirty is True
+
+
+def test_expiry_window_boundary_is_inclusive() -> None:
+    today = "2026-07-08"
+    rows = [
+        # exactly at the 30-day recently-expired boundary
+        _row("boundary-expired.md", valid_until="2026-06-08", doc_id="B-EXP"),
+        # exactly at the 30-day expiring-soon boundary
+        _row("boundary-soon.md", valid_until="2026-08-07", doc_id="B-SOON"),
+    ]
+    state = compute_maintenance_state(
+        rows, today=today, ledger_path=LEDGER_PATH,
+        recently_expired_days=30, expiring_soon_days=30,
+    )
+    assert [i.id for i in state.recently_expired] == ["B-EXP"]
+    assert [i.id for i in state.expiring_soon] == ["B-SOON"]
+
+
+def test_expiry_windows_are_configurable() -> None:
+    today = "2026-07-08"
+    rows = [_row("expired-10.md", valid_until="2026-06-28", doc_id="EXP-10")]
+    # A 5-day window excludes a doc expired 10 days ago.
+    state = compute_maintenance_state(
+        rows, today=today, ledger_path=LEDGER_PATH, recently_expired_days=5,
+    )
+    assert state.recently_expired_count == 0
+    # A 15-day window includes it.
+    state2 = compute_maintenance_state(
+        rows, today=today, ledger_path=LEDGER_PATH, recently_expired_days=15,
+    )
+    assert state2.recently_expired_count == 1
+
+
+# --- scenario 8: ledger doc excluded from its own audit -------------------
+
+
+def test_ledger_path_excluded_from_its_own_audit() -> None:
+    rows = [
+        _row(LEDGER_PATH, status="active", valid_until="2026-01-01"),
+        _row("real.md", status="active"),
+    ]
+    state = compute_maintenance_state(rows, today="2026-07-08", ledger_path=LEDGER_PATH)
+    assert state.status_present_in_all_kb_entries is True
+    assert state.recently_expired_count == 0
+    assert state.expiring_soon_count == 0
+
+
+def test_ledger_path_excluded_even_when_missing_status() -> None:
+    """Belt-and-suspenders: even if the ledger doc somehow had no status, it
+    must never appear in the missing-status list (it is excluded by path, not
+    merely because it normally carries valid frontmatter)."""
+    rows = [_row(LEDGER_PATH, status=""), _row("real.md", status="active")]
+    state = compute_maintenance_state(rows, today="2026-07-08", ledger_path=LEDGER_PATH)
+    assert state.status_present_in_all_kb_entries is True
+    assert LEDGER_PATH not in state.missing_status_paths
+
+
+# --- pending_actions envelope ---------------------------------------------
+
+
+def test_pending_actions_is_none_when_state_is_none() -> None:
+    assert pending_actions_for(None) is None
+
+
+def test_pending_actions_is_none_when_clean() -> None:
+    state = MaintenanceState(status_present_in_all_kb_entries=True)
+    assert pending_actions_for(state) is None
+
+
+def test_pending_actions_present_when_dirty_with_all_three_kinds() -> None:
+    state = MaintenanceState(
+        status_present_in_all_kb_entries=False,
+        missing_status_paths=("a.md",), missing_status_count=1,
+        recently_expired=(ExpiryItem(id="X", path="x.md", valid_until="2026-06-28"),),
+        recently_expired_count=1,
+        expiring_soon=(ExpiryItem(id="Y", path="y.md", valid_until="2026-07-18"),),
+        expiring_soon_count=1,
+    )
+    actions = pending_actions_for(state)
+    assert actions is not None
+    kinds = {a["kind"] for a in actions}
+    assert kinds == {"missing_status", "recently_expired", "expiring_soon"}
+    for a in actions:
+        assert "operator confirmation" in a["message"]
+        assert isinstance(a["count"], int)
+
+
+# --- render / parse round-trip --------------------------------------------
+
+
+def test_render_parse_round_trip_preserves_state() -> None:
+    state = compute_maintenance_state(
+        [
+            _row("a.md", status=""),
+            _row("b.md", valid_until="2026-06-28", doc_id="B"),
+        ],
+        today="2026-07-08", ledger_path=LEDGER_PATH,
+    )
+    md = render_ledger_markdown(state, computed_at_iso="2026-07-08T00:00:00+00:00")
+    assert md.startswith("---\n")
+    assert "id: maintenance-ledger" in md
+    assert "status: active" in md
+    parsed = parse_ledger_state(md)
+    assert parsed == state
+
+
+def test_render_ledger_markdown_lints_clean() -> None:
+    """The rendered doc carries its own valid id/type/status/tier so it lints
+    clean rather than relying on reserved-filename exemption (issue #113)."""
+    from pathlib import Path
+
+    from data_olympus.format.document import Document
+    from data_olympus.format.frontmatter import parse_frontmatter
+    from data_olympus.format.validate import validate_document
+
+    state = MaintenanceState(status_present_in_all_kb_entries=True)
+    md = render_ledger_markdown(state, computed_at_iso="2026-07-08T00:00:00+00:00")
+    fm, body = parse_frontmatter(md)
+    doc = Document(path=Path("tooling/maintenance-ledger.md"), frontmatter=fm, body=body)
+    findings = validate_document(doc, today="2026-07-08")
+    errors = [f for f in findings if f.severity == "error"]
+    assert errors == []
+
+
+def test_parse_ledger_state_handles_absent_or_malformed_content() -> None:
+    assert parse_ledger_state(None) is None
+    assert parse_ledger_state("") is None
+    assert parse_ledger_state("no frontmatter here") is None
+    assert parse_ledger_state("---\nid: x\n---\nno maintenance block\n") is None

--- a/tests/test_maintenance_index_build.py
+++ b/tests/test_maintenance_index_build.py
@@ -1,0 +1,105 @@
+"""Index.build() computes and caches MaintenanceState (issue #113)."""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from data_olympus.index import Index
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def test_maintenance_state_none_before_first_build(tmp_path: Path) -> None:
+    idx = Index(tmp_path / "idx.db")
+    assert idx.maintenance_state is None
+
+
+def test_status_kb_has_all_statuses_present(status_kb: Path, tmp_path: Path) -> None:
+    """status_kb fixture: every doc carries an explicit status."""
+    idx = Index(tmp_path / "idx.db")
+    idx.build(status_kb, source_commit="x", today="2026-07-08")
+    state = idx.maintenance_state
+    assert state is not None
+    assert state.status_present_in_all_kb_entries is True
+    assert state.missing_status_count == 0
+
+
+def test_tmp_kb_has_missing_status_docs(tmp_kb: Path, tmp_path: Path) -> None:
+    """tmp_kb fixture has several docs with no `type`/`status` frontmatter at
+    all (e.g. WF-001, the memory/tooling files)."""
+    idx = Index(tmp_path / "idx.db")
+    idx.build(tmp_kb, source_commit="x", today="2026-07-08")
+    state = idx.maintenance_state
+    assert state is not None
+    assert state.status_present_in_all_kb_entries is False
+    assert state.missing_status_count > 0
+    assert len(state.missing_status_paths) == state.missing_status_count
+
+
+def test_recompute_after_remediation_flips_flag(tmp_kb: Path, tmp_path: Path) -> None:
+    """Remediation flow (scenario 7): fix the status-less file, rebuild, flag
+    flips true."""
+    idx = Index(tmp_path / "idx.db")
+    idx.build(tmp_kb, source_commit="x", today="2026-07-08")
+    assert idx.maintenance_state is not None
+    assert idx.maintenance_state.status_present_in_all_kb_entries is False
+
+    # Remediate: add status/type/tier to every doc missing one.
+    for rel in idx.maintenance_state.missing_status_paths:
+        p = tmp_kb / rel
+        text = p.read_text(encoding="utf-8")
+        if text.startswith("---\n"):
+            # Insert a status line into the existing frontmatter block.
+            head, _, rest = text.partition("---\n")
+            body_start = rest.find("---\n")
+            fm_body = rest[:body_start]
+            after = rest[body_start:]
+            p.write_text(f"---\n{fm_body}status: active\ntype: reference\ntier: meta\n{after}")
+        else:
+            p.write_text(f"---\nstatus: active\ntype: reference\ntier: meta\n---\n{text}")
+
+    idx.build(tmp_kb, source_commit="y", today="2026-07-08")
+    assert idx.maintenance_state.status_present_in_all_kb_entries is True
+    assert idx.maintenance_state.missing_status_count == 0
+
+
+def test_expiry_buckets_from_real_build(tmp_path: Path) -> None:
+    kb = tmp_path / "kb"
+    d = kb / "universal" / "foundation"
+    d.mkdir(parents=True)
+    (d / "expired.md").write_text(
+        "---\nid: EXP-1\ntype: standard\nstatus: active\ntier: T1\n"
+        "validity:\n  valid_until: 2026-06-28\n---\nold rule\n"
+    )
+    (d / "expiring-soon.md").write_text(
+        "---\nid: SOON-1\ntype: standard\nstatus: active\ntier: T1\n"
+        "validity:\n  valid_until: 2026-07-18\n---\nsoon-expiring rule\n"
+    )
+    idx = Index(tmp_path / "idx.db")
+    idx.build(kb, source_commit="x", today="2026-07-08")
+    state = idx.maintenance_state
+    assert state is not None
+    assert [i.id for i in state.recently_expired] == ["EXP-1"]
+    assert [i.id for i in state.expiring_soon] == ["SOON-1"]
+
+
+def test_ledger_doc_itself_excluded_from_build_time_audit(tmp_path: Path) -> None:
+    kb = tmp_path / "kb"
+    tooling = kb / "tooling"
+    tooling.mkdir(parents=True)
+    from data_olympus.maintenance import MaintenanceState, render_ledger_markdown
+    clean = MaintenanceState(status_present_in_all_kb_entries=True)
+    (tooling / "maintenance-ledger.md").write_text(
+        render_ledger_markdown(clean, computed_at_iso="2026-07-08T00:00:00+00:00")
+    )
+    (tooling / "other.md").write_text(
+        "---\nid: OTHER\ntype: reference\nstatus: active\ntier: meta\n---\nbody\n"
+    )
+    idx = Index(
+        tmp_path / "idx.db", maintenance_ledger_path="tooling/maintenance-ledger.md",
+    )
+    idx.build(kb, source_commit="x", today="2026-07-08")
+    state = idx.maintenance_state
+    assert state is not None
+    assert "tooling/maintenance-ledger.md" not in state.missing_status_paths
+    assert state.status_present_in_all_kb_entries is True

--- a/tests/test_maintenance_ledger_commit.py
+++ b/tests/test_maintenance_ledger_commit.py
@@ -1,0 +1,213 @@
+"""Integration tests for maintenance.maybe_update_ledger's commit side effect
+(issue #113, scenarios 5, 6, 7): the committed ledger, idempotence / loop
+guard, commit-failure resilience, and the remediation flow.
+
+Exercises the SAME write machinery (WorktreeRegistry / PushQueue /
+PendingQueue / WriteSerializer / tools_write.commit_multifile_in_worktree)
+real writes go through, against real git repos (a bare "origin" plus a main
+checkout), mirroring tests/test_write_pipeline_integration.py.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+from typing import TYPE_CHECKING
+
+from data_olympus.audit_log import AuditLog
+from data_olympus.git_ops import GitOps
+from data_olympus.index import Index
+from data_olympus.maintenance import maybe_update_ledger
+from data_olympus.pending import PendingQueue
+from data_olympus.push_queue import PushQueue
+from data_olympus.tools_read import kb_health_fn
+from data_olympus.worktrees import WorktreeRegistry
+from data_olympus.write_gate import WriteSerializer
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+LEDGER_PATH = "tooling/maintenance-ledger.md"
+
+
+def _env() -> dict[str, str]:
+    return {**os.environ, "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@e.com",
+            "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@e.com"}
+
+
+def _run(*args: str, cwd: str) -> None:
+    subprocess.run(list(args), cwd=cwd, check=True, env=_env(), capture_output=True)
+
+
+def _bare_remote_with_clone(tmp_path: Path) -> tuple[Path, Path]:
+    remote = tmp_path / "remote.git"
+    subprocess.run(["git", "init", "--bare", "--initial-branch=main", str(remote)],
+                   check=True, env=_env())
+    main = tmp_path / "main"
+    subprocess.run(["git", "clone", str(remote), str(main)], check=True,
+                   env=_env(), capture_output=True)
+    seed = main / "universal" / "foundation" / "STD-U-001.md"
+    seed.parent.mkdir(parents=True)
+    seed.write_text("---\nid: STD-U-001\ntype: standard\nstatus: active\ntier: T1\n"
+                    "---\nbase body\n")
+    _run("git", "add", "-A", cwd=str(main))
+    _run("git", "commit", "-m", "seed", cwd=str(main))
+    _run("git", "push", "origin", "main", cwd=str(main))
+    return remote, main
+
+
+def _harness(tmp_path: Path):
+    remote, main = _bare_remote_with_clone(tmp_path)
+    git = GitOps(main)
+    worktrees = WorktreeRegistry(git=git, worktree_root=str(tmp_path / "wts"))
+    push_queue = PushQueue(queue_root=str(tmp_path / "push-q"))
+    pending = PendingQueue(pending_root=str(tmp_path / "pending"))
+    serializer = WriteSerializer()
+    return remote, main, git, worktrees, push_queue, pending, serializer
+
+
+def _sync_main_from_origin(main: Path) -> None:
+    subprocess.run(["git", "-C", str(main), "fetch", "origin", "main"], check=True,
+                   env=_env(), capture_output=True)
+    subprocess.run(["git", "-C", str(main), "merge", "--ff-only", "origin/main"],
+                   check=True, env=_env(), capture_output=True)
+
+
+def _publish_ledger_commit(worktrees: WorktreeRegistry, git: GitOps, main: Path) -> None:
+    """Simulate the next production tick: push the system worktree's commit to
+    origin, then fast-forward "main" from it (what git_pull_loop's ff_merge
+    would do)."""
+    wt = worktrees.get_or_create(
+        source_session="system:maintenance-ledger",
+        agent_identity="data-olympus-system",
+    )
+    git.push(wt.path)
+    _sync_main_from_origin(main)
+
+
+def test_ledger_commit_lifecycle_idempotence_and_remediation(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """Combined scenario 5 + 7 walk: dirty corpus commits the ledger; an
+    unchanged recomputation (the ledger's own commit landing) does NOT create a
+    new commit; fixing the underlying doc flips the flag and produces a NEW
+    commit, after which pending_actions disappears."""
+    for k, v in _env().items():
+        if k.startswith("GIT_"):
+            monkeypatch.setenv(k, v)
+    remote, main, git, worktrees, push_queue, pending, serializer = _harness(tmp_path)
+
+    # Make the corpus dirty: a doc with no front matter at all.
+    workflows = main / "workflows"
+    workflows.mkdir(parents=True)
+    (workflows / "WF-001.md").write_text("# Ship something\n\nno front matter.\n")
+    _run("git", "add", "-A", cwd=str(main))
+    _run("git", "commit", "-m", "add dirty doc", cwd=str(main))
+    _run("git", "push", "origin", "main", cwd=str(main))
+
+    idx = Index(tmp_path / "idx.db", maintenance_ledger_path=LEDGER_PATH)
+    idx.build(main, source_commit="c1", today="2026-07-08")
+    assert idx.maintenance_state is not None
+    assert idx.maintenance_state.is_dirty is True
+
+    al = AuditLog(log_path=str(tmp_path / "audit.log"))
+
+    # --- scenario 5: first dirty computation commits the ledger -----------
+    sha1 = maybe_update_ledger(
+        idx=idx, worktrees=worktrees, push_queue=push_queue, pending=pending,
+        serializer=serializer, ledger_path=LEDGER_PATH, audit_log=al,
+    )
+    assert sha1 is not None
+
+    _publish_ledger_commit(worktrees, git, main)
+    idx.build(main, source_commit="c2", today="2026-07-08")
+    assert idx.maintenance_state.is_dirty is True  # WF-001 is still status-less
+
+    # Recomputation triggered by the ledger's own commit landing must be a
+    # no-op: no new commit for an unchanged state.
+    sha2 = maybe_update_ledger(
+        idx=idx, worktrees=worktrees, push_queue=push_queue, pending=pending,
+        serializer=serializer, ledger_path=LEDGER_PATH, audit_log=al,
+    )
+    assert sha2 is None
+
+    events = list(al.iter_filtered())
+    committed = [
+        e for e in events
+        if e.get("event_type") == "maintenance_ledger" and e.get("status") == "committed"
+    ]
+    assert len(committed) == 1
+    assert committed[0]["commit_sha"] == sha1
+
+    # --- scenario 7: remediate, rebuild, flag flips, ledger re-committed ---
+    (workflows / "WF-001.md").write_text(
+        "---\nid: WF-001\ntype: workflow\nstatus: active\ntier: meta\n---\nfixed.\n"
+    )
+    _run("git", "add", "-A", cwd=str(main))
+    _run("git", "commit", "-m", "fix missing status", cwd=str(main))
+    _run("git", "push", "origin", "main", cwd=str(main))
+
+    idx.build(main, source_commit="c3", today="2026-07-08")
+    assert idx.maintenance_state.is_dirty is False
+    assert idx.maintenance_state.status_present_in_all_kb_entries is True
+
+    sha3 = maybe_update_ledger(
+        idx=idx, worktrees=worktrees, push_queue=push_queue, pending=pending,
+        serializer=serializer, ledger_path=LEDGER_PATH, audit_log=al,
+    )
+    assert sha3 is not None
+    assert sha3 != sha1
+
+    # pending_actions has silenced automatically (no manual acking).
+    resp = kb_health_fn(idx=idx, last_git_pull_at=None, staleness_degraded_sec=600)
+    assert resp.pending_actions is None
+
+    events2 = list(al.iter_filtered())
+    committed2 = [
+        e for e in events2
+        if e.get("event_type") == "maintenance_ledger" and e.get("status") == "committed"
+    ]
+    assert len(committed2) == 2
+
+
+def test_commit_failure_is_logged_and_does_not_break_serving(
+    tmp_path: Path, monkeypatch, caplog,
+) -> None:
+    """scenario 6: a simulated commit failure is logged/audited and swallowed;
+    kb_health/kb_consult keep serving off the unaffected index."""
+    for k, v in _env().items():
+        if k.startswith("GIT_"):
+            monkeypatch.setenv(k, v)
+    _remote, main, _git, worktrees, push_queue, pending, serializer = _harness(tmp_path)
+
+    idx = Index(tmp_path / "idx.db", maintenance_ledger_path=LEDGER_PATH)
+    idx.build(main, source_commit="seed", today="2026-07-08")
+    assert idx.maintenance_state is not None
+
+    def _boom(**_kwargs: object) -> tuple[str, str]:
+        raise RuntimeError("simulated git failure")
+
+    monkeypatch.setattr(
+        "data_olympus.tools_write.commit_multifile_in_worktree", _boom,
+    )
+    al = AuditLog(log_path=str(tmp_path / "audit.log"))
+    caplog.set_level(logging.WARNING, logger="data_olympus.maintenance")
+
+    sha = maybe_update_ledger(
+        idx=idx, worktrees=worktrees, push_queue=push_queue, pending=pending,
+        serializer=serializer, ledger_path=LEDGER_PATH, audit_log=al,
+    )
+    assert sha is None
+    assert "simulated git failure" in caplog.text
+
+    events = list(al.iter_filtered())
+    failed = [
+        e for e in events
+        if e.get("event_type") == "maintenance_ledger" and e.get("status") == "commit_failed"
+    ]
+    assert len(failed) == 1
+
+    # Serving continues: kb_health must not raise and reports off the index
+    # exactly as before the failed commit attempt.
+    resp = kb_health_fn(idx=idx, last_git_pull_at=None, staleness_degraded_sec=600)
+    assert resp.kb_commit == "seed"

--- a/tests/test_maintenance_ledger_commit.py
+++ b/tests/test_maintenance_ledger_commit.py
@@ -211,3 +211,124 @@ def test_commit_failure_is_logged_and_does_not_break_serving(
     # exactly as before the failed commit attempt.
     resp = kb_health_fn(idx=idx, last_git_pull_at=None, staleness_degraded_sec=600)
     assert resp.kb_commit == "seed"
+
+
+def _dirty_main(tmp_path: Path):
+    """A harness whose main checkout carries one status-less doc (dirty corpus),
+    pushed to origin, plus a built Index over it."""
+    remote, main, git, worktrees, push_queue, pending, serializer = _harness(tmp_path)
+    workflows = main / "workflows"
+    workflows.mkdir(parents=True)
+    (workflows / "WF-001.md").write_text("# Ship something\n\nno front matter.\n")
+    _run("git", "add", "-A", cwd=str(main))
+    _run("git", "commit", "-m", "add dirty doc", cwd=str(main))
+    _run("git", "push", "origin", "main", cwd=str(main))
+    idx = Index(tmp_path / "idx.db", maintenance_ledger_path=LEDGER_PATH)
+    idx.build(main, source_commit="c1", today="2026-07-08")
+    assert idx.maintenance_state is not None
+    assert idx.maintenance_state.is_dirty is True
+    return remote, main, git, worktrees, push_queue, pending, serializer, idx
+
+
+def test_no_duplicate_commit_before_publication(tmp_path: Path, monkeypatch) -> None:
+    """Codex review blocker: two consecutive maybe_update_ledger calls on the
+    SAME dirty index, with the first ledger commit NOT yet pushed / merged /
+    re-indexed (the pull loop's steady state between publication ticks), must
+    produce exactly ONE commit. Before the in-process last-committed memo, the
+    second call saw a still-stale index copy, decided 'state changed', and
+    committed a duplicate on every tick."""
+    for k, v in _env().items():
+        if k.startswith("GIT_"):
+            monkeypatch.setenv(k, v)
+    (_remote, _main, _git, worktrees, push_queue, pending, serializer, idx) = (
+        _dirty_main(tmp_path)
+    )
+    al = AuditLog(log_path=str(tmp_path / "audit.log"))
+
+    sha1 = maybe_update_ledger(
+        idx=idx, worktrees=worktrees, push_queue=push_queue, pending=pending,
+        serializer=serializer, ledger_path=LEDGER_PATH, audit_log=al,
+    )
+    assert sha1 is not None
+
+    # NO push, NO merge into main, NO index rebuild: the very next tick.
+    sha2 = maybe_update_ledger(
+        idx=idx, worktrees=worktrees, push_queue=push_queue, pending=pending,
+        serializer=serializer, ledger_path=LEDGER_PATH, audit_log=al,
+    )
+    assert sha2 is None
+
+    committed = [
+        e for e in al.iter_filtered()
+        if e.get("event_type") == "maintenance_ledger" and e.get("status") == "committed"
+    ]
+    assert len(committed) == 1
+
+
+def test_no_duplicate_commit_after_restart_before_publication(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """Restart window: a NEW process (fresh Index, empty in-process memo) whose
+    index still predates the ledger's publication must NOT re-commit an
+    identical state -- the system worktree's HEAD already carries it (the
+    worktree survives restarts; unpushed commits block its GC)."""
+    for k, v in _env().items():
+        if k.startswith("GIT_"):
+            monkeypatch.setenv(k, v)
+    (_remote, main, _git, worktrees, push_queue, pending, serializer, idx) = (
+        _dirty_main(tmp_path)
+    )
+    al = AuditLog(log_path=str(tmp_path / "audit.log"))
+    sha1 = maybe_update_ledger(
+        idx=idx, worktrees=worktrees, push_queue=push_queue, pending=pending,
+        serializer=serializer, ledger_path=LEDGER_PATH, audit_log=al,
+    )
+    assert sha1 is not None
+
+    # Simulate a process restart: a brand-new Index (memo lost), rebuilt from
+    # the same main checkout (the ledger commit has not been merged into it).
+    idx2 = Index(tmp_path / "idx2.db", maintenance_ledger_path=LEDGER_PATH)
+    idx2.build(main, source_commit="c1", today="2026-07-08")
+    sha2 = maybe_update_ledger(
+        idx=idx2, worktrees=worktrees, push_queue=push_queue, pending=pending,
+        serializer=serializer, ledger_path=LEDGER_PATH, audit_log=al,
+    )
+    assert sha2 is None
+
+    committed = [
+        e for e in al.iter_filtered()
+        if e.get("event_type") == "maintenance_ledger" and e.get("status") == "committed"
+    ]
+    assert len(committed) == 1
+
+
+def test_unindexable_ledger_path_is_skipped(tmp_path: Path, monkeypatch, caplog) -> None:
+    """Codex review concern: a KB_MAINTENANCE_LEDGER_PATH outside every indexed
+    prefix must be refused (logged, audited, no commit) rather than committing
+    a doc the index will never serve."""
+    for k, v in _env().items():
+        if k.startswith("GIT_"):
+            monkeypatch.setenv(k, v)
+    (_remote, _main, _git, worktrees, push_queue, pending, serializer, idx) = (
+        _dirty_main(tmp_path)
+    )
+    al = AuditLog(log_path=str(tmp_path / "audit.log"))
+    caplog.set_level(logging.WARNING, logger="data_olympus.maintenance")
+
+    sha = maybe_update_ledger(
+        idx=idx, worktrees=worktrees, push_queue=push_queue, pending=pending,
+        serializer=serializer, ledger_path="outside/ledger.md", audit_log=al,
+    )
+    assert sha is None
+    assert "not_in_indexed_prefixes" in caplog.text
+
+    events = list(al.iter_filtered())
+    assert not any(
+        e.get("event_type") == "maintenance_ledger" and e.get("status") == "committed"
+        for e in events
+    )
+    skipped = [
+        e for e in events
+        if e.get("event_type") == "maintenance_ledger" and e.get("status") == "skipped_bad_path"
+    ]
+    assert len(skipped) == 1

--- a/tests/test_maintenance_pending_actions.py
+++ b/tests/test_maintenance_pending_actions.py
@@ -1,0 +1,132 @@
+"""pending_actions CTA surface on kb_consult / kb_health, never kb_search
+(issue #113, test scenario 4)."""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from data_olympus.enforce_policy import ConsultationLedger, IntentClassifier
+from data_olympus.index import Index
+from data_olympus.tools_enforce import kb_consult_fn
+from data_olympus.tools_read import kb_health_fn, kb_search_fn
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def test_kb_health_omits_pending_actions_when_clean(status_kb: Path, tmp_path: Path) -> None:
+    idx = Index(tmp_path / "idx.db")
+    idx.build(status_kb, source_commit="x", today="2026-07-08")
+    resp = kb_health_fn(idx=idx, last_git_pull_at=None, staleness_degraded_sec=600)
+    assert resp.pending_actions is None
+
+
+def test_kb_health_includes_pending_actions_when_dirty(tmp_kb: Path, tmp_path: Path) -> None:
+    idx = Index(tmp_path / "idx.db")
+    idx.build(tmp_kb, source_commit="x", today="2026-07-08")
+    resp = kb_health_fn(idx=idx, last_git_pull_at=None, staleness_degraded_sec=600)
+    assert resp.pending_actions is not None
+    assert any(a["kind"] == "missing_status" for a in resp.pending_actions)
+
+
+def test_kb_health_compact_dump_omits_pending_actions_when_clean(
+    status_kb: Path, tmp_path: Path,
+) -> None:
+    idx = Index(tmp_path / "idx.db")
+    idx.build(status_kb, source_commit="x", today="2026-07-08")
+    resp = kb_health_fn(idx=idx, last_git_pull_at=None, staleness_degraded_sec=600)
+    compact = resp.compact_dump()
+    assert "pending_actions" not in compact
+
+
+def test_kb_health_compact_dump_includes_pending_actions_when_dirty(
+    tmp_kb: Path, tmp_path: Path,
+) -> None:
+    idx = Index(tmp_path / "idx.db")
+    idx.build(tmp_kb, source_commit="x", today="2026-07-08")
+    resp = kb_health_fn(idx=idx, last_git_pull_at=None, staleness_degraded_sec=600)
+    compact = resp.compact_dump()
+    assert "pending_actions" in compact
+
+
+def test_kb_consult_includes_pending_actions_when_dirty(tmp_kb: Path, tmp_path: Path) -> None:
+    idx = Index(tmp_path / "idx.db")
+    idx.build(tmp_kb, source_commit="x", today="2026-07-08")
+    led = ConsultationLedger()
+    resp = kb_consult_fn(
+        idx=idx, classifier=IntentClassifier(), ledger=led,
+        workspace="proj", intent="say hello", source_session="s1",
+        agent_identity="claude", ttl_sec=300.0, now=1000.0, audit_log=None,
+    )
+    assert resp.pending_actions is not None
+
+
+def test_kb_consult_omits_pending_actions_when_clean(status_kb: Path, tmp_path: Path) -> None:
+    idx = Index(tmp_path / "idx.db")
+    idx.build(status_kb, source_commit="x", today="2026-07-08")
+    led = ConsultationLedger()
+    resp = kb_consult_fn(
+        idx=idx, classifier=IntentClassifier(), ledger=led,
+        workspace="proj", intent="say hello", source_session="s1",
+        agent_identity="claude", ttl_sec=300.0, now=1000.0, audit_log=None,
+    )
+    assert resp.pending_actions is None
+
+
+def test_kb_consult_model_dump_exclude_none_omits_field_when_clean(
+    status_kb: Path, tmp_path: Path,
+) -> None:
+    """Mirrors how the MCP/REST wrappers serialize: model_dump(exclude_none=True)."""
+    idx = Index(tmp_path / "idx.db")
+    idx.build(status_kb, source_commit="x", today="2026-07-08")
+    led = ConsultationLedger()
+    resp = kb_consult_fn(
+        idx=idx, classifier=IntentClassifier(), ledger=led,
+        workspace="proj", intent="say hello", source_session="s1",
+        agent_identity="claude", ttl_sec=300.0, now=1000.0, audit_log=None,
+    )
+    dumped = resp.model_dump(exclude_none=True)
+    assert "pending_actions" not in dumped
+
+
+def test_kb_search_never_has_pending_actions(tmp_kb: Path, tmp_path: Path) -> None:
+    """kb_search must NEVER carry pending_actions, dirty or not (per-hit noise
+    trains agents to ignore it -- issue #113)."""
+    idx = Index(tmp_path / "idx.db")
+    idx.build(tmp_kb, source_commit="x", today="2026-07-08")
+    assert idx.maintenance_state is not None
+    assert idx.maintenance_state.is_dirty is True  # sanity: this KB IS dirty
+    resp = kb_search_fn(idx=idx, query="worktree")
+    assert not hasattr(resp, "pending_actions")
+    assert "pending_actions" not in resp.model_dump()
+    assert "pending_actions" not in resp.compact_dump()
+
+
+def test_index_without_maintenance_state_yet_omits_pending_actions(tmp_path: Path) -> None:
+    """A fresh Index that has never built() yet (maintenance_state is None)
+    must not crash kb_health/kb_consult; the field is simply omitted."""
+    idx = Index(tmp_path / "idx.db")
+    resp = kb_health_fn(idx=idx, last_git_pull_at=None, staleness_degraded_sec=600)
+    assert resp.pending_actions is None
+
+
+class _FakeIndexNoMaintenance:
+    """A minimal Index stand-in with no maintenance_state attribute at all,
+    mirroring test_tools_enforce_consult.py's _FakeIndex. kb_consult_fn must
+    not crash on it (defensive getattr)."""
+
+    def search(self, query, limit=20, tier=None, category=None, status=None,  # noqa: ARG002
+               in_force=False, doc_type=None, **kwargs):  # noqa: ARG002
+        return []
+
+    def health(self):
+        return {"source_commit": "deadbeef"}
+
+
+def test_kb_consult_tolerates_index_with_no_maintenance_state_attribute() -> None:
+    led = ConsultationLedger()
+    resp = kb_consult_fn(
+        idx=_FakeIndexNoMaintenance(), classifier=IntentClassifier(), ledger=led,
+        workspace="proj", intent="say hello", source_session="s1",
+        agent_identity="claude", ttl_sec=300.0, now=1000.0, audit_log=None,
+    )
+    assert resp.pending_actions is None

--- a/tests/test_server_config_wiring.py
+++ b/tests/test_server_config_wiring.py
@@ -81,6 +81,33 @@ def test_non_default_config_is_threaded_into_app(
     assert state.config.write_block_paths == ["decisions/DEC-008-*.md"]
 
 
+def test_maintenance_ledger_config_reaches_the_index(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """KB_MAINTENANCE_* (issue #113) must reach the live Index instance, not
+    just state.config."""
+    kb = tmp_path / "kb"
+    kb.mkdir()
+    monkeypatch.setenv("KB_MAIN_PATH", str(kb))
+    monkeypatch.setenv("KB_INDEX_PATH", str(tmp_path / "kb.db"))
+    monkeypatch.setenv("KB_MAINTENANCE_LEDGER_PATH", "ops/kb-ledger.md")
+    monkeypatch.setenv("KB_MAINTENANCE_RECENTLY_EXPIRED_DAYS", "14")
+    monkeypatch.setenv("KB_MAINTENANCE_EXPIRING_SOON_DAYS", "45")
+
+    cfg = load_config()
+    assert cfg.maintenance_ledger_path == "ops/kb-ledger.md"
+    assert cfg.maintenance_recently_expired_days == 14
+    assert cfg.maintenance_expiring_soon_days == 45
+
+    app = server.build_app_from_config(cfg, bootstrap_now=False)
+    state = app._dolympus_state  # type: ignore[attr-defined]
+
+    assert state.config.maintenance_ledger_path == "ops/kb-ledger.md"
+    assert state.idx._maintenance_ledger_path == "ops/kb-ledger.md"
+    assert state.idx._maintenance_recently_expired_days == 14
+    assert state.idx._maintenance_expiring_soon_days == 45
+
+
 def test_write_block_tiers_reach_blocklist(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, tmp_git_kb: Path
 ) -> None:


### PR DESCRIPTION
## Summary

Implements #113: a committed runtime maintenance ledger plus a `pending_actions` CTA surface.

- **Maintenance state, computed at every index build** (same single corpus walk, nearly free): `status_present_in_all_kb_entries` with a capped (50 paths + total count) missing-`status` list (reserved filenames exempt), and recently-expired / expiring-soon buckets from #107 validity data within configurable windows (`KB_MAINTENANCE_RECENTLY_EXPIRED_DAYS` / `KB_MAINTENANCE_EXPIRING_SOON_DAYS`, default 30/30). Persisted in the index meta table and cached on the `Index` instance.
- **Committed ledger doc** at `KB_MAINTENANCE_LEDGER_PATH` (default `tooling/maintenance-ledger.md`, inside the generic taxonomy's indexed `tooling/` prefix; private deployments with a custom taxonomy must keep it inside an indexed prefix). Committed server-side and best-effort through the existing serialized write machinery (`commit_multifile_in_worktree`: write serializer, per-path locks, secret scan, validation gates) under a system identity, ONLY when the structured state changes. Commit failures are logged + audited and never break refresh or serving.
- **Loop guard** (hardened after companion review): three-tier duplicate-commit guard comparing the structured state, never the rendered markdown — in-process last-committed memo, indexed ledger copy, and the system worktree's HEAD copy (restart-safe). The ledger doc is excluded from its own audit and carries full valid frontmatter, so it lints clean without reserved-filename semantics. A ledger path outside the indexed prefixes is refused with a `skipped_bad_path` audit event.
- **CTA surface**: `pending_actions` (`{kind, message, count}` items) on `kb_consult` and `kb_health` responses only — explicitly never `kb_search` — omitted entirely when clean (token discipline). Tool descriptions instruct the model to surface open items to the operator and act only on operator confirmation. `kb health -o plain` displays open items. The `kb_consult` change is envelope-only (one field on `ConsultResponse` + `exclude_none` serialization) to ease the merge with the parallel in-force-filtering work package.
- **Docs**: new `docs/operations.md` §5 (maintenance ledger runbook + env var table); CHANGELOG `[Unreleased]` entry. No SPEC change (no reserved-filename semantics added).

## Test evidence

- Full suite green: `uv run pytest -q` — 1,449 passed, 2 skipped (pre-existing optional-dep skips: sentence_transformers, tiktoken).
- `uv run ruff check src/ tests/` — all checks passed; `uv run mypy` (strict) clean on all touched files.
- All bats suites green, including `test_kb_cli.bats` for the `bin/kb` change.
- New tests (28 across 5 files) covering every scenario in the issue: all-statuses-present clean state; >50 status-less files capped at 50 with true total; expiry buckets (expired 10 days ago in, expiring in 10 days in, expired 60 days ago out; boundary days inclusive; windows configurable); `pending_actions` present on dirty / absent on clean consult+health, never on `kb_search`; first dirty computation commits, unchanged recomputation is a no-op (including two consecutive ticks before publication and a restart before publication); simulated commit failure logs + audits and serving continues; remediation flips the flag, re-commits, and auto-silences `pending_actions`; the ledger doc lints clean and is excluded from its own audit; render/parse round-trip; config/env wiring down to the live `Index`.

## Companion review (codex)

Two review rounds via `codex exec --sandbox read-only`:

- **Round 1: NO-GO.** Blocker: `maybe_update_ledger` compared only against the indexed ledger copy, so every pull-loop tick between a ledger commit and its publication (push → merge → re-index) re-committed the same state. Concern: the ledger path bypassed the structural writable-path check. Both fixed in 7f4d360 with the three-tier guard, the `is_writable_path` refusal, and three new tests reproducing the blocker.
- **Round 2: GO, blockers: none.** Confirmed the memo is set only after a successful commit (failure retries next tick), the worktree-HEAD check closes the restart window, the bad-path refusal audits `skipped_bad_path`, and the three new tests are on target. One residual non-blocking caveat recorded: with an already-indexed ledger at an unchanged state, a newly-misconfigured path is silent (no `skipped_bad_path` event) until the state next changes — it still never commits to the bad path.