### PR TITLE
feat(release): add release-readiness evaluator and evidence adapters

### DIFF
--- a/scripts/ci_status.py
+++ b/scripts/ci_status.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Release CI-status gate: fail-closed check that GitHub Actions check-runs
+for an EXACT commit SHA are all green.
+
+Used as a readiness gate before cutting/publishing a release: a commit with
+no check-runs, an incomplete check-run, or a non-success conclusion is
+treated as NOT ready (fail-closed), not silently skipped.
+
+CLI: `python3 scripts/ci_status.py --sha <sha> [--repo knaisoma/data-olympus]
+      [--required "lint,test,build"] [--json]`
+Exit 0 = all required checks completed successfully, 1 = not ready.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from typing import Any
+
+_SHA_RE = re.compile(r"^[0-9a-fA-F]{7,40}$")
+
+_SUCCESS_STATUS = "completed"
+_SUCCESS_CONCLUSION = "success"
+
+
+def _passes(check_run: dict[str, Any]) -> bool:
+    return (
+        check_run.get("status") == _SUCCESS_STATUS
+        and check_run.get("conclusion") == _SUCCESS_CONCLUSION
+    )
+
+
+def evaluate(check_runs: list[dict[str, Any]], required: list[str]) -> dict[str, Any]:
+    """Fail-closed CI readiness decision for a single commit's check-runs.
+
+    A check "passes" iff status == "completed" AND conclusion == "success".
+    Any other status (queued, in_progress) or conclusion (failure, cancelled,
+    timed_out, action_required, neutral, startup_failure, or None) counts as
+    NOT passing. With no check_runs at all, readiness is False (fail-closed).
+    """
+    checks = [
+        {
+            "name": cr.get("name"),
+            "status": cr.get("status"),
+            "conclusion": cr.get("conclusion"),
+        }
+        for cr in check_runs
+    ]
+    found_any = len(check_runs) > 0
+
+    passing_names = {c["name"] for c in checks if _passes(c)}
+    missing_required = [name for name in required if name not in passing_names]
+
+    all_present_pass = all(_passes(c) for c in checks)
+
+    if required:
+        all_success = found_any and not missing_required and all_present_pass
+    else:
+        all_success = found_any and all_present_pass
+
+    return {
+        "checks": checks,
+        "found_any": found_any,
+        "all_success": all_success,
+        "required": required,
+        "missing_required": missing_required,
+    }
+
+
+def _fetch(sha: str, repo: str) -> list[dict[str, Any]]:
+    """Fetch check-runs for an exact commit SHA via gh, one object per line."""
+    path = f"repos/{repo}/commits/{sha}/check-runs"
+    out = subprocess.run(
+        ["gh", "api", "--paginate", path, "--jq", ".check_runs[]"],
+        capture_output=True, text=True,
+    )
+    if out.returncode != 0:
+        raise RuntimeError(f"gh api {path} failed:\n{out.stderr}")
+    return [json.loads(line) for line in out.stdout.splitlines() if line.strip()]
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="ci_status")
+    parser.add_argument("--sha", required=True, help="exact commit SHA (7-40 hex chars)")
+    parser.add_argument("--repo", default="knaisoma/data-olympus")
+    parser.add_argument("--required", default="", help="comma-separated required check names")
+    parser.add_argument("--json", action="store_true", dest="as_json")
+    args = parser.parse_args(argv)
+
+    if not _SHA_RE.match(args.sha):
+        print(f"invalid --sha {args.sha!r}: expected 7-40 hex characters", file=sys.stderr)
+        return 2
+
+    required = [name.strip() for name in args.required.split(",") if name.strip()]
+
+    try:
+        check_runs = _fetch(args.sha, args.repo)
+    except RuntimeError as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+
+    result = evaluate(check_runs, required)
+
+    if args.as_json:
+        print(json.dumps({"sha": args.sha, "repo": args.repo, **result}, indent=2))
+    else:
+        status = "READY" if result["all_success"] else "NOT READY"
+        print(f"CI status for {args.repo}@{args.sha}: {status}")
+        print(f"  found_any={result['found_any']} all_success={result['all_success']}")
+        if result["missing_required"]:
+            print(f"  missing required: {', '.join(result['missing_required'])}")
+        for c in result["checks"]:
+            print(f"  - {c['name']}: status={c['status']} conclusion={c['conclusion']}")
+
+    return 0 if result["all_success"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/deployed_digest.py
+++ b/scripts/deployed_digest.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Release deployed-digest gate: resolve the image digest currently deployed
+to a named release channel (e.g. "stable", "latest"), fail-closed.
+
+Used as an evidence adapter feeding release_readiness.py's rc_digest_deployed
+condition: the evaluator compares this digest against the expected_rc_digest
+recorded in the release manifest. A channel with no matching tag, more than
+one matching tag (ambiguous), or an unreachable registry does NOT resolve a
+digest (fail-closed), never silently skipped.
+
+CLI: `python3 scripts/deployed_digest.py --target <channel>
+      [--package data-olympus] [--org knaisoma] [--json]`
+Exit 0 = digest resolved, 1 = not resolved, 2 = registry unreachable.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from typing import Any
+
+
+def _tags(version: dict[str, Any]) -> list[str]:
+    metadata = version.get("metadata")
+    container = metadata.get("container") if isinstance(metadata, dict) else None
+    tags = container.get("tags") if isinstance(container, dict) else None
+    if not isinstance(tags, list):
+        return []
+    return [t for t in tags if isinstance(t, str)]
+
+
+def evaluate(versions: list[dict[str, Any]], target: str) -> dict[str, Any]:
+    """PURE. Resolve the digest for the package version tagged `target`.
+
+    Fails closed (digest: None) unless exactly one version carries the
+    target tag and that version has a non-empty digest (its "name" field,
+    a "sha256:..." string in the GitHub Packages API shape).
+    """
+    matches = [v for v in versions if target in _tags(v)]
+    matched_versions = len(matches)
+
+    digest: str | None = None
+    if matched_versions == 1:
+        candidate = matches[0].get("name")
+        if isinstance(candidate, str) and candidate.strip():
+            digest = candidate
+
+    return {
+        "target": target,
+        "digest": digest,
+        "source": f"ghcr:{target}" if digest else None,
+        "matched_versions": matched_versions,
+    }
+
+
+def _fetch_versions(package: str, org: str) -> list[dict[str, Any]]:
+    """Fetch every package version (one JSON object per line) via gh api.
+
+    This is the digest source: the single seam release_readiness callers
+    (and tests) mock to avoid a real network/registry dependency.
+    """
+    path = f"/orgs/{org}/packages/container/{package}/versions"
+    out = subprocess.run(
+        ["gh", "api", "--paginate", path, "--jq", ".[]"],
+        capture_output=True, text=True,
+    )
+    if out.returncode != 0:
+        raise RuntimeError(f"gh api {path} failed:\n{out.stderr}")
+    return [json.loads(line) for line in out.stdout.splitlines() if line.strip()]
+
+
+def _unresolved(target: str, matched_versions: int = 0) -> dict[str, Any]:
+    return {
+        "target": target,
+        "digest": None,
+        "source": None,
+        "matched_versions": matched_versions,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="deployed_digest")
+    parser.add_argument("--target", required=True, help="release channel/tag, e.g. stable")
+    parser.add_argument("--package", default="data-olympus")
+    parser.add_argument("--org", default="knaisoma")
+    parser.add_argument("--json", action="store_true", dest="as_json")
+    args = parser.parse_args(argv)
+
+    try:
+        versions = _fetch_versions(args.package, args.org)
+    except RuntimeError as exc:
+        result = _unresolved(args.target)
+        if args.as_json:
+            print(json.dumps(result))
+        else:
+            print(f"deployed digest for {args.target}: UNRESOLVED (registry unreachable)")
+        print(str(exc), file=sys.stderr)
+        return 2
+
+    result = evaluate(versions, args.target)
+
+    if args.as_json:
+        print(json.dumps(result))
+    elif result["digest"]:
+        print(f"deployed digest for {args.target}: {result['digest']} (source={result['source']})")
+    else:
+        print(
+            f"deployed digest for {args.target}: UNRESOLVED "
+            f"(matched {result['matched_versions']} versions, expected exactly 1)"
+        )
+
+    return 0 if result["digest"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/deployed_digest.py
+++ b/scripts/deployed_digest.py
@@ -16,12 +16,17 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import subprocess
 import sys
 from typing import Any
 
+_DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
 
-def _tags(version: dict[str, Any]) -> list[str]:
+
+def _tags(version: Any) -> list[str]:
+    if not isinstance(version, dict):
+        return []
     metadata = version.get("metadata")
     container = metadata.get("container") if isinstance(metadata, dict) else None
     tags = container.get("tags") if isinstance(container, dict) else None
@@ -34,8 +39,10 @@ def evaluate(versions: list[dict[str, Any]], target: str) -> dict[str, Any]:
     """PURE. Resolve the digest for the package version tagged `target`.
 
     Fails closed (digest: None) unless exactly one version carries the
-    target tag and that version has a non-empty digest (its "name" field,
-    a "sha256:..." string in the GitHub Packages API shape).
+    target tag and that version has a digest (its "name" field) matching
+    the expected "sha256:<64 hex chars>" shape. Any other shape (empty,
+    truncated, non-hex, or not a string at all) is treated as no valid
+    digest, same as a no-match or ambiguous-match result.
     """
     matches = [v for v in versions if target in _tags(v)]
     matched_versions = len(matches)
@@ -43,7 +50,7 @@ def evaluate(versions: list[dict[str, Any]], target: str) -> dict[str, Any]:
     digest: str | None = None
     if matched_versions == 1:
         candidate = matches[0].get("name")
-        if isinstance(candidate, str) and candidate.strip():
+        if isinstance(candidate, str) and _DIGEST_RE.match(candidate):
             digest = candidate
 
     return {
@@ -58,16 +65,26 @@ def _fetch_versions(package: str, org: str) -> list[dict[str, Any]]:
     """Fetch every package version (one JSON object per line) via gh api.
 
     This is the digest source: the single seam release_readiness callers
-    (and tests) mock to avoid a real network/registry dependency.
+    (and tests) mock to avoid a real network/registry dependency. Every
+    failure mode (missing gh binary, subprocess failure, malformed JSON) is
+    normalized to RuntimeError so callers have one exception type to expect;
+    main() still fails closed on any other exception type as a backstop.
     """
     path = f"/orgs/{org}/packages/container/{package}/versions"
-    out = subprocess.run(
-        ["gh", "api", "--paginate", path, "--jq", ".[]"],
-        capture_output=True, text=True,
-    )
+    try:
+        out = subprocess.run(
+            ["gh", "api", "--paginate", path, "--jq", ".[]"],
+            capture_output=True, text=True,
+        )
+    except OSError as exc:
+        # e.g. the "gh" binary is not installed or not on PATH.
+        raise RuntimeError(f"gh api {path} could not be started: {exc}") from exc
     if out.returncode != 0:
         raise RuntimeError(f"gh api {path} failed:\n{out.stderr}")
-    return [json.loads(line) for line in out.stdout.splitlines() if line.strip()]
+    try:
+        return [json.loads(line) for line in out.stdout.splitlines() if line.strip()]
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"gh api {path} returned malformed JSON: {exc}") from exc
 
 
 def _unresolved(target: str, matched_versions: int = 0) -> dict[str, Any]:
@@ -89,16 +106,22 @@ def main(argv: list[str] | None = None) -> int:
 
     try:
         versions = _fetch_versions(args.package, args.org)
-    except RuntimeError as exc:
+        if not isinstance(versions, list):
+            raise TypeError(f"expected a list of package versions, got {type(versions).__name__}")
+        result = evaluate(versions, args.target)
+    except Exception as exc:
+        # Fail-closed backstop: any failure resolving or evaluating the
+        # digest lookup (subprocess/gh missing, malformed JSON, an
+        # unexpectedly-shaped payload, etc.) must emit the clean
+        # {"digest": null, "source": null} contract and a non-zero exit,
+        # never an uncaught traceback.
         result = _unresolved(args.target)
         if args.as_json:
             print(json.dumps(result))
         else:
-            print(f"deployed digest for {args.target}: UNRESOLVED (registry unreachable)")
+            print(f"deployed digest for {args.target}: UNRESOLVED (lookup failed)")
         print(str(exc), file=sys.stderr)
         return 2
-
-    result = evaluate(versions, args.target)
 
     if args.as_json:
         print(json.dumps(result))

--- a/scripts/release_readiness.py
+++ b/scripts/release_readiness.py
@@ -1,0 +1,426 @@
+#!/usr/bin/env python3
+"""Release-readiness gate: pure, fail-closed evaluator over an evidence bundle.
+
+Re-derives every hard-gate condition from raw typed records in the bundle. It
+NEVER trusts a caller-supplied boolean like "ready": true or
+"review_validated": true — those keys, if present, are ignored. Any
+missing/None/unparseable field makes its condition False (fail-closed). A
+malformed bundle never raises; it is simply NOT_READY with a blocker
+explaining why.
+
+CLI: `python3 scripts/release_readiness.py [--evidence <path>] [--json]`
+Reads the evidence bundle as JSON from --evidence or stdin. Exit 0 iff ready,
+else 1.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+_SHA40_RE = re.compile(r"^[0-9a-fA-F]{40}$")
+
+
+def _is_sha40(value: Any) -> bool:
+    return isinstance(value, str) and bool(_SHA40_RE.match(value))
+
+
+def _non_empty_str(value: Any) -> bool:
+    return isinstance(value, str) and value != ""
+
+
+def _is_exit_zero(value: Any) -> bool:
+    """True only for the integer 0. Rejects False (== 0) and 0.0 truthiness traps."""
+    return isinstance(value, int) and not isinstance(value, bool) and value == 0
+
+
+def _as_dict(value: Any) -> dict[str, Any]:
+    """Coerce a possibly-missing/malformed field into a dict, never raising."""
+    return value if isinstance(value, dict) else {}
+
+
+def _as_list(value: Any) -> list[Any]:
+    """Coerce a possibly-missing/malformed field into a list, never raising."""
+    return value if isinstance(value, list) else []
+
+
+@dataclass(frozen=True)
+class GateResult:
+    ready: bool
+    conditions: dict[str, bool]
+    blockers: list[str] = field(default_factory=list)
+    report_md: str = ""
+
+
+def _tickets_by_feature(bundle: dict[str, Any]) -> dict[str, list[dict[str, Any]]]:
+    """Index tickets by id; malformed ticket entries are dropped, not raised."""
+    by_id: dict[str, list[dict[str, Any]]] = {}
+    for raw in _as_list(bundle.get("tickets")):
+        if not isinstance(raw, dict):
+            continue
+        tid = raw.get("id")
+        if not isinstance(tid, str):
+            continue
+        by_id.setdefault(tid, []).append(raw)
+    return by_id
+
+
+def _check_manifest_complete(
+    manifest: dict[str, Any], feature_ids: list[Any], by_feature: dict[str, list[dict[str, Any]]]
+) -> tuple[bool, list[str]]:
+    blockers: list[str] = []
+    ok = True
+    if not _non_empty_str(manifest.get("version")):
+        ok = False
+        blockers.append("manifest_complete: manifest.version missing or empty")
+    if not _is_sha40(manifest.get("integration_sha")):
+        ok = False
+        blockers.append("manifest_complete: manifest.integration_sha missing or not 40-hex")
+    if not feature_ids:
+        ok = False
+        blockers.append("manifest_complete: manifest.feature_ids missing or empty")
+    if not _non_empty_str(manifest.get("contract_blob_sha")):
+        ok = False
+        blockers.append("manifest_complete: manifest.contract_blob_sha missing or empty")
+    for fid in feature_ids:
+        if not isinstance(fid, str):
+            ok = False
+            blockers.append(f"manifest_complete: feature_id {fid!r} is not a string")
+            continue
+        count = len(by_feature.get(fid, []))
+        if count != 1:
+            ok = False
+            blockers.append(
+                f"manifest_complete: feature {fid} appears {count} time(s) "
+                "in tickets (expected exactly 1)"
+            )
+    return ok, blockers
+
+
+def _check_every_feature_done(
+    feature_ids: list[Any], by_feature: dict[str, list[dict[str, Any]]]
+) -> tuple[bool, list[str]]:
+    blockers: list[str] = []
+    ok = True
+    for fid in feature_ids:
+        if not isinstance(fid, str):
+            ok = False
+            continue
+        tickets = by_feature.get(fid, [])
+        if len(tickets) != 1 or tickets[0].get("status") != "done":
+            ok = False
+            status = tickets[0].get("status") if len(tickets) == 1 else None
+            blockers.append(
+                f"every_feature_done: ticket {fid} status is {status!r}, expected 'done'"
+            )
+    return ok, blockers
+
+
+def _check_review_validated(
+    feature_ids: list[Any],
+    by_feature: dict[str, list[dict[str, Any]]],
+    security_classification: dict[str, Any],
+) -> tuple[bool, list[str]]:
+    blockers: list[str] = []
+    ok = True
+    for fid in feature_ids:
+        if not isinstance(fid, str):
+            ok = False
+            continue
+        tickets = by_feature.get(fid, [])
+        if len(tickets) != 1:
+            ok = False
+            blockers.append(f"every_review_validated: {fid} has no unique ticket record")
+            continue
+        review = _as_dict(tickets[0].get("review_evidence"))
+        if review.get("companion_review_present") is not True:
+            ok = False
+            blockers.append(
+                f"every_review_validated: {fid} companion_review_present is not True"
+            )
+        if review.get("verdict") != "approved":
+            ok = False
+            blockers.append(
+                f"every_review_validated: {fid} review verdict is "
+                f"{review.get('verdict')!r}, expected 'approved'"
+            )
+        if not _is_sha40(review.get("reviewed_sha")):
+            ok = False
+            blockers.append(
+                f"every_review_validated: {fid} review reviewed_sha missing or not 40-hex"
+            )
+        if review.get("acceptance_verified") is not True:
+            ok = False
+            blockers.append(f"every_review_validated: {fid} acceptance_verified is not True")
+        # Fail-closed classification: any value that is not exactly "standard"
+        # (including a missing/unknown classification) requires an approved
+        # security_verdict. Absent classification defaults to high-risk.
+        if (
+            security_classification.get(fid) != "standard"
+            and review.get("security_verdict") != "approved"
+        ):
+            ok = False
+            blockers.append(
+                f"every_review_validated: {fid} is security-classified "
+                f"({security_classification.get(fid)!r} != 'standard') but security_verdict "
+                f"is {review.get('security_verdict')!r}, expected 'approved'"
+            )
+    return ok, blockers
+
+
+def _check_integration_review(
+    integration_review: dict[str, Any], manifest: dict[str, Any]
+) -> tuple[bool, list[str]]:
+    blockers: list[str] = []
+    ok = True
+    if integration_review.get("approved") is not True:
+        ok = False
+        blockers.append("integration_review_approved: integration_review.approved is not True")
+    if not _non_empty_str(integration_review.get("reviewer")):
+        ok = False
+        blockers.append(
+            "integration_review_approved: integration_review.reviewer missing or empty"
+        )
+    if not _non_empty_str(integration_review.get("locked_revision_id")):
+        ok = False
+        blockers.append(
+            "integration_review_approved: "
+            "integration_review.locked_revision_id missing or empty"
+        )
+    reviewed_sha = integration_review.get("reviewed_sha")
+    integration_sha = manifest.get("integration_sha")
+    if not _is_sha40(reviewed_sha) or reviewed_sha != integration_sha:
+        ok = False
+        blockers.append(
+            "integration_review_approved: integration_review.reviewed_sha "
+            f"{reviewed_sha!r} does not match manifest.integration_sha {integration_sha!r}"
+        )
+    return ok, blockers
+
+
+def _check_ci(ci: dict[str, Any], manifest: dict[str, Any]) -> tuple[bool, list[str]]:
+    blockers: list[str] = []
+    ok = True
+    if ci.get("found_any") is not True:
+        ok = False
+        blockers.append("ci_green_for_exact_sha: ci.found_any is not True")
+    if ci.get("all_success") is not True:
+        ok = False
+        blockers.append("ci_green_for_exact_sha: ci.all_success is not True")
+    integration_sha = manifest.get("integration_sha")
+    if ci.get("sha") != integration_sha:
+        ok = False
+        blockers.append(
+            f"ci_green_for_exact_sha: ci.sha {ci.get('sha')!r} does not match "
+            f"manifest.integration_sha {integration_sha!r}"
+        )
+    missing_required = ci.get("missing_required")
+    if missing_required != []:
+        ok = False
+        blockers.append(
+            f"ci_green_for_exact_sha: ci.missing_required is {missing_required!r}, expected []"
+        )
+    return ok, blockers
+
+
+def _check_rc_digest(
+    deployed_digest: dict[str, Any], expected_rc_digest: Any
+) -> tuple[bool, list[str]]:
+    digest = deployed_digest.get("digest")
+    if (
+        _non_empty_str(digest)
+        and _non_empty_str(expected_rc_digest)
+        and digest == expected_rc_digest
+    ):
+        return True, []
+    return False, [
+        f"rc_digest_deployed: deployed_digest.digest {digest!r} does not match "
+        f"expected_rc_digest {expected_rc_digest!r}"
+    ]
+
+
+def _check_verify(verify: dict[str, Any]) -> tuple[bool, list[str]]:
+    # MVP: verify_passed requires a strict integer-0 exit code. The served-digest
+    # identity check is deliberately NOT done here (it would be fail-open on a
+    # missing digest_served, which the MVP verify cannot yet produce); the
+    # deployed-vs-expected digest binding is enforced by rc_digest_deployed. The
+    # authenticated served-digest identity is hardening-ledger item 2.
+    if _is_exit_zero(verify.get("exit_code")):
+        return True, []
+    return False, [
+        f"verify_passed: verify.exit_code is {verify.get('exit_code')!r}, expected integer 0"
+    ]
+
+
+def _check_version_free(version_free: dict[str, Any]) -> tuple[bool, list[str]]:
+    if version_free.get("free") is True:
+        return True, []
+    return False, ["version_unpublished: version_free.free is not True"]
+
+
+def _check_security(security: dict[str, Any]) -> tuple[bool, list[str]]:
+    if _is_exit_zero(security.get("exit_code")):
+        return True, []
+    return False, [
+        f"security_clear: security.exit_code is {security.get('exit_code')!r}, expected integer 0"
+    ]
+
+
+def _check_no_open_blockers(bundle: dict[str, Any]) -> tuple[bool, list[str]]:
+    open_blockers = bundle.get("open_blockers", [])
+    if open_blockers == []:
+        return True, []
+    return False, [f"no_open_blockers: open_blockers is {open_blockers!r}, expected []"]
+
+
+def evaluate(bundle: dict[str, Any]) -> GateResult:
+    """Derive every hard-gate condition from raw records in `bundle`.
+
+    Pure function: never raises on missing/malformed input, never trusts any
+    caller-supplied "ready"/"validated"-style boolean shortcut.
+    """
+    if not isinstance(bundle, dict):
+        bundle = {}
+
+    manifest = _as_dict(bundle.get("manifest"))
+    feature_ids_raw = manifest.get("feature_ids")
+    feature_ids = _as_list(feature_ids_raw)
+    by_feature = _tickets_by_feature(bundle)
+    security_classification = _as_dict(manifest.get("security_classification"))
+
+    conditions: dict[str, bool] = {}
+    blockers: list[str] = []
+
+    ok, bl = _check_manifest_complete(manifest, feature_ids, by_feature)
+    conditions["manifest_complete"] = ok
+    blockers += bl
+
+    ok, bl = _check_every_feature_done(feature_ids, by_feature)
+    conditions["every_feature_done"] = ok
+    blockers += bl
+
+    ok, bl = _check_review_validated(feature_ids, by_feature, security_classification)
+    conditions["every_review_validated"] = ok
+    blockers += bl
+
+    ok, bl = _check_integration_review(_as_dict(bundle.get("integration_review")), manifest)
+    conditions["integration_review_approved"] = ok
+    blockers += bl
+
+    ok, bl = _check_ci(_as_dict(bundle.get("ci")), manifest)
+    conditions["ci_green_for_exact_sha"] = ok
+    blockers += bl
+
+    expected_rc_digest = bundle.get("expected_rc_digest")
+    ok, bl = _check_rc_digest(_as_dict(bundle.get("deployed_digest")), expected_rc_digest)
+    conditions["rc_digest_deployed"] = ok
+    blockers += bl
+
+    ok, bl = _check_verify(_as_dict(bundle.get("verify")))
+    conditions["verify_passed"] = ok
+    blockers += bl
+
+    ok, bl = _check_version_free(_as_dict(bundle.get("version_free")))
+    conditions["version_unpublished"] = ok
+    blockers += bl
+
+    ok, bl = _check_security(_as_dict(bundle.get("security")))
+    conditions["security_clear"] = ok
+    blockers += bl
+
+    ok, bl = _check_no_open_blockers(bundle)
+    conditions["no_open_blockers"] = ok
+    blockers += bl
+
+    ready = all(conditions.values())
+    report_md = _render_report(manifest, conditions, blockers, ready)
+    return GateResult(ready=ready, conditions=conditions, blockers=blockers, report_md=report_md)
+
+
+def _render_report(
+    manifest: dict[str, Any], conditions: dict[str, bool], blockers: list[str], ready: bool
+) -> str:
+    version = manifest.get("version", "?")
+    integration_sha = manifest.get("integration_sha", "?")
+    lines = [
+        "# Release readiness report",
+        "",
+        f"- version: {version}",
+        f"- integration_sha: {integration_sha}",
+        "",
+        "## Conditions",
+        "",
+    ]
+    for name, passed in conditions.items():
+        lines.append(f"- {name}: {'PASS' if passed else 'FAIL'}")
+    lines.append("")
+    lines.append("## Blockers")
+    lines.append("")
+    if blockers:
+        for b in blockers:
+            lines.append(f"- {b}")
+    else:
+        lines.append("- (none)")
+    lines.append("")
+    lines.append("READY" if ready else "NOT_READY")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="release_readiness")
+    parser.add_argument("--evidence", help="path to evidence bundle JSON (default: stdin)")
+    parser.add_argument(
+        "--json", action="store_true", help="print GateResult as JSON instead of report_md"
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        if args.evidence:
+            with open(args.evidence, encoding="utf-8") as fh:
+                text = fh.read()
+        else:
+            text = sys.stdin.read()
+    except OSError as exc:
+        # Fail-closed: an unreadable evidence source is NOT_READY, never a crash.
+        result = GateResult(
+            ready=False,
+            conditions={},
+            blockers=[f"could not read evidence source: {exc}"],
+            report_md=(
+                "# Release readiness report\n\n"
+                f"could not read evidence source: {exc}\n\nNOT_READY"
+            ),
+        )
+        if args.json:
+            print(json.dumps(asdict(result), indent=2))
+        else:
+            print(result.report_md)
+        return 1
+
+    try:
+        bundle = json.loads(text) if text.strip() else {}
+    except json.JSONDecodeError as exc:
+        result = GateResult(
+            ready=False,
+            conditions={},
+            blockers=[f"evidence bundle is not valid JSON: {exc}"],
+            report_md=(
+                "# Release readiness report\n\n"
+                f"evidence bundle is not valid JSON: {exc}\n\nNOT_READY"
+            ),
+        )
+    else:
+        result = evaluate(bundle)
+
+    if args.json:
+        print(json.dumps(asdict(result), indent=2))
+    else:
+        print(result.report_md)
+    return 0 if result.ready else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/release_readiness.py
+++ b/scripts/release_readiness.py
@@ -270,7 +270,12 @@ def _check_security(security: dict[str, Any]) -> tuple[bool, list[str]]:
 
 
 def _check_no_open_blockers(bundle: dict[str, Any]) -> tuple[bool, list[str]]:
-    open_blockers = bundle.get("open_blockers", [])
+    # Fail-closed: a MISSING open_blockers key is NOT ready (it means the field
+    # was never populated, not that there are no blockers). Only a top-level
+    # key that is explicitly present and equal to [] counts as clear.
+    if "open_blockers" not in bundle:
+        return False, ["no_open_blockers: open_blockers key is missing from evidence bundle"]
+    open_blockers = bundle["open_blockers"]
     if open_blockers == []:
         return True, []
     return False, [f"no_open_blockers: open_blockers is {open_blockers!r}, expected []"]

--- a/scripts/version_free.py
+++ b/scripts/version_free.py
@@ -11,6 +11,16 @@ forbidden.
 CLI: `python3 scripts/version_free.py --version X.Y.Z [--package data-olympus]
 [--repo knaisoma/data-olympus] [--json]`
 Exit 0 = free (safe to publish), 1 = taken or unreachable.
+
+Intentionally separate from scripts/check_version_free.py. That script is the
+tag-release pipeline guard: it has idempotent-reconcile and operator-bypass
+allowances (it can exit 0 to allow a reconcile even when the version is already
+taken), so its answer is 'is it safe for the pipeline to proceed', not 'is this
+version free'. This module is the Release Manager's typed-evidence adapter: a
+pure evaluate() with strict fail-closed semantics and JSON output, answering
+only 'is this version absent from every registry'. Do not merge the two: the
+pipeline guard's reconcile/bypass allowances would corrupt release-readiness
+evidence.
 """
 from __future__ import annotations
 

--- a/scripts/version_free.py
+++ b/scripts/version_free.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Release version-freshness gate: fail unless a target version is absent from
+every external registry (PyPI, ghcr, GitHub releases), fail-closed.
+
+A version is only "free" (safe to publish) when it is confirmed absent from
+all three registries AND every registry was reachable. If any registry could
+not be queried, the version is treated as NOT free: never assume free during
+an outage, since republishing an already-taken (immutable) version is
+forbidden.
+
+CLI: `python3 scripts/version_free.py --version X.Y.Z [--package data-olympus]
+[--repo knaisoma/data-olympus] [--json]`
+Exit 0 = free (safe to publish), 1 = taken or unreachable.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from typing import cast
+
+_SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+(?:[-+].+)?$")
+
+
+def evaluate(
+    pypi_present: bool | None,
+    ghcr_present: bool | None,
+    gh_release_present: bool | None,
+) -> dict[str, object]:
+    """PURE. Each arg is True (found/taken), False (confirmed absent), or
+    None (unreachable/unknown). A version is free only if all three are
+    exactly False; any True means taken, any None means unreachable and
+    fails closed (not free)."""
+    checks = (
+        ("pypi", pypi_present),
+        ("ghcr", ghcr_present),
+        ("github_release", gh_release_present),
+    )
+    unreachable = [name for name, present in checks if present is None]
+    free = all(present is False for _, present in checks)
+    result: dict[str, object] = {
+        "pypi_taken": pypi_present,
+        "ghcr_taken": ghcr_present,
+        "github_release_taken": gh_release_present,
+        "unreachable": unreachable,
+        "free": free,
+    }
+    return result
+
+
+def _pypi_present(version: str, package: str = "data-olympus") -> bool | None:
+    url = f"https://pypi.org/pypi/{package}/{version}/json"
+    try:
+        with urllib.request.urlopen(url, timeout=10) as resp:  # noqa: S310
+            status: int = resp.status
+            return status == 200
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            return False
+        return None
+    except urllib.error.URLError:
+        return None
+
+
+def _ghcr_present(version: str, package: str = "data-olympus") -> bool | None:
+    tag = f"v{version}"
+    out = subprocess.run(
+        [
+            "gh", "api",
+            "--paginate",
+            f"/orgs/knaisoma/packages/container/{package}/versions",
+            "--jq", ".[].metadata.container.tags[]",
+        ],
+        capture_output=True, text=True,
+    )
+    if out.returncode != 0:
+        return None
+    tags = {line.strip() for line in out.stdout.splitlines() if line.strip()}
+    return tag in tags
+
+
+def _gh_release_present(version: str, repo: str = "knaisoma/data-olympus") -> bool | None:
+    out = subprocess.run(
+        ["gh", "api", f"repos/{repo}/releases/tags/v{version}"],
+        capture_output=True, text=True,
+    )
+    if out.returncode == 0:
+        return True
+    if "404" in out.stderr or "Not Found" in out.stderr:
+        return False
+    return None
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="version_free")
+    parser.add_argument("--version", required=True, help="target version, e.g. 1.2.3")
+    parser.add_argument("--package", default="data-olympus")
+    parser.add_argument("--repo", default="knaisoma/data-olympus")
+    parser.add_argument("--json", action="store_true", help="emit JSON instead of a summary")
+    args = parser.parse_args(argv)
+
+    if not _SEMVER_RE.match(args.version):
+        print(f"invalid semver: {args.version!r}", file=sys.stderr)
+        return 1
+
+    pypi = _pypi_present(args.version, args.package)
+    ghcr = _ghcr_present(args.version, args.package)
+    gh_release = _gh_release_present(args.version, args.repo)
+    result = evaluate(pypi, ghcr, gh_release)
+
+    if args.json:
+        print(json.dumps(result))
+    elif result["free"]:
+        print(f"{args.version} is free: absent from PyPI, ghcr, and GitHub releases")
+    else:
+        taken = [
+            name
+            for name, key in (
+                ("PyPI", "pypi_taken"),
+                ("ghcr", "ghcr_taken"),
+                ("GitHub releases", "github_release_taken"),
+            )
+            if result[key] is True
+        ]
+        if taken:
+            print(f"{args.version} is NOT free: already present on {', '.join(taken)}")
+        unreachable = cast("list[str]", result["unreachable"])
+        if unreachable:
+            print(
+                f"{args.version} is NOT free: unreachable registries "
+                f"{', '.join(unreachable)} (fail-closed)"
+            )
+
+    return 0 if result["free"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_ci_status.py
+++ b/tests/test_ci_status.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from scripts.ci_status import evaluate
+
+
+def _check(name: str, status: str = "completed", conclusion: str | None = "success") -> dict:
+    return {"name": name, "status": status, "conclusion": conclusion}
+
+
+def test_all_required_present_and_success() -> None:
+    checks = [_check("lint"), _check("test"), _check("build")]
+    result = evaluate(checks, ["lint", "test"])
+    assert result["all_success"] is True
+    assert result["found_any"] is True
+    assert result["missing_required"] == []
+
+
+def test_required_check_missing() -> None:
+    checks = [_check("lint")]
+    result = evaluate(checks, ["lint", "test"])
+    assert result["all_success"] is False
+    assert result["missing_required"] == ["test"]
+
+
+def test_required_check_present_but_failed() -> None:
+    checks = [_check("lint"), _check("test", conclusion="failure")]
+    result = evaluate(checks, ["lint", "test"])
+    assert result["all_success"] is False
+    assert "test" in result["missing_required"]
+
+
+def test_empty_check_runs_fails_closed() -> None:
+    result = evaluate([], ["lint"])
+    assert result["found_any"] is False
+    assert result["all_success"] is False
+
+
+def test_no_required_all_present_success() -> None:
+    checks = [_check("lint"), _check("test")]
+    result = evaluate(checks, [])
+    assert result["all_success"] is True
+    assert result["missing_required"] == []
+
+
+def test_no_required_one_failure() -> None:
+    checks = [_check("lint"), _check("test", conclusion="failure")]
+    result = evaluate(checks, [])
+    assert result["all_success"] is False
+
+
+def test_in_progress_check_not_success() -> None:
+    checks = [_check("lint", status="in_progress", conclusion=None)]
+    result = evaluate(checks, [])
+    assert result["all_success"] is False
+
+
+def test_neutral_conclusion_not_success() -> None:
+    checks = [_check("lint", conclusion="neutral")]
+    result = evaluate(checks, [])
+    assert result["all_success"] is False
+
+
+def test_cancelled_conclusion_not_success() -> None:
+    checks = [_check("lint", conclusion="cancelled")]
+    result = evaluate(checks, [])
+    assert result["all_success"] is False
+
+
+def test_empty_check_runs_with_no_required_fails_closed() -> None:
+    result = evaluate([], [])
+    assert result["found_any"] is False
+    assert result["all_success"] is False
+
+
+def test_checks_field_shape() -> None:
+    checks = [_check("lint")]
+    result = evaluate(checks, [])
+    assert result["checks"] == [{"name": "lint", "status": "completed", "conclusion": "success"}]
+    assert result["required"] == []

--- a/tests/test_deployed_digest.py
+++ b/tests/test_deployed_digest.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from scripts.deployed_digest import evaluate, main
+
+if TYPE_CHECKING:
+    import pytest
+
+
+def _version(name: str, tags: list[str]) -> dict:
+    return {"name": name, "metadata": {"container": {"tags": tags}}}
+
+
+def test_evaluate_single_match_resolves_digest() -> None:
+    versions = [
+        _version("sha256:aaaa", ["edge"]),
+        _version("sha256:bbbb", ["stable", "v0.5.0"]),
+    ]
+    result = evaluate(versions, "stable")
+    assert result["digest"] == "sha256:bbbb"
+    assert result["source"] == "ghcr:stable"
+    assert result["matched_versions"] == 1
+
+
+def test_evaluate_no_match_fails_closed() -> None:
+    versions = [_version("sha256:aaaa", ["edge"])]
+    result = evaluate(versions, "stable")
+    assert result["digest"] is None
+    assert result["source"] is None
+    assert result["matched_versions"] == 0
+
+
+def test_evaluate_ambiguous_match_fails_closed() -> None:
+    versions = [
+        _version("sha256:aaaa", ["stable"]),
+        _version("sha256:bbbb", ["stable"]),
+    ]
+    result = evaluate(versions, "stable")
+    assert result["digest"] is None
+    assert result["matched_versions"] == 2
+
+
+def test_evaluate_empty_digest_name_fails_closed() -> None:
+    versions = [_version("", ["stable"])]
+    result = evaluate(versions, "stable")
+    assert result["digest"] is None
+
+
+def test_evaluate_malformed_metadata_ignored() -> None:
+    versions = [{"name": "sha256:aaaa", "metadata": "not-a-dict"}]
+    result = evaluate(versions, "stable")
+    assert result["digest"] is None
+    assert result["matched_versions"] == 0
+
+
+def _patch_fetch(monkeypatch: pytest.MonkeyPatch, *, versions: object) -> None:
+    import scripts.deployed_digest as mod
+
+    def _raise_or_return(_package: str, _org: str) -> list[dict]:
+        if isinstance(versions, Exception):
+            raise versions
+        return versions  # type: ignore[return-value]
+
+    monkeypatch.setattr(mod, "_fetch_versions", _raise_or_return)
+
+
+def test_main_success_path_exits_zero(monkeypatch: pytest.MonkeyPatch, capsys) -> None:
+    _patch_fetch(monkeypatch, versions=[_version("sha256:cccc", ["stable"])])
+    code = main(["--target", "stable", "--json"])
+    assert code == 0
+    out = capsys.readouterr().out
+    assert "sha256:cccc" in out
+    assert '"digest": null' not in out
+
+
+def test_main_fail_closed_on_lookup_error(monkeypatch: pytest.MonkeyPatch, capsys) -> None:
+    _patch_fetch(monkeypatch, versions=RuntimeError("gh api unreachable"))
+    code = main(["--target", "stable", "--json"])
+    assert code != 0
+    out = capsys.readouterr().out
+    assert '"digest": null' in out
+
+
+def test_main_fail_closed_on_no_match(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_fetch(monkeypatch, versions=[_version("sha256:aaaa", ["edge"])])
+    code = main(["--target", "stable", "--json"])
+    assert code != 0

--- a/tests/test_deployed_digest.py
+++ b/tests/test_deployed_digest.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from scripts.deployed_digest import evaluate, main
 
@@ -12,13 +12,19 @@ def _version(name: str, tags: list[str]) -> dict:
     return {"name": name, "metadata": {"container": {"tags": tags}}}
 
 
+# Valid-shape sha256 digests ("sha256:" + 64 hex chars) for tests that expect
+# a successful resolution; format validation now rejects anything shorter.
+_DIGEST_B = "sha256:" + "b" * 64
+_DIGEST_C = "sha256:" + "c" * 64
+
+
 def test_evaluate_single_match_resolves_digest() -> None:
     versions = [
         _version("sha256:aaaa", ["edge"]),
-        _version("sha256:bbbb", ["stable", "v0.5.0"]),
+        _version(_DIGEST_B, ["stable", "v0.5.0"]),
     ]
     result = evaluate(versions, "stable")
-    assert result["digest"] == "sha256:bbbb"
+    assert result["digest"] == _DIGEST_B
     assert result["source"] == "ghcr:stable"
     assert result["matched_versions"] == 1
 
@@ -66,11 +72,11 @@ def _patch_fetch(monkeypatch: pytest.MonkeyPatch, *, versions: object) -> None:
 
 
 def test_main_success_path_exits_zero(monkeypatch: pytest.MonkeyPatch, capsys) -> None:
-    _patch_fetch(monkeypatch, versions=[_version("sha256:cccc", ["stable"])])
+    _patch_fetch(monkeypatch, versions=[_version(_DIGEST_C, ["stable"])])
     code = main(["--target", "stable", "--json"])
     assert code == 0
     out = capsys.readouterr().out
-    assert "sha256:cccc" in out
+    assert _DIGEST_C in out
     assert '"digest": null' not in out
 
 
@@ -86,3 +92,69 @@ def test_main_fail_closed_on_no_match(monkeypatch: pytest.MonkeyPatch) -> None:
     _patch_fetch(monkeypatch, versions=[_version("sha256:aaaa", ["edge"])])
     code = main(["--target", "stable", "--json"])
     assert code != 0
+
+
+def test_evaluate_non_sha256_digest_fails_closed() -> None:
+    versions = [_version("not-a-digest", ["stable"])]
+    result = evaluate(versions, "stable")
+    assert result["digest"] is None
+    assert result["source"] is None
+    assert result["matched_versions"] == 1
+
+
+def test_main_fail_closed_on_non_sha256_digest(monkeypatch: pytest.MonkeyPatch, capsys) -> None:
+    _patch_fetch(monkeypatch, versions=[_version("not-a-digest", ["stable"])])
+    code = main(["--target", "stable", "--json"])
+    assert code != 0
+    out = capsys.readouterr().out
+    assert '"digest": null' in out
+
+
+def test_main_fail_closed_on_malformed_json(monkeypatch: pytest.MonkeyPatch, capsys) -> None:
+    import json as json_mod
+
+    _patch_fetch(
+        monkeypatch, versions=json_mod.JSONDecodeError("bad json", "{not valid", 0)
+    )
+    code = main(["--target", "stable", "--json"])
+    assert code != 0
+    out = capsys.readouterr().out
+    assert '"digest": null' in out
+    assert '"source": null' in out
+
+
+def test_main_fail_closed_on_non_dict_payload_shape(
+    monkeypatch: pytest.MonkeyPatch, capsys
+) -> None:
+    # _fetch_versions returning something that isn't a list of version dicts
+    # (e.g. a single dict instead of a list) must not crash main(); it must
+    # fail closed the same as any other lookup failure.
+    _patch_fetch(monkeypatch, versions={"unexpected": "shape"})
+    code = main(["--target", "stable", "--json"])
+    assert code != 0
+    out = capsys.readouterr().out
+    assert '"digest": null' in out
+
+
+def test_evaluate_tolerates_non_dict_version_entries() -> None:
+    # Individual entries in the versions list that are not dicts at all
+    # (e.g. a bare string or None) must be ignored, not raise.
+    versions: list[Any] = [1, "x", None, {}]
+    result = evaluate(versions, "stable")
+    assert result["digest"] is None
+    assert result["matched_versions"] == 0
+
+
+def test_main_fail_closed_on_missing_gh_binary(
+    monkeypatch: pytest.MonkeyPatch, capsys
+) -> None:
+    import scripts.deployed_digest as mod
+
+    def _missing_gh(*_args: object, **_kwargs: object) -> None:
+        raise FileNotFoundError("gh: command not found")
+
+    monkeypatch.setattr(mod.subprocess, "run", _missing_gh)
+    code = main(["--target", "stable", "--json"])
+    assert code != 0
+    out = capsys.readouterr().out
+    assert '"digest": null' in out

--- a/tests/test_release_readiness.py
+++ b/tests/test_release_readiness.py
@@ -1,0 +1,328 @@
+from __future__ import annotations
+
+import copy
+import json
+import subprocess
+import sys
+from typing import Any
+
+import pytest
+
+from scripts.release_readiness import GateResult, evaluate, main
+
+SHA_INTEGRATION = "a" * 40
+SHA_REVIEW_67 = "b" * 40
+SHA_REVIEW_68 = "c" * 40
+DIGEST = "sha256:" + "d" * 64
+
+
+def _valid_bundle() -> dict[str, Any]:
+    return {
+        "manifest": {
+            "version": "0.5.0",
+            "integration_sha": SHA_INTEGRATION,
+            "feature_ids": ["KNA-67", "KNA-68"],
+            "contract_blob_sha": "deadbeef",
+            "security_classification": {"KNA-67": "standard", "KNA-68": "security"},
+        },
+        "tickets": [
+            {
+                "id": "KNA-67",
+                "status": "done",
+                "review_evidence": {
+                    "companion_review_present": True,
+                    "verdict": "approved",
+                    "reviewed_sha": SHA_REVIEW_67,
+                    "acceptance_verified": True,
+                },
+            },
+            {
+                "id": "KNA-68",
+                "status": "done",
+                "review_evidence": {
+                    "companion_review_present": True,
+                    "verdict": "approved",
+                    "reviewed_sha": SHA_REVIEW_68,
+                    "acceptance_verified": True,
+                    "security_verdict": "approved",
+                },
+            },
+        ],
+        "ci": {
+            "sha": SHA_INTEGRATION,
+            "all_success": True,
+            "found_any": True,
+            "missing_required": [],
+        },
+        "verify": {
+            "exit_code": 0,
+            "digest_served": DIGEST,
+            "target": "https://example.invalid/verify",
+        },
+        "version_free": {"free": True},
+        "deployed_digest": {"digest": DIGEST, "source": "kndev"},
+        "expected_rc_digest": DIGEST,
+        "integration_review": {
+            "approved": True,
+            "reviewer": "Reviewer High-Risk",
+            "locked_revision_id": "rev-123",
+            "reviewed_sha": SHA_INTEGRATION,
+        },
+        "security": {"exit_code": 0},
+        "open_blockers": [],
+    }
+
+
+ALL_CONDITIONS = [
+    "manifest_complete",
+    "every_feature_done",
+    "every_review_validated",
+    "integration_review_approved",
+    "ci_green_for_exact_sha",
+    "rc_digest_deployed",
+    "verify_passed",
+    "version_unpublished",
+    "security_clear",
+    "no_open_blockers",
+]
+
+
+def test_all_pass_is_ready() -> None:
+    result = evaluate(_valid_bundle())
+    assert isinstance(result, GateResult)
+    assert result.ready is True
+    assert all(result.conditions.values())
+    assert result.conditions.keys() == set(ALL_CONDITIONS)
+    assert result.blockers == []
+    assert "READY" in result.report_md
+    assert "NOT_READY" not in result.report_md
+
+
+def test_empty_bundle_is_not_ready_and_does_not_raise() -> None:
+    result = evaluate({})
+    assert result.ready is False
+    assert result.conditions["manifest_complete"] is False
+    assert len(result.blockers) > 0
+
+
+def test_none_like_bundle_types_do_not_raise() -> None:
+    # Malformed bundle: wrong types everywhere. Must fail closed, never raise.
+    bundle = {
+        "manifest": None,
+        "tickets": "not-a-list",
+        "ci": 5,
+        "verify": [],
+        "version_free": None,
+        "deployed_digest": "oops",
+        "expected_rc_digest": None,
+        "integration_review": None,
+        "security": None,
+        "open_blockers": "nope",
+    }
+    result = evaluate(bundle)
+    assert result.ready is False
+    # manifest.feature_ids is empty because manifest itself is malformed, so
+    # the per-feature loops (every_feature_done / every_review_validated) are
+    # vacuously True over zero features; manifest_complete still correctly
+    # fails and gates overall readiness, which is what matters for fail-closed.
+    assert result.conditions["manifest_complete"] is False
+    non_vacuous = {
+        k: v
+        for k, v in result.conditions.items()
+        if k not in {"every_feature_done", "every_review_validated"}
+    }
+    assert all(v is False for v in non_vacuous.values()), result.conditions
+
+
+def test_caller_supplied_ready_true_is_ignored_when_ci_fails() -> None:
+    bundle = _valid_bundle()
+    bundle["ready"] = True
+    bundle["review_validated"] = True
+    bundle["ci"]["all_success"] = False
+    result = evaluate(bundle)
+    assert result.ready is False
+    assert result.conditions["ci_green_for_exact_sha"] is False
+    assert any("ci_green_for_exact_sha" in b for b in result.blockers)
+
+
+def test_caller_supplied_ready_true_alone_does_not_make_it_ready() -> None:
+    bundle = {"ready": True, "review_validated": True}
+    result = evaluate(bundle)
+    assert result.ready is False
+
+
+@pytest.mark.parametrize(
+    ("mutate", "failed_condition"),
+    [
+        (lambda b: b["manifest"].pop("version"), "manifest_complete"),
+        (lambda b: b["manifest"].__setitem__("integration_sha", "not-a-sha"), "manifest_complete"),
+        (lambda b: b["manifest"].__setitem__("feature_ids", []), "manifest_complete"),
+        (lambda b: b["manifest"].pop("contract_blob_sha"), "manifest_complete"),
+        (
+            lambda b: b["tickets"].append(copy.deepcopy(b["tickets"][0])),
+            "manifest_complete",
+        ),
+        (lambda b: b["tickets"][0].__setitem__("status", "in_progress"), "every_feature_done"),
+        (lambda b: b["tickets"].pop(0), "every_feature_done"),
+        (
+            lambda b: b["tickets"][0]["review_evidence"].__setitem__(
+                "companion_review_present", False
+            ),
+            "every_review_validated",
+        ),
+        (
+            lambda b: b["tickets"][0]["review_evidence"].__setitem__(
+                "verdict", "changes_requested"
+            ),
+            "every_review_validated",
+        ),
+        (
+            lambda b: b["tickets"][0]["review_evidence"].__setitem__("reviewed_sha", "short"),
+            "every_review_validated",
+        ),
+        (
+            lambda b: b["tickets"][0]["review_evidence"].__setitem__("acceptance_verified", False),
+            "every_review_validated",
+        ),
+        (
+            lambda b: b["tickets"][1]["review_evidence"].pop("security_verdict"),
+            "every_review_validated",
+        ),
+        (
+            lambda b: b["tickets"][1]["review_evidence"].__setitem__(
+                "security_verdict", "pending"
+            ),
+            "every_review_validated",
+        ),
+        (
+            lambda b: b["integration_review"].__setitem__("approved", False),
+            "integration_review_approved",
+        ),
+        (
+            lambda b: b["integration_review"].__setitem__("reviewer", ""),
+            "integration_review_approved",
+        ),
+        (
+            lambda b: b["integration_review"].__setitem__("locked_revision_id", ""),
+            "integration_review_approved",
+        ),
+        (
+            lambda b: b["integration_review"].__setitem__("reviewed_sha", "e" * 40),
+            "integration_review_approved",
+        ),
+        (lambda b: b["ci"].__setitem__("found_any", False), "ci_green_for_exact_sha"),
+        (lambda b: b["ci"].__setitem__("all_success", False), "ci_green_for_exact_sha"),
+        (lambda b: b["ci"].__setitem__("sha", "f" * 40), "ci_green_for_exact_sha"),
+        (lambda b: b["ci"].__setitem__("missing_required", ["build"]), "ci_green_for_exact_sha"),
+        (
+            lambda b: b["deployed_digest"].__setitem__("digest", "sha256:" + "0" * 64),
+            "rc_digest_deployed",
+        ),
+        (lambda b: b.__setitem__("expected_rc_digest", ""), "rc_digest_deployed"),
+        (lambda b: b["verify"].__setitem__("exit_code", 1), "verify_passed"),
+        (lambda b: b["version_free"].__setitem__("free", False), "version_unpublished"),
+        (lambda b: b["security"].__setitem__("exit_code", 1), "security_clear"),
+        (
+            lambda b: b.__setitem__("open_blockers", ["KNA-99 needs a follow-up"]),
+            "no_open_blockers",
+        ),
+    ],
+)
+def test_single_condition_failure(mutate, failed_condition: str) -> None:
+    bundle = _valid_bundle()
+    mutate(bundle)
+    result = evaluate(bundle)
+    assert result.conditions[failed_condition] is False, result.conditions
+    assert result.ready is False
+    assert any(b.startswith(failed_condition) for b in result.blockers), result.blockers
+    assert "NOT_READY" in result.report_md
+
+
+def test_extra_unknown_keys_are_tolerated() -> None:
+    bundle = _valid_bundle()
+    bundle["unexpected_top_level_key"] = {"whatever": "value"}
+    bundle["manifest"]["unexpected_manifest_key"] = "value"
+    bundle["tickets"][0]["unexpected_ticket_key"] = "value"
+    result = evaluate(bundle)
+    assert result.ready is True
+
+
+def test_missing_verify_digest_served_does_not_fail_verify_passed() -> None:
+    bundle = _valid_bundle()
+    del bundle["verify"]["digest_served"]
+    result = evaluate(bundle)
+    assert result.conditions["verify_passed"] is True
+    assert result.ready is True
+
+
+def test_report_md_lists_version_sha_and_all_condition_lines() -> None:
+    result = evaluate(_valid_bundle())
+    for name in ALL_CONDITIONS:
+        assert name in result.report_md
+    assert "0.5.0" in result.report_md
+    assert SHA_INTEGRATION in result.report_md
+
+
+def test_duplicate_ticket_for_same_feature_fails_manifest_complete() -> None:
+    bundle = _valid_bundle()
+    dup = copy.deepcopy(bundle["tickets"][0])
+    bundle["tickets"].append(dup)
+    result = evaluate(bundle)
+    assert result.conditions["manifest_complete"] is False
+    assert result.ready is False
+
+
+def test_evaluate_never_raises_on_wildly_malformed_bundle() -> None:
+    result = evaluate({"manifest": {"feature_ids": [1, 2, None]}, "tickets": [1, "x", None, {}]})
+    assert result.ready is False
+
+
+def test_evaluate_never_raises_on_non_dict_bundle() -> None:
+    result = evaluate([])  # type: ignore[arg-type]
+    assert result.ready is False
+
+
+def test_main_exit_code_0_when_ready(tmp_path) -> None:
+    evidence_path = tmp_path / "evidence.json"
+    evidence_path.write_text(json.dumps(_valid_bundle()))
+    exit_code = main(["--evidence", str(evidence_path)])
+    assert exit_code == 0
+
+
+def test_main_exit_code_1_when_not_ready(tmp_path) -> None:
+    bundle = _valid_bundle()
+    bundle["security"]["exit_code"] = 1
+    evidence_path = tmp_path / "evidence.json"
+    evidence_path.write_text(json.dumps(bundle))
+    exit_code = main(["--evidence", str(evidence_path)])
+    assert exit_code == 1
+
+
+def test_main_json_flag_emits_gate_result_json(tmp_path, capsys) -> None:
+    evidence_path = tmp_path / "evidence.json"
+    evidence_path.write_text(json.dumps(_valid_bundle()))
+    exit_code = main(["--evidence", str(evidence_path), "--json"])
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ready"] is True
+    assert "conditions" in payload and "blockers" in payload and "report_md" in payload
+
+
+def test_main_reads_stdin_when_no_evidence_flag() -> None:
+    bundle_json = json.dumps(_valid_bundle())
+    proc = subprocess.run(
+        [sys.executable, "-m", "scripts.release_readiness"],
+        input=bundle_json,
+        capture_output=True,
+        text=True,
+        cwd=__file__.rsplit("/tests/", 1)[0],
+    )
+    assert proc.returncode == 0
+    assert "READY" in proc.stdout
+
+
+def test_main_not_valid_json_is_not_ready_not_a_crash(tmp_path) -> None:
+    evidence_path = tmp_path / "evidence.json"
+    evidence_path.write_text("{not valid json")
+    exit_code = main(["--evidence", str(evidence_path)])
+    assert exit_code == 1

--- a/tests/test_release_readiness.py
+++ b/tests/test_release_readiness.py
@@ -21,13 +21,13 @@ def _valid_bundle() -> dict[str, Any]:
         "manifest": {
             "version": "0.5.0",
             "integration_sha": SHA_INTEGRATION,
-            "feature_ids": ["KNA-67", "KNA-68"],
+            "feature_ids": ["FEATURE-1", "FEATURE-2"],
             "contract_blob_sha": "deadbeef",
-            "security_classification": {"KNA-67": "standard", "KNA-68": "security"},
+            "security_classification": {"FEATURE-1": "standard", "FEATURE-2": "security"},
         },
         "tickets": [
             {
-                "id": "KNA-67",
+                "id": "FEATURE-1",
                 "status": "done",
                 "review_evidence": {
                     "companion_review_present": True,
@@ -37,7 +37,7 @@ def _valid_bundle() -> dict[str, Any]:
                 },
             },
             {
-                "id": "KNA-68",
+                "id": "FEATURE-2",
                 "status": "done",
                 "review_evidence": {
                     "companion_review_present": True,
@@ -60,7 +60,7 @@ def _valid_bundle() -> dict[str, Any]:
             "target": "https://example.invalid/verify",
         },
         "version_free": {"free": True},
-        "deployed_digest": {"digest": DIGEST, "source": "kndev"},
+        "deployed_digest": {"digest": DIGEST, "source": "test-channel"},
         "expected_rc_digest": DIGEST,
         "integration_review": {
             "approved": True,
@@ -223,7 +223,7 @@ def test_caller_supplied_ready_true_alone_does_not_make_it_ready() -> None:
         (lambda b: b["version_free"].__setitem__("free", False), "version_unpublished"),
         (lambda b: b["security"].__setitem__("exit_code", 1), "security_clear"),
         (
-            lambda b: b.__setitem__("open_blockers", ["KNA-99 needs a follow-up"]),
+            lambda b: b.__setitem__("open_blockers", ["FEATURE-3 needs a follow-up"]),
             "no_open_blockers",
         ),
     ],

--- a/tests/test_release_readiness_hardening.py
+++ b/tests/test_release_readiness_hardening.py
@@ -23,13 +23,13 @@ def _ready_bundle() -> dict:
         "manifest": {
             "version": "0.5.0",
             "integration_sha": _SHA,
-            "feature_ids": ["KNA-67"],
+            "feature_ids": ["FEATURE-1"],
             "contract_blob_sha": "deadbeef",
-            "security_classification": {"KNA-67": "standard"},
+            "security_classification": {"FEATURE-1": "standard"},
         },
         "tickets": [
             {
-                "id": "KNA-67",
+                "id": "FEATURE-1",
                 "status": "done",
                 "review_evidence": {
                     "companion_review_present": True,
@@ -64,7 +64,7 @@ def test_security_classification_non_standard_requires_verdict() -> None:
     # security_verdict; "high-security", True, and 1 must NOT bypass it.
     for label in ("high-security", "security", True, 1):
         b = _ready_bundle()
-        b["manifest"]["security_classification"]["KNA-67"] = label
+        b["manifest"]["security_classification"]["FEATURE-1"] = label
         # no security_verdict present -> must be NOT ready
         assert evaluate(b).ready is False, f"classification {label!r} bypassed security review"
         # with an approved security_verdict -> ready again
@@ -74,7 +74,7 @@ def test_security_classification_non_standard_requires_verdict() -> None:
 
 def test_missing_classification_defaults_to_security_required() -> None:
     b = _ready_bundle()
-    b["manifest"]["security_classification"] = {}  # no entry for KNA-67
+    b["manifest"]["security_classification"] = {}  # no entry for FEATURE-1
     assert evaluate(b).ready is False
     b["tickets"][0]["review_evidence"]["security_verdict"] = "approved"
     assert evaluate(b).ready is True

--- a/tests/test_release_readiness_hardening.py
+++ b/tests/test_release_readiness_hardening.py
@@ -1,0 +1,109 @@
+"""Regression tests for companion-review findings on the readiness evaluator.
+
+Covers the four fail-open / crash gaps found in adversarial review:
+1. security-classification bypass (only exact "security" matched),
+2. exit_code truthiness trap (False / 0.0 accepted as success),
+3. digest fail-open (missing digest_served skipped the check),
+4. CLI file-read crash instead of fail-closed.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from scripts.release_readiness import evaluate, main  # noqa: E402
+
+_SHA = "a" * 40
+
+
+def _ready_bundle() -> dict:
+    return {
+        "manifest": {
+            "version": "0.5.0",
+            "integration_sha": _SHA,
+            "feature_ids": ["KNA-67"],
+            "contract_blob_sha": "deadbeef",
+            "security_classification": {"KNA-67": "standard"},
+        },
+        "tickets": [
+            {
+                "id": "KNA-67",
+                "status": "done",
+                "review_evidence": {
+                    "companion_review_present": True,
+                    "verdict": "approved",
+                    "reviewed_sha": _SHA,
+                    "acceptance_verified": True,
+                },
+            }
+        ],
+        "ci": {"sha": _SHA, "found_any": True, "all_success": True, "missing_required": []},
+        "verify": {"exit_code": 0},
+        "version_free": {"free": True},
+        "deployed_digest": {"digest": "sha256:abc"},
+        "expected_rc_digest": "sha256:abc",
+        "integration_review": {
+            "approved": True,
+            "reviewer": "Reviewer High-Risk",
+            "locked_revision_id": "rev1",
+            "reviewed_sha": _SHA,
+        },
+        "security": {"exit_code": 0},
+        "open_blockers": [],
+    }
+
+
+def test_baseline_is_ready() -> None:
+    assert evaluate(_ready_bundle()).ready is True
+
+
+def test_security_classification_non_standard_requires_verdict() -> None:
+    # Any classification that is not exactly "standard" must require an approved
+    # security_verdict; "high-security", True, and 1 must NOT bypass it.
+    for label in ("high-security", "security", True, 1):
+        b = _ready_bundle()
+        b["manifest"]["security_classification"]["KNA-67"] = label
+        # no security_verdict present -> must be NOT ready
+        assert evaluate(b).ready is False, f"classification {label!r} bypassed security review"
+        # with an approved security_verdict -> ready again
+        b["tickets"][0]["review_evidence"]["security_verdict"] = "approved"
+        assert evaluate(b).ready is True
+
+
+def test_missing_classification_defaults_to_security_required() -> None:
+    b = _ready_bundle()
+    b["manifest"]["security_classification"] = {}  # no entry for KNA-67
+    assert evaluate(b).ready is False
+    b["tickets"][0]["review_evidence"]["security_verdict"] = "approved"
+    assert evaluate(b).ready is True
+
+
+def test_exit_code_false_is_not_success() -> None:
+    b = _ready_bundle()
+    b["verify"]["exit_code"] = False
+    assert evaluate(b).conditions["verify_passed"] is False
+    b = _ready_bundle()
+    b["security"]["exit_code"] = False
+    assert evaluate(b).conditions["security_clear"] is False
+
+
+def test_exit_code_float_is_not_success() -> None:
+    b = _ready_bundle()
+    b["verify"]["exit_code"] = 0.0
+    assert evaluate(b).conditions["verify_passed"] is False
+
+
+def test_rc_digest_mismatch_fails_closed() -> None:
+    b = _ready_bundle()
+    b["deployed_digest"]["digest"] = "sha256:different"
+    assert evaluate(b).conditions["rc_digest_deployed"] is False
+    b = _ready_bundle()
+    b["deployed_digest"] = {}  # missing digest
+    assert evaluate(b).conditions["rc_digest_deployed"] is False
+
+
+def test_cli_missing_file_fails_closed_no_crash() -> None:
+    rc = main(["--evidence", "/nonexistent/path/to/evidence.json"])
+    assert rc == 1  # fail-closed, no traceback

--- a/tests/test_release_readiness_hardening.py
+++ b/tests/test_release_readiness_hardening.py
@@ -5,11 +5,19 @@ Covers the four fail-open / crash gaps found in adversarial review:
 2. exit_code truthiness trap (False / 0.0 accepted as success),
 3. digest fail-open (missing digest_served skipped the check),
 4. CLI file-read crash instead of fail-closed.
+
+Also covers a fifth gap found in a later hardening pass: a MISSING
+top-level evidence key (e.g. "open_blockers" simply absent from the
+bundle) must fail closed, the same as a present-but-invalid value.
+Previously "open_blockers" defaulted to [] when absent, so an evidence
+bundle that never populated that field was silently treated as clear.
 """
 from __future__ import annotations
 
 import sys
 from pathlib import Path
+
+import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
@@ -107,3 +115,45 @@ def test_rc_digest_mismatch_fails_closed() -> None:
 def test_cli_missing_file_fails_closed_no_crash() -> None:
     rc = main(["--evidence", "/nonexistent/path/to/evidence.json"])
     assert rc == 1  # fail-closed, no traceback
+
+
+def test_missing_open_blockers_key_is_not_ready() -> None:
+    # A bundle that never populated open_blockers must NOT be treated as
+    # equivalent to an explicit empty list. Missing evidence is not the
+    # same claim as verified-clear evidence.
+    b = _ready_bundle()
+    del b["open_blockers"]
+    result = evaluate(b)
+    assert result.conditions["no_open_blockers"] is False
+    assert result.ready is False
+    assert any(bl.startswith("no_open_blockers") for bl in result.blockers), result.blockers
+
+
+@pytest.mark.parametrize(
+    ("top_level_key", "failed_condition"),
+    [
+        ("manifest", "manifest_complete"),
+        ("tickets", "every_feature_done"),
+        ("integration_review", "integration_review_approved"),
+        ("ci", "ci_green_for_exact_sha"),
+        ("expected_rc_digest", "rc_digest_deployed"),
+        ("deployed_digest", "rc_digest_deployed"),
+        ("verify", "verify_passed"),
+        ("version_free", "version_unpublished"),
+        ("security", "security_clear"),
+        ("open_blockers", "no_open_blockers"),
+    ],
+)
+def test_missing_required_top_level_field_is_not_ready(
+    top_level_key: str, failed_condition: str
+) -> None:
+    # Omitting any of the top-level evidence keys the gate reads must make
+    # its owning condition (and therefore the overall verdict) NOT ready.
+    # This is the fail-closed principle applied to absence, not just to
+    # present-but-malformed values (which the other tests in this module
+    # and in test_release_readiness.py already cover).
+    b = _ready_bundle()
+    del b[top_level_key]
+    result = evaluate(b)
+    assert result.conditions[failed_condition] is False, result.conditions
+    assert result.ready is False

--- a/tests/test_version_free.py
+++ b/tests/test_version_free.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from scripts.version_free import evaluate
+
+
+def test_evaluate_all_absent_is_free() -> None:
+    result = evaluate(False, False, False)
+    assert result == {
+        "pypi_taken": False,
+        "ghcr_taken": False,
+        "github_release_taken": False,
+        "unreachable": [],
+        "free": True,
+    }
+
+
+def test_evaluate_pypi_present_not_free() -> None:
+    result = evaluate(True, False, False)
+    assert result["pypi_taken"] is True
+    assert result["free"] is False
+    assert result["unreachable"] == []
+
+
+def test_evaluate_any_none_not_free_and_unreachable() -> None:
+    result = evaluate(None, False, False)
+    assert result["free"] is False
+    assert "pypi" in result["unreachable"]
+
+
+def test_evaluate_mixed_unreachable_ghcr_only() -> None:
+    result = evaluate(False, None, False)
+    assert result["free"] is False
+    assert result["unreachable"] == ["ghcr"]
+    assert result["pypi_taken"] is False
+    assert result["ghcr_taken"] is None
+    assert result["github_release_taken"] is False
+
+
+def test_evaluate_all_none_all_unreachable() -> None:
+    result = evaluate(None, None, None)
+    assert result["free"] is False
+    assert result["unreachable"] == ["pypi", "ghcr", "github_release"]
+    assert result["pypi_taken"] is None
+    assert result["ghcr_taken"] is None
+    assert result["github_release_taken"] is None
+
+
+def test_evaluate_ghcr_present_not_free() -> None:
+    result = evaluate(False, True, False)
+    assert result["free"] is False
+    assert result["ghcr_taken"] is True
+
+
+def test_evaluate_gh_release_present_not_free() -> None:
+    result = evaluate(False, False, True)
+    assert result["free"] is False
+    assert result["github_release_taken"] is True

--- a/uv.lock
+++ b/uv.lock
@@ -466,7 +466,7 @@ wheels = [
 
 [[package]]
 name = "data-olympus"
-version = "0.4.1"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },
@@ -485,6 +485,7 @@ dev = [
     { name = "fastembed" },
     { name = "httpx" },
     { name = "mypy" },
+    { name = "prometheus-client" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
@@ -495,6 +496,9 @@ dev = [
 embeddings = [
     { name = "fastembed" },
 ]
+metrics = [
+    { name = "prometheus-client" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -504,6 +508,8 @@ requires-dist = [
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.13" },
     { name = "numpy", marker = "extra == 'bench'", specifier = ">=1.26" },
+    { name = "prometheus-client", marker = "extra == 'dev'", specifier = ">=0.20" },
+    { name = "prometheus-client", marker = "extra == 'metrics'", specifier = ">=0.20" },
     { name = "pydantic", specifier = ">=2.9" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.3" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24" },
@@ -516,7 +522,7 @@ requires-dist = [
     { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0" },
     { name = "types-regex", marker = "extra == 'dev'", specifier = ">=2024.5" },
 ]
-provides-extras = ["embeddings", "dev", "bench"]
+provides-extras = ["embeddings", "metrics", "dev", "bench"]
 
 [[package]]
 name = "dnspython"
@@ -1593,6 +1599,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "prometheus-client"
+version = "0.25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/fb/d9aa83ffe43ce1f19e557c0971d04b90561b0cfd50762aafb01968285553/prometheus_client-0.25.0.tar.gz", hash = "sha256:5e373b75c31afb3c86f1a52fa1ad470c9aace18082d39ec0d2f918d11cc9ba28", size = 86035, upload-time = "2026-04-09T19:53:42.359Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/9b/d4b1e644385499c8346fa9b622a3f030dce14cd6ef8a1871c221a17a67e7/prometheus_client-0.25.0-py3-none-any.whl", hash = "sha256:d5aec89e349a6ec230805d0df882f3807f74fd6c1a2fa86864e3c2279059fed1", size = 64154, upload-time = "2026-04-09T19:53:41.324Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adds the generic release-gating scripts data-olympus uses to decide when a release is ready, plus their tests. No orchestration or environment-specific data.

## Scripts
- `scripts/release_readiness.py` — pure, fail-closed evaluator over a typed evidence bundle. Missing or malformed evidence is treated as NOT ready, never as pass. Covered by a parametrized single-condition-failure suite plus a hardening suite that regression-tests four previously-found fail-open bugs.
- `scripts/ci_status.py` — reads GitHub check-runs for an exact SHA.
- `scripts/version_free.py` — reports whether a version is absent from PyPI, ghcr, and GitHub releases (typed evidence, `--json`, fail-closed). Documented as intentionally distinct from the existing `check_version_free.py` (the tag-release pipeline guard) so the two are not merged.
- `scripts/deployed_digest.py` (new) — reports the deployed image digest for a channel; fail-closed (`{"digest": null}` + non-zero exit) on any lookup error or ambiguity.

## Verification
- `ruff check .` clean, `mypy src` clean (72 files), `pytest` green.
- `deployed_digest.py` exercised for the zero-match, ambiguous-match, and exception paths (all fail closed).

Landed as a reviewed branch-and-PR per GDEC-021 (extracts into the public repo are reviewed before landing). No internal identifiers.