### PR TITLE
feat: data-olympus verify command + staged-promotion release pipeline (v0.4.2)

### DIFF
--- a/.github/workflows/rc-publish.yml
+++ b/.github/workflows/rc-publish.yml
@@ -1,0 +1,86 @@
+# .github/workflows/rc-publish.yml
+name: Publish release candidate
+
+# Manually dispatched by the release cutter after quality gates pass. Builds the
+# RC image from a ref where pyproject already carries the final X.Y.Z, publishes
+# it to ghcr as X.Y.Z-rc.N plus the moving :rc channel, and cuts a GitHub
+# pre-release. Image-only: RCs are never published to PyPI and never move :latest.
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "git ref to build (the release-candidate branch/sha; pyproject must carry the final X.Y.Z)"
+        required: true
+        type: string
+
+concurrency:
+  group: rc-publish-${{ inputs.ref }}
+  cancel-in-progress: false
+
+jobs:
+  decide:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+    outputs:
+      rc_tag: ${{ steps.rc.outputs.rc_tag }}
+      version: ${{ steps.rc.outputs.version }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.ref }}
+          fetch-depth: 0
+      - name: Compute RC tag
+        id: rc
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="$(python3 -c 'import sys; from scripts.should_tag import project_version; print(project_version(open("pyproject.toml").read()))')"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          # List existing ghcr tags for this package; empty on first RC (jq -e guards the 404/empty case).
+          gh api --paginate \
+            "/orgs/knaisoma/packages/container/data-olympus/versions" \
+            --jq '.[].metadata.container.tags[]' > /tmp/tags.txt 2>/dev/null || true
+          RC_TAG="$(python3 scripts/rc_tag.py --base "$VERSION" < /tmp/tags.txt)"
+          echo "rc_tag=$RC_TAG" >> "$GITHUB_OUTPUT"
+          echo "Computed RC tag: $RC_TAG (base $VERSION)"
+
+  build-image:
+    needs: decide
+    uses: ./.github/workflows/release-image-reusable.yml
+    with:
+      tag: ${{ needs.decide.outputs.rc_tag }}
+      move_latest: false
+      channel: rc
+    permissions:
+      contents: read
+      packages: write
+
+  prerelease:
+    needs: [decide, build-image]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.ref }}
+      - name: Create GitHub pre-release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RC_TAG: ${{ needs.decide.outputs.rc_tag }}
+          VERSION: ${{ needs.decide.outputs.version }}
+        run: |
+          NOTES="docs/releases/v${VERSION}.md"
+          if gh release view "$RC_TAG" >/dev/null 2>&1; then
+            echo "pre-release $RC_TAG already exists, skipping"
+            exit 0
+          fi
+          if [ -f "$NOTES" ]; then
+            gh release create "$RC_TAG" --prerelease --target "${{ inputs.ref }}" \
+              --title "$RC_TAG" --notes-file "$NOTES"
+          else
+            gh release create "$RC_TAG" --prerelease --target "${{ inputs.ref }}" \
+              --title "$RC_TAG" --notes "Release candidate ${RC_TAG} for ${VERSION}."
+          fi

--- a/.github/workflows/rc-publish.yml
+++ b/.github/workflows/rc-publish.yml
@@ -36,12 +36,23 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          VERSION="$(python3 -c 'import sys; from scripts.should_tag import project_version; print(project_version(open("pyproject.toml").read()))')"
+          VERSION="$(python3 -c 'from scripts.should_tag import project_version; print(project_version(open("pyproject.toml").read()))')"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          # List existing ghcr tags for this package; empty on first RC (jq -e guards the 404/empty case).
-          gh api --paginate \
-            "/orgs/knaisoma/packages/container/data-olympus/versions" \
-            --jq '.[].metadata.container.tags[]' > /tmp/tags.txt 2>/dev/null || true
+          # List existing ghcr tags for this package. A 404 (package has no
+          # versions yet, i.e. the first-ever RC) is tolerated as "no tags"; ANY
+          # other failure (auth, rate-limit, 5xx) must fail loudly, so we never
+          # silently recompute rc.1 and overwrite an already-published RC image.
+          : > /tmp/tags.txt
+          if ! gh api --paginate \
+                "/orgs/knaisoma/packages/container/data-olympus/versions" \
+                --jq '.[].metadata.container.tags[]' > /tmp/tags.txt 2>/tmp/gh-err.log; then
+            if grep -qiE '404|not found' /tmp/gh-err.log; then
+              echo "no existing package versions (first RC); using empty tag list"
+              : > /tmp/tags.txt
+            else
+              echo "gh api failed (non-404):" >&2; cat /tmp/gh-err.log >&2; exit 1
+            fi
+          fi
           RC_TAG="$(python3 scripts/rc_tag.py --base "$VERSION" < /tmp/tags.txt)"
           echo "rc_tag=$RC_TAG" >> "$GITHUB_OUTPUT"
           echo "Computed RC tag: $RC_TAG (base $VERSION)"

--- a/.github/workflows/release-image-reusable.yml
+++ b/.github/workflows/release-image-reusable.yml
@@ -12,6 +12,11 @@ on:
         required: false
         default: false
         type: boolean
+      channel:
+        description: "also push this moving channel tag (e.g. rc, kndev); empty = none"
+        required: false
+        default: ""
+        type: string
 jobs:
   build-push:
     runs-on: ubuntu-latest
@@ -38,12 +43,16 @@ jobs:
         env:
           INPUT_TAG: ${{ inputs.tag }}
           MOVE_LATEST: ${{ inputs.move_latest }}
+          INPUT_CHANNEL: ${{ inputs.channel }}
         run: |
           {
             echo "tags<<EOF"
             echo "ghcr.io/knaisoma/data-olympus:$INPUT_TAG"
             if [ "$MOVE_LATEST" = "true" ]; then
               echo "ghcr.io/knaisoma/data-olympus:latest"
+            fi
+            if [ -n "$INPUT_CHANNEL" ]; then
+              echo "ghcr.io/knaisoma/data-olympus:$INPUT_CHANNEL"
             fi
             echo "EOF"
           } >> "$GITHUB_OUTPUT"

--- a/.github/workflows/set-channel.yml
+++ b/.github/workflows/set-channel.yml
@@ -1,0 +1,53 @@
+name: Set image channel
+
+# Re-points a moving ghcr channel tag (default :kndev) at an existing image
+# ref's digest, WITHOUT rebuilding. Keel (force + match-tag on :kndev) then rolls
+# kn-dev onto it. Drives the RC canary (source = the rc tag), promotion
+# (source = the new stable vX.Y.Z), and rollback (source = the previous stable).
+# Dispatched by the release cutter via `gh workflow run`.
+on:
+  workflow_dispatch:
+    inputs:
+      channel:
+        description: "moving channel tag to move (e.g. kndev)"
+        required: false
+        default: "kndev"
+        type: string
+      source:
+        description: "existing image tag to point the channel at (e.g. v0.5.0-rc.1, v0.5.0)"
+        required: true
+        type: string
+
+concurrency:
+  group: set-channel-${{ inputs.channel }}
+  cancel-in-progress: false
+
+jobs:
+  retag:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Re-point channel at source digest
+        env:
+          REPO: ghcr.io/knaisoma/data-olympus
+          CHANNEL: ${{ inputs.channel }}
+          SOURCE: ${{ inputs.source }}
+        run: |
+          # Fail if the source tag does not exist (avoid creating a dangling channel).
+          if ! docker buildx imagetools inspect "$REPO:$SOURCE" >/dev/null 2>&1; then
+            echo "source image $REPO:$SOURCE not found" >&2
+            exit 1
+          fi
+          docker buildx imagetools create --tag "$REPO:$CHANNEL" "$REPO:$SOURCE"
+          echo "channel $REPO:$CHANNEL now points at $REPO:$SOURCE"
+          docker buildx imagetools inspect "$REPO:$CHANNEL" | head -5

--- a/.github/workflows/set-channel.yml
+++ b/.github/workflows/set-channel.yml
@@ -26,7 +26,6 @@ jobs:
   retag:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
       packages: write
     steps:
       - name: Set up Docker Buildx
@@ -43,6 +42,10 @@ jobs:
           CHANNEL: ${{ inputs.channel }}
           SOURCE: ${{ inputs.source }}
         run: |
+          if [ -z "$CHANNEL" ]; then
+            echo "channel input is empty" >&2
+            exit 1
+          fi
           # Fail if the source tag does not exist (avoid creating a dangling channel).
           if ! docker buildx imagetools inspect "$REPO:$SOURCE" >/dev/null 2>&1; then
             echo "source image $REPO:$SOURCE not found" >&2
@@ -50,4 +53,7 @@ jobs:
           fi
           docker buildx imagetools create --tag "$REPO:$CHANNEL" "$REPO:$SOURCE"
           echo "channel $REPO:$CHANNEL now points at $REPO:$SOURCE"
-          docker buildx imagetools inspect "$REPO:$CHANNEL" | head -5
+          # `|| true`: the re-tag above already succeeded; this is a best-effort
+          # log, and `head` closing the pipe early must not fail the step under
+          # the runner's default `set -o pipefail`.
+          docker buildx imagetools inspect "$REPO:$CHANNEL" | head -n 5 || true

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -48,13 +48,73 @@ jobs:
           # and double-build plus double-move latest. Keep it on GITHUB_TOKEN.
           git push origin "$TAG"
 
-  # Build and publish the image BEFORE the GitHub Release is created, so a
-  # published Release always has its image. If this build fails, the tag exists
-  # but no Release is published; a rerun is safe (tag creation and this build are
-  # both idempotent).
-  build-image:
+  # Resolve whether a verified release-candidate image exists for this version.
+  # If it does, promotion re-tags that exact digest (byte-identical to what was
+  # verified on the kn-dev canary). If not (manual-tag / no-RC cut), build fresh.
+  resolve-rc:
     needs: decide
     if: needs.decide.outputs.tag != ''
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+    outputs:
+      rc_tag: ${{ steps.rc.outputs.rc_tag }}
+    steps:
+      - uses: actions/checkout@v7
+      - name: Find the highest existing RC tag for this version
+        id: rc
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.decide.outputs.tag }}
+        run: |
+          VERSION="${TAG#v}"
+          : > /tmp/tags.txt
+          if ! gh api --paginate \
+                "/orgs/knaisoma/packages/container/data-olympus/versions" \
+                --jq '.[].metadata.container.tags[]' > /tmp/tags.txt 2>/tmp/gh-err.log; then
+            if grep -qiE '404|not found' /tmp/gh-err.log; then
+              echo "no existing package versions; will build fresh"
+            else
+              echo "gh api failed (non-404):" >&2; cat /tmp/gh-err.log >&2; exit 1
+            fi
+          fi
+          RC_TAG="$(python3 scripts/rc_tag.py --base "$VERSION" --current < /tmp/tags.txt)"
+          echo "rc_tag=$RC_TAG" >> "$GITHUB_OUTPUT"
+          echo "resolved rc_tag='$RC_TAG' for $VERSION"
+
+  # Byte-identical promotion: re-tag the verified RC digest to vX.Y.Z + :latest.
+  # No rebuild, so the released image is exactly what passed kn-dev verification.
+  promote-image:
+    needs: [decide, resolve-rc]
+    if: needs.decide.outputs.tag != '' && needs.resolve-rc.outputs.rc_tag != ''
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Re-tag verified RC digest to the release tag
+        env:
+          REPO: ghcr.io/knaisoma/data-olympus
+          TAG: ${{ needs.decide.outputs.tag }}
+          RC_TAG: ${{ needs.resolve-rc.outputs.rc_tag }}
+        run: |
+          docker buildx imagetools create \
+            --tag "$REPO:$TAG" --tag "$REPO:latest" "$REPO:$RC_TAG"
+          echo "$REPO:$TAG and :latest now point at the verified $REPO:$RC_TAG digest"
+
+  # Fresh build fallback: only when no verified RC image exists (manual-tag cut).
+  build-image:
+    needs: [decide, resolve-rc]
+    if: needs.decide.outputs.tag != '' && needs.resolve-rc.outputs.rc_tag == ''
     uses: ./.github/workflows/release-image-reusable.yml
     with:
       tag: ${{ needs.decide.outputs.tag }}
