### PR TITLE
feat(automation): make weekly releases outcome based

### DIFF
--- a/.rules/release-planning.md
+++ b/.rules/release-planning.md
@@ -1,71 +1,92 @@
-# data-olympus-release-planner routine
+# Data Olympus release planning
 
 Status: active
-Since: 2026-07-11
-Schedule: cron `0 18 * * 5` (Friday 18:00 Europe/Madrid)
-Purpose: turn open GitHub issues into a scoped, reviewed, operator-approved release
-with implementation tickets, so the Monday cutter has a ready epic.
+Since: 2026-07-31
+Schedule: Friday at 18:00 Europe/Bucharest
+Automation status: disabled until baseline certification
 
-## What it does each run
+## Purpose
 
-1. Hygiene + gh auth: clean `main` checkout, `gh` reachable
-   (`tooling/paperclip-gh-auth-context`).
-2. Gather: `gh issue list --state open --json number,title,labels,milestone,body`.
-3. Select + cluster: target 4 (range 3-5) highest-value issues, then pull in
-   closely-related ones (shared files, labels, milestone, epic). Produce a Release
-   Scope Brief: chosen set with rationale, explicitly-deferred set, projected bump.
-4. Security clearance (MANDATORY, first phase). No release may be prepared while
-   any known weakness is open. Hard rule: by the end of this phase,
-   `python3 scripts/security_alerts.py` MUST exit 0 (zero open Dependabot AND zero
-   open CodeQL alerts) - that is the exact gate the Monday cutter re-checks and
-   blocks on (`.rules/release-routine.md` step 2a).
+The planning run identifies one release candidate from work that is already
+merged, reviewed, green, and unreleased on `origin/main`.
 
-   Query every OPEN alert (`python3 scripts/security_alerts.py` lists them; or
-   `gh api /repos/knaisoma/data-olympus/dependabot/alerts?state=open` and
-   `.../code-scanning/alerts?state=open`). Drive EVERY open alert to a disposition,
-   one of:
-   - **Fix / dependency update** - scope it as an implementation sub-ticket in the
-     release epic (the fix must land before the cutter runs); or
-   - **Dismissal with a recorded justification** - only after confirming it is a
-     false positive, not exploitable, or an accepted risk. Apply via:
-     `gh api -X PATCH /repos/knaisoma/data-olympus/code-scanning/alerts/<n>
-     -f state=dismissed -f dismissed_reason="false positive" -f
-     dismissed_comment="<why, <=280 chars>"`. Valid `dismissed_reason` values are
-     exactly `"false positive"`, `"won't fix"`, `"used in tests"` (Dependabot uses
-     `tolerable_risk`, `inaccurate`, `not_used`, `no_bandwidth`). The comment is a
-     hard cap of 280 characters.
+It does not select future issues, create a weekly feature batch, or promise that
+unfinished work will ship on Monday. Product planning and release planning are
+separate outcomes.
 
-   Dismissals are a security judgment: the planner PROPOSES each disposition, and
-   the OPERATOR approves them at the approval gate below (step 6) before anything
-   is dismissed. The release scope brief MUST list every open alert with its
-   planned disposition (fix ticket or dismissal + reason). A release is not scoped
-   until every alert has a disposition and the gate exits 0.
-5. Dual-architect review: the routine (Architect, Claude Opus) drafts the scope +
-   a per-issue implementation spec. The companion architect is `agy` with
-   Gemini 3.5 Flash (High):
-   `agy -p '<review prompt + brief>' --model 'Gemini 3.5 Flash (High)'`.
-   Fallback when agy/Gemini is unavailable: codex CLI with gpt-5.6-sol high
-   reasoning: `codex exec --sandbox read-only --skip-git-repo-check -m gpt-5.6-sol
-   -c model_reasoning_effort="high" -C <dir> '<review prompt>'`. Iterate until both
-   agree; record a `## Companion review (<agy | codex>)` evidence block
-   (WF-004 / collaboration protocol).
-6. Operator approval gate: request a Paperclip approval carrying the brief + specs;
-   notify the operator (Telegram, GDEC-007). Wait.
-7. On approval: create the release parent epic + one implementation sub-ticket per
-   selected issue, each with a `Ready for Build` block, a reviewer assigned
-   (GDEC-028), and `Branch: feature/<release-epic-id>` (WF-004 section 2.2 epic
-   integration branch). The iterative changes-requested and re-review cycle follows WF-004 section 7 (In Review to In Progress until the reviewer approves).
-   Create the `feature/<release-epic-id>` branch off `main`.
+## Authority
 
-## Constraints
+The run reads these sources before acting:
 
-- No em-dashes.
-- One release epic per week; the batch is expected ready by the following Monday
-  (strict 1-week pipeline). The Monday cutter (`.rules/release-routine.md`) gates on
-  readiness and never ships a batch that is not Done + reviewed + green.
-- The epic uses the WF-004 section 2.2 shared integration branch: each feature is
-  one squashed Conventional Commit per ticket on the branch, each sub-ticket updates
-  the CHANGELOG `[Unreleased]` block, and the single integration MR merges to `main`
-  with a MERGE COMMIT (never a squash), per `.rules/versioning.md`, so
-  `compute_release.py` sees each per-feature commit. This reconciles the "release
-  branch" model with STD-U-810 section 2 (no long-lived gitflow release branch).
+* The active Data Olympus records named by the AI Operations contract.
+* `AGENTS.md`.
+* `.rules/versioning.md`.
+* `.rules/release-routine.md`.
+* `.rules/release-rollback.md`.
+* The exact `origin/main` revision under consideration.
+
+The authority revision, contract digest, and source revision are recorded
+before admission.
+
+## Friday planning sequence
+
+1. Fetch `origin/main` and work from a clean dedicated worktree.
+2. Bind the candidate source to the exact remote `main` SHA.
+3. Run `uv run python scripts/compute_release.py`.
+4. If `releasable` is false, record `No action` with the computation and stop.
+5. If a release is due, require a version greater than the current stable
+   version. `v0.6.0` is immutable and can never be selected again.
+6. Run `python3 scripts/security_alerts.py`. Any open or unreadable alert blocks
+   planning. Alert dismissal remains a separate operator approved security
+   action and is never an automatic release planning side effect.
+7. Record the changelog hash and the test evidence bound to the exact source
+   SHA.
+8. Read the current kn dev workload image and record the exact rollback digest.
+   The intended Keel policy is `never`.
+9. Create or update exactly one open private GitHub issue for the candidate.
+   Discover the GitHub FastMCP surface first. If it cannot create or edit
+   issues, use the authenticated `gh` CLI and record the missing gateway
+   capability as the fallback reason.
+10. Leave the issue awaiting the Monday gates and exact SHA approval. Do not
+    publish a release candidate, move a channel, or change kn dev during
+    planning.
+
+## Required release issue fields
+
+The private release issue contains:
+
+* Candidate version.
+* Exact source SHA.
+* Authority revision.
+* AI Operations contract digest.
+* Changelog summary and content hash.
+* Security state and evidence hash.
+* Test commands, result, and evidence hash.
+* Current kn dev image and exact rollback digest.
+* Intended Keel policy.
+* Companion review state.
+* Operator approval state and approved source SHA.
+* Delivery, verification, notification, and rollback evidence as it becomes
+  available.
+
+The issue is a write ahead record. It is not completion evidence by itself.
+
+## Manual context
+
+Every manual run receives `ExtraContext` with the exact default:
+
+`No extra context for this run`
+
+The run may use meaningful extra context to adjust the candidate assessment,
+but it records only whether the default was used, normalized length, and a
+SHA256 hash. Raw extra context is not stored in the runner ledger.
+
+## Completion
+
+Planning is complete only when:
+
+* `No action` is proven from the exact remote `main` revision, or
+* One private release issue records the complete candidate evidence.
+
+An empty issue, a future scope, a list of open feature requests, or an alert
+query failure is not successful planning.

--- a/.rules/release-rollback.md
+++ b/.rules/release-rollback.md
@@ -1,59 +1,107 @@
-# Rule: release promotion and rollback (kn-dev canary)
+# Data Olympus release rollback
 
 Status: active
-Since: 2026-07-11
-Applies to: the data-olympus release train (staged-promotion pipeline)
+Since: 2026-07-31
+Applies to: Data Olympus release canary and stable deployment on kn dev
 
-## Channel model
+## Deployment model
 
-kn-dev runs whatever the moving ghcr tag `:kndev` points at (Keel `policy: force`,
-`match-tag: true`, poll). The pipeline moves `:kndev` via the `set-channel.yml`
-workflow (`gh workflow run set-channel.yml -f source=<tag>`); it never rebuilds an
-image, so the channel and its source share one digest.
+The kn dev StatefulSet runs immutable GHCR digests. Keel policy is `never`.
 
-## Promotion sequence (cutter, after approval)
+The `kndev` moving registry tag may be updated for traceability, but it does not
+deploy the workload. Canary, stable deployment, and rollback apply an exact
+digest to both StatefulSet containers through the kn dev FastMCP gateway.
 
-0. Record the rollback point: note the tag `:kndev` currently points at (the stable
-   version kn-dev is running, e.g. the latest non-prerelease GitHub Release, or read
-   it with `docker buildx imagetools inspect ghcr.io/knaisoma/data-olympus:kndev`).
-   The canary and post-release rollbacks below re-point `:kndev` back at this value.
-1. Publish the complete candidate from an exact source SHA. The candidate
-   transaction includes its wheel, sdist, `release-provenance.json`, PyPI
-   prerelease, GHCR image, and GitHub prerelease.
-2. Canary: `set-channel source=X.Y.Z-rc.N` makes Keel roll the candidate onto
-   kn-dev.
-3. Pre-release verify: `data-olympus verify --target <kn-dev ingress>` must be
-   green, including default tool discovery and enforcement checks.
-4. Obtain the Paperclip approval to ship from the operator.
-5. Merge the exact reviewed candidate source to `main` with the required merge
-   method. Wait for CI on the resulting `main` SHA.
-6. Explicitly dispatch `tag-release.yml` through `workflow_dispatch`, passing
-   `candidate_tag=X.Y.Z-rc.N`. The workflow accepts only the highest complete
-   candidate, enters the protected `pypi` environment, compares the stable
-   Python payload with the candidate payload, publishes stable PyPI, creates
-   `vX.Y.Z` at the candidate source SHA, promotes the exact GHCR digest, and
-   creates the GitHub release.
-7. Promote the canary channel to stable with `set-channel source=vX.Y.Z`.
-8. Run post-release verification against kn-dev.
+This rule replaces the former assumption that Keel `force` plus `matchTag`
+would follow the moving `kndev` tag.
 
-## Rollback
+## Required rollback point
 
-* Candidate publication interrupted before finalization: rerun the same candidate
-  number only from the same exact source SHA. Existing PyPI files and the GHCR
-  image must match their recorded hashes and revision. Otherwise stop and use a
-  higher candidate number.
-* Canary failure or rejected approval: restore `kndev` to the recorded rollback
-  point. The candidate remains externally visible as a prerelease. A published
-  PyPI candidate cannot be replaced. Yank it when it is unsuitable for further
-  testing, then publish a corrected higher candidate number.
-* Post-release failure: restore `kndev` to the rollback point, yank the stable
-  PyPI version, mark the GitHub release as a prerelease, open a `release blocked`
-  issue, and notify the operator. Published files and version tags remain
-  immutable.
+Before candidate deployment, record:
 
