### PR TITLE
docs(ops): document fastmcp host allowlist behind proxies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Documented the fastmcp 3.4.3 host allowlist requirement behind
+  proxies/ingress** (docs/serving.md, docs/operations.md section 3.4).
+  v0.4.1's fastmcp bump enables DNS-rebinding protection that answers 421
+  Misdirected Request for undeclared public hostnames while health probes
+  keep passing; deployments behind a reverse proxy must set
+  `FASTMCP_HTTP_ALLOWED_HOSTS`. First-class handling tracked in #139.
+
 ## [0.4.1] - 2026-07-08
 
 ### Changed

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -205,6 +205,26 @@ an empty index.
 
 ---
 
+### 3.4 Reverse proxy / ingress host allowlist (v0.4.1+, fastmcp >= 3.4.3)
+
+fastmcp 3.4.3 enables DNS-rebinding protection on streamable HTTP: it
+validates the `Host` (and `Origin`) header and answers **421 Misdirected
+Request** for any hostname outside its allowlist. Localhost and direct
+pod-IP requests pass, so kubelet probes and local smoke tests stay green
+while EVERY request through a reverse proxy or ingress fails. If you serve
+data-olympus behind any public hostname, declare it:
+
+```yaml
+# ConfigMap (JSON list, parsed by fastmcp's pydantic-settings)
+FASTMCP_HTTP_ALLOWED_HOSTS: '["kb.example.com"]'
+```
+
+Symptom checklist for a missed allowlist after upgrading to v0.4.1+:
+readiness green, `421 Misdirected Request` in the pod log for every
+ingress-sourced request, agents' enforcement hooks failing open. A
+first-class data-olympus knob plus a startup warning is tracked in
+issue #139.
+
 ## 4. Recovery playbooks
 
 ### 4.1 Degraded / `fetch_failed`

--- a/docs/serving.md
+++ b/docs/serving.md
@@ -798,6 +798,23 @@ reverse proxy (terminate TLS there). See `SECURITY.md` for the full threat model
 the route/capability table, payload limits, the tamper-evident audit log, and the
 git sync-failure health fields.
 
+### Host allowlist behind a proxy (`FASTMCP_HTTP_ALLOWED_HOSTS`, v0.4.1+)
+
+fastmcp >= 3.4.3 validates the `Host` header on streamable HTTP
+(DNS-rebinding protection) and returns `421 Misdirected Request` for
+hostnames outside its allowlist. When data-olympus is served behind a
+reverse proxy or ingress, set the public hostname explicitly:
+
+```bash
+FASTMCP_HTTP_ALLOWED_HOSTS='["kb.example.com"]'
+```
+
+Direct localhost/pod requests are always allowed, so health probes pass
+while proxied traffic fails: check the server log for 421 lines if agents
+suddenly cannot reach the endpoint after an upgrade. Operational details
+in docs/operations.md section 3.4; a first-class knob is tracked in
+issue #139.
+
 ### Proxy headers and the rate limiter (`KB_TRUSTED_PROXIES`)
 
 The rate limiter keys on the client remote address (plus principal). Behind an


### PR DESCRIPTION
Documents the v0.4.1 operational gotcha found on kn-dev (issue #139): fastmcp 3.4.3's DNS-rebinding protection 421s every proxied request unless FASTMCP_HTTP_ALLOWED_HOSTS declares the public hostname, while direct probes keep passing. Adds docs/operations.md section 3.4 (symptom checklist included), a serving.md subsection next to the existing KB_TRUSTED_PROXIES proxy note, and a changelog entry. Docs only; the first-class knob + startup warning remain tracked in #139.