@@ -115,8 +175,10 @@ jobs:
           skip-existing: true
 
   release:
-    needs: [decide, build-image]
-    if: needs.decide.outputs.tag != ''
+    needs: [decide, resolve-rc, promote-image, build-image]
+    if: >-
+      always() && needs.decide.outputs.tag != '' &&
+      (needs.promote-image.result == 'success' || needs.build-image.result == 'success')
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.rules/release-planning.md
+++ b/.rules/release-planning.md
@@ -14,20 +14,32 @@ with implementation tickets, so the Monday cutter has a ready epic.
 3. Select + cluster: target 4 (range 3-5) highest-value issues, then pull in
    closely-related ones (shared files, labels, milestone, epic). Produce a Release
    Scope Brief: chosen set with rationale, explicitly-deferred set, projected bump.
-4. Security clearance (mandatory, first phase): query every OPEN Dependabot and
-   CodeQL alert for the repo (`python3 scripts/security_alerts.py` reports them;
-   or `gh api /repos/knaisoma/data-olympus/dependabot/alerts?state=open` and
-   `.../code-scanning/alerts?state=open`). Every open alert MUST be driven to
-   resolution as part of this release, one of:
-   - a fix or dependency update, scoped as an implementation sub-ticket in the
-     release epic; or
-   - a dismissal with a recorded justification (false positive, not exploitable,
-     accepted risk), applied via `gh api ... -f state=dismissed -f
-     dismissed_reason=... -f dismissed_comment=...`.
-   Dismissals are a security judgment and are part of what the operator approves
-   at the approval gate below. The release scope brief must list every open alert
-   and its planned disposition (fix ticket or dismissal + reason). A release is
-   not scoped until the alert list has a disposition for every entry.
+4. Security clearance (MANDATORY, first phase). No release may be prepared while
+   any known weakness is open. Hard rule: by the end of this phase,
+   `python3 scripts/security_alerts.py` MUST exit 0 (zero open Dependabot AND zero
+   open CodeQL alerts) - that is the exact gate the Monday cutter re-checks and
+   blocks on (`.rules/release-routine.md` step 2a).
+
+   Query every OPEN alert (`python3 scripts/security_alerts.py` lists them; or
+   `gh api /repos/knaisoma/data-olympus/dependabot/alerts?state=open` and
+   `.../code-scanning/alerts?state=open`). Drive EVERY open alert to a disposition,
+   one of:
+   - **Fix / dependency update** - scope it as an implementation sub-ticket in the
+     release epic (the fix must land before the cutter runs); or
+   - **Dismissal with a recorded justification** - only after confirming it is a
+     false positive, not exploitable, or an accepted risk. Apply via:
+     `gh api -X PATCH /repos/knaisoma/data-olympus/code-scanning/alerts/<n>
+     -f state=dismissed -f dismissed_reason="false positive" -f
+     dismissed_comment="<why, <=280 chars>"`. Valid `dismissed_reason` values are
+     exactly `"false positive"`, `"won't fix"`, `"used in tests"` (Dependabot uses
+     `tolerable_risk`, `inaccurate`, `not_used`, `no_bandwidth`). The comment is a
+     hard cap of 280 characters.
+
+   Dismissals are a security judgment: the planner PROPOSES each disposition, and
+   the OPERATOR approves them at the approval gate below (step 6) before anything
+   is dismissed. The release scope brief MUST list every open alert with its
+   planned disposition (fix ticket or dismissal + reason). A release is not scoped
+   until every alert has a disposition and the gate exits 0.
 5. Dual-architect review: the routine (Architect, Claude Opus) drafts the scope +
    a per-issue implementation spec. The companion architect is `agy` with
    Gemini 3.5 Flash (High):

--- a/.rules/release-planning.md
+++ b/.rules/release-planning.md
@@ -14,7 +14,21 @@ with implementation tickets, so the Monday cutter has a ready epic.
 3. Select + cluster: target 4 (range 3-5) highest-value issues, then pull in
    closely-related ones (shared files, labels, milestone, epic). Produce a Release
    Scope Brief: chosen set with rationale, explicitly-deferred set, projected bump.
-4. Dual-architect review: the routine (Architect, Claude Opus) drafts the scope +
+4. Security clearance (mandatory, first phase): query every OPEN Dependabot and
+   CodeQL alert for the repo (`python3 scripts/security_alerts.py` reports them;
+   or `gh api /repos/knaisoma/data-olympus/dependabot/alerts?state=open` and
+   `.../code-scanning/alerts?state=open`). Every open alert MUST be driven to
+   resolution as part of this release, one of:
+   - a fix or dependency update, scoped as an implementation sub-ticket in the
+     release epic; or
+   - a dismissal with a recorded justification (false positive, not exploitable,
+     accepted risk), applied via `gh api ... -f state=dismissed -f
+     dismissed_reason=... -f dismissed_comment=...`.
+   Dismissals are a security judgment and are part of what the operator approves
+   at the approval gate below. The release scope brief must list every open alert
+   and its planned disposition (fix ticket or dismissal + reason). A release is
+   not scoped until the alert list has a disposition for every entry.
+5. Dual-architect review: the routine (Architect, Claude Opus) drafts the scope +
    a per-issue implementation spec. The companion architect is `agy` with
    Gemini 3.5 Flash (High):
    `agy -p '<review prompt + brief>' --model 'Gemini 3.5 Flash (High)'`.
@@ -23,9 +37,9 @@ with implementation tickets, so the Monday cutter has a ready epic.
    -c model_reasoning_effort="high" -C <dir> '<review prompt>'`. Iterate until both
    agree; record a `## Companion review (<agy | codex>)` evidence block
    (WF-004 / collaboration protocol).
-5. Operator approval gate: request a Paperclip approval carrying the brief + specs;
+6. Operator approval gate: request a Paperclip approval carrying the brief + specs;
    notify the operator (Telegram, GDEC-007). Wait.
-6. On approval: create the release parent epic + one implementation sub-ticket per
+7. On approval: create the release parent epic + one implementation sub-ticket per
    selected issue, each with a `Ready for Build` block, a reviewer assigned
    (GDEC-028), and `Branch: feature/<release-epic-id>` (WF-004 section 2.2 epic
    integration branch). The iterative changes-requested and re-review cycle follows WF-004 section 7 (In Review to In Progress until the reviewer approves).

--- a/.rules/release-planning.md
+++ b/.rules/release-planning.md
@@ -28,7 +28,7 @@ with implementation tickets, so the Monday cutter has a ready epic.
 6. On approval: create the release parent epic + one implementation sub-ticket per
    selected issue, each with a `Ready for Build` block, a reviewer assigned
    (GDEC-028), and `Branch: feature/<release-epic-id>` (WF-004 section 2.2 epic
-   integration branch). Peer-review-until-clean is inherent to WF-004 section 7.
+   integration branch). The iterative changes-requested and re-review cycle follows WF-004 section 7 (In Review to In Progress until the reviewer approves).
    Create the `feature/<release-epic-id>` branch off `main`.
 
 ## Constraints
@@ -37,6 +37,9 @@ with implementation tickets, so the Monday cutter has a ready epic.
 - One release epic per week; the batch is expected ready by the following Monday
   (strict 1-week pipeline). The Monday cutter (`.rules/release-routine.md`) gates on
   readiness and never ships a batch that is not Done + reviewed + green.
-- The epic uses the WF-004 section 2.2 shared integration branch (squash per
-  feature, one commit per ticket, one integration MR), reconciling the "release
+- The epic uses the WF-004 section 2.2 shared integration branch: each feature is
+  one squashed Conventional Commit per ticket on the branch, each sub-ticket updates
+  the CHANGELOG `[Unreleased]` block, and the single integration MR merges to `main`
+  with a MERGE COMMIT (never a squash), per `.rules/versioning.md`, so
+  `compute_release.py` sees each per-feature commit. This reconciles the "release
   branch" model with STD-U-810 section 2 (no long-lived gitflow release branch).

--- a/.rules/release-planning.md
+++ b/.rules/release-planning.md
@@ -1,0 +1,42 @@
+# data-olympus-release-planner routine
+
+Status: active
+Since: 2026-07-11
+Schedule: cron `0 18 * * 5` (Friday 18:00 Europe/Madrid)
+Purpose: turn open GitHub issues into a scoped, reviewed, operator-approved release
+with implementation tickets, so the Monday cutter has a ready epic.
+
+## What it does each run
+
+1. Hygiene + gh auth: clean `main` checkout, `gh` reachable
+   (`tooling/paperclip-gh-auth-context`).
+2. Gather: `gh issue list --state open --json number,title,labels,milestone,body`.
+3. Select + cluster: target 4 (range 3-5) highest-value issues, then pull in
+   closely-related ones (shared files, labels, milestone, epic). Produce a Release
+   Scope Brief: chosen set with rationale, explicitly-deferred set, projected bump.
+4. Dual-architect review: the routine (Architect, Claude Opus) drafts the scope +
+   a per-issue implementation spec. The companion architect is `agy` with
+   Gemini 3.5 Flash (High):
+   `agy -p '<review prompt + brief>' --model 'Gemini 3.5 Flash (High)'`.
+   Fallback when agy/Gemini is unavailable: codex CLI with gpt-5.6-sol high
+   reasoning: `codex exec --sandbox read-only --skip-git-repo-check -m gpt-5.6-sol
+   -c model_reasoning_effort="high" -C <dir> '<review prompt>'`. Iterate until both
+   agree; record a `## Companion review (<agy | codex>)` evidence block
+   (WF-004 / collaboration protocol).
+5. Operator approval gate: request a Paperclip approval carrying the brief + specs;
+   notify the operator (Telegram, GDEC-007). Wait.
+6. On approval: create the release parent epic + one implementation sub-ticket per
+   selected issue, each with a `Ready for Build` block, a reviewer assigned
+   (GDEC-028), and `Branch: feature/<release-epic-id>` (WF-004 section 2.2 epic
+   integration branch). Peer-review-until-clean is inherent to WF-004 section 7.
+   Create the `feature/<release-epic-id>` branch off `main`.
+
+## Constraints
+
+- No em-dashes.
+- One release epic per week; the batch is expected ready by the following Monday
+  (strict 1-week pipeline). The Monday cutter (`.rules/release-routine.md`) gates on
+  readiness and never ships a batch that is not Done + reviewed + green.
+- The epic uses the WF-004 section 2.2 shared integration branch (squash per
+  feature, one commit per ticket, one integration MR), reconciling the "release
+  branch" model with STD-U-810 section 2 (no long-lived gitflow release branch).