-## Note
+* Exact image reference.
+* Exact image digest.
+* Source revision from provenance.
+* Main container name.
+* Init container name.
+* Current StatefulSet generation.
+* Intended Keel policy.
+* Health and readiness result.
 
-Stable image promotion is byte identical. `tag-release.yml` re-tags the verified
-`X.Y.Z-rc.N` digest to `vX.Y.Z`, `stable`, and `latest`; it has no image build
-job. Stable Python artifacts are rebuilt from the same exact source SHA and
-compared with the candidate wheel. Only normalized version metadata may differ.
+The rollback point is invalid if either container is missing or the recorded
+digest cannot be resolved.
+
+## Rollback sequence
+
+Execute these steps in order:
+
+1. Set or confirm `keel.sh/policy: never`.
+2. Apply the previous exact digest to:
+
+   * `data-olympus-mcp`
+   * `prepare-git`
+
+3. Wait for the StatefulSet rollout to finish.
+4. Verify:
+
+   * Both containers use the rollback digest.
+   * Pod health passes.
+   * Readiness passes.
+   * The public MCP endpoint responds.
+   * Search works.
+   * Enforcement works.
+
+5. Restore the intended Keel policy. The approved intended policy is `never`,
+   so this step confirms the policy rather than enabling automatic upgrades.
+6. Record the failed digest, restored digest, rollout evidence, verification
+   evidence, gateway calls, and terminal state.
+
+The project command accepts rollback only when the evidence names these events
+in the same order:
+
+* `keel-paused`
+* `digest-restored`
+* `deployment-verified`
+* `keel-policy-restored`
+
+## Registry channels
+
+If a failed candidate or stable release changed `kndev`, restore that channel
+to the prior known good tag through `set-channel.yml` after service recovery.
+Channel repair does not replace direct digest rollback and does not count as
+deployment verification.
+
+## Published artifacts
+
+Published files and immutable version tags are never replaced.
+
+When a candidate is unsuitable:
+
+* Leave the GitHub prerelease immutable.
+* Yank the PyPI candidate when continued installation would be unsafe.
+* Correct the defect under a new source SHA.
+* Publish a higher candidate number.
+
+When a stable release is unsuitable:
+
+* Restore kn dev first.
+* Yank the PyPI stable version when required.
+* Mark the GitHub release as a prerelease when required.
+* Open or update the private release issue with the failure evidence.
+* Prepare a new patch version. Do not move the existing stable tag.
+
+## Failure
+
+A rollback is failed when:
+
+* Keel was not paused first.
+* Only one container was changed.
+* A tag was applied without an exact digest.
+* Rollout did not complete.
+* The observed digest differs.
+* Health or readiness failed.
+* Policy was restored before deployment verification.
+* Required evidence is missing.
+
+In every such case, keep the release schedule disabled and notify the operator
+with the exact failed step.

--- a/.rules/release-routine.md
+++ b/.rules/release-routine.md
@@ -48,6 +48,12 @@ lifecycle stages plus rollback:
 * `notify`
 * `rollback`
 
+The command validates supplied evidence. It does not fetch Git, Data Olympus,
+GitHub, registry, cluster, or Telegram state by itself. The central runner
+adapter must fetch those sources, compare the real revisions, and supply the
+bounded stage input. A format valid SHA is not proof that a remote or authority
+revision exists.
+
 ## Monday sequence
 
 1. Load the single private release issue and the exact Friday source SHA.

--- a/.rules/release-routine.md
+++ b/.rules/release-routine.md
@@ -1,102 +1,153 @@
-# data-olympus-release-cutter routine
+# Data Olympus release routine
 
 Status: active
-Since: 2026-07-01 (rewritten 2026-07-11 for staged promotion)
-Schedule: cron `0 5 * * 1` (Monday 05:00 Europe/Madrid)
-Human gate: a single Paperclip approval to ship after the complete release
-candidate is live on kn-dev and pre-release verification is green. The routine
-does not merge or promote stable before that approval.
+Since: 2026-07-31
+Schedule: Monday at 05:00 Europe/Bucharest
+Automation status: disabled until baseline certification
 
-## What it does each run (strict 1-week pipeline)
+## Outcome
 
-1. Resolve the current release epic (the batch the planner scoped the prior
-   Friday; see `.rules/release-planning.md`). If none is ready, report and exit.
-2. Readiness gate: all sub-tickets Done and reviewed, the integration branch
-   `feature/<release-epic-id>` green (CI). If not ready, post blockers on the epic,
-   notify the operator (Telegram, GDEC-007), and STOP. Never cut a red release.
-2a. Security readiness gate (hard block): run `python3 scripts/security_alerts.py`.
-    It exits 0 only when there are ZERO open Dependabot and ZERO open CodeQL
-    alerts. On a non-zero exit, post the reported open-alert list on the epic,
-    notify the operator, and STOP: do not build the RC. Every release must be
-    clean of known weaknesses at cut time; the planner phase
-    (`.rules/release-planning.md` step 4) is where they are cleared, and this gate
-    confirms nothing regressed since.
-3. Sync + prepare the release commit (the cutter owns the version cut; no other
-   step performs it): on the integration branch, run
-   `uv run python scripts/compute_release.py`; if `releasable` is false, exit
-   quietly. Read `next_version` = X.Y.Z. Set the `[project]` version in
-   `pyproject.toml` to `X.Y.Z`; rename the topmost CHANGELOG `[Unreleased]` block to
-   `[X.Y.Z] - <UTC date>` and open a fresh empty `[Unreleased]`; write
-   `docs/releases/vX.Y.Z.md` (two H2 sections `## New features` and `## Fixed`, plain
-   language). Commit to the integration branch as `chore(release): vX.Y.Z`. Per-feature
-   `[Unreleased]` CHANGELOG entries were already added by each sub-ticket
-   (`.rules/versioning.md`). The RC built next therefore carries the final X.Y.Z.
-4. Quality gates (all must pass, else open a `release blocked: <reason>` issue and
-   stop): `uv run pytest -q`, `uv run ruff check .`, `uv run mypy src`,
-   `bats -r tests`, a security review over `git diff <lasttag>..HEAD`, and `kb_health`.
-4a. Stable version immutability readiness (hard block): run
-    `python3 scripts/check_version_free.py --version X.Y.Z`. A published version
-    (PyPI, the ghcr `:vX.Y.Z` image tag, or a GitHub release/tag) is immutable, so
-    a non-zero exit means the cut version is already taken (exit 3) or a registry
-    was unreachable and the guard failed closed (exit 4). On either, STOP: bump the
-    version (re-run step 3) or wait for the registry, then re-check. The same guard
-    runs in PR CI, so this is the cutter's early confirmation. A genuine
-    reconcile is allowed only when every existing artifact names the same exact
-    source and hash. Only the operator may override a stuck registry with
-    `KB_BYPASS_VERSION_CHECK=1`.
-5. Resolve `SOURCE_SHA` from the final reviewed integration head and select the
-   next unused candidate number, which must be 3 or greater for 0.6.0. Dispatch
-   `gh workflow run rc-publish.yml -f ref="$SOURCE_SHA" -f number="$RC_NUMBER"`.
-   The workflow publishes `X.Y.ZrcN` to PyPI, the
-   `ghcr.io/knaisoma/data-olympus:X.Y.Z-rc.N` image, a wheel, sdist,
-   `release-provenance.json`, and the GitHub prerelease from the exact source SHA.
-   The `rc` channel moves only after all candidate surfaces verify. Wait for the
-   run to succeed and capture every hash and digest from the provenance asset.
-6. Canary + record rollback point: read the current `:kndev` source (the stable
-   version kn-dev runs) and record it (`.rules/release-rollback.md` step 0). Then
-   `gh workflow run set-channel.yml -f source=X.Y.Z-rc.N`. Keel rolls the RC onto
-   kn-dev within ~2 minutes.
-7. Pre-release verify: `data-olympus verify --target <kn-dev ingress>` must be
-   green (health, readiness, search, enforcement). If red, roll back
-   (`set-channel source=<rollback point>`) and open a `release blocked` issue.
-8. Approval-to-ship: request a Paperclip approval on the epic and notify the
-   operator (Telegram). The operator may exercise the RC live on kn-dev, then
-   approves or rejects. On rejection, roll back and stop.
-9. Promote (on approval): merge the integration MR (`feature/<release-epic-id>`
-   to `main`) with a MERGE COMMIT, never a squash (per `.rules/versioning.md`: each
-   per-feature commit and the `chore(release)` version-cut commit must reach `main`
-   individually so `compute_release.py` sees them). Wait for required CI on the
-   resulting `main` SHA. Then explicitly dispatch `tag-release.yml` through
-   `workflow_dispatch` with `candidate_tag=X.Y.Z-rc.N`. The workflow rejects any
-   candidate other than the highest complete candidate, requires its source to
-   be an ancestor of `main`, and enters the protected `pypi` environment before
-   publishing stable Python artifacts. It creates `vX.Y.Z` at the candidate
-   source SHA only after PyPI succeeds, then promotes the exact verified GHCR
-   digest to `vX.Y.Z`, `stable`, and `latest` without rebuilding. Finally run
-   `gh workflow run set-channel.yml -f source=vX.Y.Z` so kn-dev runs stable.
-10. Post-release verify: `data-olympus verify --target <kn-dev ingress>` green. If
-    red, roll back per `.rules/release-rollback.md` (post-release path) and notify.
-11. Release note into the Paperclip task: post the `docs/releases/vX.Y.Z.md` content
-    as a comment on the routine's Paperclip issue.
-12. Retro to company-knowledge: run a short retro (what the RC/verify cycle
-    surfaced, any gate that fired, any manual fix, kn-dev-vs-stable drift) and
-    propose a lessons-learned update to company-knowledge via the data-olympus MCP
-    (`kb_propose_edit` / `kb_propose_memory` targeting a data-olympus-scoped KB path
-    such as a project note or an operator memory, operator-gated). This is how the
-    pipeline improves release over release.
-13. Hold open for the operator's external announcement: keep the Paperclip task
-    open with a Telegram reminder. The release artifact ships on approval + verify;
-    the held-open task is the reminder to post the announcement.
+Publish one immutable release from already merged, reviewed, green,
+unreleased work, then prove that every artifact and the kn dev service match
+one exact reviewed source revision.
 
-## Constraints
+The routine is outcome based. It is not a weekly cutter and has no obligation
+to release when the evidence says no release is due.
 
