### PR TITLE
chore: add Glama claim metadata

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": [
+    "ajdelaguila"
+  ]
+}


### PR DESCRIPTION
## Summary

Adds a root `glama.json` file so the org-owned Glama MCP server listing can be claimed and managed by the authenticated maintainer account.

## Type of change

- [ ] Tool / code change (CLI, MCP server, `kb` client, deploy)
- [ ] Spec / format change (requires a linked Spec Proposal issue with maintainer sign-off)
- [x] Documentation
- [ ] CI

<!-- If this is a spec change, link the Spec Proposal issue here: -->
<!-- Spec Proposal issue: # -->

## Checklist

- [x] Tests pass (`uv run --extra dev pytest`: 1536 passed, 2 skipped)
- [x] `ruff` reports no errors (`uv run ruff check .`)
- [x] `data-olympus lint` exits 0 on any bundle touched by this PR (N/A: no bundles touched)
- [x] Documentation updated (N/A: registry metadata only)
- [x] `SPEC.md` and the validator are consistent (N/A: no schema change)
- [x] No em-dashes in any prose added or modified by this PR
- [x] No credentials or secrets committed