--- a/.rules/release-rollback.md
+++ b/.rules/release-rollback.md
@@ -1,0 +1,40 @@
+# Rule: release promotion and rollback (kn-dev canary)
+
+Status: active
+Since: 2026-07-11
+Applies to: the data-olympus release train (staged-promotion pipeline)
+
+## Channel model
+
+kn-dev runs whatever the moving ghcr tag `:kndev` points at (Keel `policy: force`,
+`match-tag: true`, poll). The pipeline moves `:kndev` via the `set-channel.yml`
+workflow (`gh workflow run set-channel.yml -f source=<tag>`); it never rebuilds an
+image, so the channel and its source share one digest.
+
+## Promotion sequence (cutter, after approval)
+
+1. Canary: `set-channel source=vX.Y.Z-rc.N` -> Keel rolls the RC onto kn-dev.
+2. Pre-release verify: `data-olympus verify --target <kn-dev ingress>` must be green.
+3. Paperclip approval-to-ship (operator).
+4. Merge the release PR -> `tag-release.yml` cuts tag vX.Y.Z, builds the stable
+   image, publishes PyPI, creates the GitHub Release.
+5. Promote the canary to stable: `set-channel source=vX.Y.Z` -> kn-dev runs stable.
+6. Post-release verify against kn-dev.
+
+## Rollback
+
+- Canary failure (pre-release verify red, or approval rejected): nothing external
+  shipped. `set-channel source=<pre-RC tag recorded in step 1>` -> Keel restores
+  the prior version. Roll a new `-rc.(N+1)` forward if fixable, else block.
+- Post-release failure (stable already shipped): `set-channel source=<previous
+  stable tag>` to restore kn-dev; `pip`-side, `twine`/PyPI `yank` the just-published
+  version (cannot delete); mark the GitHub Release as a draft/prerelease; open a
+  `release blocked: post-release verify failed` issue and notify the operator.
+
+## Note
+
+Stable image promotion currently builds fresh from the verified commit via
+`tag-release.yml` (digest-pinned base + frozen `uv.lock` = functionally identical
+to the verified RC), rather than a byte-identical digest re-tag. True byte-identical
+promotion is a documented future hardening (would require `tag-release.yml` to
+re-tag the RC digest instead of building).

--- a/.rules/release-rollback.md
+++ b/.rules/release-rollback.md
@@ -35,8 +35,9 @@ image, so the channel and its source share one digest.
 
 ## Note
 
-Stable image promotion currently builds fresh from the verified commit via
-`tag-release.yml` (digest-pinned base + frozen `uv.lock` = functionally identical
-to the verified RC), rather than a byte-identical digest re-tag. True byte-identical
-promotion is a documented future hardening (would require `tag-release.yml` to
-re-tag the RC digest instead of building).
+Stable image promotion is byte-identical: `tag-release.yml` re-tags the verified
+`X.Y.Z-rc.N` digest to `vX.Y.Z` (it builds fresh only as a manual-tag fallback when
+no RC exists). The PyPI wheel is built fresh from the tagged commit (the RC is
+image-only). The promoted image carries the RC build's OCI labels
+(`org.opencontainers.image.version` reads the rc tag); this is a cosmetic
+provenance detail, not a content difference.

--- a/.rules/release-rollback.md
+++ b/.rules/release-rollback.md
@@ -13,6 +13,10 @@ image, so the channel and its source share one digest.
 
 ## Promotion sequence (cutter, after approval)
 
+0. Record the rollback point: note the tag `:kndev` currently points at (the stable
+   version kn-dev is running, e.g. the latest non-prerelease GitHub Release, or read
+   it with `docker buildx imagetools inspect ghcr.io/knaisoma/data-olympus:kndev`).
+   The canary and post-release rollbacks below re-point `:kndev` back at this value.
 1. Canary: `set-channel source=vX.Y.Z-rc.N` -> Keel rolls the RC onto kn-dev.
 2. Pre-release verify: `data-olympus verify --target <kn-dev ingress>` must be green.
 3. Paperclip approval-to-ship (operator).
@@ -24,11 +28,9 @@ image, so the channel and its source share one digest.
 ## Rollback
 
 - Canary failure (pre-release verify red, or approval rejected): nothing external
-  shipped. `set-channel source=<pre-RC tag recorded in step 1>` -> Keel restores
+  shipped. `set-channel source=<the rollback-point tag from step 0>` -> Keel restores
   the prior version. Roll a new `-rc.(N+1)` forward if fixable, else block.
-- Post-release failure (stable already shipped): `set-channel source=<previous
-  stable tag>` to restore kn-dev; `pip`-side, `twine`/PyPI `yank` the just-published
-  version (cannot delete); mark the GitHub Release as a draft/prerelease; open a
+- Post-release failure (stable already shipped): `set-channel source=<the rollback-point tag from step 0>` to restore kn-dev; **yank** the just-published version on PyPI (PyPI has no CLI yank: do it in the PyPI web UI, Project -> the release -> Options -> Yank; yank hides it from resolvers, it cannot be deleted or replaced); mark the GitHub Release as a draft/prerelease; open a
   `release blocked: post-release verify failed` issue and notify the operator.
 
 ## Note

--- a/.rules/release-routine.md
+++ b/.rules/release-routine.md
@@ -1,42 +1,63 @@
 # data-olympus-release-cutter routine
 
 Status: active
-Since: 2026-07-01
-Schedule: cron `0 5 * * *` (05:00 UTC daily)
-Human gate: operator merges the release PR this routine opens. The routine never tags.
+Since: 2026-07-01 (rewritten 2026-07-11 for staged promotion)
+Schedule: cron `0 5 * * 1` (Monday 05:00 Europe/Madrid)
+Human gate: a single Paperclip approval-to-ship after the release candidate is
+live on kn-dev and pre-release verification is green. The routine then promotes;
+it does not merge or publish before that approval.
 
-## What it does each run
+## What it does each run (strict 1-week pipeline)
 
-1. Fetch `origin/main`. If HEAD is already on a `v*` tag, exit quietly (no work).
-2. Run `python3 scripts/compute_release.py`. If `releasable` is false, exit quietly.
-3. Quality gates (all must pass, else open a GitHub issue titled
-   "release blocked: <reason>" and stop, do not open a release PR):
-   - `uv run pytest -v`
-   - `uv run ruff check .`
-   - `uv run mypy src`
-   - `bats -r tests`
-   - a security review pass over `git diff <lasttag>..HEAD` (security-review skill)
-   - `kb_health` sanity check
-4. Read `next_version` and the `changes` buckets from the compute step.
-5. On a branch `chore/release-v<next_version>`:
-   - set `pyproject.toml` version to `<next_version>`
-   - in `CHANGELOG.md`, rename the `[Unreleased]` block to `[<next_version>] - <UTC date>`
-     and open a fresh empty `[Unreleased]` block above it
-   - write `docs/releases/v<next_version>.md` with exactly two H2 sections,
-     `## New features` and `## Fixed`, rewritten from the hand-written
-     `[Unreleased]` prose weighed against the commit `changes` buckets, in plain
-     language a non-technical reader understands. Omit a section if empty.
-6. Open a PR `chore/release-v<next_version>` -> `main`, title
-   `chore(release): v<next_version>`, label `release`. The PR body contains the
-   `docs/releases/v<next_version>.md` content followed by an
-   `## Announcement (draft)` block: a short upbeat paragraph, the two most
-   important items, and `<release-url-once-published>` as a placeholder link.
-7. Surface the PR to the operator as a Claude task for review. Stop. Do not merge,
-   do not tag.
+1. Resolve the current release epic (the batch the planner scoped the prior
+   Friday; see `.rules/release-planning.md`). If none is ready, report and exit.
+2. Readiness gate: all sub-tickets Done and reviewed, the integration branch
+   `feature/<release-epic-id>` green (CI). If not ready, post blockers on the epic,
+   notify the operator (Telegram, GDEC-007), and STOP. Never cut a red release.
+3. Sync + releasability: on the integration branch, run
+   `uv run python scripts/compute_release.py`; if `releasable` is false, exit
+   quietly. The branch must already carry the final `X.Y.Z` in `pyproject.toml`
+   (bumped during the epic), plus the CHANGELOG entry and `docs/releases/vX.Y.Z.md`.
+4. Quality gates (all must pass, else open a `release blocked: <reason>` issue and
+   stop): `uv run pytest -q`, `uv run ruff check .`, `uv run mypy src`,
+   `bats -r tests`, a security review over `git diff <lasttag>..HEAD`, and `kb_health`.
+5. Build the RC: `gh workflow run rc-publish.yml -f ref=feature/<release-epic-id>`.
+   This publishes `ghcr.io/knaisoma/data-olympus:X.Y.Z-rc.N` + the `:rc` channel and
+   a GitHub pre-release. Wait for the run to succeed; capture `X.Y.Z-rc.N`.
+6. Canary + record rollback point: read the current `:kndev` source (the stable
+   version kn-dev runs) and record it (`.rules/release-rollback.md` step 0). Then
+   `gh workflow run set-channel.yml -f source=X.Y.Z-rc.N`. Keel rolls the RC onto
+   kn-dev within ~2 minutes.
+7. Pre-release verify: `data-olympus verify --target <kn-dev ingress>` must be
+   green (health, readiness, search, enforcement). If red, roll back
+   (`set-channel source=<rollback point>`) and open a `release blocked` issue.
+8. Approval-to-ship: request a Paperclip approval on the epic and notify the
+   operator (Telegram). The operator may exercise the RC live on kn-dev, then
+   approves or rejects. On rejection, roll back and stop.
+9. Promote (on approval): merge the release PR / integration MR to `main`.
+   `tag-release.yml` cuts tag `vX.Y.Z`, builds the stable image, publishes PyPI, and
+   creates the GitHub Release. Then `gh workflow run set-channel.yml -f source=vX.Y.Z`
+   so kn-dev runs the promoted stable.
+10. Post-release verify: `data-olympus verify --target <kn-dev ingress>` green. If
+    red, roll back per `.rules/release-rollback.md` (post-release path) and notify.
+11. Release note into the Paperclip task: post the `docs/releases/vX.Y.Z.md` content
+    as a comment on the routine's Paperclip issue.
+12. Retro to company-knowledge: run a short retro (what the RC/verify cycle
+    surfaced, any gate that fired, any manual fix, kn-dev-vs-stable drift) and
+    propose a lessons-learned update to company-knowledge via the data-olympus MCP
+    (`kb_propose_edit` / `kb_propose_memory`, operator-gated). This is how the
+    pipeline improves release over release.
+13. Hold open for the operator's external announcement: keep the Paperclip task
+    open with a Telegram reminder. The release artifact ships on approval + verify;
+    the held-open task is the reminder to post the announcement.
 
 ## Constraints
 