-* No em dashes in authored prose.
-* The RC image carries the final `X.Y.Z` from `pyproject.toml`; `-rc.N` is a
-  registry channel tag only. See `.rules/versioning.md` and STD-U-810.
-* Candidate Python artifacts use the PEP 440 version `X.Y.ZrcN` and are part of
-  the public candidate transaction.
-* GHCR operations run in CI through `gh workflow run`; the runtime needs
-  ghcr package-write via CI's token and the `kn-dev` SSH key only for direct
-  cluster inspection/rollback.
-* Exactly one release epic is in flight. The pipeline is reconcilable. Rerunning
-  a green `rc-publish`, `tag-release`, or `set-channel` step is idempotent.
+## Command interface
+
+The project command is:
+
+`python3.13 scripts/operations/release.py <stage>`
+
+It reads one JSON object from `AI_OPERATIONS_STAGE_INPUT` and emits one JSON
+object with these fields:
+
+* `status`
+* `reason`
+* `evidence`
+* `outputs`
+
+Accepted statuses are:
+
+* `pass`
+* `no_action`
+* `blocked`
+* `failed`
+
+`no_action` is valid only during admission. The command supports the fixed
+lifecycle stages plus rollback:
+
+* `authority`
+* `admission`
+* `prepare`
+* `validate`
+* `review`
+* `deliver`
+* `verify`
+* `notify`
+* `rollback`
+
+## Monday sequence
+
+1. Load the single private release issue and the exact Friday source SHA.
+2. Fetch `origin/main` and rerun `scripts/compute_release.py`.
+3. Stop as `Blocked` when the source SHA, computed version, changelog, security
+   state, test evidence, or rollback point changed.
+4. If the repository now proves that no unreleased work exists, close the
+   candidate as `No action`. Never manufacture a release to satisfy the
+   schedule.
+5. Prepare the version change and release notes on one short lived
+   `chore/release-vX.Y.Z` branch from the approved source SHA.
+6. Set `pyproject.toml` to `X.Y.Z`, close the matching changelog block, open a
+   new empty `[Unreleased]` block, and write `docs/releases/vX.Y.Z.md`.
+7. Obtain independent crossed review of the exact branch SHA, merge the one
+   logical release change through the repository rules, and bind the candidate
+   source to the resulting exact `main` SHA.
+8. Rerun all release gates against that SHA:
+
+   * Complete test suite.
+   * Ruff.
+   * mypy.
+   * Bats.
+   * Benchmark documentation checks.
+   * Installed wheel and sdist smoke tests.
+   * `scripts/security_alerts.py`.
+   * `scripts/ci_status.py`.
+   * Version availability across PyPI, GHCR, GitHub tags, and GitHub releases.
+
+9. Require one Claude and Codex crossed pair. One family executes and the other
+   independently reviews. Self review is prohibited.
+10. Require operator approval bound to the exact candidate source SHA.
+11. Dispatch `rc-publish.yml` for that SHA and the next unused candidate
+    number. Do not reproduce version computation or publication logic in the
+    runner.
+12. Verify the complete candidate transaction:
+
+    * GitHub prerelease.
+    * Candidate wheel.
+    * Candidate sdist.
+    * PyPI prerelease.
+    * `release-provenance.json`.
+    * GHCR image digest.
+
+13. Keep Keel at `never`. Deploy the candidate exact digest to both StatefulSet
+    containers through the kn dev FastMCP gateway, wait for rollout, and verify
+    health, readiness, MCP search, enforcement, and documentation.
+14. If canary verification passes, dispatch `tag-release.yml` with the exact
+    candidate tag. The workflow promotes the existing candidate and must not
+    rebuild the OCI image.
+15. Dispatch `set-channel.yml` with `source=vX.Y.Z` for registry channel
+    traceability. The moving channel does not drive the kn dev deployment while
+    Keel is `never`.
+16. Deploy the same stable digest explicitly to kn dev and run the full
+    external verification stage.
+17. Send one Telegram completion message to the semantic destination
+    `data-olympus-operations`. Completion requires exact independent readback
+    of the destination, message identifier, run marker, and content.
+18. Update the private release issue with immutable evidence and the truthful
+    terminal state.
+
+## Exact source rule
+
+Candidate preparation, review, operator approval, workflow receipts,
+provenance, tags, artifacts, deployment, verification, and notification all
+name the same source SHA.
+
+Any source change invalidates approval and restarts the release assessment.
+
+## Existing release mechanisms
+
+The routine reuses:
+
+* `scripts/compute_release.py` for version computation.
+* `scripts/security_alerts.py` for security clearance.
+* `scripts/ci_status.py` for exact SHA CI status.
+* `scripts/release_readiness.py` for evidence evaluation where its schema
+  applies.
+* `scripts/release_artifacts.py` for artifact identity.
+* `rc-publish.yml` for candidate publication.
+* `tag-release.yml` for stable promotion.
+* `set-channel.yml` for moving registry channels.
+
+The runner does not contain a second implementation of these rules.
+
+## Failure
+
+Any missing, stale, mismatched, unparseable, or unreachable gate fails closed.
+
+If external state changed before failure, run `.rules/release-rollback.md`,
+verify the restored exact digest, and record `Failed`. A blocked or failed run
+is never relabeled as complete because a workflow started.
+
+## Completion
+
+The release is complete only when:
+
+* GitHub release `vX.Y.Z` points at the reviewed SHA.
+* PyPI `X.Y.Z` provenance points at the reviewed SHA.
+* GHCR `vX.Y.Z` points at the reviewed candidate digest.
+* kn dev runs that exact digest in both containers.
+* Health, readiness, MCP search, enforcement, and documentation pass.
+* Telegram send and exact readback are confirmed.
+* The runner ledger and private release issue record the same terminal state.

--- a/.rules/versioning.md
+++ b/.rules/versioning.md
@@ -1,86 +1,104 @@
-# Rule: how data-olympus versions and releases
+# Data Olympus versioning and release rule
 
 Status: active
-Since: 2026-07-01
-Applies to: the data-olympus product (this repository)
+Since: 2026-07-31
+Applies to: the Data Olympus product
 Governing standard: STD-U-810
 
-## Bump mapping (pre-1.0)
+## Version mapping before 1.0
 
-data-olympus is pre-1.0. STD-U-810 §3.1.1 lets a pre-1.0 project adopt a
-features-as-minor mapping instead of the squashed default, provided the choice is
-documented in the project's local rules. data-olympus adopts it: a `feat:` drives
-a MINOR bump, so shipped features are visible in the version number. Conventional
-Commit types on commits since the last tag drive the bump:
+Data Olympus uses the documented pre 1.0 project deviation where features
+advance the minor version.
 
-- `feat:` -> minor (new functionality; resets patch, e.g. 0.1.x -> 0.2.0)
-- `feat!:`, any `type!:`, or a `BREAKING CHANGE:` footer -> minor (a breaking change pre-1.0 stays pre-1.0; it does NOT force 1.0.0)
-- `fix:` / `perf:` -> patch
-- `chore/docs/ci/build/refactor/test/style` -> no release, EXCEPT floored to patch when a functional path changed
+Conventional Commit types since the last stable tag drive the bump:
 
-This DEVIATES from the STD-U-810 §3.1.1 default (which maps pre-1.0 `feat:` to a
-patch); the deviation is the documented project choice §3.1.1 requires. Pre-1.0 a
-breaking change is a minor bump, not major, so the project stays in the `0.x`
-series until `v1.0.0` is cut deliberately.
+* `feat:` advances the minor version.
+* Any breaking change advances the minor version while the project remains
+  before 1.0.
+* `fix:` and `perf:` advance the patch version.
+* Other types do not create a release unless a functional path changed.
 
-"Functional path" is the exact set `scripts/check_changelog.py` defines: `src/`,
-`bin/`, `deploy/`, and `SPEC.md`. This safety net guarantees source changes are
-never left unreleased even if the commit type is non-user-facing.
+Functional paths are defined by `scripts/check_changelog.py`:
 
-The project stays pre-1.0 until `v1.0.0` is cut deliberately. When it reaches
-1.0, `bump_for` in `scripts/compute_release.py` switches breaking -> major
-(`feat:` already maps to minor), and this rule is updated.
+* `src/`
+* `bin/`
+* `deploy/`
+* `SPEC.md`
 
-## Engine
+A functional path change creates at least a patch release even when its commit
+type would otherwise produce no release.
 
-* `scripts/compute_release.py` computes the bump as the single source of the
-  bump rules.
-* The release cutter prepares the final version commit on the integration
-  branch before any candidate is published.
-* `rc-publish.yml` receives an exact source SHA and explicit candidate number.
-  It publishes a wheel, sdist, `release-provenance.json`, GHCR image, PyPI
-  prerelease, and GitHub prerelease from that exact source SHA. The moving `rc`
-  channel changes only after every candidate surface verifies successfully.
-* Candidate Python versions use `X.Y.ZrcN`. GHCR and GitHub candidates use
-  `X.Y.Z-rc.N`.
-* After canary verification and human approval, the integration branch is
-  merged to `main`. Stable publication does not start from the merge event.
-  The operator explicitly dispatches `tag-release.yml` with `candidate_tag`
-  naming the highest complete candidate.
-* Stable promotion requires the candidate source to be an ancestor of `main`.
-  It rebuilds the wheel and sdist from the candidate source, permits only
-  normalized version metadata to differ, publishes through the protected
-  `pypi` environment, creates the stable tag at the candidate source SHA, and
-  promotes the exact candidate image digest without rebuilding it.
-* `pyproject.toml` is the single version source of truth (STD-U-810 §11.4).
+## Single source
 
-## PR discipline
+`scripts/compute_release.py` is the single source for bump computation.
 
-Merge method follows the granularity of the change (amended 2026-07-04; the
-previous rule was squash-only):
+`pyproject.toml` is the single source for the package version.
 
