### PR TITLE
fix(cli): scaffold stamps the current format version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **`data-olympus init` stamped a stale format version** (found by the
+  release-gate review): the scaffold's root `index.md` declared
+  `spec_version: "0.1"` while the shipped format is `0.2`. Corrected, with a
+  drift test tying the scaffold constant to SPEC.md's header and
+  `example-bundle/index.md` so future format bumps fail fast.
+
 - **Graph-exclusion source guard now applies the memory-inbox floor** (found
   by the v0.4.0 release-gate review). `graph_excluded_ids_sql` checked the
   superseding source's status class and validity window but not `is_inbox`,

--- a/src/data_olympus/scaffold.py
+++ b/src/data_olympus/scaffold.py
@@ -26,7 +26,10 @@ from data_olympus.cli.indexgen import regenerate_indexes
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
-SPEC_VERSION = "0.1"
+# Must track the current SPEC.md format version (the drift test in
+# tests/test_cli_init.py compares this against SPEC.md's header and
+# example-bundle/index.md, so a future format bump fails fast here).
+SPEC_VERSION = "0.2"
 OKF_VERSION = "0.1"
 
 # The six top-level tier directories `--tiers` selects among (issue #66's

--- a/tests/test_cli_init.py
+++ b/tests/test_cli_init.py
@@ -217,3 +217,25 @@ def test_init_missing_path_argument_returns_nonzero():
     # module as the other init error-handling tests for discoverability.
     with pytest.raises(SystemExit):
         main(["init"])
+
+
+def test_scaffold_spec_version_tracks_current_format() -> None:
+    """The scaffold's SPEC_VERSION must match both SPEC.md's header and
+    example-bundle/index.md, so `data-olympus init` never generates a fresh
+    bundle declaring a stale format version (v0.4.0 release-gate blocker:
+    the scaffold shipped stamping 0.1 after the format moved to 0.2)."""
+    import re
+    from pathlib import Path
+
+    from data_olympus.scaffold import SPEC_VERSION
+
+    root = Path(__file__).resolve().parents[1]
+    spec_header = re.search(
+        r"^\*\*Version:\*\*\s+(\S+)$", (root / "SPEC.md").read_text(), re.MULTILINE
+    )
+    assert spec_header is not None
+    assert SPEC_VERSION == spec_header.group(1)
+    bundle_index = (root / "example-bundle" / "index.md").read_text()
+    m = re.search(r'^spec_version:\s*"([^"]+)"', bundle_index, re.MULTILINE)
+    assert m is not None
+    assert SPEC_VERSION == m.group(1)

--- a/tests/test_cli_init.py
+++ b/tests/test_cli_init.py
@@ -234,8 +234,8 @@ def test_scaffold_spec_version_tracks_current_format() -> None:
         r"^\*\*Version:\*\*\s+(\S+)$", (root / "SPEC.md").read_text(), re.MULTILINE
     )
     assert spec_header is not None
-    assert SPEC_VERSION == spec_header.group(1)
+    assert spec_header.group(1) == SPEC_VERSION
     bundle_index = (root / "example-bundle" / "index.md").read_text()
     m = re.search(r'^spec_version:\s*"([^"]+)"', bundle_index, re.MULTILINE)
     assert m is not None
-    assert SPEC_VERSION == m.group(1)
+    assert m.group(1) == SPEC_VERSION


### PR DESCRIPTION
Fixes the round-3 release-gate blocker: `data-olympus init` stamped `spec_version: "0.1"` in the generated root index.md while the shipped format is 0.2 (the scaffold landed in Wave 1, before #118 bumped the format). Sets the constant to 0.2 and adds a drift test asserting the scaffold constant equals both SPEC.md's version header and example-bundle/index.md, so any future format bump fails fast instead of shipping stale scaffolds. Full suite exit 0; changelog guard ok.

## Companion review (codex)

This item IS the codex release-gate round-3 finding (consolidated verdict to be recorded on PR #133); this PR is its mechanical remediation plus the guard the reviewer implied.