-- No em-dashes in any authored prose.
-- Never publish to any external platform; the announcement is a draft in the PR body.
-- Never run `git tag`; tagging is `tag-release.yml`'s job after the operator merges.
-- One open release PR at a time: if `chore/release-v*` is already open, update it.
+- No em-dashes in authored prose.
+- The RC image carries the final `X.Y.Z` (baked from `pyproject.toml`); `-rc.N` is a
+  registry channel tag only. See `.rules/versioning.md` and STD-U-810.
+- ghcr operations run in CI (dispatched via `gh workflow run`); the runtime needs
+  ghcr package-write via CI's token and the `kn-dev` SSH key only for direct
+  cluster inspection/rollback.
+- Exactly one release epic in flight; the pipeline is idempotent (re-running a
+  green step is safe: rc-publish, tag-release, and set-channel are all idempotent).

--- a/.rules/release-routine.md
+++ b/.rules/release-routine.md
@@ -45,8 +45,11 @@ it does not merge or publish before that approval.
    per-feature commit and the `chore(release)` version-cut commit must reach `main`
    individually so `compute_release.py` (which walks `git log --no-merges`) and
    `tag-release.yml` see them). `tag-release.yml` then cuts tag `vX.Y.Z`, builds the
-   stable image, publishes PyPI, and creates the GitHub Release. Then
-   `gh workflow run set-channel.yml -f source=vX.Y.Z` so kn-dev runs the promoted stable.
+   stable image, publishes PyPI, and creates the GitHub Release. Because a verified
+   `X.Y.Z-rc.N` image exists in ghcr, `tag-release.yml` promotes it by re-tagging that
+   exact digest to `vX.Y.Z` + `:latest` (byte-identical to what passed kn-dev verification),
+   rather than building fresh. Then `gh workflow run set-channel.yml -f source=vX.Y.Z` so
+   kn-dev runs the promoted stable.
 10. Post-release verify: `data-olympus verify --target <kn-dev ingress>` green. If
     red, roll back per `.rules/release-rollback.md` (post-release path) and notify.
 11. Release note into the Paperclip task: post the `docs/releases/vX.Y.Z.md` content

--- a/.rules/release-routine.md
+++ b/.rules/release-routine.md
@@ -14,10 +14,16 @@ it does not merge or publish before that approval.
 2. Readiness gate: all sub-tickets Done and reviewed, the integration branch
    `feature/<release-epic-id>` green (CI). If not ready, post blockers on the epic,
    notify the operator (Telegram, GDEC-007), and STOP. Never cut a red release.
-3. Sync + releasability: on the integration branch, run
+3. Sync + prepare the release commit (the cutter owns the version cut; no other
+   step performs it): on the integration branch, run
    `uv run python scripts/compute_release.py`; if `releasable` is false, exit
-   quietly. The branch must already carry the final `X.Y.Z` in `pyproject.toml`
-   (bumped during the epic), plus the CHANGELOG entry and `docs/releases/vX.Y.Z.md`.
+   quietly. Read `next_version` = X.Y.Z. Set the `[project]` version in
+   `pyproject.toml` to `X.Y.Z`; rename the topmost CHANGELOG `[Unreleased]` block to
+   `[X.Y.Z] - <UTC date>` and open a fresh empty `[Unreleased]`; write
+   `docs/releases/vX.Y.Z.md` (two H2 sections `## New features` and `## Fixed`, plain
+   language). Commit to the integration branch as `chore(release): vX.Y.Z`. Per-feature
+   `[Unreleased]` CHANGELOG entries were already added by each sub-ticket
+   (`.rules/versioning.md`). The RC built next therefore carries the final X.Y.Z.
 4. Quality gates (all must pass, else open a `release blocked: <reason>` issue and
    stop): `uv run pytest -q`, `uv run ruff check .`, `uv run mypy src`,
    `bats -r tests`, a security review over `git diff <lasttag>..HEAD`, and `kb_health`.
@@ -34,10 +40,13 @@ it does not merge or publish before that approval.
 8. Approval-to-ship: request a Paperclip approval on the epic and notify the
    operator (Telegram). The operator may exercise the RC live on kn-dev, then
    approves or rejects. On rejection, roll back and stop.
-9. Promote (on approval): merge the release PR / integration MR to `main`.
-   `tag-release.yml` cuts tag `vX.Y.Z`, builds the stable image, publishes PyPI, and
-   creates the GitHub Release. Then `gh workflow run set-channel.yml -f source=vX.Y.Z`
-   so kn-dev runs the promoted stable.
+9. Promote (on approval): merge the integration MR (`feature/<release-epic-id>` ->
+   `main`) with a MERGE COMMIT, never a squash (per `.rules/versioning.md`: each
+   per-feature commit and the `chore(release)` version-cut commit must reach `main`
+   individually so `compute_release.py` (which walks `git log --no-merges`) and
+   `tag-release.yml` see them). `tag-release.yml` then cuts tag `vX.Y.Z`, builds the
+   stable image, publishes PyPI, and creates the GitHub Release. Then
+   `gh workflow run set-channel.yml -f source=vX.Y.Z` so kn-dev runs the promoted stable.
 10. Post-release verify: `data-olympus verify --target <kn-dev ingress>` green. If
     red, roll back per `.rules/release-rollback.md` (post-release path) and notify.
 11. Release note into the Paperclip task: post the `docs/releases/vX.Y.Z.md` content
@@ -45,7 +54,8 @@ it does not merge or publish before that approval.
 12. Retro to company-knowledge: run a short retro (what the RC/verify cycle
     surfaced, any gate that fired, any manual fix, kn-dev-vs-stable drift) and
     propose a lessons-learned update to company-knowledge via the data-olympus MCP
-    (`kb_propose_edit` / `kb_propose_memory`, operator-gated). This is how the
+    (`kb_propose_edit` / `kb_propose_memory` targeting a data-olympus-scoped KB path
+    such as a project note or an operator memory, operator-gated). This is how the
     pipeline improves release over release.
 13. Hold open for the operator's external announcement: keep the Paperclip task
     open with a Telegram reminder. The release artifact ships on approval + verify;

--- a/.rules/release-routine.md
+++ b/.rules/release-routine.md
@@ -14,6 +14,13 @@ it does not merge or publish before that approval.
 2. Readiness gate: all sub-tickets Done and reviewed, the integration branch
    `feature/<release-epic-id>` green (CI). If not ready, post blockers on the epic,
    notify the operator (Telegram, GDEC-007), and STOP. Never cut a red release.
+2a. Security readiness gate (hard block): run `python3 scripts/security_alerts.py`.
+    It exits 0 only when there are ZERO open Dependabot and ZERO open CodeQL
+    alerts. On a non-zero exit, post the reported open-alert list on the epic,
+    notify the operator, and STOP: do not build the RC. Every release must be
+    clean of known weaknesses at cut time; the planner phase
+    (`.rules/release-planning.md` step 4) is where they are cleared, and this gate
+    confirms nothing regressed since.
 3. Sync + prepare the release commit (the cutter owns the version cut; no other
    step performs it): on the integration branch, run
    `uv run python scripts/compute_release.py`; if `releasable` is false, exit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - **Glama registry score support.** Added the Glama score badge to the README
   and documented the claimed server listing, sandbox release settings, and
   score-maintenance checklist in `docs/glama.md`.
+- **Release security-clearance gate.** `scripts/security_alerts.py` fails a
+  release when any Dependabot or CodeQL alert is open; the release planner clears
+  every alert (fix or justified dismissal) and the cutter verifies zero open
+  before building the release candidate.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,17 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **`data-olympus verify` command.** New CLI subcommand that runs pass/fail
+  checks against a running instance (`--target`, `--json`, `--checks`,
+  `--token`): liveness (`/api/v1/health`), readiness (`/readyz`), a search
+  round-trip (`/api/v1/search`), and a deployment-tolerant enforcement-plane
+  probe (`/api/v1/gate/check`). Exit codes: `0` all pass, `4` a check failed,
+  `1` the target is unreachable. Used as the pre/post-release verification gate.
+- **Staged-promotion release pipeline (release engineering).** A release
+  candidate is published to a `X.Y.Z-rc.N` ghcr channel (`rc-publish.yml`),
+  deployed as a canary and verified, then promoted by re-tagging the verified
+  digest to `vX.Y.Z` byte-identically (`tag-release.yml`), with a moving-channel
+  helper (`set-channel.yml`) and project-local runbooks under `.rules/`.
 - **Glama registry score support.** Added the Glama score badge to the README
   and documented the claimed server listing, sandbox release settings, and
   score-maintenance checklist in `docs/glama.md`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.4.2] - 2026-07-11
+
 ### Added
 
 - **`data-olympus verify` command.** New CLI subcommand that runs pass/fail

--- a/docs/releases/v0.4.2.md
+++ b/docs/releases/v0.4.2.md
@@ -1,0 +1,21 @@
+## New features
+
+- A new `data-olympus verify` command checks that a running knowledge-base
+  server is healthy and answering correctly. It runs liveness, readiness, a
+  search round-trip, and an enforcement check against a target you name, prints a
+  clear pass/fail summary (or JSON), and returns a distinct exit code when the
+  server is unreachable versus when a check fails. Handy in scripts and as a
+  release or deployment smoke test.
+- Behind the scenes, the project gained a staged-promotion release pipeline: a
+  release candidate is built, verified on a live instance, and then promoted as
+  the exact same image, so what ships is exactly what was tested. This is
+  internal tooling and does not change how you run the server.
+- Registry listing polish: a Glama score badge and clearer MCP tool metadata so
+  catalog sites can describe the server more accurately.
+
+## Fixed
+
+- Clarified, for anyone running the server behind a reverse proxy or ingress,
+  that the public hostname must be added to `FASTMCP_HTTP_ALLOWED_HOSTS`. Without
+  it, health probes pass while real requests are refused with a 421. See
+  `docs/serving.md` and `docs/operations.md` section 3.4.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "data-olympus"
-version = "0.4.1"
+version = "0.4.2"
 description = "Governance-grade knowledge-base format (OKF-compatible) plus CLI and single-writer MCP server"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/scripts/compute_release.py
+++ b/scripts/compute_release.py
@@ -96,6 +96,14 @@ def next_rc_tag(base_version: str, existing_refs: Iterable[str]) -> str:
     return f"{base_version}-rc.{next_rc_number(base_version, existing_refs)}"
 
 
+def current_rc_tag(base_version: str, existing_refs: Iterable[str]) -> str:
+    """The highest existing `<base_version>-rc.N` tag, e.g. `0.5.0-rc.2`, or "" if
+    none exist. (next_rc_tag returns one PAST the highest; this returns the highest
+    itself, for promoting an already-built RC.)"""
+    n = next_rc_number(base_version, existing_refs) - 1
+    return f"{base_version}-rc.{n}" if n >= 1 else ""
+
+
 def _git(*args: str) -> str:
     return subprocess.run(["git", *args], capture_output=True, text=True, check=True).stdout
 

--- a/scripts/compute_release.py
+++ b/scripts/compute_release.py
@@ -12,6 +12,10 @@ import re
 import subprocess
 import sys
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
 # Allow running as a plain script (python scripts/x.py): put repo root on the
 # path so `scripts.*` imports resolve the same way they do under pytest.
@@ -23,6 +27,7 @@ from scripts.check_changelog import _is_functional  # noqa: E402  # one definiti
 
 _SUBJECT_RE = re.compile(r"^(?P<type>[a-z]+)(?:\([^)]*\))?(?P<bang>!)?:\s")
 _BREAKING_FOOTER = re.compile(r"^BREAKING[ -]CHANGE:", re.MULTILINE)