-- **Feature/fix PRs (one logical change) are squash-merged.** The PR title is
-  the one Conventional Commit and is linted by
-  `.github/workflows/pr-title-lint.yml` (STD-U-810 §7.1 equivalent). This
-  applies equally to PRs targeting `main` and PRs targeting a release branch.
-- **Release integration branches (`feature/<release-epic-id>`) merge into `main` with a
-  merge commit, never a squash.** Each constituent commit on the release branch
-  is already one squashed Conventional Commit per feature/fix, so a merge
-  commit preserves one readable commit per change on `main` (blame and bisect
-  keep per-feature granularity), while squashing again would collapse the whole
-  release into a single opaque commit. The release PR title still follows the
-  Conventional format (`chore(release): vX.Y.Z`) for the PR-title lint, but the
-  merge commit itself carries no bump-relevant type: `compute_release.py` reads
-  the constituent commits. Stable promotion is dispatched explicitly after the
-  merge and checks that the candidate source is an ancestor of `main`, so it is
-  also unaffected by the merge method.
-  (`compute_release.py` walks `git log --no-merges`, so the merge commit is
-  invisible to the bump computation by construction.)
-- **Do not confuse the two release branch kinds.** The daily release-cutter
-  routine (`.rules/release-routine.md`) opens `chore/release-v<next>` PR
-  branches containing a single version-cut commit; those are one logical
-  change and stay squash-merged. `feature/<release-epic-id>` integration branches, used
-  when a coordinated program lands many features/fixes together before one
-  gated merge to `main`, are the case the merge-commit rule above exists for.
-- Every functional PR updates the CHANGELOG `[Unreleased]` block (see
-  `.rules/changelog-per-release.md`).
+The AI Operations runner consumes their output and never reimplements the
+mapping.
+
+## Outcome based release
+
+The release routine examines work already merged to `origin/main`.
+
+It does not create a feature batch, choose a quota of issues, or assume that
+Friday planning must produce a Monday release.
+
+When a release is due:
+
+1. Create one short lived `chore/release-vX.Y.Z` branch from the approved main
+   SHA.
+2. Update `pyproject.toml`, the changelog, and the release note in one logical
+   release change.
+3. Review and merge that change through the current repository rules.
+4. Bind the candidate to the resulting exact main SHA.
+5. Publish and promote only through the existing release workflows.
+
+## Pull request discipline
+
+Feature and fix pull requests contain one logical change and are squash merged.
+The pull request title is the Conventional Commit recorded on `main`.
+
+The release pull request also contains one logical release change and is squash
+merged.
+
+The repository currently enforces linear history. Ordinary release work must
+not require a merge commit or an integration branch that bypasses that rule.
+
+The exceptional 2026-07-31 history reconciliation preserved the already
+published `v0.6.0` ancestry through an explicit recovery merge. That exception
+does not define the future release pattern.
+
+## Candidate and stable publication
+
+Candidate identities use:
+
+* Python version `X.Y.ZrcN`.
+* GHCR and GitHub prerelease tag `X.Y.Z-rc.N`.
+
+`rc-publish.yml` receives an exact source SHA and candidate number. It publishes
+the complete candidate transaction and moves the `rc` channel only after every
+surface verifies.
+
+`tag-release.yml` is invoked only by explicit `workflow_dispatch` with the
+`candidate_tag` input naming the highest complete candidate. It requires the
+candidate source to be an ancestor of `main`. It enters the protected `pypi` environment,
+publishes stable Python artifacts from the same source, creates `vX.Y.Z` at that
+source, and promotes the exact OCI digest without rebuilding it.
+
+`set-channel.yml` moves registry channels to an existing image digest. It does
+not build an image and does not deploy kn dev while Keel policy is `never`.
+
+## Immutability
+
+Published versions, Git tags, GitHub releases, and OCI version tags are
+immutable.
+
+`v0.6.0` is already published and reconciled into `main`. It must never be
+rebuilt, retagged, or republished. The next valid release is a forward version,
+currently expected to be `v0.6.1` when the exact main history remains
+releasable.
+
+Any collision or source mismatch blocks the release. Recovery uses a new
+version or a higher candidate number, never replacement of an existing
+artifact.

