### PR TITLE
fix(release): build images from requested ref

### DIFF
--- a/.github/workflows/rc-publish.yml
+++ b/.github/workflows/rc-publish.yml
@@ -26,11 +26,15 @@ jobs:
     outputs:
       rc_tag: ${{ steps.rc.outputs.rc_tag }}
       version: ${{ steps.rc.outputs.version }}
+      source_sha: ${{ steps.source.outputs.sha }}
     steps:
       - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.ref }}
           fetch-depth: 0
+      - name: Resolve source revision
+        id: source
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
       - name: Compute RC tag
         id: rc
         env:
@@ -61,6 +65,7 @@ jobs:
     needs: decide
     uses: ./.github/workflows/release-image-reusable.yml
     with:
+      ref: ${{ needs.decide.outputs.source_sha }}
       tag: ${{ needs.decide.outputs.rc_tag }}
       move_latest: false
       channel: rc
@@ -76,12 +81,13 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ inputs.ref }}
+          ref: ${{ needs.decide.outputs.source_sha }}
       - name: Create GitHub pre-release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RC_TAG: ${{ needs.decide.outputs.rc_tag }}
           VERSION: ${{ needs.decide.outputs.version }}
+          SOURCE_SHA: ${{ needs.decide.outputs.source_sha }}
         run: |
           NOTES="docs/releases/v${VERSION}.md"
           if gh release view "$RC_TAG" >/dev/null 2>&1; then
@@ -89,9 +95,9 @@ jobs:
             exit 0
           fi
           if [ -f "$NOTES" ]; then
-            gh release create "$RC_TAG" --prerelease --target "${{ inputs.ref }}" \
+            gh release create "$RC_TAG" --prerelease --target "$SOURCE_SHA" \
               --title "$RC_TAG" --notes-file "$NOTES"
           else
-            gh release create "$RC_TAG" --prerelease --target "${{ inputs.ref }}" \
+            gh release create "$RC_TAG" --prerelease --target "$SOURCE_SHA" \
               --title "$RC_TAG" --notes "Release candidate ${RC_TAG} for ${VERSION}."
           fi

--- a/.github/workflows/release-image-reusable.yml
+++ b/.github/workflows/release-image-reusable.yml
@@ -3,6 +3,10 @@ name: build-and-push-image
 on:
   workflow_call:
     inputs:
+      ref:
+        description: "immutable git ref to build"
+        required: true
+        type: string
       tag:
         description: "image tag to publish, e.g. v0.1.0 or edge"
         required: true
@@ -27,7 +31,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
         with:
+          ref: ${{ inputs.ref }}
           fetch-depth: 0
+      - name: Resolve source revision
+        id: source
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
       - name: Set up Docker Buildx
@@ -66,6 +74,6 @@ jobs:
           tags: ${{ steps.image-tag.outputs.tags }}
           labels: |
             org.opencontainers.image.version=${{ inputs.tag }}
-            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.revision=${{ steps.source.outputs.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -20,6 +20,7 @@ jobs:
     if: github.event_name == 'push' && github.ref_type == 'tag'
     uses: ./.github/workflows/release-image-reusable.yml
     with:
+      ref: ${{ github.ref_name }}
       tag: ${{ github.ref_name }}
       move_latest: true
     permissions:
@@ -29,6 +30,7 @@ jobs:
     if: github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/release-image-reusable.yml
     with:
+      ref: ${{ github.sha }}
       tag: ${{ inputs.tag }}
       move_latest: false
     permissions:

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -130,6 +130,7 @@ jobs:
     if: needs.decide.outputs.tag != '' && needs.resolve-rc.outputs.rc_tag == ''
     uses: ./.github/workflows/release-image-reusable.yml
     with:
+      ref: ${{ needs.decide.outputs.tag }}
       tag: ${{ needs.decide.outputs.tag }}
       move_latest: true
     permissions:

--- a/tests/test_publish_workflows.py
+++ b/tests/test_publish_workflows.py
@@ -130,3 +130,54 @@ def test_publish_pr_dry_run_ref_is_not_untrusted():
             "${{ github.ref_name }}",
             "${{ inputs.ref }}",
         ), (job, ref)
+
+
+def test_reusable_image_build_checks_out_and_labels_explicit_ref():
+    doc = _load("release-image-reusable.yml")
+    triggers = doc.get("on", doc.get(True))  # PyYAML 1.1 may parse `on` as true.
+    ref_input = triggers["workflow_call"]["inputs"]["ref"]
+    assert ref_input["required"] is True
+
+    steps = doc["jobs"]["build-push"]["steps"]
+    checkout = next(s for s in steps if "actions/checkout" in str(s.get("uses", "")))
+    assert checkout["with"]["ref"] == "${{ inputs.ref }}"
+
+    source = next(s for s in steps if s.get("id") == "source")
+    assert "git rev-parse HEAD" in source["run"]
+
+    build = next(s for s in steps if "docker/build-push-action" in str(s.get("uses", "")))
+    assert "org.opencontainers.image.revision=${{ steps.source.outputs.sha }}" in build["with"][
+        "labels"
+    ]
+
+
+def test_every_reusable_image_caller_passes_a_ref():
+    for name in ("rc-publish.yml", "release-image.yml", "tag-release.yml"):
+        doc = _load(name)
+        callers = [
+            job
+            for job in doc["jobs"].values()
+            if str(job.get("uses", "")).endswith("release-image-reusable.yml")
+        ]
+        assert callers, name
+        for caller in callers:
+            assert caller["with"].get("ref"), (name, caller)
+
+
+def test_rc_resolves_requested_ref_once_and_reuses_exact_sha():
+    doc = _load("rc-publish.yml")
+    decide = doc["jobs"]["decide"]
+    assert decide["outputs"]["source_sha"] == "${{ steps.source.outputs.sha }}"
+    source = next(s for s in decide["steps"] if s.get("id") == "source")
+    assert "git rev-parse HEAD" in source["run"]
+
+    assert doc["jobs"]["build-image"]["with"]["ref"] == (
+        "${{ needs.decide.outputs.source_sha }}"
+    )
+    prerelease = doc["jobs"]["prerelease"]
+    checkout = next(
+        s for s in prerelease["steps"] if "actions/checkout" in str(s.get("uses", ""))
+    )
+    assert checkout["with"]["ref"] == "${{ needs.decide.outputs.source_sha }}"
+    create = next(s for s in prerelease["steps"] if s.get("name") == "Create GitHub pre-release")
+    assert '--target "$SOURCE_SHA"' in create["run"]


### PR DESCRIPTION
## Summary

Fix RC and release image provenance so the reusable image workflow builds the explicit requested ref instead of the caller workflow SHA.

## Verification

* `uv run --python 3.13 --extra dev pytest -q tests/test_publish_workflows.py`: 12 passed
* `actionlint`: passed
* Independent Claude high risk review: APPROVE at `33b05a208c60e89b17db825242b0041dc47f4f57`

The operator supplied release ref is consumed by `actions/checkout`, not interpolated into shell. The resolved commit is obtained with `git rev-parse HEAD` after checkout and reused immutably by image and prerelease jobs.

RC.1 exposed this defect and was not deployed. A new RC will be cut only after this correction lands on the trusted `main` workflow definition.