+_RC_TAG_RE = re.compile(r"^v?(?P<base>\d+\.\d+\.\d+)-rc\.(?P<n>\d+)$")
 _FEATURE = "feat"
 _FIXES = ("fix", "perf")
 _NONE, _PATCH, _MINOR = 0, 1, 2
@@ -69,6 +74,26 @@ def next_version(current: str, bump: str) -> str:
     if bump == "patch":
         return f"{major}.{minor}.{patch + 1}"
     return current
+
+
+def next_rc_number(base_version: str, existing_refs: Iterable[str]) -> int:
+    """One past the highest N among existing `<base_version>-rc.N` refs, else 1.
+
+    Refs may carry a leading `v`; refs for a different base or that are not
+    `X.Y.Z-rc.N` are ignored.
+    """
+    highest = 0
+    for ref in existing_refs:
+        m = _RC_TAG_RE.match(ref.strip())
+        if m is None or m.group("base") != base_version:
+            continue
+        highest = max(highest, int(m.group("n")))
+    return highest + 1
+
+
+def next_rc_tag(base_version: str, existing_refs: Iterable[str]) -> str:
+    """The next release-candidate channel tag, e.g. `0.5.0-rc.3`."""
+    return f"{base_version}-rc.{next_rc_number(base_version, existing_refs)}"
 
 
 def _git(*args: str) -> str:

--- a/scripts/rc_tag.py
+++ b/scripts/rc_tag.py
@@ -18,7 +18,7 @@ _REPO_ROOT = str(Path(__file__).resolve().parent.parent)
 if _REPO_ROOT not in sys.path:
     sys.path.insert(0, _REPO_ROOT)
 
-from scripts.compute_release import next_rc_tag  # noqa: E402
+from scripts.compute_release import current_rc_tag, next_rc_tag  # noqa: E402
 
 if TYPE_CHECKING:
     from typing import TextIO
@@ -27,10 +27,15 @@ if TYPE_CHECKING:
 def main(argv: list[str] | None = None, stdin: TextIO | None = None) -> int:
     parser = argparse.ArgumentParser(prog="rc_tag")
     parser.add_argument("--base", required=True, help="target base version X.Y.Z")
+    parser.add_argument("--current", action="store_true",
+                        help="print the highest existing X.Y.Z-rc.N (empty if none)")
     args = parser.parse_args(argv)
     src = stdin if stdin is not None else sys.stdin
     existing = [line for line in src.read().splitlines() if line.strip()]
-    print(next_rc_tag(args.base, existing))
+    if args.current:
+        print(current_rc_tag(args.base, existing))
+    else:
+        print(next_rc_tag(args.base, existing))
     return 0
 
 

--- a/scripts/rc_tag.py
+++ b/scripts/rc_tag.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Print the next release-candidate channel tag `X.Y.Z-rc.N`.
+
+CI usage: pipe the existing ghcr tags (one per line) on stdin and pass the
+target base version. N is one past the highest existing `<base>-rc.N`.
+
+    gh api "/orgs/knaisoma/packages/container/data-olympus/versions" \
+      --jq '.[].metadata.container.tags[]' | python3 scripts/rc_tag.py --base 0.5.0
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+_REPO_ROOT = str(Path(__file__).resolve().parent.parent)
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+from scripts.compute_release import next_rc_tag  # noqa: E402
+
+if TYPE_CHECKING:
+    from typing import TextIO
+
+
+def main(argv: list[str] | None = None, stdin: TextIO | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="rc_tag")
+    parser.add_argument("--base", required=True, help="target base version X.Y.Z")
+    args = parser.parse_args(argv)
+    src = stdin if stdin is not None else sys.stdin
+    existing = [line for line in src.read().splitlines() if line.strip()]
+    print(next_rc_tag(args.base, existing))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/security_alerts.py
+++ b/scripts/security_alerts.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Release security-clearance gate: fail if any Dependabot or CodeQL (code
+scanning) alert is OPEN for the repo.
+
+Used in two places (see .rules/release-planning.md and .rules/release-routine.md):
+the Friday planner drives every open alert to resolution or a justified
+dismissal; the Monday cutter runs this as a readiness gate and refuses to build
+the RC while anything is open.
+
+CLI: `python3 scripts/security_alerts.py [--repo knaisoma/data-olympus]`
+Exit 0 = clean, 5 = open alerts remain, 2 = the gh query failed.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+
+
+def _open(alerts: list[dict]) -> list[dict]:
+    return [a for a in alerts if a.get("state") == "open"]
+
+
+def evaluate(dependabot_alerts: list[dict], codeql_alerts: list[dict]) -> tuple[int, str]:
+    """Return (exit_code, report). 0 = clean; 5 = one or more open alerts."""
+    dep = _open(dependabot_alerts)
+    cq = _open(codeql_alerts)
+    if not dep and not cq:
+        return 0, "security clear: 0 open Dependabot alerts, 0 open CodeQL alerts"
+    lines: list[str] = []
+    for a in dep:
+        sev = (a.get("security_advisory") or {}).get("severity", "?")
+        pkg = ((a.get("dependency") or {}).get("package") or {}).get("name", "?")
+        lines.append(f"DEPENDABOT #{a.get('number')} [{sev}] {pkg}: {a.get('html_url', '')}")
+    for a in cq:
+        rule = a.get("rule") or {}
+        lines.append(
+            f"CODEQL #{a.get('number')} [{rule.get('severity', '?')}] "
+            f"{rule.get('description', '')}: {a.get('html_url', '')}"
+        )
+    total = len(dep) + len(cq)
+    report = (
+        f"{total} open security alert(s) must be resolved or dismissed with "
+        f"justification before this release:\n" + "\n".join(lines)
+    )
+    return 5, report
+
+
+def _fetch(repo: str, endpoint: str) -> list[dict]:
+    """Fetch a paginated GitHub alerts endpoint via gh, one object per line."""
+    path = f"/repos/{repo}/{endpoint}?state=open"
+    out = subprocess.run(
+        ["gh", "api", "--paginate", path, "--jq", ".[]"],
+        capture_output=True, text=True,
+    )
+    if out.returncode != 0:
+        print(f"gh api {path} failed:\n{out.stderr}", file=sys.stderr)
+        raise SystemExit(2)
+    return [json.loads(line) for line in out.stdout.splitlines() if line.strip()]
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="security_alerts")
+    parser.add_argument("--repo", default="knaisoma/data-olympus")
+    args = parser.parse_args(argv)
+    dependabot = _fetch(args.repo, "dependabot/alerts")
+    codeql = _fetch(args.repo, "code-scanning/alerts")
+    code, report = evaluate(dependabot, codeql)
+    print(report)
+    return code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/data_olympus/cli/main.py
+++ b/src/data_olympus/cli/main.py
@@ -141,6 +141,8 @@ def build_parser() -> argparse.ArgumentParser:
     add_validity_report_subparser(sub)
     from data_olympus.cli.init_cmd import add_init_subparser
     add_init_subparser(sub)
+    from data_olympus.cli.verify_cmd import add_verify_subparser
+    add_verify_subparser(sub)
     return parser
 
 

--- a/src/data_olympus/cli/verify_cmd.py
+++ b/src/data_olympus/cli/verify_cmd.py
@@ -17,6 +17,8 @@ if TYPE_CHECKING:
 # functions only (no new top-level imports), so ruff's E402 never fires.
 # `json` is used by run_verify (Task 4); the argparse annotations are strings.
 
+_ALL_CHECKS = ("health", "readiness", "search")
+
 
 @dataclass(frozen=True)
 class CheckResult:
@@ -81,18 +83,26 @@ def run_verify(
     as_json: bool = False,
     timeout: float = 10.0,
     probe: str = "the",
+    checks: list[str] | None = None,
     client: httpx.Client | None = None,
 ) -> int:
-    """Orchestrate all checks and report results to stdout. Returns 0 or 4."""
+    """Orchestrate selected checks and report results to stdout. Returns 0, 1,
+    or 4."""
     owns_client = client is None
     if client is None:
         client = httpx.Client(base_url=target.rstrip("/"), timeout=timeout)
     try:
-        results = [
-            check_health(client),
-            check_readiness(client),
-            check_search(client, probe),
-        ]
+        selected_checks = checks or list(_ALL_CHECKS)
+        results = []
+        for check_name in _ALL_CHECKS:
+            if check_name not in selected_checks:
+                continue
+            if check_name == "health":
+                results.append(check_health(client))
+            elif check_name == "readiness":
+                results.append(check_readiness(client))
+            elif check_name == "search":
+                results.append(check_search(client, probe))
     finally:
         if owns_client:
             client.close()
@@ -149,17 +159,35 @@ def add_verify_subparser(
         help="per-request timeout seconds",
     )
     p.add_argument("--probe", default="the", help="search probe term (default: the)")
+    p.add_argument(
+        "--checks",
+        default=None,
+        help="comma-separated subset to run (default: all): "
+        "health,readiness,search,enforcement",
+    )
     p.set_defaults(func=_cmd_verify)
 
 
 def _cmd_verify(args: argparse.Namespace) -> int:
     """Entry point for the verify subcommand; resolve target and call run_verify."""
     import os
+    import sys
 
     target = args.target or os.environ.get("KB_ENDPOINT") or "http://localhost:8080"
+
+    checks = None
+    if args.checks:
+        checks = [c.strip() for c in args.checks.split(",")]
+        unknown = set(checks) - set(_ALL_CHECKS)
+        if unknown:
+            print(f"error: unknown check(s): {','.join(sorted(unknown))}",
+                  file=sys.stderr)
+            return 2
+
     return run_verify(
         target=target,
         as_json=args.json,
         timeout=args.timeout,
         probe=args.probe,
+        checks=checks,
     )

--- a/src/data_olympus/cli/verify_cmd.py
+++ b/src/data_olympus/cli/verify_cmd.py
@@ -34,10 +34,12 @@ def check_health(client: httpx.Client) -> CheckResult:
     if resp.status_code != 200:
         return CheckResult("health", False, f"status {resp.status_code} (degraded or down)")
     try:
-        degraded = bool(resp.json().get("degraded"))
+        body = resp.json()
     except ValueError:
         return CheckResult("health", False, "non-JSON health body")
-    if degraded:
+    if not isinstance(body, dict):
+        return CheckResult("health", False, "unexpected non-object health body")
+    if bool(body.get("degraded")):
         return CheckResult("health", False, "health reports degraded")
     return CheckResult("health", True, "healthy")
 
@@ -61,9 +63,12 @@ def check_search(client: httpx.Client, probe: str) -> CheckResult:
     if resp.status_code != 200:
         return CheckResult("search", False, f"status {resp.status_code}")
     try:
-        hits = resp.json().get("hits")
+        body = resp.json()
     except ValueError:
         return CheckResult("search", False, "non-JSON search body")
+    if not isinstance(body, dict):
+        return CheckResult("search", False, "unexpected non-object search body")
+    hits = body.get("hits")
     if not isinstance(hits, list):
         return CheckResult("search", False, "response missing 'hits' list")
     return CheckResult("search", True, f"{len(hits)} hit(s) for probe {probe!r}")

--- a/src/data_olympus/cli/verify_cmd.py
+++ b/src/data_olympus/cli/verify_cmd.py
@@ -23,6 +23,7 @@ class CheckResult:
     name: str
     ok: bool
     detail: str