--- a/scripts/operations/release.py
+++ b/scripts/operations/release.py
@@ -1,0 +1,834 @@
+#!/usr/bin/env python3
+"""Fail closed stage decisions for the Data Olympus release outcome."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from hashlib import sha256
+from typing import Any
+
+DEFAULT_EXTRA_CONTEXT = "No extra context for this run"
+
+_SHA40 = re.compile(r"^[0-9a-f]{40}$")
+_HEX_REVISION = re.compile(r"^[0-9a-f]{40}(?:[0-9a-f]{24})?$")
+_SHA256 = re.compile(r"^[0-9a-f]{64}$")
+_DIGEST = re.compile(r"^sha256:[0-9a-f]{64}$")
+_VERSION = re.compile(r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$")
+_CANDIDATE_TAG = re.compile(r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)-rc\.([1-9]\d*)$")
+_ALLOWED_STAGES = {
+    "authority",
+    "admission",
+    "prepare",
+    "validate",
+    "review",
+    "deliver",
+    "verify",
+    "notify",
+    "rollback",
+}
+
+StageResult = dict[str, Any]
+
+
+class ReleaseInputError(ValueError):
+    """Raised when a release stage input is missing or inconsistent."""
+
+
+def _result(
+    status: str,
+    reason: str,
+    evidence: dict[str, Any] | None = None,
+    outputs: dict[str, Any] | None = None,
+) -> StageResult:
+    return {
+        "status": status,
+        "reason": reason,
+        "evidence": evidence or {},
+        "outputs": outputs or {},
+    }
+
+
+def _object(value: Any, name: str) -> dict[str, Any]:
+    if type(value) is not dict:
+        raise ReleaseInputError(f"{name} must be an object")
+    return value
+
+
+def _string(value: Any, name: str) -> str:
+    if type(value) is not str or not value.strip():
+        raise ReleaseInputError(f"{name} must be a nonempty string")
+    return value
+
+
+def _sha40(value: Any, name: str) -> str:
+    text = _string(value, name)
+    if _SHA40.fullmatch(text) is None:
+        raise ReleaseInputError(f"{name} must be a 40 character git SHA")
+    return text
+
+
+def _revision(value: Any, name: str) -> str:
+    text = _string(value, name)
+    if _HEX_REVISION.fullmatch(text) is None:
+        raise ReleaseInputError(f"{name} must be a 40 or 64 character hexadecimal revision")
+    return text
+
+
+def _hash(value: Any, name: str) -> str:
+    text = _string(value, name)
+    if _SHA256.fullmatch(text) is None:
+        raise ReleaseInputError(f"{name} must be a SHA256 value")
+    return text
+
+
+def _digest(value: Any, name: str) -> str:
+    text = _string(value, name)
+    if _DIGEST.fullmatch(text) is None:
+        raise ReleaseInputError(f"{name} must be an OCI SHA256 digest")
+    return text
+
+
+def _version(value: Any, name: str) -> str:
+    text = _string(value, name)
+    if _VERSION.fullmatch(text) is None:
+        raise ReleaseInputError(f"{name} must be a semantic version")
+    return text
+
+
+def _integer(value: Any, name: str) -> int:
+    if type(value) is not int:
+        raise ReleaseInputError(f"{name} must be an integer")
+    return value
+
+
+def _true(value: Any, name: str) -> None:
+    if value is not True:
+        raise ReleaseInputError(f"{name} must be true")
+
+
+def _exit_zero(value: Any, name: str) -> None:
+    if type(value) is not int or value != 0:
+        raise ReleaseInputError(f"{name} must be integer zero")
+
+
+def _version_tuple(value: str) -> tuple[int, int, int]:
+    return tuple(int(part) for part in value.split("."))  # type: ignore[return-value]
+
+
+def _same_source(
+    expected: str,
+    value: Any,
+    name: str,
+) -> None:
+    observed = _sha40(value, name)
+    if observed != expected:
+        raise ReleaseInputError(f"{name} does not match the candidate source")
+
+
+def _candidate(
+    value: Any,
+    *,
+    require_artifact: bool,
+) -> tuple[dict[str, Any], str, str]:
+    candidate = _object(value, "candidate")
+    version = _version(candidate.get("version"), "candidate.version")
+    if version == "0.6.0":
+        raise ReleaseInputError("v0.6.0 is immutable and cannot be a candidate")
+    source_revision = _sha40(
+        candidate.get("source_revision"),
+        "candidate.source_revision",
+    )
+    if require_artifact:
+        candidate_tag = _string(
+            candidate.get("candidate_tag"),
+            "candidate.candidate_tag",
+        )
+        match = _CANDIDATE_TAG.fullmatch(candidate_tag)
+        if match is None or candidate_tag.split("-rc.", 1)[0] != version:
+            raise ReleaseInputError("candidate.candidate_tag does not match candidate.version")
+        _digest(candidate.get("image_digest"), "candidate.image_digest")
+    return candidate, version, source_revision
+
+
+def _extra_context(value: Any) -> dict[str, Any]:
+    text = (
+        _string(value, "extra_context")
+        .replace("\r\n", "\n")
+        .replace(
+            "\r",
+            "\n",
+        )
+        .strip()
+    )
+    return {
+        "default": text == DEFAULT_EXTRA_CONTEXT,
+        "length": len(text),
+        "sha256": sha256(text.encode("utf-8")).hexdigest(),
+    }
+
+
+def _authority(input_document: dict[str, Any]) -> StageResult:
+    authority_revision = _sha40(
+        input_document.get("authority_revision"),
+        "authority_revision",
+    )
+    contract_revision = _revision(
+        input_document.get("contract_revision"),
+        "contract_revision",
+    )
+    source_revision = _sha40(
+        input_document.get("source_revision"),
+        "source_revision",
+    )
+    evidence = {
+        "authority_revision": authority_revision,
+        "contract_revision": contract_revision,
+        "source_revision": source_revision,
+    }
+    return _result(
+        "pass",
+        "authority, release contract, and source revisions are bound",
+        evidence,
+    )
+
+
+def _admission(input_document: dict[str, Any]) -> StageResult:
+    branch = _string(input_document.get("branch"), "branch")
+    if branch != "main":
+        raise ReleaseInputError("release admission requires the main branch")
+    source_revision = _sha40(
+        input_document.get("source_revision"),
+        "source_revision",
+    )
+    remote_main_revision = _sha40(
+        input_document.get("remote_main_revision"),
+        "remote_main_revision",
+    )
+    if source_revision != remote_main_revision:
+        raise ReleaseInputError("candidate source does not match remote main")
+
+    computed = _object(
+        input_document.get("computed_release"),
+        "computed_release",
+    )
+    releasable = computed.get("releasable")
+    if type(releasable) is not bool:
+        raise ReleaseInputError("computed_release.releasable must be boolean")
+    bump = _string(computed.get("bump"), "computed_release.bump")
+    current = _version(
+        computed.get("current_version"),
+        "computed_release.current_version",
+    )
+    next_version = _version(
+        computed.get("next_version"),
+        "computed_release.next_version",
+    )
+    changes = _object(
+        computed.get("changes"),
+        "computed_release.changes",
+    )
+
+    evidence = {
+        "source_revision": source_revision,
+        "current_version": current,
+        "computed_release": {
+            "releasable": releasable,
+            "bump": bump,
+            "next_version": next_version,
+            "functional_changed": computed.get("functional_changed"),
+            "changes": changes,
+        },
+    }
+    if not releasable:
+        if bump != "none" or next_version != current:
+            raise ReleaseInputError("nonreleasable computation is internally inconsistent")
+        return _result(
+            "no_action",
+            "no merged unreleased work exists on remote main",
+            evidence,
+        )
+
+    if bump not in {"patch", "minor"}:
+        raise ReleaseInputError("releasable computation must use patch or minor bump")
+    if next_version == "0.6.0":
+        raise ReleaseInputError("v0.6.0 is immutable; the next release must move forward")
+    if _version_tuple(next_version) <= _version_tuple(current):
+        raise ReleaseInputError("computed release does not move beyond the current version")
+    return _result(
+        "pass",
+        f"release {next_version} is admitted from remote main",
+        evidence,
+        {
+            "candidate": {
+                "version": next_version,
+                "source_revision": source_revision,
+                "bump": bump,
+            }
+        },
+    )
+
+
+def _prepare(input_document: dict[str, Any]) -> StageResult:
+    _, version, source_revision = _candidate(
+        input_document.get("candidate"),
+        require_artifact=False,
+    )
+    context = _extra_context(input_document.get("extra_context"))
+
+    changelog = _object(input_document.get("changelog"), "changelog")
+    _same_source(
+        source_revision,
+        changelog.get("source_revision"),
+        "changelog.source_revision",
+    )
+    changelog_hash = _hash(
+        changelog.get("content_hash"),
+        "changelog.content_hash",
+    )
+
+    security = _object(input_document.get("security"), "security")
+    _exit_zero(security.get("exit_code"), "security.exit_code")
+    security_hash = _hash(
+        security.get("report_hash"),
+        "security.report_hash",
+    )
+
+    tests = _object(input_document.get("tests"), "tests")
+    _same_source(
+        source_revision,
+        tests.get("source_revision"),
+        "tests.source_revision",
+    )
+    _true(tests.get("passed"), "tests.passed")
+    tests_hash = _hash(
+        tests.get("evidence_hash"),
+        "tests.evidence_hash",
+    )
+
+    rollback = _object(
+        input_document.get("rollback_point"),
+        "rollback_point",
+    )
+    rollback_digest = _digest(
+        rollback.get("digest"),
+        "rollback_point.digest",
+    )
+    image = _string(rollback.get("image"), "rollback_point.image")
+    if not image.endswith(rollback_digest):
+        raise ReleaseInputError("rollback_point.image does not match rollback_point.digest")
+    if rollback.get("keel_policy") != "never":
+        raise ReleaseInputError("rollback_point.keel_policy must be never")
+
+    issue = _object(
+        input_document.get("release_issue"),
+        "release_issue",
+    )
+    if _integer(issue.get("count"), "release_issue.count") != 1:
+        raise ReleaseInputError("exactly one private release issue is required")
+    _true(issue.get("private"), "release_issue.private")
+    number = _integer(issue.get("number"), "release_issue.number")
+    if number <= 0:
+        raise ReleaseInputError("release_issue.number must be positive")
+    url = _string(issue.get("url"), "release_issue.url")
+    if not url.startswith("https://github.com/knaisoma/data-olympus/issues/"):
+        raise ReleaseInputError("release_issue.url is outside the repository")
+    _same_source(
+        source_revision,
+        issue.get("source_revision"),
+        "release_issue.source_revision",
+    )
+    if issue.get("candidate_version") != version:
+        raise ReleaseInputError("release_issue.candidate_version does not match the candidate")
+    issue_hash = _hash(
+        issue.get("body_hash"),
+        "release_issue.body_hash",
+    )
+
+    return _result(
+        "pass",
+        f"private release issue {number} records candidate {version}",
+        {
+            "source_revision": source_revision,
+            "version": version,
+            "extra_context": context,
+            "changelog_hash": changelog_hash,
+            "security_hash": security_hash,
+            "tests_hash": tests_hash,
+            "rollback_digest": rollback_digest,
+            "release_issue_hash": issue_hash,
+        },
+        {
+            "release_issue_number": number,
+            "release_issue_url": url,
+        },
+    )
+
+
+def _validate(input_document: dict[str, Any]) -> StageResult:
+    _, version, source_revision = _candidate(
+        input_document.get("candidate"),
+        require_artifact=True,
+    )
+    _same_source(
+        source_revision,
+        input_document.get("current_source_revision"),
+        "current_source_revision",
+    )
+
+    ci = _object(input_document.get("ci"), "ci")
+    _same_source(
+        source_revision,
+        ci.get("source_revision"),
+        "ci.source_revision",
+    )
+    _true(ci.get("all_success"), "ci.all_success")
+    if ci.get("missing_required") != []:
+        raise ReleaseInputError("ci.missing_required must be empty")
+
+    security = _object(input_document.get("security"), "security")
+    _exit_zero(security.get("exit_code"), "security.exit_code")
+
+    version_free = _object(
+        input_document.get("version_free"),
+        "version_free",
+    )
+    if version_free.get("version") != version:
+        raise ReleaseInputError("version_free.version does not match the candidate")
+    _true(version_free.get("free"), "version_free.free")
+
+    tests = _object(input_document.get("tests"), "tests")
+    _same_source(
+        source_revision,
+        tests.get("source_revision"),
+        "tests.source_revision",
+    )
+    _true(tests.get("passed"), "tests.passed")
+
+    return _result(
+        "pass",
+        f"candidate {version} is unchanged and every gate passed",
+        {
+            "source_revision": source_revision,
+            "version": version,
+            "ci_green": True,
+            "security_clear": True,
+            "version_free": True,
+            "tests_passed": True,
+        },
+    )
+
+
+def _review(input_document: dict[str, Any]) -> StageResult:
+    _, version, source_revision = _candidate(
+        input_document.get("candidate"),
+        require_artifact=True,
+    )
+    _same_source(
+        source_revision,
+        input_document.get("current_source_revision"),
+        "current_source_revision",
+    )
+
+    executor = _object(input_document.get("executor"), "executor")
+    executor_family = _string(executor.get("family"), "executor.family")
+    if executor_family not in {"claude", "codex"}:
+        raise ReleaseInputError("executor.family must be claude or codex for a red release")
+    _same_source(
+        source_revision,
+        executor.get("source_revision"),
+        "executor.source_revision",
+    )
+
+    review = _object(
+        input_document.get("companion_review"),
+        "companion_review",
+    )
+    reviewer_family = _string(
+        review.get("family"),
+        "companion_review.family",
+    )
+    if {executor_family, reviewer_family} != {"claude", "codex"}:
+        raise ReleaseInputError("release execution and review must cross Claude and Codex families")
+    if review.get("verdict") != "APPROVE":
+        raise ReleaseInputError("companion_review.verdict must be APPROVE")
+    _same_source(
+        source_revision,
+        review.get("reviewed_source_revision"),
+        "companion_review.reviewed_source_revision",
+    )
+    review_hash = _hash(
+        review.get("evidence_hash"),
+        "companion_review.evidence_hash",
+    )
+
+    approval = _object(
+        input_document.get("operator_approval"),
+        "operator_approval",
+    )
+    _true(approval.get("approved"), "operator_approval.approved")
+    _same_source(
+        source_revision,
+        approval.get("source_revision"),
+        "operator_approval.source_revision",
+    )
+    approval_id = _string(
+        approval.get("approval_id"),
+        "operator_approval.approval_id",
+    )
+
+    return _result(
+        "pass",
+        f"candidate {version} has crossed review and SHA bound approval",
+        {
+            "source_revision": source_revision,
+            "executor_family": executor_family,
+            "reviewer_family": reviewer_family,
+            "review_hash": review_hash,
+            "operator_approval_id": approval_id,
+        },
+    )
+
+
+def _deliver(input_document: dict[str, Any]) -> StageResult:
+    candidate, version, source_revision = _candidate(
+        input_document.get("candidate"),
+        require_artifact=True,
+    )
+    _same_source(
+        source_revision,
+        input_document.get("current_source_revision"),
+        "current_source_revision",
+    )
+    candidate_tag = candidate["candidate_tag"]
+
+    workflows = input_document.get("workflows")
+    if type(workflows) is not list:
+        raise ReleaseInputError("workflows must be an array")
+    by_name: dict[str, dict[str, Any]] = {}
+    for index, raw in enumerate(workflows):
+        workflow = _object(raw, f"workflows[{index}]")
+        name = _string(workflow.get("name"), f"workflows[{index}].name")
+        if name in by_name:
+            raise ReleaseInputError(f"duplicate workflow receipt: {name}")
+        by_name[name] = workflow
+    required = {"rc-publish.yml", "tag-release.yml", "set-channel.yml"}
+    if set(by_name) != required:
+        raise ReleaseInputError(
+            "delivery must use only rc-publish.yml, tag-release.yml, and set-channel.yml"
+        )
+    for name, workflow in by_name.items():
+        if workflow.get("conclusion") != "success":
+            raise ReleaseInputError(f"{name} did not conclude successfully")
+        _same_source(
+            source_revision,
+            workflow.get("source_revision"),
+            f"{name}.source_revision",
+        )
+    if by_name["rc-publish.yml"].get("candidate_tag") != candidate_tag:
+        raise ReleaseInputError("rc-publish.yml candidate tag does not match")
+    if by_name["tag-release.yml"].get("candidate_tag") != candidate_tag:
+        raise ReleaseInputError("tag-release.yml candidate tag does not match")
+    if by_name["set-channel.yml"].get("source_tag") != f"v{version}":
+        raise ReleaseInputError("set-channel.yml source tag does not match stable version")
+
+    canary = _object(input_document.get("canary"), "canary")
+    if canary.get("candidate_tag") != candidate_tag:
+        raise ReleaseInputError("canary.candidate_tag does not match")
+    _same_source(
+        source_revision,
+        canary.get("source_revision"),
+        "canary.source_revision",
+    )
+    canary_digest = _digest(canary.get("digest"), "canary.digest")
+    if canary_digest != candidate["image_digest"]:
+        raise ReleaseInputError("canary.digest does not match the candidate")
+    if canary.get("keel_policy") != "never":
+        raise ReleaseInputError("canary.keel_policy must remain never")
+    for field in (
+        "rollout_complete",
+        "healthy",
+        "ready",
+        "mcp_search",
+        "enforcement",
+    ):
+        _true(canary.get(field), f"canary.{field}")
+
+    deployment = _object(
+        input_document.get("deployment"),
+        "deployment",
+    )
+    if deployment.get("keel_policy") != "never":
+        raise ReleaseInputError("deployment.keel_policy must remain never")
+    _same_source(
+        source_revision,
+        deployment.get("source_revision"),
+        "deployment.source_revision",
+    )
+    digest = _digest(
+        deployment.get("image_digest"),
+        "deployment.image_digest",
+    )
+    if digest != candidate["image_digest"]:
+        raise ReleaseInputError("deployment.image_digest does not match the candidate")
+    _true(
+        deployment.get("rollout_complete"),
+        "deployment.rollout_complete",
+    )
+
+    return _result(
+        "pass",
+        f"release {version} was delivered by the approved workflows",
+        {
+            "source_revision": source_revision,
+            "candidate_tag": candidate_tag,
+            "digest": digest,
+            "workflows": sorted(required),
+        },
+        {"published_version": version},
+    )
+
+
+def _verify(input_document: dict[str, Any]) -> StageResult:
+    candidate, version, source_revision = _candidate(
+        input_document.get("candidate"),
+        require_artifact=True,
+    )
+    digest = candidate["image_digest"]
+
+    github_release = _object(
+        input_document.get("github_release"),
+        "github_release",
+    )
+    if github_release.get("tag") != f"v{version}":
+        raise ReleaseInputError("github_release.tag does not match")
+    _same_source(
+        source_revision,
+        github_release.get("source_revision"),
+        "github_release.source_revision",
+    )
+
+    pypi = _object(input_document.get("pypi"), "pypi")
+    if pypi.get("version") != version:
+        raise ReleaseInputError("pypi.version does not match")
+    _same_source(
+        source_revision,
+        pypi.get("provenance_source_revision"),
+        "pypi.provenance_source_revision",
+    )
+
+    image = _object(input_document.get("image"), "image")
+    if image.get("tag") != f"v{version}":
+        raise ReleaseInputError("image.tag does not match")
+    if _digest(image.get("digest"), "image.digest") != digest:
+        raise ReleaseInputError("image.digest does not match")
+
+    deployment = _object(
+        input_document.get("deployment"),
+        "deployment",
+    )
+    _same_source(
+        source_revision,
+        deployment.get("source_revision"),
+        "deployment.source_revision",
+    )
+    if _digest(deployment.get("digest"), "deployment.digest") != digest:
+        raise ReleaseInputError("deployment.digest does not match")
+    for field in (
+        "healthy",
+        "ready",
+        "mcp_search",
+        "enforcement",
+        "documentation",
+    ):
+        _true(deployment.get(field), f"deployment.{field}")
+
+    return _result(
+        "pass",
+        f"release {version} and kn dev match the reviewed source",
+        {
+            "source_revision": source_revision,
+            "version": version,
+            "digest": digest,
+            "health": "verified",
+            "mcp": "verified",
+            "documentation": "verified",
+        },
+    )
+
+
+def _notify(input_document: dict[str, Any]) -> StageResult:
+    destination = _string(
+        input_document.get("destination"),
+        "destination",
+    )
+    readback_destination = _string(
+        input_document.get("readback_destination"),
+        "readback_destination",
+    )
+    if readback_destination != destination:
+        raise ReleaseInputError("notification destination does not match")
+    sent_id = _string(
+        input_document.get("sent_message_id"),
+        "sent_message_id",
+    )
+    readback_id = _string(
+        input_document.get("readback_message_id"),
+        "readback_message_id",
+    )
+    if sent_id != readback_id:
+        raise ReleaseInputError("notification message identifier does not match")
+    sent_hash = _hash(
+        input_document.get("sent_content_hash"),
+        "sent_content_hash",
+    )
+    readback_hash = _hash(
+        input_document.get("readback_content_hash"),
+        "readback_content_hash",
+    )
+    if sent_hash != readback_hash:
+        raise ReleaseInputError("notification content does not match")
+    return _result(
+        "pass",
+        "release notification was sent and read back exactly",
+        {
+            "destination": destination,
+            "content_hash": sent_hash,
+        },
+        {"message_id": sent_id},
+    )
+
+
+def _rollback(input_document: dict[str, Any]) -> StageResult:
+    failed_digest = _digest(
+        input_document.get("failed_digest"),
+        "failed_digest",
+    )
+    rollback = _object(
+        input_document.get("rollback_point"),
+        "rollback_point",
+    )
+    restored_digest = _digest(
+        rollback.get("digest"),
+        "rollback_point.digest",
+    )
+    if restored_digest == failed_digest:
+        raise ReleaseInputError("rollback point must differ from the failed digest")
+    image = _string(rollback.get("image"), "rollback_point.image")
+    if not image.endswith(restored_digest):
+        raise ReleaseInputError("rollback_point.image does not match rollback_point.digest")
+    intended_policy = _string(
+        rollback.get("intended_keel_policy"),
+        "rollback_point.intended_keel_policy",
+    )
+    if intended_policy != "never":
+        raise ReleaseInputError("rollback_point.intended_keel_policy must be never")
+
+    events = input_document.get("events")
+    if type(events) is not list:
+        raise ReleaseInputError("events must be an array")
+    expected_names = [
+        "keel-paused",
+        "digest-restored",
+        "deployment-verified",
+        "keel-policy-restored",
+    ]
+    names = [
+        _string(_object(event, "rollback event").get("name"), "event.name") for event in events
+    ]
+    if names != expected_names:
+        raise ReleaseInputError("rollback events are missing or out of order")
+
+    paused, restored, verified, policy_restored = [
+        _object(event, f"events[{index}]") for index, event in enumerate(events)
+    ]
+    if paused.get("policy") != "never":
+        raise ReleaseInputError("Keel was not paused before rollback")
+    if _digest(restored.get("digest"), "digest-restored.digest") != (restored_digest):
+        raise ReleaseInputError("restored digest does not match rollback point")
+    containers = restored.get("containers")
+    if type(containers) is not list or set(containers) != {
+        "data-olympus-mcp",
+        "prepare-git",
+    }:
+        raise ReleaseInputError("both Data Olympus containers must restore the exact digest")
+    if _digest(verified.get("digest"), "deployment-verified.digest") != (restored_digest):
+        raise ReleaseInputError("verified digest does not match rollback point")
+    _true(verified.get("healthy"), "deployment-verified.healthy")
+    _true(verified.get("ready"), "deployment-verified.ready")
+    if policy_restored.get("policy") != intended_policy:
+        raise ReleaseInputError("Keel policy was not restored to the intended value")
+
+    return _result(
+        "pass",
+        "previous exact digest was restored and verified while Keel stayed paused",
+        {
+            "failed_digest": failed_digest,
+            "restored_digest": restored_digest,
+            "keel_policy": intended_policy,
+        },
+    )
+
+
+_EVALUATORS = {
+    "authority": _authority,
+    "admission": _admission,
+    "prepare": _prepare,
+    "validate": _validate,
+    "review": _review,
+    "deliver": _deliver,
+    "verify": _verify,
+    "notify": _notify,
+    "rollback": _rollback,
+}
+
+
+def evaluate_stage(stage: str, input_document: Any) -> StageResult:
+    """Evaluate one release lifecycle stage without trusting shortcut booleans."""
+    if stage not in _ALLOWED_STAGES:
+        return _result("failed", f"unknown release stage: {stage}")
+    try:
+        value = _object(input_document, "stage input")
+        return _EVALUATORS[stage](value)
+    except ReleaseInputError as error:
+        status = (
+            "blocked"
+            if stage in {"authority", "admission", "prepare", "validate", "review"}
+            else "failed"
+        )
+        return _result(status, str(error))
+
+
+def main(argv: list[str] | None = None) -> int:
+    arguments = list(sys.argv[1:] if argv is None else argv)
+    if len(arguments) != 1:
+        output = _result("failed", "exactly one release stage is required")
+        print(json.dumps(output, separators=(",", ":"), sort_keys=True))
+        return 2
+    stage = arguments[0]
+    raw_input = os.environ.get("AI_OPERATIONS_STAGE_INPUT")
+    if raw_input is None:
+        output = _result(
+            "failed",
+            "AI_OPERATIONS_STAGE_INPUT is required",
+        )
+        print(json.dumps(output, separators=(",", ":"), sort_keys=True))
+        return 2
+    try:
+        input_document = json.loads(raw_input)
+    except json.JSONDecodeError:
+        output = _result(
+            "failed",
+            "AI_OPERATIONS_STAGE_INPUT must be valid JSON",
+        )
+        print(json.dumps(output, separators=(",", ":"), sort_keys=True))
+        return 2
+    output = evaluate_stage(stage, input_document)
+    print(json.dumps(output, separators=(",", ":"), sort_keys=True))
+    return 0 if output["status"] in {"pass", "no_action"} else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/operations/release.py
+++ b/scripts/operations/release.py
@@ -118,6 +118,15 @@ def _version_tuple(value: str) -> tuple[int, int, int]:
     return tuple(int(part) for part in value.split("."))  # type: ignore[return-value]
 
 
+def _expected_next_version(current: str, bump: str) -> str:
+    major, minor, patch = _version_tuple(current)
+    if bump == "patch":
+        return f"{major}.{minor}.{patch + 1}"
+    if bump == "minor":
+        return f"{major}.{minor + 1}.0"
+    raise ReleaseInputError("releasable computation must use patch or minor bump")
+
+
 def _same_source(
     expected: str,
     value: Any,
@@ -251,10 +260,11 @@ def _admission(input_document: dict[str, Any]) -> StageResult:
             evidence,
         )
 
-    if bump not in {"patch", "minor"}:
-        raise ReleaseInputError("releasable computation must use patch or minor bump")
     if next_version == "0.6.0":
         raise ReleaseInputError("v0.6.0 is immutable; the next release must move forward")
+    expected_next = _expected_next_version(current, bump)
+    if next_version != expected_next:
+        raise ReleaseInputError("computed_release.next_version does not match its bump")
     if _version_tuple(next_version) <= _version_tuple(current):
         raise ReleaseInputError("computed release does not move beyond the current version")
     return _result(

--- a/tests/test_operations_release.py
+++ b/tests/test_operations_release.py
@@ -1,0 +1,614 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from scripts.operations.release import (
+    DEFAULT_EXTRA_CONTEXT,
+    evaluate_stage,
+    main,
+)
+
+SOURCE_SHA = "a" * 40
+AUTHORITY_SHA = "b" * 40
+CONTRACT_SHA = "c" * 64
+IMAGE_DIGEST = "sha256:" + "d" * 64
+PREVIOUS_DIGEST = "sha256:" + "e" * 64
+
+
+def _candidate() -> dict[str, object]:
+    return {
+        "version": "0.6.1",
+        "candidate_tag": "0.6.1-rc.1",
+        "source_revision": SOURCE_SHA,
+        "image_digest": IMAGE_DIGEST,
+    }
+
+
+def _authority_input() -> dict[str, object]:
+    return {
+        "authority_revision": AUTHORITY_SHA,
+        "contract_revision": CONTRACT_SHA,
+        "source_revision": SOURCE_SHA,
+    }
+
+
+def _admission_input(*, releasable: bool = True) -> dict[str, object]:
+    return {
+        "branch": "main",
+        "source_revision": SOURCE_SHA,
+        "remote_main_revision": SOURCE_SHA,
+        "computed_release": {
+            "releasable": releasable,
+            "bump": "patch" if releasable else "none",
+            "current_version": "0.6.0",
+            "next_version": "0.6.1" if releasable else "0.6.0",
+            "functional_changed": False,
+            "changes": {
+                "features": [],
+                "fixes": (
+                    ["fix(ci): allow immutable history reconciliation"] if releasable else []
+                ),
+                "breaking": [],
+            },
+        },
+    }
+
+
+def test_authority_binds_governance_contract_and_source_revisions() -> None:
+    result = evaluate_stage("authority", _authority_input())
+
+    assert result["status"] == "pass"
+    assert result["evidence"] == _authority_input()
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("authority_revision", "not-a-sha"),
+        ("contract_revision", ""),
+        ("source_revision", "short"),
+    ],
+)
+def test_authority_fails_closed_on_invalid_revisions(
+    field: str,
+    value: str,
+) -> None:
+    input_document = _authority_input()
+    input_document[field] = value
+
+    result = evaluate_stage("authority", input_document)
+
+    assert result["status"] == "blocked"
+    assert field in result["reason"]
+
+
+def test_admission_returns_truthful_no_action_only_for_no_release() -> None:
+    result = evaluate_stage(
+        "admission",
+        _admission_input(releasable=False),
+    )
+
+    assert result["status"] == "no_action"
+    assert result["evidence"]["source_revision"] == SOURCE_SHA
+    assert result["outputs"] == {}
+
+
+def test_admission_emits_exact_forward_candidate() -> None:
+    result = evaluate_stage("admission", _admission_input())
+
+    assert result["status"] == "pass"
+    assert result["outputs"]["candidate"] == {
+        "version": "0.6.1",
+        "source_revision": SOURCE_SHA,
+        "bump": "patch",
+    }
+
+
+@pytest.mark.parametrize(
+    ("mutate", "reason"),
+    [
+        (
+            lambda value: value.__setitem__("branch", "feature/not-main"),
+            "main",
+        ),
+        (
+            lambda value: value.__setitem__(
+                "remote_main_revision",
+                "f" * 40,
+            ),
+            "remote main",
+        ),
+        (
+            lambda value: value["computed_release"].__setitem__(
+                "next_version",
+                "0.6.0",
+            ),
+            "v0.6.0",
+        ),
+    ],
+)
+def test_admission_blocks_unmerged_changed_or_v060_candidate(
+    mutate,
+    reason: str,
+) -> None:
+    input_document = _admission_input()
+    mutate(input_document)
+
+    result = evaluate_stage("admission", input_document)
+
+    assert result["status"] == "blocked"
+    assert reason in result["reason"]
+
+
+def test_prepare_confirms_one_private_issue_and_hashes_extra_context() -> None:
+    result = evaluate_stage(
+        "prepare",
+        {
+            "candidate": _candidate(),
+            "extra_context": DEFAULT_EXTRA_CONTEXT,
+            "changelog": {
+                "source_revision": SOURCE_SHA,
+                "content_hash": "1" * 64,
+            },
+            "security": {"exit_code": 0, "report_hash": "2" * 64},
+            "tests": {
+                "source_revision": SOURCE_SHA,
+                "passed": True,
+                "evidence_hash": "3" * 64,
+            },
+            "rollback_point": {
+                "image": f"ghcr.io/knaisoma/data-olympus@{PREVIOUS_DIGEST}",
+                "digest": PREVIOUS_DIGEST,
+                "keel_policy": "never",
+            },
+            "release_issue": {
+                "count": 1,
+                "private": True,
+                "number": 177,
+                "url": "https://github.com/knaisoma/data-olympus/issues/177",
+                "source_revision": SOURCE_SHA,
+                "candidate_version": "0.6.1",
+                "body_hash": "4" * 64,
+            },
+        },
+    )
+
+    assert result["status"] == "pass"
+    context = result["evidence"]["extra_context"]
+    assert context["default"] is True
+    assert context["length"] == len(DEFAULT_EXTRA_CONTEXT)
+    assert len(context["sha256"]) == 64
+    assert DEFAULT_EXTRA_CONTEXT not in json.dumps(result)
+    assert result["outputs"]["release_issue_number"] == 177
+
+
+def test_prepare_blocks_when_the_private_release_issue_is_missing() -> None:
+    input_document = {
+        "candidate": _candidate(),
+        "extra_context": DEFAULT_EXTRA_CONTEXT,
+        "changelog": {
+            "source_revision": SOURCE_SHA,
+            "content_hash": "1" * 64,
+        },
+        "security": {"exit_code": 0, "report_hash": "2" * 64},
+        "tests": {
+            "source_revision": SOURCE_SHA,
+            "passed": True,
+            "evidence_hash": "3" * 64,
+        },
+        "rollback_point": {
+            "image": f"ghcr.io/knaisoma/data-olympus@{PREVIOUS_DIGEST}",
+            "digest": PREVIOUS_DIGEST,
+            "keel_policy": "never",
+        },
+        "release_issue": {
+            "count": 0,
+            "private": True,
+            "number": 177,
+            "url": "https://github.com/knaisoma/data-olympus/issues/177",
+            "source_revision": SOURCE_SHA,
+            "candidate_version": "0.6.1",
+            "body_hash": "4" * 64,
+        },
+    }
+
+    result = evaluate_stage("prepare", input_document)
+
+    assert result["status"] == "blocked"
+    assert "exactly one private release issue" in result["reason"]
+
+
+def test_validate_requires_unchanged_candidate_and_all_exact_gates() -> None:
+    result = evaluate_stage(
+        "validate",
+        {
+            "candidate": _candidate(),
+            "current_source_revision": SOURCE_SHA,
+            "ci": {
+                "source_revision": SOURCE_SHA,
+                "all_success": True,
+                "missing_required": [],
+            },
+            "security": {"exit_code": 0},
+            "version_free": {"version": "0.6.1", "free": True},
+            "tests": {
+                "source_revision": SOURCE_SHA,
+                "passed": True,
+            },
+        },
+    )
+
+    assert result["status"] == "pass"
+    assert result["evidence"]["source_revision"] == SOURCE_SHA
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        lambda value: value.__setitem__(
+            "current_source_revision",
+            "f" * 40,
+        ),
+        lambda value: value["ci"].__setitem__("all_success", False),
+        lambda value: value["security"].__setitem__("exit_code", 5),
+        lambda value: value["version_free"].__setitem__("free", False),
+        lambda value: value["tests"].__setitem__("passed", False),
+    ],
+)
+def test_validate_fails_closed_when_any_gate_changes(mutate) -> None:
+    input_document = {
+        "candidate": _candidate(),
+        "current_source_revision": SOURCE_SHA,
+        "ci": {
+            "source_revision": SOURCE_SHA,
+            "all_success": True,
+            "missing_required": [],
+        },
+        "security": {"exit_code": 0},
+        "version_free": {"version": "0.6.1", "free": True},
+        "tests": {"source_revision": SOURCE_SHA, "passed": True},
+    }
+    mutate(input_document)
+
+    result = evaluate_stage("validate", input_document)
+
+    assert result["status"] == "blocked"
+
+
+def test_review_requires_crossed_claude_codex_families_and_sha_approval() -> None:
+    result = evaluate_stage(
+        "review",
+        {
+            "candidate": _candidate(),
+            "current_source_revision": SOURCE_SHA,
+            "executor": {"family": "codex", "source_revision": SOURCE_SHA},
+            "companion_review": {
+                "family": "claude",
+                "verdict": "APPROVE",
+                "reviewed_source_revision": SOURCE_SHA,
+                "evidence_hash": "5" * 64,
+            },
+            "operator_approval": {
+                "approved": True,
+                "source_revision": SOURCE_SHA,
+                "approval_id": "approval-0.6.1",
+            },
+        },
+    )
+
+    assert result["status"] == "pass"
+    assert result["evidence"]["reviewer_family"] == "claude"
+    assert result["evidence"]["executor_family"] == "codex"
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        lambda value: value["companion_review"].__setitem__(
+            "family",
+            "codex",
+        ),
+        lambda value: value["companion_review"].__setitem__(
+            "verdict",
+            "BLOCK",
+        ),
+        lambda value: value["companion_review"].__setitem__(
+            "reviewed_source_revision",
+            "f" * 40,
+        ),
+        lambda value: value["operator_approval"].__setitem__(
+            "approved",
+            False,
+        ),
+        lambda value: value["operator_approval"].__setitem__(
+            "source_revision",
+            "f" * 40,
+        ),
+    ],
+)
+def test_review_blocks_self_review_changed_sha_or_missing_approval(
+    mutate,
+) -> None:
+    input_document = {
+        "candidate": _candidate(),
+        "current_source_revision": SOURCE_SHA,
+        "executor": {"family": "codex", "source_revision": SOURCE_SHA},
+        "companion_review": {
+            "family": "claude",
+            "verdict": "APPROVE",
+            "reviewed_source_revision": SOURCE_SHA,
+            "evidence_hash": "5" * 64,
+        },
+        "operator_approval": {
+            "approved": True,
+            "source_revision": SOURCE_SHA,
+            "approval_id": "approval-0.6.1",
+        },
+    }
+    mutate(input_document)
+
+    result = evaluate_stage("review", input_document)
+
+    assert result["status"] == "blocked"
+
+
+def test_deliver_accepts_only_existing_workflows_bound_to_candidate() -> None:
+    result = evaluate_stage(
+        "deliver",
+        {
+            "candidate": _candidate(),
+            "current_source_revision": SOURCE_SHA,
+            "workflows": [
+                {
+                    "name": "rc-publish.yml",
+                    "conclusion": "success",
+                    "source_revision": SOURCE_SHA,
+                    "candidate_tag": "0.6.1-rc.1",
+                },
+                {
+                    "name": "tag-release.yml",
+                    "conclusion": "success",
+                    "source_revision": SOURCE_SHA,
+                    "candidate_tag": "0.6.1-rc.1",
+                },
+                {
+                    "name": "set-channel.yml",
+                    "conclusion": "success",
+                    "source_revision": SOURCE_SHA,
+                    "source_tag": "v0.6.1",
+                },
+            ],
+            "canary": {
+                "candidate_tag": "0.6.1-rc.1",
+                "source_revision": SOURCE_SHA,
+                "digest": IMAGE_DIGEST,
+                "keel_policy": "never",
+                "rollout_complete": True,
+                "healthy": True,
+                "ready": True,
+                "mcp_search": True,
+                "enforcement": True,
+            },
+            "deployment": {
+                "keel_policy": "never",
+                "image_digest": IMAGE_DIGEST,
+                "source_revision": SOURCE_SHA,
+                "rollout_complete": True,
+            },
+        },
+    )
+
+    assert result["status"] == "pass"
+    assert result["outputs"]["published_version"] == "0.6.1"
+
+
+def test_deliver_blocks_stable_promotion_without_verified_canary() -> None:
+    input_document = {
+        "candidate": _candidate(),
+        "current_source_revision": SOURCE_SHA,
+        "workflows": [
+            {
+                "name": "rc-publish.yml",
+                "conclusion": "success",
+                "source_revision": SOURCE_SHA,
+                "candidate_tag": "0.6.1-rc.1",
+            },
+            {
+                "name": "tag-release.yml",
+                "conclusion": "success",
+                "source_revision": SOURCE_SHA,
+                "candidate_tag": "0.6.1-rc.1",
+            },
+            {
+                "name": "set-channel.yml",
+                "conclusion": "success",
+                "source_revision": SOURCE_SHA,
+                "source_tag": "v0.6.1",
+            },
+        ],
+        "canary": {
+            "candidate_tag": "0.6.1-rc.1",
+            "source_revision": SOURCE_SHA,
+            "digest": IMAGE_DIGEST,
+            "keel_policy": "never",
+            "rollout_complete": True,
+            "healthy": False,
+            "ready": True,
+            "mcp_search": True,
+            "enforcement": True,
+        },
+        "deployment": {
+            "keel_policy": "never",
+            "image_digest": IMAGE_DIGEST,
+            "source_revision": SOURCE_SHA,
+            "rollout_complete": True,
+        },
+    }
+
+    result = evaluate_stage("deliver", input_document)
+
+    assert result["status"] == "failed"
+    assert "canary.healthy" in result["reason"]
+
+
+def test_verify_requires_every_surface_and_live_service_to_match() -> None:
+    result = evaluate_stage(
+        "verify",
+        {
+            "candidate": _candidate(),
+            "github_release": {
+                "tag": "v0.6.1",
+                "source_revision": SOURCE_SHA,
+            },
+            "pypi": {
+                "version": "0.6.1",
+                "provenance_source_revision": SOURCE_SHA,
+            },
+            "image": {"tag": "v0.6.1", "digest": IMAGE_DIGEST},
+            "deployment": {
+                "source_revision": SOURCE_SHA,
+                "digest": IMAGE_DIGEST,
+                "healthy": True,
+                "ready": True,
+                "mcp_search": True,
+                "enforcement": True,
+                "documentation": True,
+            },
+        },
+    )
+
+    assert result["status"] == "pass"
+    assert result["evidence"]["digest"] == IMAGE_DIGEST
+
+
+def test_notify_requires_exact_independent_readback() -> None:
+    result = evaluate_stage(
+        "notify",
+        {
+            "destination": "data-olympus-operations",
+            "readback_destination": "data-olympus-operations",
+            "sent_message_id": "120",
+            "readback_message_id": "120",
+            "sent_content_hash": "6" * 64,
+            "readback_content_hash": "6" * 64,
+        },
+    )
+
+    assert result["status"] == "pass"
+    assert result["outputs"]["message_id"] == "120"
+
+
+def test_notify_fails_when_readback_content_differs() -> None:
+    result = evaluate_stage(
+        "notify",
+        {
+            "destination": "data-olympus-operations",
+            "readback_destination": "data-olympus-operations",
+            "sent_message_id": "120",
+            "readback_message_id": "120",
+            "sent_content_hash": "6" * 64,
+            "readback_content_hash": "7" * 64,
+        },
+    )
+
+    assert result["status"] == "failed"
+    assert "content does not match" in result["reason"]
+
+
+def test_rollback_requires_direct_digest_restore_while_keel_stays_paused() -> None:
+    result = evaluate_stage(
+        "rollback",
+        {
+            "failed_digest": IMAGE_DIGEST,
+            "rollback_point": {
+                "image": f"ghcr.io/knaisoma/data-olympus@{PREVIOUS_DIGEST}",
+                "digest": PREVIOUS_DIGEST,
+                "intended_keel_policy": "never",
+            },
+            "events": [
+                {
+                    "name": "keel-paused",
+                    "policy": "never",
+                },
+                {
+                    "name": "digest-restored",
+                    "digest": PREVIOUS_DIGEST,
+                    "containers": [
+                        "data-olympus-mcp",
+                        "prepare-git",
+                    ],
+                },
+                {
+                    "name": "deployment-verified",
+                    "digest": PREVIOUS_DIGEST,
+                    "healthy": True,
+                    "ready": True,
+                },
+                {
+                    "name": "keel-policy-restored",
+                    "policy": "never",
+                },
+            ],
+        },
+    )
+
+    assert result["status"] == "pass"
+    assert result["evidence"]["restored_digest"] == PREVIOUS_DIGEST
+
+
+def test_rollback_fails_when_events_are_out_of_order() -> None:
+    result = evaluate_stage(
+        "rollback",
+        {
+            "failed_digest": IMAGE_DIGEST,
+            "rollback_point": {
+                "image": f"ghcr.io/knaisoma/data-olympus@{PREVIOUS_DIGEST}",
+                "digest": PREVIOUS_DIGEST,
+                "intended_keel_policy": "never",
+            },
+            "events": [
+                {
+                    "name": "digest-restored",
+                    "digest": PREVIOUS_DIGEST,
+                    "containers": [
+                        "data-olympus-mcp",
+                        "prepare-git",
+                    ],
+                },
+                {"name": "keel-paused", "policy": "never"},
+                {
+                    "name": "deployment-verified",
+                    "digest": PREVIOUS_DIGEST,
+                    "healthy": True,
+                    "ready": True,
+                },
+                {
+                    "name": "keel-policy-restored",
+                    "policy": "never",
+                },
+            ],
+        },
+    )
+
+    assert result["status"] == "failed"
+    assert "out of order" in result["reason"]
+
+
+def test_cli_emits_one_failed_json_object_when_input_is_missing(
+    monkeypatch,
+    capsys,
+) -> None:
+    monkeypatch.delenv("AI_OPERATIONS_STAGE_INPUT", raising=False)
+
+    exit_code = main(["authority"])
+    output = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 2
+    assert output == {
+        "status": "failed",
+        "reason": "AI_OPERATIONS_STAGE_INPUT is required",
+        "evidence": {},
+        "outputs": {},
+    }

--- a/tests/test_operations_release.py
+++ b/tests/test_operations_release.py
@@ -127,6 +127,13 @@ def test_admission_emits_exact_forward_candidate() -> None:
             ),
             "v0.6.0",
         ),
+        (
+            lambda value: value["computed_release"].__setitem__(
+                "next_version",
+                "0.9.0",
+            ),
+            "does not match",
+        ),
     ],
 )
 def test_admission_blocks_unmerged_changed_or_v060_candidate(
@@ -404,7 +411,7 @@ def test_deliver_accepts_only_existing_workflows_bound_to_candidate() -> None:
     assert result["outputs"]["published_version"] == "0.6.1"
 
 
-def test_deliver_blocks_stable_promotion_without_verified_canary() -> None:
+def test_deliver_fails_stable_promotion_without_verified_canary() -> None:
     input_document = {
         "candidate": _candidate(),
         "current_source_revision": SOURCE_SHA,
@@ -481,6 +488,57 @@ def test_verify_requires_every_surface_and_live_service_to_match() -> None:
 
     assert result["status"] == "pass"
     assert result["evidence"]["digest"] == IMAGE_DIGEST
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        lambda value: value["github_release"].__setitem__(
+            "source_revision",
+            "f" * 40,
+        ),
+        lambda value: value["pypi"].__setitem__("version", "0.6.2"),
+        lambda value: value["image"].__setitem__(
+            "digest",
+            PREVIOUS_DIGEST,
+        ),
+        lambda value: value["deployment"].__setitem__("healthy", False),
+        lambda value: value["deployment"].__setitem__("ready", False),
+        lambda value: value["deployment"].__setitem__("mcp_search", False),
+        lambda value: value["deployment"].__setitem__("enforcement", False),
+        lambda value: value["deployment"].__setitem__(
+            "documentation",
+            False,
+        ),
+    ],
+)
+def test_verify_fails_closed_when_any_external_surface_differs(mutate) -> None:
+    input_document = {
+        "candidate": _candidate(),
+        "github_release": {
+            "tag": "v0.6.1",
+            "source_revision": SOURCE_SHA,
+        },
+        "pypi": {
+            "version": "0.6.1",
+            "provenance_source_revision": SOURCE_SHA,
+        },
+        "image": {"tag": "v0.6.1", "digest": IMAGE_DIGEST},
+        "deployment": {
+            "source_revision": SOURCE_SHA,
+            "digest": IMAGE_DIGEST,
+            "healthy": True,
+            "ready": True,
+            "mcp_search": True,
+            "enforcement": True,
+            "documentation": True,
+        },
+    }
+    mutate(input_document)
+
+    result = evaluate_stage("verify", input_document)
+
+    assert result["status"] == "failed"
 
 
 def test_notify_requires_exact_independent_readback() -> None:
@@ -596,6 +654,24 @@ def test_rollback_fails_when_events_are_out_of_order() -> None:
     assert "out of order" in result["reason"]
 
 
+def test_rollback_fails_when_rollback_digest_is_the_failed_digest() -> None:
+    result = evaluate_stage(
+        "rollback",
+        {
+            "failed_digest": IMAGE_DIGEST,
+            "rollback_point": {
+                "image": f"ghcr.io/knaisoma/data-olympus@{IMAGE_DIGEST}",
+                "digest": IMAGE_DIGEST,
+                "intended_keel_policy": "never",
+            },
+            "events": [],
+        },
+    )
+
+    assert result["status"] == "failed"
+    assert "must differ" in result["reason"]
+
+
 def test_cli_emits_one_failed_json_object_when_input_is_missing(
     monkeypatch,
     capsys,
@@ -612,3 +688,34 @@ def test_cli_emits_one_failed_json_object_when_input_is_missing(
         "evidence": {},
         "outputs": {},
     }
+
+
+def test_cli_rejects_wrong_argument_count(capsys) -> None:
+    exit_code = main([])
+    output = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 2
+    assert output["status"] == "failed"
+    assert output["reason"] == "exactly one release stage is required"
+
+
+def test_cli_rejects_malformed_json(monkeypatch, capsys) -> None:
+    monkeypatch.setenv("AI_OPERATIONS_STAGE_INPUT", "{")
+
+    exit_code = main(["authority"])
+    output = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 2
+    assert output["status"] == "failed"
+    assert output["reason"] == "AI_OPERATIONS_STAGE_INPUT must be valid JSON"
+
+
+def test_cli_rejects_unknown_stage(monkeypatch, capsys) -> None:
+    monkeypatch.setenv("AI_OPERATIONS_STAGE_INPUT", "{}")
+
+    exit_code = main(["not-a-stage"])
+    output = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 1
+    assert output["status"] == "failed"
+    assert output["reason"] == "unknown release stage: not-a-stage"

--- a/tests/test_release_contract_docs.py
+++ b/tests/test_release_contract_docs.py
@@ -59,10 +59,23 @@ def test_release_notes_cover_the_expanded_060_contract() -> None:
         assert required in combined
 
 
-def test_versioning_rule_uses_the_release_routine_integration_branch() -> None:
+def test_versioning_rule_uses_one_linear_release_change() -> None:
     versioning = _read(".rules/versioning.md")
     routine = _read(".rules/release-routine.md")
 
-    assert "feature/<release-epic-id>" in versioning
-    assert "feature/<release-epic-id>" in routine
-    assert "release/X.Y.Z integration branches" not in versioning
+    assert "`chore/release-vX.Y.Z`" in versioning
+    assert "`chore/release-vX.Y.Z`" in routine
+    assert "linear history" in versioning
+    assert "squash merged" in versioning
+    assert "feature/<release-epic-id>" not in versioning
+    assert "feature/<release-epic-id>" not in routine
+
+
+def test_release_planning_is_outcome_based() -> None:
+    planning = _read(".rules/release-planning.md")
+
+    assert "already\nmerged, reviewed, green, and unreleased" in planning
+    assert "does not select future issues" in planning
+    assert "No action" in planning
+    assert "three to five" not in planning
+    assert "strict 1-week" not in planning


### PR DESCRIPTION
## Summary

* Replace the old Friday issue batching and Monday cutter assumptions with an outcome based release contract.
* Add the fixed stage decision command at `scripts/operations/release.py`.
* Bind admission, review, approval, delivery, verification, notification, and rollback evidence to one exact source revision.
* Preserve immutable `v0.6.0` and admit only the forward `v0.6.1` disposition when the current history remains releasable.
* Align kn dev rollback with the observed deployment model: Keel policy `never` and direct restoration of the prior exact digest to both containers.
* Update documentation contract tests for linear history and one short lived release change.

## Verification

* Full pytest suite passed. Two optional dependency tests were skipped as expected.
* 74 Bats tests passed.
* Ruff passed.
* mypy passed.
* Benchmark documentation, documentation consistency, changelog, and example bundle guards passed.
* Pinned Google OKF conformance passed in both directions.
* Wheel and source distribution built successfully.
* Strict package metadata and isolated installed artifact smoke tests passed.

## Companion review (Claude)

Claude Code issued `APPROVE` for exact head `0238fdfbc71d523ab6029cb44643ae5d186704c0` after the deterministic bump, fail closed negative coverage, and adapter trust boundary findings were addressed.

## Operational boundary

This pull request does not publish a release, move a channel, or change kn dev. The central runner project command adapter is still a separate required slice.

GitHub reported one moderate Dependabot vulnerability on the default branch during push. The real `v0.6.1` release remains blocked until the security gate is clear or a separate operator approved disposition is recorded.