### PR TITLE
chore: ignore linked worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ id_ed25519*
 id_rsa*
 # Claude Code working directory (worktrees, local settings, skill/plugin scratch)
 .claude/
+.worktrees/
 # internal planning/design docs are not committed; docs/ holds only user-facing material
 docs/plans/
 docs/specs/


### PR DESCRIPTION
## Outcome

Ignore project local linked worktrees so the approved detached AI operations runtime checkout does not pollute the primary working tree.

## Verification

* Git resolves .worktrees/aiops-runtime through the new ignore rule.
* The dirty primary checkout remains untouched.
* Diff checks pass.

## Companion review (Claude Sonnet 5)

APPROVE for commit f7ed593.