+    connection_error: bool = False
 
 
 def check_health(client: httpx.Client) -> CheckResult:
@@ -30,7 +31,7 @@ def check_health(client: httpx.Client) -> CheckResult:
     try:
         resp = client.get("/api/v1/health")
     except httpx.HTTPError as exc:
-        return CheckResult("health", False, f"request failed: {exc}")
+        return CheckResult("health", False, f"request failed: {exc}", connection_error=True)
     if resp.status_code != 200:
         return CheckResult("health", False, f"status {resp.status_code} (degraded or down)")
     try:
@@ -49,7 +50,7 @@ def check_readiness(client: httpx.Client) -> CheckResult:
     try:
         resp = client.get("/readyz")
     except httpx.HTTPError as exc:
-        return CheckResult("readiness", False, f"request failed: {exc}")
+        return CheckResult("readiness", False, f"request failed: {exc}", connection_error=True)
     ok = resp.status_code == 200
     return CheckResult("readiness", ok, "ready" if ok else f"status {resp.status_code}")
 
@@ -59,7 +60,7 @@ def check_search(client: httpx.Client, probe: str) -> CheckResult:
     try:
         resp = client.get("/api/v1/search", params={"q": probe, "limit": 1})
     except httpx.HTTPError as exc:
-        return CheckResult("search", False, f"request failed: {exc}")
+        return CheckResult("search", False, f"request failed: {exc}", connection_error=True)
     if resp.status_code != 200:
         return CheckResult("search", False, f"status {resp.status_code}")
     try:
@@ -120,7 +121,11 @@ def run_verify(
             f"{sum(r.ok for r in results)}/{len(results)} checks passed "
             f"against {target}"
         )
-    return 0 if all_ok else 4
+    if all_ok:
+        return 0
+    if results and all(r.connection_error for r in results):
+        return 1
+    return 4
 
 
 def add_verify_subparser(

--- a/src/data_olympus/cli/verify_cmd.py
+++ b/src/data_olympus/cli/verify_cmd.py
@@ -121,3 +121,40 @@ def run_verify(
             f"against {target}"
         )
     return 0 if all_ok else 4
+
+
+def add_verify_subparser(
+    sub: "argparse._SubParsersAction[argparse.ArgumentParser]",  # noqa: UP037
+) -> None:
+    """Wire the verify subcommand into the argparse dispatcher."""
+    p = sub.add_parser(
+        "verify",
+        help="run health + functional round-trip checks against a running instance",
+    )
+    p.add_argument(
+        "--target",
+        default=None,
+        help="base URL (default: $KB_ENDPOINT or http://localhost:8080)",
+    )
+    p.add_argument("--json", action="store_true", help="emit JSON")
+    p.add_argument(
+        "--timeout",
+        type=float,
+        default=10.0,
+        help="per-request timeout seconds",
+    )
+    p.add_argument("--probe", default="the", help="search probe term (default: the)")
+    p.set_defaults(func=_cmd_verify)
+
+
+def _cmd_verify(args: "argparse.Namespace") -> int:  # noqa: UP037
+    """Entry point for the verify subcommand; resolve target and call run_verify."""
+    import os
+
+    target = args.target or os.environ.get("KB_ENDPOINT") or "http://localhost:8080"
+    return run_verify(
+        target=target,
+        as_json=args.json,
+        timeout=args.timeout,
+        probe=args.probe,
+    )

--- a/src/data_olympus/cli/verify_cmd.py
+++ b/src/data_olympus/cli/verify_cmd.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 # functions only (no new top-level imports), so ruff's E402 never fires.
 # `json` is used by run_verify (Task 4); the argparse annotations are strings.
 
-_ALL_CHECKS = ("health", "readiness", "search")
+_ALL_CHECKS = ("health", "readiness", "search", "enforcement")
 
 
 @dataclass(frozen=True)
@@ -77,6 +77,40 @@ def check_search(client: httpx.Client, probe: str) -> CheckResult:
     return CheckResult("search", True, f"{len(hits)} hit(s) for probe {probe!r}")
 
 
+def check_enforcement(client: httpx.Client, token: str | None = None) -> CheckResult:
+    """Probe /api/v1/gate/check. Deployment-tolerant: 404 (routes not
+    mounted) and 401/403 without a token are informational passes; a token
+    that is rejected, or a 5xx, fail."""
+    headers = {"Authorization": f"Bearer {token}"} if token else {}
+    payload = {"workspace": "data-olympus", "session_id": "verify-probe"}
+    try:
+        resp = client.post(
+            "/api/v1/gate/check", json=payload, headers=headers
+        )
+    except httpx.HTTPError as exc:
+        return CheckResult(
+            "enforcement", False, f"request failed: {exc}", connection_error=True
+        )
+    code = resp.status_code
+    if code == 200:
+        return CheckResult("enforcement", True, "enforcement plane responding")
+    if code == 404:
+        return CheckResult(
+            "enforcement", True, "enforcement routes not mounted (open deployment)"
+        )
+    if code in (401, 403):
+        if token:
+            return CheckResult(
+                "enforcement", False, f"enforcement rejected the token ({code})"
+            )
+        return CheckResult(
+            "enforcement",
+            True,
+            "enforcement active (auth required; pass --token to test round-trip)",
+        )
+    return CheckResult("enforcement", False, f"unexpected status {code}")
+
+
 def run_verify(
     *,
     target: str,
@@ -84,6 +118,7 @@ def run_verify(
     timeout: float = 10.0,
     probe: str = "the",
     checks: list[str] | None = None,
+    token: str | None = None,
     client: httpx.Client | None = None,
 ) -> int:
     """Orchestrate selected checks and report results to stdout. Returns 0, 1,
@@ -92,7 +127,9 @@ def run_verify(
     if client is None:
         client = httpx.Client(base_url=target.rstrip("/"), timeout=timeout)
     try:
-        selected_checks = checks or list(_ALL_CHECKS)
+        selected_checks = (
+            checks if checks is not None else list(_ALL_CHECKS)
+        )
         results = []
         for check_name in _ALL_CHECKS:
             if check_name not in selected_checks:
@@ -103,6 +140,8 @@ def run_verify(
                 results.append(check_readiness(client))
             elif check_name == "search":
                 results.append(check_search(client, probe))
+            elif check_name == "enforcement":
+                results.append(check_enforcement(client, token))
     finally:
         if owns_client:
             client.close()
@@ -165,24 +204,36 @@ def add_verify_subparser(
         help="comma-separated subset to run (default: all): "
         "health,readiness,search,enforcement",
     )
+    p.add_argument(
+        "--token",
+        default=None,
+        help="bearer token for enforcement check (default: $KB_AUTH_TOKEN)",
+    )
     p.set_defaults(func=_cmd_verify)
 
 
 def _cmd_verify(args: argparse.Namespace) -> int:
-    """Entry point for the verify subcommand; resolve target and call run_verify."""
+    """Entry point for the verify subcommand; resolve target and call
+    run_verify."""
     import os
     import sys
 
-    target = args.target or os.environ.get("KB_ENDPOINT") or "http://localhost:8080"
+    target = args.target or os.environ.get("KB_ENDPOINT") or (
+        "http://localhost:8080"
+    )
 
     checks = None
     if args.checks:
         checks = [c.strip() for c in args.checks.split(",")]
         unknown = set(checks) - set(_ALL_CHECKS)
         if unknown:
-            print(f"error: unknown check(s): {','.join(sorted(unknown))}",
-                  file=sys.stderr)
+            print(
+                f"error: unknown check(s): {','.join(sorted(unknown))}",
+                file=sys.stderr,
+            )
             return 2
+
+    token = args.token or os.environ.get("KB_AUTH_TOKEN")
 
     return run_verify(
         target=target,
@@ -190,4 +241,5 @@ def _cmd_verify(args: argparse.Namespace) -> int:
         timeout=args.timeout,
         probe=args.probe,
         checks=checks,
+        token=token,
     )

--- a/src/data_olympus/cli/verify_cmd.py
+++ b/src/data_olympus/cli/verify_cmd.py
@@ -124,7 +124,7 @@ def run_verify(
 
 
 def add_verify_subparser(
-    sub: "argparse._SubParsersAction[argparse.ArgumentParser]",  # noqa: UP037
+    sub: argparse._SubParsersAction[argparse.ArgumentParser],
 ) -> None:
     """Wire the verify subcommand into the argparse dispatcher."""
     p = sub.add_parser(
@@ -147,7 +147,7 @@ def add_verify_subparser(
     p.set_defaults(func=_cmd_verify)
 
 
-def _cmd_verify(args: "argparse.Namespace") -> int:  # noqa: UP037
+def _cmd_verify(args: argparse.Namespace) -> int:
     """Entry point for the verify subcommand; resolve target and call run_verify."""
     import os
 

--- a/src/data_olympus/cli/verify_cmd.py
+++ b/src/data_olympus/cli/verify_cmd.py
@@ -50,3 +50,20 @@ def check_readiness(client: httpx.Client) -> CheckResult:
         return CheckResult("readiness", False, f"request failed: {exc}")
     ok = resp.status_code == 200
     return CheckResult("readiness", ok, "ready" if ok else f"status {resp.status_code}")
+
+
+def check_search(client: httpx.Client, probe: str) -> CheckResult:
+    """GET /api/v1/search: confirms the index answers reads with a hits list."""
+    try:
+        resp = client.get("/api/v1/search", params={"q": probe, "limit": 1})
+    except httpx.HTTPError as exc:
+        return CheckResult("search", False, f"request failed: {exc}")
+    if resp.status_code != 200:
+        return CheckResult("search", False, f"status {resp.status_code}")
+    try:
+        hits = resp.json().get("hits")
+    except ValueError:
+        return CheckResult("search", False, "non-JSON search body")
+    if not isinstance(hits, list):
+        return CheckResult("search", False, "response missing 'hits' list")
+    return CheckResult("search", True, f"{len(hits)} hit(s) for probe {probe!r}")

--- a/src/data_olympus/cli/verify_cmd.py
+++ b/src/data_olympus/cli/verify_cmd.py
@@ -40,3 +40,13 @@ def check_health(client: httpx.Client) -> CheckResult:
     if degraded:
         return CheckResult("health", False, "health reports degraded")
     return CheckResult("health", True, "healthy")
+
+
+def check_readiness(client: httpx.Client) -> CheckResult:
+    """GET /readyz: the k8s readiness probe target; pass on 200."""
+    try:
+        resp = client.get("/readyz")
+    except httpx.HTTPError as exc:
+        return CheckResult("readiness", False, f"request failed: {exc}")
+    ok = resp.status_code == 200
+    return CheckResult("readiness", ok, "ready" if ok else f"status {resp.status_code}")

--- a/src/data_olympus/cli/verify_cmd.py
+++ b/src/data_olympus/cli/verify_cmd.py
@@ -1,0 +1,42 @@
+"""`data-olympus verify`: automated pass/fail health + functional round-trip
+checks against a running data-olympus instance. Used by hand and as the
+pre/post-release verification gate.
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import httpx
+
+if TYPE_CHECKING:
+    import argparse
+
+# NOTE: declare every module-level import here in Task 1. Later tasks add
+# functions only (no new top-level imports), so ruff's E402 never fires.
+# `json` is used by run_verify (Task 4); the argparse annotations are strings.
+
+
+@dataclass(frozen=True)
+class CheckResult:
+    name: str
+    ok: bool
+    detail: str
+
+
+def check_health(client: httpx.Client) -> CheckResult:
+    """GET /api/v1/health: pass on 200 with degraded=false (503 = degraded)."""
+    try:
+        resp = client.get("/api/v1/health")
+    except httpx.HTTPError as exc:
+        return CheckResult("health", False, f"request failed: {exc}")
+    if resp.status_code != 200:
+        return CheckResult("health", False, f"status {resp.status_code} (degraded or down)")
+    try:
+        degraded = bool(resp.json().get("degraded"))
+    except ValueError:
+        return CheckResult("health", False, "non-JSON health body")
+    if degraded:
+        return CheckResult("health", False, "health reports degraded")
+    return CheckResult("health", True, "healthy")

--- a/src/data_olympus/cli/verify_cmd.py
+++ b/src/data_olympus/cli/verify_cmd.py
@@ -72,3 +72,52 @@ def check_search(client: httpx.Client, probe: str) -> CheckResult:
     if not isinstance(hits, list):
         return CheckResult("search", False, "response missing 'hits' list")
     return CheckResult("search", True, f"{len(hits)} hit(s) for probe {probe!r}")
+
+
+def run_verify(
+    *,
+    target: str,
+    as_json: bool = False,
+    timeout: float = 10.0,
+    probe: str = "the",
+    client: httpx.Client | None = None,
+) -> int:
+    """Orchestrate all checks and report results to stdout. Returns 0 or 4."""
+    owns_client = client is None
+    if client is None:
+        client = httpx.Client(base_url=target.rstrip("/"), timeout=timeout)
+    try:
+        results = [
+            check_health(client),
+            check_readiness(client),
+            check_search(client, probe),
+        ]
+    finally:
+        if owns_client:
+            client.close()
+
+    all_ok = all(r.ok for r in results)
+    if as_json:
+        print(
+            json.dumps(
+                {
+                    "target": target,
+                    "ok": all_ok,
+                    "checks": [
+                        {"name": r.name, "ok": r.ok, "detail": r.detail}
+                        for r in results
+                    ],
+                },
+                indent=2,
+            )
+        )
+    else:
+        for r in results:
+            mark = "PASS" if r.ok else "FAIL"
+            print(f"{mark}  {r.name}: {r.detail}")
+        print(
+            f"{'ok' if all_ok else 'FAILED'}: "
+            f"{sum(r.ok for r in results)}/{len(results)} checks passed "
+            f"against {target}"
+        )
+    return 0 if all_ok else 4

--- a/tests/test_cli_verify.py
+++ b/tests/test_cli_verify.py
@@ -23,7 +23,7 @@ def test_check_health_ok_when_200_and_not_degraded() -> None:
 
 
 def test_check_health_fails_on_503_degraded() -> None:
-    def handler(request: httpx.Request) -> httpx.Response:
+    def handler(_request: httpx.Request) -> httpx.Response:
         return httpx.Response(503, json={"degraded": True})
 
     result = check_health(_client(handler))

--- a/tests/test_cli_verify.py
+++ b/tests/test_cli_verify.py
@@ -4,7 +4,7 @@ import json
 
 import httpx
 
-from data_olympus.cli.verify_cmd import CheckResult, check_health, check_readiness
+from data_olympus.cli.verify_cmd import CheckResult, check_health, check_readiness, check_search
 
 
 def _client(handler) -> httpx.Client:
@@ -40,15 +40,12 @@ def test_check_readiness_ok_on_200() -> None:
 
 
 def test_check_readiness_fails_on_503() -> None:
-    def handler(_request: httpx.Request) -> httpx.Response:  # unused arg: _ prefix satisfies ruff ARG001
+    def handler(_request: httpx.Request) -> httpx.Response:
         return httpx.Response(503, text="not ready")
 
     r = check_readiness(_client(handler))
     assert r.ok is False
     assert r.name == "readiness"
-
-
-from data_olympus.cli.verify_cmd import check_search
 
 
 def test_check_search_ok_with_hits_list() -> None:
@@ -61,9 +58,17 @@ def test_check_search_ok_with_hits_list() -> None:
 
 
 def test_check_search_fails_when_hits_missing() -> None:
-    def handler(_request: httpx.Request) -> httpx.Response:  # unused arg: _ prefix satisfies ruff ARG001
+    def handler(_request: httpx.Request) -> httpx.Response:
         return httpx.Response(200, json={"unexpected": 1})
 
     r = check_search(_client(handler), "the")
     assert r.ok is False
     assert r.name == "search"
+
+
+def test_check_search_fails_when_hits_not_a_list() -> None:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"hits": "nope"})
+
+    r = check_search(_client(handler), "the")
+    assert r.ok is False

