### PR TITLE
ci: fix startup failure of PyPI dry-run on pull requests

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -48,6 +48,16 @@ jobs:
       upload: false
     permissions:
       contents: read
+      # id-token: write is NOT used on this path (upload=false skips the only
+      # job with an OIDC step) but must be granted anyway: GitHub validates a
+      # called workflow's job-level permission requests against the caller's
+      # grant statically at startup, BEFORE `if:` conditions are evaluated, so
+      # omitting it startup-fails every pull_request run. Exposure is bounded:
+      # the reusable `build` job runs with contents: read only, the `upload`
+      # job (the only OIDC consumer) is gated off by `if: inputs.upload`, and
+      # a real PyPI exchange additionally requires the `pypi` environment
+      # (deployment policy: main + v* tags) and a matching Trusted Publisher.
+      id-token: write
 
   release:
     if: github.event_name == 'push' && github.ref_type == 'tag'


### PR DESCRIPTION
Cherry-pick of #117 onto the release/0.4.0 integration branch so PRs targeting it stop startup-failing.

Every pull_request run of "Publish to PyPI" dies at startup with: `The nested job 'upload' is requesting 'id-token: write', but is only allowed 'id-token: none'`. GitHub validates a called workflow's job-level permission requests against the caller's grant statically, BEFORE `if:` conditions are evaluated, so the dry-run caller job must grant `id-token: write` even though the upload job is always skipped on PRs (`upload: false`). Exposure is bounded: the reusable build job runs with `contents: read` only, the upload job is gated off, and a real PyPI exchange additionally requires the `pypi` environment (main + v* tags) and a matching Trusted Publisher.

Empirical proof on #117: its own `dry-run / build` check started and passed (build + twine check + wheel smoke test) with `dry-run / upload` skipped; this PR's checks demonstrate the same on the release lane.

## Companion review (codex)

Verdict: GO, no blockers (recorded on #117; this is an identical cherry-pick). The reviewer's one concern (overstated safety comment) was already reworded before #117 was opened. #117 itself remains open for main and needs operator approval.