### PR TITLE
fix(docs): refresh release metadata for v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1494,7 +1494,10 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `docs/adoption.md`: bring-your-own-KB guide (author, lint, index, serve, wire an agent).
 - `docs/comparison.md`: how data-olympus relates to OKF, enterprise catalogs, markdown KB tools, agent-context conventions, RAG, and ADR tooling.
 
-[Unreleased]: https://github.com/knaisoma/data-olympus/compare/v0.3.3...HEAD
+[Unreleased]: https://github.com/knaisoma/data-olympus/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/knaisoma/data-olympus/compare/v0.3.5...v0.4.0
+[0.3.5]: https://github.com/knaisoma/data-olympus/compare/v0.3.4...v0.3.5
+[0.3.4]: https://github.com/knaisoma/data-olympus/compare/v0.3.3...v0.3.4
 [0.3.3]: https://github.com/knaisoma/data-olympus/compare/v0.3.2...v0.3.3
 [0.3.2]: https://github.com/knaisoma/data-olympus/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/knaisoma/data-olympus/compare/v0.3.0...v0.3.1

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ data-olympus is a governance-grade knowledge-base format and server for agent wo
 
 It governs *decisions*, not code. When an agent is about to make a choice (a library, a pattern, a migration), data-olympus surfaces the established standard or decision that should govern that choice. It is deliberately **not** a code-search, reference-finding, or "where is X used" tool: LSP, grep, and Sourcegraph already do that well. The retrieval task it targets is coding-intent to governing-rule, and it helps where current model interaction during vibe-coding is weakest: keeping the model aligned to patterns the team has already established as correct.
 
-**Status: pre-1.0 beta. Latest release: v0.3.0.**
+**Status: pre-1.0 beta. Latest release: v0.4.0.**
 
 ## Why
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -2,7 +2,7 @@
 
 **Version:** 0.2
 **Date:** 2026-07-08
-**Status:** Stable (shipped with data-olympus v0.3.0; the format is versioned independently of the package, see section 10)
+**Status:** Stable (shipped with data-olympus v0.4.0; the format is versioned independently of the package, see section 10)
 
 ---
 


### PR DESCRIPTION
Fixes the three round-2 release-gate blockers: (1) CHANGELOG compare-link footer was stuck at v0.3.3 (adds [0.4.0], backfills [0.3.4]/[0.3.5], repoints [Unreleased] at v0.4.0...HEAD); (2) README latest-release line said v0.3.0; (3) SPEC.md header said format 0.2 shipped with v0.3.0, corrected to v0.4.0. Guards green.

## Companion review (codex)

These three items ARE the codex release-gate round-2 findings (recorded on PR #133 when the gate verdict posts); this PR is their mechanical remediation, verified by the changelog and doc-consistency guards.