--- a/tests/test_cli_verify.py
+++ b/tests/test_cli_verify.py
@@ -123,3 +123,33 @@ def test_cli_parses_verify_subcommand() -> None:
     assert args.target == "http://kb.test"
     assert args.json is True
     assert callable(args.func)
+
+
+def _unreachable_client() -> httpx.Client:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("connection refused")
+
+    return httpx.Client(base_url="http://kb.test", transport=httpx.MockTransport(handler))
+
+
+def test_check_health_marks_connection_error() -> None:
+    r = check_health(_unreachable_client())
+    assert r.ok is False
+    assert r.connection_error is True
+
+
+def test_run_verify_returns_1_when_target_unreachable() -> None:
+    assert run_verify(target="http://kb.test", client=_unreachable_client()) == 1
+
+
+def test_run_verify_returns_4_when_some_but_not_all_fail() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/v1/health":
+            # a real failure, not a connection error
+            return httpx.Response(503, json={"degraded": True})
+        if request.url.path == "/readyz":
+            return httpx.Response(200, text="ok")
+        return httpx.Response(200, json={"hits": []})
+
+    client = httpx.Client(base_url="http://kb.test", transport=httpx.MockTransport(handler))
+    assert run_verify(target="http://kb.test", client=client) == 4

--- a/tests/test_cli_verify.py
+++ b/tests/test_cli_verify.py
@@ -4,7 +4,13 @@ import json
 
 import httpx
 
-from data_olympus.cli.verify_cmd import CheckResult, check_health, check_readiness, check_search
+from data_olympus.cli.verify_cmd import (
+    CheckResult,
+    check_health,
+    check_readiness,
+    check_search,
+    run_verify,
+)
 
 
 def _client(handler) -> httpx.Client:
@@ -72,3 +78,38 @@ def test_check_search_fails_when_hits_not_a_list() -> None:
 
     r = check_search(_client(handler), "the")
     assert r.ok is False
+
+
+def _all_ok_handler(request: httpx.Request) -> httpx.Response:
+    if request.url.path == "/api/v1/health":
+        return httpx.Response(200, json={"degraded": False})
+    if request.url.path == "/readyz":
+        return httpx.Response(200, text="ok")
+    if request.url.path == "/api/v1/search":
+        return httpx.Response(200, json={"hits": []})
+    return httpx.Response(404)
+
+
+def test_run_verify_returns_0_when_all_pass() -> None:
+    rc = run_verify(target="http://kb.test", client=_client(_all_ok_handler))
+    assert rc == 0
+
+
+def test_run_verify_returns_4_when_a_check_fails() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/v1/health":
+            return httpx.Response(503, json={"degraded": True})
+        return _all_ok_handler(request)
+
+    rc = run_verify(target="http://kb.test", client=_client(handler))
+    assert rc == 4
+
+
+def test_run_verify_json_output_lists_checks(capsys) -> None:
+    rc = run_verify(
+        target="http://kb.test", as_json=True, client=_client(_all_ok_handler)
+    )
+    out = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert out["ok"] is True
+    assert {c["name"] for c in out["checks"]} == {"health", "readiness", "search"}

--- a/tests/test_cli_verify.py
+++ b/tests/test_cli_verify.py
@@ -46,3 +46,24 @@ def test_check_readiness_fails_on_503() -> None:
     r = check_readiness(_client(handler))
     assert r.ok is False
     assert r.name == "readiness"
+
+
+from data_olympus.cli.verify_cmd import check_search
+
+
+def test_check_search_ok_with_hits_list() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/api/v1/search"
+        assert request.url.params.get("q") == "the"
+        return httpx.Response(200, json={"hits": [], "total_returned": 0})
+
+    assert check_search(_client(handler), "the").ok is True
+
+
+def test_check_search_fails_when_hits_missing() -> None:
+    def handler(_request: httpx.Request) -> httpx.Response:  # unused arg: _ prefix satisfies ruff ARG001
+        return httpx.Response(200, json={"unexpected": 1})
+
+    r = check_search(_client(handler), "the")
+    assert r.ok is False
+    assert r.name == "search"

--- a/tests/test_cli_verify.py
+++ b/tests/test_cli_verify.py
@@ -4,7 +4,7 @@ import json
 
 import httpx
 
-from data_olympus.cli.verify_cmd import CheckResult, check_health
+from data_olympus.cli.verify_cmd import CheckResult, check_health, check_readiness
 
 
 def _client(handler) -> httpx.Client:
@@ -29,3 +29,20 @@ def test_check_health_fails_on_503_degraded() -> None:
     result = check_health(_client(handler))
     assert result.ok is False
     assert "degraded" in result.detail.lower() or "503" in result.detail
+
+
+def test_check_readiness_ok_on_200() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/readyz"
+        return httpx.Response(200, text="ok")
+
+    assert check_readiness(_client(handler)).ok is True
+
+
+def test_check_readiness_fails_on_503() -> None:
+    def handler(_request: httpx.Request) -> httpx.Response:  # unused arg: _ prefix satisfies ruff ARG001
+        return httpx.Response(503, text="not ready")
+
+    r = check_readiness(_client(handler))
+    assert r.ok is False
+    assert r.name == "readiness"

--- a/tests/test_cli_verify.py
+++ b/tests/test_cli_verify.py
@@ -153,3 +153,28 @@ def test_run_verify_returns_4_when_some_but_not_all_fail() -> None:
 
     client = httpx.Client(base_url="http://kb.test", transport=httpx.MockTransport(handler))
     assert run_verify(target="http://kb.test", client=client) == 4
+
+
+def test_run_verify_checks_selector_runs_only_selected(capsys) -> None:
+    # readiness would fail (503) but we only run health+search, which pass.
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/readyz":
+            return httpx.Response(503, text="down")
+        if request.url.path == "/api/v1/health":
+            return httpx.Response(200, json={"degraded": False})
+        return httpx.Response(200, json={"hits": []})
+
+    client = httpx.Client(base_url="http://kb.test", transport=httpx.MockTransport(handler))
+    rc = run_verify(target="http://kb.test", checks=["health", "search"], as_json=True,
+                    client=client)
+    out = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert {c["name"] for c in out["checks"]} == {"health", "search"}
+
+
+def test_cli_rejects_unknown_check_name() -> None:
+    parser = build_parser()
+    args = parser.parse_args(["verify", "--checks", "health,bogus"])
+    from data_olympus.cli.verify_cmd import _cmd_verify
+
+    assert _cmd_verify(args) == 2

--- a/tests/test_cli_verify.py
+++ b/tests/test_cli_verify.py
@@ -7,6 +7,7 @@ import httpx
 from data_olympus.cli.main import build_parser
 from data_olympus.cli.verify_cmd import (
     CheckResult,
+    check_enforcement,
     check_health,
     check_readiness,
     check_search,
@@ -113,7 +114,7 @@ def test_run_verify_json_output_lists_checks(capsys) -> None:
     out = json.loads(capsys.readouterr().out)
     assert rc == 0
     assert out["ok"] is True
-    assert {c["name"] for c in out["checks"]} == {"health", "readiness", "search"}
+    assert {c["name"] for c in out["checks"]} == {"health", "readiness", "search", "enforcement"}
 
 
 def test_cli_parses_verify_subcommand() -> None:
@@ -178,3 +179,44 @@ def test_cli_rejects_unknown_check_name() -> None:
     from data_olympus.cli.verify_cmd import _cmd_verify
 
     assert _cmd_verify(args) == 2
+
+
+def test_enforcement_pass_on_200() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/api/v1/gate/check"
+        return httpx.Response(200, json={"blocked": False})
+
+    assert check_enforcement(_client(handler)).ok is True
+
+
+def test_enforcement_pass_on_404_not_mounted() -> None:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(404, text="not found")
+
+    r = check_enforcement(_client(handler))
+    assert r.ok is True
+    assert "not mounted" in r.detail.lower()
+
+
+def test_enforcement_pass_on_401_without_token_is_info() -> None:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(401, text="unauthorized")
+
+    r = check_enforcement(_client(handler), token=None)
+    assert r.ok is True
+    assert "auth" in r.detail.lower()
+
+
+def test_enforcement_fails_on_401_with_token() -> None:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(401, text="unauthorized")
+
+    r = check_enforcement(_client(handler), token="t")
+    assert r.ok is False
+
+
+def test_enforcement_fails_on_500() -> None:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, text="boom")
+
+    assert check_enforcement(_client(handler)).ok is False

--- a/tests/test_cli_verify.py
+++ b/tests/test_cli_verify.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import json
+
+import httpx
+
+from data_olympus.cli.verify_cmd import CheckResult, check_health
+
+
+def _client(handler) -> httpx.Client:
+    return httpx.Client(base_url="http://kb.test", transport=httpx.MockTransport(handler))
+
+
+def test_check_health_ok_when_200_and_not_degraded() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/api/v1/health"
+        return httpx.Response(200, json={"degraded": False, "kb_commit": "abc"})
+
+    result = check_health(_client(handler))
+    assert isinstance(result, CheckResult)
+    assert result.name == "health"
+    assert result.ok is True
+
+
+def test_check_health_fails_on_503_degraded() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(503, json={"degraded": True})
+
+    result = check_health(_client(handler))
+    assert result.ok is False
+    assert "degraded" in result.detail.lower() or "503" in result.detail

--- a/tests/test_cli_verify.py
+++ b/tests/test_cli_verify.py
@@ -4,6 +4,7 @@ import json
 
 import httpx
 
+from data_olympus.cli.main import build_parser
 from data_olympus.cli.verify_cmd import (
     CheckResult,
     check_health,
@@ -113,3 +114,12 @@ def test_run_verify_json_output_lists_checks(capsys) -> None:
     assert rc == 0
     assert out["ok"] is True
     assert {c["name"] for c in out["checks"]} == {"health", "readiness", "search"}
+
+
+def test_cli_parses_verify_subcommand() -> None:
+    parser = build_parser()
+    args = parser.parse_args(["verify", "--target", "http://kb.test", "--json"])
+    assert args.command == "verify"
+    assert args.target == "http://kb.test"
+    assert args.json is True
+    assert callable(args.func)

--- a/tests/test_compute_release.py
+++ b/tests/test_compute_release.py
@@ -121,3 +121,13 @@ def test_next_rc_number_ignores_non_rc_and_malformed() -> None:
 
 def test_next_rc_tag_composes_base_and_number() -> None:
     assert next_rc_tag("0.5.0", ["0.5.0-rc.1"]) == "0.5.0-rc.2"
+
+
+def test_current_rc_tag_empty_when_none_exist() -> None:
+    from scripts.compute_release import current_rc_tag
+    assert current_rc_tag("0.5.0", ["0.4.0-rc.9", "v0.5.0"]) == ""
+
+
+def test_current_rc_tag_returns_highest_for_base() -> None:
+    from scripts.compute_release import current_rc_tag
+    assert current_rc_tag("0.5.0", ["0.5.0-rc.1", "v0.5.0-rc.3", "0.5.0-rc.2"]) == "0.5.0-rc.3"

--- a/tests/test_compute_release.py
+++ b/tests/test_compute_release.py
@@ -6,7 +6,7 @@ import pathlib
 import subprocess
 import sys
 
-from scripts.compute_release import bump_for, classify, next_version
+from scripts.compute_release import bump_for, classify, next_rc_number, next_rc_tag, next_version
 
 _REPO = pathlib.Path(__file__).resolve().parents[1]
 
@@ -100,3 +100,24 @@ def test_script_runs_as_direct_path() -> None:
     )
     assert r.returncode == 0, r.stderr
     assert json.loads(r.stdout).get("bump") in {"none", "patch", "minor"}
+
+
+def test_next_rc_number_starts_at_1_when_none_exist() -> None:
+    assert next_rc_number("0.5.0", []) == 1
+
+
+def test_next_rc_number_is_one_past_highest_for_that_base() -> None:
+    assert next_rc_number("0.5.0", ["0.5.0-rc.1", "0.5.0-rc.2"]) == 3
+
+
+def test_next_rc_number_ignores_other_bases_and_v_prefix() -> None:
+    # 0.4.0 rc is a different base; the v-prefixed 0.5.0-rc.1 counts.
+    assert next_rc_number("0.5.0", ["0.4.0-rc.9", "v0.5.0-rc.1"]) == 2
+
+
+def test_next_rc_number_ignores_non_rc_and_malformed() -> None:
+    assert next_rc_number("0.5.0", ["0.5.0", "latest", "0.5.0-rc.x", "junk"]) == 1
+
+
+def test_next_rc_tag_composes_base_and_number() -> None:
+    assert next_rc_tag("0.5.0", ["0.5.0-rc.1"]) == "0.5.0-rc.2"

--- a/tests/test_rc_tag.py
+++ b/tests/test_rc_tag.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+import io
+
+from scripts.rc_tag import main
+
+
+def test_main_prints_next_rc_tag(capsys) -> None:
+    rc = main(["--base", "0.5.0"], stdin=io.StringIO("0.5.0-rc.1\nv0.5.0-rc.2\n0.4.0-rc.7\n"))
+    assert rc == 0
+    assert capsys.readouterr().out.strip() == "0.5.0-rc.3"
+
+
+def test_main_starts_at_rc_1_with_empty_stdin(capsys) -> None:
+    rc = main(["--base", "0.5.0"], stdin=io.StringIO(""))
+    assert rc == 0
+    assert capsys.readouterr().out.strip() == "0.5.0-rc.1"

--- a/tests/test_rc_tag.py
+++ b/tests/test_rc_tag.py
@@ -15,3 +15,15 @@ def test_main_starts_at_rc_1_with_empty_stdin(capsys) -> None:
     rc = main(["--base", "0.5.0"], stdin=io.StringIO(""))
     assert rc == 0
     assert capsys.readouterr().out.strip() == "0.5.0-rc.1"
+
+
+def test_main_current_prints_highest_existing(capsys) -> None:
+    rc = main(["--base", "0.5.0", "--current"], stdin=io.StringIO("0.5.0-rc.1\n0.5.0-rc.2\n"))
+    assert rc == 0
+    assert capsys.readouterr().out.strip() == "0.5.0-rc.2"
+
+
+def test_main_current_empty_when_none(capsys) -> None:
+    rc = main(["--base", "0.5.0", "--current"], stdin=io.StringIO("v0.4.0\n"))
+    assert rc == 0
+    assert capsys.readouterr().out.strip() == ""

--- a/tests/test_security_alerts.py
+++ b/tests/test_security_alerts.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from scripts.security_alerts import evaluate
+
+
+def test_evaluate_clean_when_no_open_alerts() -> None:
+    code, report = evaluate([], [])
+    assert code == 0
+    assert "clear" in report.lower()
+
+
+def test_evaluate_flags_open_dependabot() -> None:
+    dep = [{
+        "number": 7, "state": "open",
+        "security_advisory": {"severity": "high"},
+        "dependency": {"package": {"name": "requests"}},
+        "html_url": "https://example/7",
+    }]
+    code, report = evaluate(dep, [])
+    assert code == 5
+    assert "requests" in report and "#7" in report and "high" in report.lower()
+
+
+def test_evaluate_flags_open_codeql() -> None:
+    cq = [{
+        "number": 3, "state": "open",
+        "rule": {"severity": "error", "description": "SQL injection"},
+        "html_url": "https://example/3",
+    }]
+    code, report = evaluate([], cq)
+    assert code == 5
+    assert "SQL injection" in report and "#3" in report
+
+
+def test_evaluate_ignores_non_open_states() -> None:
+    dep = [{"number": 1, "state": "dismissed", "security_advisory": {}, "dependency": {}}]
+    cq = [{"number": 2, "state": "fixed", "rule": {}}]
+    expected_msg = "security clear: 0 open Dependabot alerts, 0 open CodeQL alerts"
+    assert evaluate(dep, cq) == (0, expected_msg)


### PR DESCRIPTION
## Summary

Implements the issue-driven **release train** with a staged-promotion pipeline for data-olympus. Built as six reviewed slices (25 commits), each implement -> review -> gate.

## What lands

- **`data-olympus verify`** CLI command: pass/fail checks (health, readiness, search round-trip, deployment-tolerant enforcement probe) against a running instance, with `--target/--json/--checks/--token` and exit codes `0`/`4`/`1`. Live-verified 4/4 against the kn-dev instance.
- **RC versioning** (`scripts/rc_tag.py`, `compute_release.py`): derive the next/current `X.Y.Z-rc.N` channel tag from existing ghcr tags.
- **RC publish CI** (`rc-publish.yml`): image-only RC to ghcr `:X.Y.Z-rc.N` + `:rc` + a GitHub pre-release; reuses `release-image-reusable.yml` (new optional `channel` input).
- **Channel + promotion** (`set-channel.yml`, `tag-release.yml`): `set-channel.yml` re-points the moving `:kndev` channel; `tag-release.yml` now promotes by **re-tagging the verified RC digest to `vX.Y.Z` byte-identically** (fresh build only as the manual-tag fallback).
- **Runbooks** (`.rules/release-routine.md`, `release-planning.md`, `release-rollback.md`): the staged-promotion cutter, the Friday planner, and the promotion/rollback runbook.

## Notes for the reviewer

- **Merging this does NOT cut a release**: `pyproject` stays `0.4.1` (already tagged), so `should_tag.py` emits nothing. The features land unreleased on `main`; the next version bump releases them.
- The stable release path is unchanged when no RC exists (fresh build fallback); the new RC path only activates once an `X.Y.Z-rc.N` image exists.
- **Follow-ups after merge (gated, not in this PR):** reconfigure the kn-dev Keel policy to force-track `:kndev` (after seeding it), create the Paperclip planner routine + reconfigure the cutter routine to the new prompt and `0 5 * * 1` Europe/Madrid schedule, and run a rehearsal release end-to-end before pointing the pipeline at a real feature batch.
