### PR TITLE
feat(automation): execute weekly release outcome

### DIFF
--- a/.rules/release-planning.md
+++ b/.rules/release-planning.md
@@ -1,11 +1,23 @@
 # Data Olympus release planning
 
-Status: active
+Status: retired
 Since: 2026-07-31
-Schedule: Friday at 18:00 Europe/Bucharest
-Automation status: disabled until baseline certification
+Retired: 2026-07-31
+Replacement: `.rules/release-routine.md`
 
-## Purpose
+## Retirement
+
+The separate Friday planning handoff and private release issue were removed
+before baseline certification. They duplicated admission state, created a stale
+handoff between routines, and could not provide exact candidate approval after
+a squash merge.
+
+The single outcome based Monday routine now performs admission, deterministic
+release preparation, exact final review, ledger bound standing approval,
+delivery, verification, and notification as one controlled run. This file is
+retained only as decision history and does not govern execution.
+
+## Former purpose
 
 The planning run identifies one release candidate from work that is already
 merged, reviewed, green, and unreleased on `origin/main`.

--- a/.rules/release-rollback.md
+++ b/.rules/release-rollback.md
@@ -87,7 +87,7 @@ When a stable release is unsuitable:
 * Restore kn dev first.
 * Yank the PyPI stable version when required.
 * Mark the GitHub release as a prerelease when required.
-* Open or update the private release issue with the failure evidence.
+* Record the immutable failure and recovery evidence in the runner ledger.
 * Prepare a new patch version. Do not move the existing stable tag.
 
 ## Failure

--- a/.rules/release-routine.md
+++ b/.rules/release-routine.md
@@ -59,6 +59,11 @@ revision when known, and incomplete recovery state.
 Workflow preflight reads remain safely retryable and `blocked`. The delivery
 mutation boundary begins immediately before the first workflow dispatch;
 dispatch ambiguity and every later failure are `failed`.
+The deployment mutation boundary begins immediately before the Kubernetes
+apply. A rollback preflight read may block without recovery evidence. Once the
+apply begins, an ambiguous apply or failed postapply acceptance returns a
+failed recovery result that records the rollback digest, apply confirmation,
+rollout state, acceptance state, and incomplete recovery.
 
 The central runner owns authority admission, immutable run control, model
 tickets, exact candidate approval, the durable ledger, Telegram delivery, and

--- a/.rules/release-routine.md
+++ b/.rules/release-routine.md
@@ -56,6 +56,9 @@ After the conditional merge mutation begins, an unknown merge outcome or any
 confirmed postmerge gate failure is `failed`, never `blocked`. Its result
 records the pull request, reviewed head, merge confirmation state, resulting
 revision when known, and incomplete recovery state.
+Workflow preflight reads remain safely retryable and `blocked`. The delivery
+mutation boundary begins immediately before the first workflow dispatch;
+dispatch ambiguity and every later failure are `failed`.
 
 The central runner owns authority admission, immutable run control, model
 tickets, exact candidate approval, the durable ledger, Telegram delivery, and

--- a/.rules/release-routine.md
+++ b/.rules/release-routine.md
@@ -52,6 +52,10 @@ precondition. They reuse governed repository commands and record the direct
 GitHub fallback because the gateway exposes none of those exact operations.
 An unconditional gateway merge is not an acceptable substitute for the
 expected head precondition.
+After the conditional merge mutation begins, an unknown merge outcome or any
+confirmed postmerge gate failure is `failed`, never `blocked`. Its result
+records the pull request, reviewed head, merge confirmation state, resulting
+revision when known, and incomplete recovery state.
 
 The central runner owns authority admission, immutable run control, model
 tickets, exact candidate approval, the durable ledger, Telegram delivery, and
@@ -91,7 +95,8 @@ Rollback is the same executable with the `rollback` argument. It reads
    * Version availability across PyPI, GHCR, GitHub tags, and GitHub releases.
 
 9. The deterministic executor requests one central, run controlled Claude
-   review of the exact final SHA. Self review is prohibited.
+   review of the exact final SHA. Self review is prohibited. Review evidence
+   hashes both the submitted packet and the ticket bound Claude response.
 10. Require the candidate approval ledger entry to bind the run, contract
     digest, final SHA, and consumed Claude review. The approved standing
     delegation may materialize that exact entry only after the review passes.

--- a/.rules/release-routine.md
+++ b/.rules/release-routine.md
@@ -45,10 +45,13 @@ The fixed milestones are:
 * `verify`
 
 The project command owns Git, release artifact, workflow, registry, and kn dev
-evidence. Supported external mutations and reads go through FastMCP. The two
-current GitHub evidence gaps, security alert enumeration and container package
-digest lookup, reuse the governed repository scripts and record the direct
-GitHub fallback because the gateway exposes neither operation.
+evidence. Supported external mutations and reads go through FastMCP. The three
+current GitHub capability gaps are security alert enumeration, container
+package digest lookup, and a pull request merge with an expected head SHA
+precondition. They reuse governed repository commands and record the direct
+GitHub fallback because the gateway exposes none of those exact operations.
+An unconditional gateway merge is not an acceptable substitute for the
+expected head precondition.
 
 The central runner owns authority admission, immutable run control, model
 tickets, exact candidate approval, the durable ledger, Telegram delivery, and

--- a/.rules/release-routine.md
+++ b/.rules/release-routine.md
@@ -16,61 +16,66 @@ to release when the evidence says no release is due.
 
 ## Command interface
 
-The project command is:
+The complete project command is:
 
-`python3.13 scripts/operations/release.py <stage>`
+`python3.13 scripts/operations/release.py`
 
-It reads one JSON object from `AI_OPERATIONS_STAGE_INPUT` and emits one JSON
-object with these fields:
+It reads the bounded run document from `AI_OPERATIONS_RUN_INPUT`. It emits
+newline delimited JSON with contiguous sequence numbers. The only event types
+are:
 
-* `status`
-* `reason`
-* `evidence`
-* `outputs`
+* `heartbeat`
+* `milestone`
+* `result`
 
-Accepted statuses are:
+The terminal result status is one of:
 
-* `pass`
+* `delivered`
 * `no_action`
 * `blocked`
 * `failed`
 
-`no_action` is valid only during admission. The command supports the fixed
-lifecycle stages plus rollback:
+The fixed milestones are:
 
-* `authority`
 * `admission`
 * `prepare`
 * `validate`
-* `review`
+* `domain_review`
 * `deliver`
 * `verify`
-* `notify`
-* `rollback`
 
-The command validates supplied evidence. It does not fetch Git, Data Olympus,
-GitHub, registry, cluster, or Telegram state by itself. The central runner
-adapter must fetch those sources, compare the real revisions, and supply the
-bounded stage input. A format valid SHA is not proof that a remote or authority
-revision exists.
+The project command owns Git, release artifact, workflow, registry, and kn dev
+evidence. Supported external mutations and reads go through FastMCP. The two
+current GitHub evidence gaps, security alert enumeration and container package
+digest lookup, reuse the governed repository scripts and record the direct
+GitHub fallback because the gateway exposes neither operation.
+
+The central runner owns authority admission, immutable run control, model
+tickets, exact candidate approval, the durable ledger, Telegram delivery, and
+exact Telegram readback.
+
+Rollback is the same executable with the `rollback` argument. It reads
+`AI_OPERATIONS_RECOVERY_INPUT` and returns one closed recovery result.
 
 ## Monday sequence
 
-1. Load the single private release issue and the exact Friday source SHA.
-2. Fetch `origin/main` and rerun `scripts/compute_release.py`.
-3. Stop as `Blocked` when the source SHA, computed version, changelog, security
-   state, test evidence, or rollback point changed.
-4. If the repository now proves that no unreleased work exists, close the
+1. Bind the authority revision, contract digest, run identifier, and exact
+   `origin/main` source SHA.
+2. Rerun `scripts/compute_release.py` from that exact clean source.
+3. If the repository proves that no unreleased work exists, close the
    candidate as `No action`. Never manufacture a release to satisfy the
    schedule.
-5. Prepare the version change and release notes on one short lived
-   `chore/release-vX.Y.Z` branch from the approved source SHA.
-6. Set `pyproject.toml` to `X.Y.Z`, close the matching changelog block, open a
+4. Prepare the version change and release notes on one short lived
+   `chore/release-vX.Y.Z-RUN` branch from the admitted source SHA.
+5. Set `pyproject.toml` to `X.Y.Z`, update `uv.lock`, close the matching
+   changelog block, open a
    new empty `[Unreleased]` block, and write `docs/releases/vX.Y.Z.md`.
-7. Obtain independent crossed review of the exact branch SHA, merge the one
-   logical release change through the repository rules, and bind the candidate
-   source to the resulting exact `main` SHA.
-8. Rerun all release gates against that SHA:
+6. Open one public pull request through FastMCP. Require every repository check
+   to complete successfully. Confirm that remote `main` still equals the
+   admitted SHA, then squash merge the one deterministic release change.
+7. Bind the candidate to the resulting exact `main` SHA and require its parent
+   to equal the admitted SHA. A concurrent main change blocks the run.
+8. Rerun all release gates against that final SHA:
 
    * Complete test suite.
    * Ruff.
@@ -82,9 +87,11 @@ revision exists.
    * `scripts/ci_status.py`.
    * Version availability across PyPI, GHCR, GitHub tags, and GitHub releases.
 
-9. Require one Claude and Codex crossed pair. One family executes and the other
-   independently reviews. Self review is prohibited.
-10. Require operator approval bound to the exact candidate source SHA.
+9. The deterministic executor requests one central, run controlled Claude
+   review of the exact final SHA. Self review is prohibited.
+10. Require the candidate approval ledger entry to bind the run, contract
+    digest, final SHA, and consumed Claude review. The approved standing
+    delegation may materialize that exact entry only after the review passes.
 11. Dispatch `rc-publish.yml` for that SHA and the next unused candidate
     number. Do not reproduce version computation or publication logic in the
     runner.
@@ -108,17 +115,21 @@ revision exists.
     Keel is `never`.
 16. Deploy the same stable digest explicitly to kn dev and run the full
     external verification stage.
-17. Send one Telegram completion message to the semantic destination
-    `data-olympus-operations`. Completion requires exact independent readback
-    of the destination, message identifier, run marker, and content.
-18. Update the private release issue with immutable evidence and the truthful
-    terminal state.
+17. Return a delivered project result with the release pull request, previous
+   rollback digest, published version, exact candidate SHA, image digest, and
+   verification receipts.
+18. The central runner sends one Telegram completion message to the semantic
+   destination `data-olympus-operations`. Completion requires exact independent
+   readback of the destination, message identifier, run marker, and content.
+19. The durable runner ledger records the truthful terminal state. No private
+   issue is an authority or completion dependency.
 
 ## Exact source rule
 
-Candidate preparation, review, operator approval, workflow receipts,
-provenance, tags, artifacts, deployment, verification, and notification all
-name the same source SHA.
+The release branch SHA is premerge evidence only because squash merge produces
+a new commit. Final review, exact approval, workflow receipts, provenance,
+tags, artifacts, deployment, verification, and notification all name the same
+resulting `main` source SHA.
 
 Any source change invalidates approval and restarts the release assessment.
 
@@ -156,4 +167,5 @@ The release is complete only when:
 * kn dev runs that exact digest in both containers.
 * Health, readiness, MCP search, enforcement, and documentation pass.
 * Telegram send and exact readback are confirmed.
-* The runner ledger and private release issue record the same terminal state.
+* The runner ledger records the same terminal project, review, approval,
+  deployment, and notification evidence.

--- a/.rules/versioning.md
+++ b/.rules/versioning.md
@@ -46,8 +46,9 @@ Friday planning must produce a Monday release.
 
 When a release is due:
 
-1. Create one short lived `chore/release-vX.Y.Z` branch from the approved main
-   SHA.
+1. Create one short lived `chore/release-vX.Y.Z-RUN` branch from the approved
+   main SHA. The run suffix prevents a failed clean retry from colliding with a
+   prior local or remote branch.
 2. Update `pyproject.toml`, the changelog, and the release note in one logical
    release change.
 3. Review and merge that change through the current repository rules.
@@ -95,9 +96,9 @@ Published versions, Git tags, GitHub releases, and OCI version tags are
 immutable.
 
 `v0.6.0` is already published and reconciled into `main`. It must never be
-rebuilt, retagged, or republished. The next valid release is a forward version,
-currently expected to be `v0.6.1` when the exact main history remains
-releasable.
+rebuilt, retagged, or republished. The next valid release is always the forward
+version returned by `scripts/compute_release.py` for the exact admitted
+`origin/main` history. No rule document hard codes the next version.
 
 Any collision or source mismatch blocks the release. Recovery uses a new
 version or a higher candidate number, never replacement of an existing

--- a/scripts/operations/release.py
+++ b/scripts/operations/release.py
@@ -472,8 +472,8 @@ def _review(input_document: dict[str, Any]) -> StageResult:
         review.get("family"),
         "companion_review.family",
     )
-    if reviewer_family not in {"claude", "codex"}:
-        raise ReleaseInputError("release review must use Claude or Codex")
+    if reviewer_family != "claude":
+        raise ReleaseInputError("release review must use Claude")
     if review.get("verdict") != "APPROVE":
         raise ReleaseInputError("companion_review.verdict must be APPROVE")
     _same_source(
@@ -948,7 +948,11 @@ def _issued_model_ticket(value: Any) -> dict[str, Any]:
         raise ReleaseInputError("model ticket identifier must be a positive integer")
     if ticket["purpose"] != "review":
         raise ReleaseInputError("release model ticket purpose must be review")
-    _string(ticket["route_id"], "model ticket route")
+    route_id = _string(ticket["route_id"], "model ticket route")
+    if route_id != "claude-code":
+        raise ReleaseInputError(
+            "release review ticket must use the qualified Claude route"
+        )
     _sha40(ticket["source_revision"], "model ticket source_revision")
     _string(ticket["ticket"], "model ticket")
     return ticket
@@ -1409,12 +1413,19 @@ def execute_release_run(
         if run_input is None:
             raise
         delivered = any(event.get("name") == "deliver" for event in events)
+        external_state_changed = bool(
+            getattr(error, "external_state_changed", False)
+        )
+        failure_evidence = getattr(error, "evidence", {})
+        if type(failure_evidence) is not dict:
+            failure_evidence = {}
         record(
             _project_result(
                 len(events) + 1,
-                "failed" if delivered else "blocked",
+                "failed" if delivered or external_state_changed else "blocked",
                 str(error),
                 run_input,
+                failure_evidence,
                 candidate_revision=candidate_revision,
             )
         )

--- a/scripts/operations/release.py
+++ b/scripts/operations/release.py
@@ -1348,7 +1348,11 @@ def execute_release_run(
                     "verdict": "APPROVE",
                     "reviewed_source_revision": candidate_revision,
                     "evidence_hash": sha256(
-                        json.dumps(packet, separators=(",", ":"), sort_keys=True).encode()
+                        json.dumps(
+                            {"packet": packet, "response": review},
+                            separators=(",", ":"),
+                            sort_keys=True,
+                        ).encode()
                     ).hexdigest(),
                 },
                 "candidate_approval": approval,

--- a/scripts/operations/release.py
+++ b/scripts/operations/release.py
@@ -1499,7 +1499,11 @@ def main(
             if type(failure_evidence) is not dict:
                 failure_evidence = {}
             recovery = {
-                "status": "failed",
+                "status": (
+                    "failed"
+                    if bool(getattr(error, "external_state_changed", False))
+                    else "blocked"
+                ),
                 "reason": str(error),
                 "evidence": failure_evidence,
                 "source_revision": (

--- a/scripts/operations/release.py
+++ b/scripts/operations/release.py
@@ -6,9 +6,16 @@ from __future__ import annotations
 import json
 import os
 import re
+import shutil
+import subprocess
 import sys
+import tempfile
 from hashlib import sha256
-from typing import Any
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 DEFAULT_EXTRA_CONTEXT = "No extra context for this run"
 
@@ -332,34 +339,38 @@ def _prepare(input_document: dict[str, Any]) -> StageResult:
     if rollback.get("keel_policy") != "never":
         raise ReleaseInputError("rollback_point.keel_policy must be never")
 
-    issue = _object(
-        input_document.get("release_issue"),
-        "release_issue",
+    release_pr = _object(
+        input_document.get("release_pr"),
+        "release_pr",
     )
-    if _integer(issue.get("count"), "release_issue.count") != 1:
-        raise ReleaseInputError("exactly one private release issue is required")
-    _true(issue.get("private"), "release_issue.private")
-    number = _integer(issue.get("number"), "release_issue.number")
+    number = _integer(release_pr.get("number"), "release_pr.number")
     if number <= 0:
-        raise ReleaseInputError("release_issue.number must be positive")
-    url = _string(issue.get("url"), "release_issue.url")
-    if not url.startswith("https://github.com/knaisoma/data-olympus/issues/"):
-        raise ReleaseInputError("release_issue.url is outside the repository")
+        raise ReleaseInputError("release_pr.number must be positive")
+    url = _string(release_pr.get("url"), "release_pr.url")
+    if url != f"https://github.com/knaisoma/data-olympus/pull/{number}":
+        raise ReleaseInputError("release_pr.url is outside the Data Olympus repository")
+    _true(release_pr.get("merged"), "release_pr.merged")
+    base_revision = _sha40(
+        release_pr.get("base_source_revision"),
+        "release_pr.base_source_revision",
+    )
+    head_revision = _sha40(
+        release_pr.get("head_revision"),
+        "release_pr.head_revision",
+    )
+    if base_revision == head_revision or head_revision == source_revision:
+        raise ReleaseInputError("release_pr revisions do not prove a squash merge")
     _same_source(
         source_revision,
-        issue.get("source_revision"),
-        "release_issue.source_revision",
+        release_pr.get("source_revision"),
+        "release_pr.source_revision",
     )
-    if issue.get("candidate_version") != version:
-        raise ReleaseInputError("release_issue.candidate_version does not match the candidate")
-    issue_hash = _hash(
-        issue.get("body_hash"),
-        "release_issue.body_hash",
-    )
+    if release_pr.get("candidate_version") != version:
+        raise ReleaseInputError("release_pr.candidate_version does not match the candidate")
 
     return _result(
         "pass",
-        f"private release issue {number} records candidate {version}",
+        f"release pull request {number} produced candidate {version}",
         {
             "source_revision": source_revision,
             "version": version,
@@ -368,11 +379,12 @@ def _prepare(input_document: dict[str, Any]) -> StageResult:
             "security_hash": security_hash,
             "tests_hash": tests_hash,
             "rollback_digest": rollback_digest,
-            "release_issue_hash": issue_hash,
+            "release_pr_head_revision": head_revision,
+            "release_pr_base_revision": base_revision,
         },
         {
-            "release_issue_number": number,
-            "release_issue_url": url,
+            "release_pr_number": number,
+            "release_pr_url": url,
         },
     )
 
@@ -380,7 +392,7 @@ def _prepare(input_document: dict[str, Any]) -> StageResult:
 def _validate(input_document: dict[str, Any]) -> StageResult:
     _, version, source_revision = _candidate(
         input_document.get("candidate"),
-        require_artifact=True,
+        require_artifact=False,
     )
     _same_source(
         source_revision,
@@ -434,7 +446,7 @@ def _validate(input_document: dict[str, Any]) -> StageResult:
 def _review(input_document: dict[str, Any]) -> StageResult:
     _, version, source_revision = _candidate(
         input_document.get("candidate"),
-        require_artifact=True,
+        require_artifact=False,
     )
     _same_source(
         source_revision,
@@ -444,8 +456,8 @@ def _review(input_document: dict[str, Any]) -> StageResult:
 
     executor = _object(input_document.get("executor"), "executor")
     executor_family = _string(executor.get("family"), "executor.family")
-    if executor_family not in {"claude", "codex"}:
-        raise ReleaseInputError("executor.family must be claude or codex for a red release")
+    if executor_family != "deterministic":
+        raise ReleaseInputError("executor.family must be deterministic")
     _same_source(
         source_revision,
         executor.get("source_revision"),
@@ -460,8 +472,8 @@ def _review(input_document: dict[str, Any]) -> StageResult:
         review.get("family"),
         "companion_review.family",
     )
-    if {executor_family, reviewer_family} != {"claude", "codex"}:
-        raise ReleaseInputError("release execution and review must cross Claude and Codex families")
+    if reviewer_family not in {"claude", "codex"}:
+        raise ReleaseInputError("release review must use Claude or Codex")
     if review.get("verdict") != "APPROVE":
         raise ReleaseInputError("companion_review.verdict must be APPROVE")
     _same_source(
@@ -474,30 +486,53 @@ def _review(input_document: dict[str, Any]) -> StageResult:
         "companion_review.evidence_hash",
     )
 
-    approval = _object(
-        input_document.get("operator_approval"),
-        "operator_approval",
+    review_model_use_id = _integer(
+        input_document.get("review_model_use_id"),
+        "review_model_use_id",
     )
-    _true(approval.get("approved"), "operator_approval.approved")
+    if review_model_use_id <= 0:
+        raise ReleaseInputError("review_model_use_id must be positive")
+
+    approval = _object(
+        input_document.get("candidate_approval"),
+        "candidate_approval",
+    )
+    authority = _string(
+        approval.get("authority"),
+        "candidate_approval.authority",
+    )
+    if authority not in {"operator", "standing-delegation"}:
+        raise ReleaseInputError("candidate_approval.authority is invalid")
     _same_source(
         source_revision,
-        approval.get("source_revision"),
-        "operator_approval.source_revision",
+        approval.get("candidate_revision"),
+        "candidate_approval.candidate_revision",
     )
-    approval_id = _string(
-        approval.get("approval_id"),
-        "operator_approval.approval_id",
+    contract_digest = _hash(
+        approval.get("contract_digest"),
+        "candidate_approval.contract_digest",
     )
+    if contract_digest != input_document.get("contract_revision"):
+        raise ReleaseInputError("candidate approval contract digest changed")
+    approval_hash = _hash(
+        approval.get("approval_id_hash"),
+        "candidate_approval.approval_id_hash",
+    )
+    if approval.get("review_model_use_id") != review_model_use_id:
+        raise ReleaseInputError("candidate approval review evidence changed")
+    if approval.get("run_id") != input_document.get("run_id"):
+        raise ReleaseInputError("candidate approval run changed")
 
     return _result(
         "pass",
-        f"candidate {version} has crossed review and SHA bound approval",
+        f"candidate {version} has independent review and SHA bound approval",
         {
             "source_revision": source_revision,
             "executor_family": executor_family,
             "reviewer_family": reviewer_family,
             "review_hash": review_hash,
-            "operator_approval_id": approval_id,
+            "approval_authority": authority,
+            "approval_id_hash": approval_hash,
         },
     )
 
@@ -794,6 +829,603 @@ _EVALUATORS = {
     "rollback": _rollback,
 }
 
+_RUN_INPUT_FIELDS = {
+    "authority_revision",
+    "contract_id",
+    "contract_revision",
+    "executor_capability",
+    "extra_context",
+    "model_request",
+    "notification",
+    "outcome",
+    "project",
+    "reviewer_capability",
+    "run_id",
+    "source_revision",
+}
+_MODEL_REQUEST_FIELDS = {
+    "command",
+    "control_environment",
+    "ticket_environment",
+}
+_ISSUED_TICKET_FIELDS = {
+    "model_use_id",
+    "purpose",
+    "route_id",
+    "source_revision",
+    "ticket",
+}
+_MODEL_RESPONSE_FIELDS = {
+    "model_use_id",
+    "route_id",
+    "status",
+    "verdict",
+}
+_CANDIDATE_APPROVAL_FIELDS = {
+    "approval_id_hash",
+    "authority",
+    "candidate_revision",
+    "contract_digest",
+    "review_model_use_id",
+    "run_id",
+}
+_EXPECTED_OUTCOME = (
+    "One immutable reviewed release is published and every channel and "
+    "deployment matches its source revision."
+)
+
+
+def _exact_fields(value: dict[str, Any], fields: set[str], name: str) -> None:
+    unknown = sorted(set(value) - fields)
+    missing = sorted(fields - set(value))
+    if unknown:
+        raise ReleaseInputError(f"unknown {name} field: {unknown[0]}")
+    if missing:
+        raise ReleaseInputError(f"missing {name} field: {missing[0]}")
+
+
+def parse_release_run_input(raw_input: str) -> dict[str, Any]:
+    """Parse the exact bounded input emitted by the central runner."""
+    try:
+        parsed = json.loads(raw_input)
+    except json.JSONDecodeError as error:
+        raise ReleaseInputError("AI_OPERATIONS_RUN_INPUT must be valid JSON") from error
+    value = _object(parsed, "run input")
+    _exact_fields(value, _RUN_INPUT_FIELDS, "run input")
+    if value["contract_id"] != "data-olympus-release":
+        raise ReleaseInputError("contract identifier does not match Data Olympus release")
+    if value["project"] != "data-olympus" or value["outcome"] != _EXPECTED_OUTCOME:
+        raise ReleaseInputError("run input does not match the Data Olympus release outcome")
+    if value["executor_capability"] != "deterministic-release-execution":
+        raise ReleaseInputError("executor capability does not match Data Olympus release")
+    if value["reviewer_capability"] != "high-risk-review":
+        raise ReleaseInputError("reviewer capability does not match Data Olympus release")
+    _sha40(value["authority_revision"], "authority_revision")
+    _sha40(value["source_revision"], "source_revision")
+    _hash(value["contract_revision"], "contract_revision")
+    if re.fullmatch(
+        r"[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-"
+        r"[89ab][0-9a-f]{3}-[0-9a-f]{12}",
+        _string(value["run_id"], "run_id"),
+    ) is None:
+        raise ReleaseInputError("run_id must be a UUID")
+    _extra_context(value["extra_context"])
+
+    notification = _object(value["notification"], "notification")
+    _exact_fields(
+        notification,
+        {"confirmation", "destination", "transport"},
+        "notification",
+    )
+    if notification != {
+        "transport": "telegram",
+        "destination": "data-olympus-operations",
+        "confirmation": "send_and_readback",
+    }:
+        raise ReleaseInputError("notification does not match Data Olympus operations")
+
+    model_request = _object(value["model_request"], "model_request")
+    _exact_fields(model_request, _MODEL_REQUEST_FIELDS, "model_request")
+    command = model_request["command"]
+    if (
+        type(command) is not list
+        or len(command) < 2
+        or any(type(item) is not str or not item.strip() for item in command)
+        or command[-2:] != ["models", "request"]
+        or model_request["control_environment"] != "AI_OPERATIONS_RUN_CONTROL"
+        or model_request["ticket_environment"] != "AI_OPERATIONS_MODEL_TICKET"
+    ):
+        raise ReleaseInputError("model_request does not match the runner boundary")
+    if not Path(command[0]).is_absolute():
+        raise ReleaseInputError("model request executable must be absolute")
+    return value
+
+
+def _issued_model_ticket(value: Any) -> dict[str, Any]:
+    ticket = _object(value, "model ticket")
+    _exact_fields(ticket, _ISSUED_TICKET_FIELDS, "model ticket")
+    if type(ticket["model_use_id"]) is not int or ticket["model_use_id"] < 1:
+        raise ReleaseInputError("model ticket identifier must be a positive integer")
+    if ticket["purpose"] != "review":
+        raise ReleaseInputError("release model ticket purpose must be review")
+    _string(ticket["route_id"], "model ticket route")
+    _sha40(ticket["source_revision"], "model ticket source_revision")
+    _string(ticket["ticket"], "model ticket")
+    return ticket
+
+
+def _approved_model_response(value: Any, ticket: dict[str, Any]) -> dict[str, Any]:
+    response = _object(value, "review response")
+    _exact_fields(response, _MODEL_RESPONSE_FIELDS, "review response")
+    if response["model_use_id"] != ticket["model_use_id"]:
+        raise ReleaseInputError("review response model use does not match its ticket")
+    if response["route_id"] != ticket["route_id"]:
+        raise ReleaseInputError("review response route does not match its ticket")
+    if response["status"] != "approved" or response["verdict"] != "APPROVE":
+        raise ReleaseInputError("independent review blocked the release")
+    return response
+
+
+def _candidate_approval_response(
+    value: Any,
+    run_input: dict[str, Any],
+    candidate_revision: str,
+    review_model_use_id: int,
+) -> dict[str, Any]:
+    approval = _object(value, "candidate approval")
+    _exact_fields(
+        approval,
+        _CANDIDATE_APPROVAL_FIELDS,
+        "candidate approval",
+    )
+    if approval["authority"] not in {"operator", "standing-delegation"}:
+        raise ReleaseInputError("candidate approval authority is invalid")
+    if approval["run_id"] != run_input["run_id"]:
+        raise ReleaseInputError("candidate approval run does not match")
+    if approval["contract_digest"] != run_input["contract_revision"]:
+        raise ReleaseInputError("candidate approval contract does not match")
+    if approval["candidate_revision"] != candidate_revision:
+        raise ReleaseInputError("candidate approval revision does not match")
+    if approval["review_model_use_id"] != review_model_use_id:
+        raise ReleaseInputError("candidate approval review evidence does not match")
+    _hash(approval["approval_id_hash"], "candidate approval identifier hash")
+    return approval
+
+
+def _collect_candidate_approval(
+    run_input: dict[str, Any],
+    dependencies: dict[str, Any],
+    candidate: dict[str, Any],
+    review: dict[str, Any],
+) -> dict[str, Any]:
+    candidate_revision = _sha40(
+        candidate.get("source_revision"),
+        "candidate.source_revision",
+    )
+    if "collect_candidate_approval" in dependencies:
+        response = dependencies["collect_candidate_approval"](
+            run_input,
+            candidate,
+            review,
+        )
+    else:
+        command = run_input["model_request"]["command"]
+        process = subprocess.run(
+            [
+                *command[:-2],
+                "approvals",
+                "check",
+                run_input["run_id"],
+                candidate_revision,
+                "--contract-digest",
+                run_input["contract_revision"],
+            ],
+            cwd=Path(dependencies.get("workspace", Path.cwd())).resolve(),
+            env=dict(os.environ),
+            capture_output=True,
+            text=True,
+            timeout=60,
+            check=False,
+        )
+        if process.returncode != 0:
+            raise ReleaseInputError("candidate approval check failed")
+        try:
+            response = json.loads(process.stdout.strip())
+        except json.JSONDecodeError as error:
+            raise ReleaseInputError(
+                "candidate approval check returned invalid JSON"
+            ) from error
+    return _candidate_approval_response(
+        response,
+        run_input,
+        candidate_revision,
+        review["model_use_id"],
+    )
+
+
+def _request_model_ticket_from_runner(
+    run_input: dict[str, Any],
+    source_revision: str,
+    workspace: Path,
+) -> dict[str, Any]:
+    model_request = run_input["model_request"]
+    command = model_request["command"]
+    environment = dict(os.environ)
+    environment.pop(model_request["ticket_environment"], None)
+    process = subprocess.run(
+        [
+            *command,
+            run_input["run_id"],
+            "review",
+            str(workspace),
+            source_revision,
+        ],
+        cwd=workspace,
+        env=environment,
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=False,
+    )
+    if process.returncode != 0:
+        raise ReleaseInputError("review model ticket request failed")
+    try:
+        return _issued_model_ticket(json.loads(process.stdout.strip()))
+    except json.JSONDecodeError as error:
+        raise ReleaseInputError("review model ticket request returned invalid JSON") from error
+
+
+def _invoke_ticketed_model_from_runner(
+    run_input: dict[str, Any],
+    ticket: dict[str, Any],
+    packet: dict[str, Any],
+    workspace: Path,
+) -> dict[str, Any]:
+    model_request = run_input["model_request"]
+    scratch_root = workspace / "to-delete"
+    scratch_root.mkdir(exist_ok=True)
+    scratch = Path(tempfile.mkdtemp(prefix="aiops-release-review-", dir=scratch_root))
+    try:
+        packet_path = scratch / "review.json"
+        packet_path.write_text(
+            json.dumps(packet, separators=(",", ":"), sort_keys=True),
+            encoding="utf-8",
+        )
+        packet_path.chmod(0o600)
+        command = model_request["command"]
+        environment = dict(os.environ)
+        environment[model_request["ticket_environment"]] = ticket["ticket"]
+        process = subprocess.run(
+            [
+                *command[:-1],
+                "invoke",
+                run_input["run_id"],
+                "review",
+                str(packet_path),
+                str(workspace),
+            ],
+            cwd=workspace,
+            env=environment,
+            capture_output=True,
+            text=True,
+            timeout=900,
+            check=False,
+        )
+        try:
+            response = json.loads(process.stdout.strip())
+        except json.JSONDecodeError as error:
+            raise ReleaseInputError("review model invocation returned invalid JSON") from error
+        parsed = _approved_model_response(response, ticket)
+        if process.returncode != 0:
+            raise ReleaseInputError("review model invocation failed")
+        return parsed
+    finally:
+        shutil.rmtree(scratch, ignore_errors=True)
+
+
+def _milestone(
+    sequence: int,
+    name: str,
+    reason: str,
+    evidence: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    return {
+        "type": "milestone",
+        "sequence": sequence,
+        "name": name,
+        "status": "pass",
+        "reason": reason,
+        "evidence": evidence or {},
+    }
+
+
+def _project_result(
+    sequence: int,
+    status: str,
+    reason: str,
+    run_input: dict[str, Any],
+    evidence: dict[str, Any] | None = None,
+    candidate_revision: str | None = None,
+    review_model_use_id: int | None = None,
+) -> dict[str, Any]:
+    return {
+        "type": "result",
+        "sequence": sequence,
+        "status": status,
+        "reason": reason,
+        "evidence": evidence or {},
+        "source_revision": run_input["source_revision"],
+        "candidate_revision": candidate_revision,
+        "review_model_use_id": review_model_use_id,
+    }
+
+
+def _request_review_ticket(
+    run_input: dict[str, Any],
+    dependencies: dict[str, Any],
+    source_revision: str,
+) -> dict[str, Any]:
+    workspace = Path(dependencies.get("workspace", Path.cwd())).resolve()
+    request = {
+        "purpose": "review",
+        "run_id": run_input["run_id"],
+        "source_revision": source_revision,
+        "workspace": str(workspace),
+    }
+    if "request_model_ticket" in dependencies:
+        ticket = _issued_model_ticket(dependencies["request_model_ticket"](request))
+    else:
+        ticket = _request_model_ticket_from_runner(run_input, source_revision, workspace)
+    if ticket["source_revision"] != source_revision:
+        raise ReleaseInputError("review model ticket source does not match the candidate")
+    return ticket
+
+
+def _invoke_review(
+    run_input: dict[str, Any],
+    dependencies: dict[str, Any],
+    ticket: dict[str, Any],
+    packet: dict[str, Any],
+) -> dict[str, Any]:
+    workspace = Path(dependencies.get("workspace", Path.cwd())).resolve()
+    request = {
+        "packet": packet,
+        "purpose": "review",
+        "run_input": run_input,
+        "ticket": ticket,
+        "workspace": str(workspace),
+    }
+    if "invoke_model" in dependencies:
+        response = dependencies["invoke_model"](request)
+    else:
+        response = _invoke_ticketed_model_from_runner(
+            run_input,
+            ticket,
+            packet,
+            workspace,
+        )
+    return _approved_model_response(response, ticket)
+
+
+def execute_release_run(
+    raw_input: str,
+    dependencies: dict[str, Any],
+    *,
+    emit: Callable[[dict[str, Any]], None] | None = None,
+) -> list[dict[str, Any]]:
+    """Execute one complete project-owned release outcome."""
+    run_input: dict[str, Any] | None = None
+    events: list[dict[str, Any]] = []
+    candidate_revision: str | None = None
+
+    def record(event: dict[str, Any]) -> dict[str, Any]:
+        event["sequence"] = len(events) + 1
+        events.append(event)
+        if emit is not None:
+            emit(event)
+        return event
+
+    def heartbeat() -> None:
+        record({"type": "heartbeat", "sequence": 0})
+
+    try:
+        run_input = parse_release_run_input(raw_input)
+        if "set_heartbeat" in dependencies:
+            dependencies["set_heartbeat"](heartbeat)
+        if dependencies["source_revision"]() != run_input["source_revision"]:
+            raise ReleaseInputError("source revision does not match the admitted run")
+        admission_input = dependencies["collect_admission"](run_input)
+        admission = evaluate_stage("admission", admission_input)
+        if admission["status"] in {"blocked", "failed"}:
+            record(
+                _project_result(
+                    1,
+                    admission["status"],
+                    admission["reason"],
+                    run_input,
+                    admission["evidence"],
+                )
+            )
+            return events
+        record(
+            _milestone(1, "admission", admission["reason"], admission["evidence"])
+        )
+        if admission["status"] == "no_action":
+            ticket = _request_review_ticket(
+                run_input,
+                dependencies,
+                run_input["source_revision"],
+            )
+            review = _invoke_review(
+                run_input,
+                dependencies,
+                ticket,
+                {
+                    "admission": admission,
+                    "instruction": (
+                        "Approve only when exact current remote main evidence proves "
+                        "that no Data Olympus release is due."
+                    ),
+                    "source_revision": run_input["source_revision"],
+                },
+            )
+            record(
+                _project_result(
+                    2,
+                    "no_action",
+                    admission["reason"],
+                    run_input,
+                    admission["evidence"],
+                    review_model_use_id=review["model_use_id"],
+                )
+            )
+            return events
+
+        prepared_input = dependencies["prepare"](run_input, admission)
+        prepared = evaluate_stage("prepare", prepared_input)
+        if prepared["status"] != "pass":
+            raise ReleaseInputError(prepared["reason"])
+        candidate = _object(prepared_input["candidate"], "candidate")
+        candidate_revision = _sha40(
+            candidate.get("source_revision"),
+            "candidate.source_revision",
+        )
+        record(
+            _milestone(2, "prepare", prepared["reason"], prepared["evidence"])
+        )
+
+        validation_input = dependencies["validate"](run_input, admission, prepared)
+        validation = evaluate_stage("validate", validation_input)
+        if validation["status"] != "pass":
+            raise ReleaseInputError(validation["reason"])
+        record(
+            _milestone(3, "validate", validation["reason"], validation["evidence"])
+        )
+        revision_reader = dependencies.get(
+            "candidate_revision",
+            dependencies["source_revision"],
+        )
+        if revision_reader() != candidate_revision:
+            raise ReleaseInputError("candidate revision changed during validation")
+
+        ticket = _request_review_ticket(run_input, dependencies, candidate_revision)
+        packet = {
+            "candidate": candidate,
+            "instruction": (
+                "Independently review the exact deterministic Data Olympus release "
+                "candidate. Approve only when source identity, tests, security, "
+                "version, rollback point, and immutable release procedures pass."
+            ),
+            "prepared_evidence": prepared["evidence"],
+            "source_revision": candidate_revision,
+            "validation_evidence": validation["evidence"],
+        }
+        review = _invoke_review(run_input, dependencies, ticket, packet)
+        approval = _collect_candidate_approval(
+            run_input,
+            dependencies,
+            candidate,
+            review,
+        )
+        reviewed = evaluate_stage(
+            "review",
+            {
+                "candidate": candidate,
+                "current_source_revision": candidate_revision,
+                "contract_revision": run_input["contract_revision"],
+                "run_id": run_input["run_id"],
+                "review_model_use_id": review["model_use_id"],
+                "executor": {
+                    "family": "deterministic",
+                    "source_revision": candidate_revision,
+                },
+                "companion_review": {
+                    "family": "claude",
+                    "verdict": "APPROVE",
+                    "reviewed_source_revision": candidate_revision,
+                    "evidence_hash": sha256(
+                        json.dumps(packet, separators=(",", ":"), sort_keys=True).encode()
+                    ).hexdigest(),
+                },
+                "candidate_approval": approval,
+            },
+        )
+        if reviewed["status"] != "pass":
+            raise ReleaseInputError(reviewed["reason"])
+        record(
+            _milestone(4, "domain_review", reviewed["reason"], reviewed["evidence"])
+        )
+        if revision_reader() != candidate_revision:
+            raise ReleaseInputError("candidate revision changed before delivery")
+
+        delivery_input = dependencies["deliver"](
+            run_input,
+            admission,
+            prepared,
+            reviewed,
+        )
+        delivery = evaluate_stage("deliver", delivery_input)
+        if delivery["status"] != "pass":
+            raise ReleaseInputError(delivery["reason"])
+        record(
+            _milestone(5, "deliver", delivery["reason"], delivery["evidence"])
+        )
+
+        verification_input = dependencies["verify"](run_input, admission, delivery)
+        verification = evaluate_stage("verify", verification_input)
+        if verification["status"] != "pass":
+            raise ReleaseInputError(verification["reason"])
+        record(
+            _milestone(6, "verify", verification["reason"], verification["evidence"])
+        )
+        record(
+            _project_result(
+                7,
+                "delivered",
+                verification["reason"],
+                run_input,
+                {
+                    **delivery["outputs"],
+                    **verification["evidence"],
+                    "rollback_digest": prepared["evidence"][
+                        "rollback_digest"
+                    ],
+                    "release_pr_number": prepared["outputs"][
+                        "release_pr_number"
+                    ],
+                },
+                candidate_revision=candidate_revision,
+                review_model_use_id=review["model_use_id"],
+            )
+        )
+        return events
+    except (
+        KeyError,
+        OSError,
+        ReleaseInputError,
+        ValueError,
+        subprocess.SubprocessError,
+    ) as error:
+        if run_input is None:
+            raise
+        delivered = any(event.get("name") == "deliver" for event in events)
+        record(
+            _project_result(
+                len(events) + 1,
+                "failed" if delivered else "blocked",
+                str(error),
+                run_input,
+                candidate_revision=candidate_revision,
+            )
+        )
+        return events
+
+
+def _default_dependencies() -> dict[str, Any]:
+    from scripts.operations.release_runtime import default_release_dependencies
+
+    return default_release_dependencies()
+
 
 def evaluate_stage(stage: str, input_document: Any) -> StageResult:
     """Evaluate one release lifecycle stage without trusting shortcut booleans."""
@@ -811,33 +1443,91 @@ def evaluate_stage(stage: str, input_document: Any) -> StageResult:
         return _result(status, str(error))
 
 
-def main(argv: list[str] | None = None) -> int:
+def main(
+    argv: list[str] | None = None,
+    *,
+    dependencies: dict[str, Any] | None = None,
+) -> int:
     arguments = list(sys.argv[1:] if argv is None else argv)
-    if len(arguments) != 1:
-        output = _result("failed", "exactly one release stage is required")
-        print(json.dumps(output, separators=(",", ":"), sort_keys=True))
-        return 2
-    stage = arguments[0]
-    raw_input = os.environ.get("AI_OPERATIONS_STAGE_INPUT")
-    if raw_input is None:
-        output = _result(
-            "failed",
-            "AI_OPERATIONS_STAGE_INPUT is required",
+    if arguments == ["rollback"]:
+        active_dependencies = (
+            dependencies if dependencies is not None else _default_dependencies()
         )
-        print(json.dumps(output, separators=(",", ":"), sort_keys=True))
-        return 2
-    try:
-        input_document = json.loads(raw_input)
-    except json.JSONDecodeError:
-        output = _result(
-            "failed",
-            "AI_OPERATIONS_STAGE_INPUT must be valid JSON",
+        raw_recovery = os.environ.get("AI_OPERATIONS_RECOVERY_INPUT")
+        if raw_recovery is None:
+            output = {
+                "status": "failed",
+                "reason": "AI_OPERATIONS_RECOVERY_INPUT is required",
+                "evidence": {},
+                "source_revision": "unavailable",
+            }
+            print(json.dumps(output, separators=(",", ":"), sort_keys=True))
+            return 2
+        recovery_input: Any = None
+        try:
+            recovery_input = json.loads(raw_recovery)
+            recovery = active_dependencies["rollback"](recovery_input)
+        except (
+            KeyError,
+            OSError,
+            ReleaseInputError,
+            ValueError,
+            json.JSONDecodeError,
+            subprocess.SubprocessError,
+        ) as error:
+            recovery_source = (
+                recovery_input.get("source_revision")
+                if type(recovery_input) is dict
+                else None
+            )
+            recovery = {
+                "status": "failed",
+                "reason": str(error),
+                "evidence": {},
+                "source_revision": (
+                    recovery_source
+                    if type(recovery_source) is str
+                    and re.fullmatch(r"[0-9a-f]{40}", recovery_source)
+                    else "unavailable"
+                ),
+            }
+        print(json.dumps(recovery, separators=(",", ":"), sort_keys=True))
+        return 0 if recovery.get("status") == "pass" else 1
+    if not arguments:
+        raw_run = os.environ.get("AI_OPERATIONS_RUN_INPUT")
+        if raw_run is None:
+            output = _result("failed", "AI_OPERATIONS_RUN_INPUT is required")
+            print(json.dumps(output, separators=(",", ":"), sort_keys=True))
+            return 2
+        active_dependencies = (
+            dependencies if dependencies is not None else _default_dependencies()
         )
-        print(json.dumps(output, separators=(",", ":"), sort_keys=True))
-        return 2
-    output = evaluate_stage(stage, input_document)
+        def emit_event(event: dict[str, Any]) -> None:
+            print(
+                json.dumps(event, separators=(",", ":"), sort_keys=True),
+                flush=True,
+            )
+
+        try:
+            events = execute_release_run(
+                raw_run,
+                active_dependencies,
+                emit=emit_event,
+            )
+        except ReleaseInputError as error:
+            print(
+                json.dumps(
+                    _result("failed", str(error)),
+                    separators=(",", ":"),
+                    sort_keys=True,
+                )
+            )
+            return 1
+        final = events[-1]
+        return 0 if final["status"] in {"delivered", "no_action"} else 1
+    output = _result("failed", "unsupported Data Olympus release operation")
     print(json.dumps(output, separators=(",", ":"), sort_keys=True))
-    return 0 if output["status"] in {"pass", "no_action"} else 1
+    return 2
 
 
 if __name__ == "__main__":

--- a/scripts/operations/release.py
+++ b/scripts/operations/release.py
@@ -1495,10 +1495,13 @@ def main(
                 if type(recovery_input) is dict
                 else None
             )
+            failure_evidence = getattr(error, "evidence", {})
+            if type(failure_evidence) is not dict:
+                failure_evidence = {}
             recovery = {
                 "status": "failed",
                 "reason": str(error),
-                "evidence": {},
+                "evidence": failure_evidence,
                 "source_revision": (
                     recovery_source
                     if type(recovery_source) is str

--- a/scripts/operations/release_runtime.py
+++ b/scripts/operations/release_runtime.py
@@ -59,6 +59,16 @@ CommandOutput = Callable[[list[str], Path, int], str]
 JsonFetch = Callable[[str, int], dict[str, Any]]
 
 
+class ReleaseDeliveryError(ValueError):
+    """A delivery failure after externally visible release side effects."""
+
+    external_state_changed = True
+
+    def __init__(self, reason: str, evidence: dict[str, Any]) -> None:
+        super().__init__(reason)
+        self.evidence = evidence
+
+
 def _default_command_output(command: list[str], cwd: Path, timeout: int) -> str:
     process = subprocess.run(
         command,
@@ -668,6 +678,35 @@ class ReleaseRuntime:
             return {"checks": check_evidence, "pull": pull}
         raise ValueError(last_error)
 
+    def _merge_exact(
+        self,
+        number: int,
+        version: str,
+        head_revision: str,
+    ) -> dict[str, Any]:
+        if _SHA40.fullmatch(head_revision) is None:
+            raise ValueError("release pull request head revision is invalid")
+        raw = self.command(
+            [
+                "gh",
+                "api",
+                "--method",
+                "PUT",
+                f"repos/{GITHUB_OWNER}/{GITHUB_REPOSITORY}/pulls/{number}/merge",
+                "--field",
+                "merge_method=squash",
+                "--field",
+                f"commit_title=chore(release): prepare v{version}",
+                "--field",
+                f"sha={head_revision}",
+            ],
+            timeout=120,
+        )
+        try:
+            return _object(json.loads(raw), "release merge result")
+        except json.JSONDecodeError as error:
+            raise ValueError("release merge result is invalid") from error
+
     def _wait_main_checks(self, source_revision: str) -> dict[str, Any]:
         required = ",".join(sorted(REQUIRED_MAIN_CHECKS))
         for _attempt in range(120):
@@ -874,16 +913,7 @@ class ReleaseRuntime:
         self.command(["git", "fetch", "origin", "main"], timeout=120)
         if self.candidate_revision() != admitted:
             raise ValueError("remote main changed before release merge")
-        merged = self.gateway_object(
-            "merge_pull_request",
-            {
-                "commit_title": f"chore(release): prepare v{version}",
-                "merge_method": "squash",
-                "owner": GITHUB_OWNER,
-                "pullNumber": number,
-                "repo": GITHUB_REPOSITORY,
-            },
-        )
+        merged = self._merge_exact(number, version, head_revision)
         final_revision = merged.get("sha")
         if merged.get("merged") is not True or not isinstance(final_revision, str):
             raise ValueError("release pull request did not merge")
@@ -1275,7 +1305,10 @@ class ReleaseRuntime:
         candidate_tag = f"{version}-rc.{rc_number}"
         rollback_digest = self._prepared["raw"]["rollback_point"]["digest"]
         deployment_started = False
+        external_state_changed = False
+        rollback_completed = False
         try:
+            external_state_changed = True
             rc_receipt = self._workflow_run(
                 "rc-publish.yml",
                 source_revision,
@@ -1311,11 +1344,26 @@ class ReleaseRuntime:
                 try:
                     self._apply_digest(rollback_digest)
                     self._service_acceptance()
+                    rollback_completed = True
                 except (OSError, subprocess.SubprocessError, ValueError) as rollback_error:
-                    raise ValueError(
-                        "release delivery failed and exact digest rollback also failed"
+                    raise ReleaseDeliveryError(
+                        "release delivery failed and exact digest rollback also failed",
+                        {
+                            "deployment_started": True,
+                            "external_state_changed": True,
+                            "rollback_completed": False,
+                        },
                     ) from rollback_error
-            raise error
+            if external_state_changed:
+                raise ReleaseDeliveryError(
+                    str(error),
+                    {
+                        "deployment_started": deployment_started,
+                        "external_state_changed": True,
+                        "rollback_completed": rollback_completed,
+                    },
+                ) from error
+            raise
         final_candidate = {
             **candidate,
             "candidate_tag": candidate_tag,

--- a/scripts/operations/release_runtime.py
+++ b/scripts/operations/release_runtime.py
@@ -1,0 +1,1473 @@
+"""Live evidence and mutation boundaries for the Data Olympus release routine."""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+import re
+import shutil
+import subprocess
+import time
+import urllib.error
+import urllib.request
+from collections.abc import Callable
+from copy import deepcopy
+from hashlib import sha256
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import yaml
+
+from scripts.ci_status import evaluate as evaluate_ci_status
+from scripts.compute_release import next_rc_number
+
+if TYPE_CHECKING:
+    from datetime import date
+
+GATEWAY_URL = "http://fastmcp-gateway.mcp-gateway.apps.172.30.1.2.nip.io/mcp"
+DATA_OLYMPUS_URL = (
+    "http://data-olympus-mcp.data-olympus.apps.172.30.1.2.nip.io"
+)
+IMAGE_REPOSITORY = "ghcr.io/knaisoma/data-olympus"
+GITHUB_OWNER = "knaisoma"
+GITHUB_REPOSITORY = "data-olympus"
+
+REQUIRED_PULL_REQUEST_CHECKS = {
+    "Analyze (actions)",
+    "Analyze (javascript-typescript)",
+    "Analyze (python)",
+    "CodeQL",
+    "changelog-guard",
+    "doc-consistency-guard",
+    "lint-title",
+    "test",
+    "version-free-guard",
+}
+REQUIRED_MAIN_CHECKS = {
+    "Analyze (actions)",
+    "Analyze (javascript-typescript)",
+    "Analyze (python)",
+    "CodeQL",
+    "doc-consistency-guard",
+    "test",
+}
+
+_SHA40 = re.compile(r"^[0-9a-f]{40}$")
+_DIGEST = re.compile(r"^sha256:[0-9a-f]{64}$")
+
+CommandOutput = Callable[[list[str], Path, int], str]
+JsonFetch = Callable[[str, int], dict[str, Any]]
+
+
+def _default_command_output(command: list[str], cwd: Path, timeout: int) -> str:
+    process = subprocess.run(
+        command,
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+    if process.returncode != 0:
+        raise ValueError(f"command failed: {command[0]}")
+    return process.stdout.strip()
+
+
+def _default_json_fetch(url: str, timeout: int) -> dict[str, Any]:
+    request = urllib.request.Request(
+        url,
+        headers={"Accept": "application/json", "User-Agent": "data-olympus-release"},
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            payload = json.load(response)
+    except (OSError, urllib.error.URLError, json.JSONDecodeError) as error:
+        raise ValueError("public release evidence is unavailable") from error
+    return _object(payload, "public release evidence")
+
+
+def _object(value: Any, name: str) -> dict[str, Any]:
+    if type(value) is not dict:
+        raise ValueError(f"{name} must be an object")
+    return value
+
+
+def _parse_nested_json(value: Any) -> Any:
+    current = value
+    for _ in range(4):
+        if type(current) is not str:
+            break
+        try:
+            current = json.loads(current)
+        except json.JSONDecodeError:
+            break
+    return current
+
+
+class FastMCPGateway:
+    """Call external systems through the local FastMCP gateway."""
+
+    def __init__(
+        self,
+        gateway_url: str = GATEWAY_URL,
+        *,
+        run_command: CommandOutput = _default_command_output,
+    ) -> None:
+        if not gateway_url.startswith(("http://", "https://")):
+            raise ValueError("FastMCP gateway URL is invalid")
+        self.gateway_url = gateway_url
+        self.run_command = run_command
+
+    def execute(self, name: str, arguments: dict[str, object]) -> Any:
+        command = [
+            "fastmcp",
+            "call",
+            "--server-spec",
+            self.gateway_url,
+            "--target",
+            "execute_tool",
+            "--input-json",
+            json.dumps(
+                {"arguments": arguments, "tool_name": name},
+                separators=(",", ":"),
+                sort_keys=True,
+            ),
+            "--json",
+            "--timeout",
+            "30",
+            "--auth",
+            "none",
+        ]
+        raw = self.run_command(command, Path.cwd(), 40)
+        try:
+            envelope = _object(json.loads(raw), "FastMCP response")
+        except json.JSONDecodeError as error:
+            raise ValueError("FastMCP returned invalid JSON") from error
+        if envelope.get("is_error") is True:
+            raise ValueError("FastMCP returned an error result")
+        structured = _object(
+            envelope.get("structured_content"),
+            "FastMCP structured content",
+        )
+        if "result" not in structured:
+            raise ValueError("FastMCP structured content omitted result")
+        result = _parse_nested_json(structured["result"])
+        if type(result) is dict and set(result) >= {"tool", "result"}:
+            result = _parse_nested_json(result["result"])
+        return result
+
+
+def _sha256_text(value: str) -> str:
+    return sha256(value.encode("utf-8")).hexdigest()
+
+
+def _release_sections(changes: dict[str, Any]) -> list[tuple[str, list[str]]]:
+    sections: list[tuple[str, list[str]]] = []
+    for key, title in (
+        ("breaking", "Breaking changes"),
+        ("features", "New features"),
+        ("fixes", "Fixed"),
+    ):
+        raw_items = changes.get(key)
+        if type(raw_items) is not list or any(type(item) is not str for item in raw_items):
+            raise ValueError(f"release changes.{key} must be an array of strings")
+        items = [item.strip() for item in raw_items if item.strip()]
+        if items:
+            sections.append((title, items))
+    if not sections:
+        raise ValueError("release changes must contain at least one item")
+    return sections
+
+
+def render_release_documents(
+    repository_root: Path,
+    version: str,
+    changes: dict[str, Any],
+    release_date: date,
+) -> dict[str, str]:
+    """Render the one deterministic release commit from computed changes."""
+    if re.fullmatch(r"[0-9]+\.[0-9]+\.[0-9]+", version) is None:
+        raise ValueError("release version must be X.Y.Z")
+    sections = _release_sections(changes)
+    pyproject_path = repository_root / "pyproject.toml"
+    pyproject = pyproject_path.read_text(encoding="utf-8")
+    updated_project, replacements = re.subn(
+        r'(?m)^(version = ")[^"]+("\s*)$',
+        rf"\g<1>{version}\g<2>",
+        pyproject,
+        count=1,
+    )
+    if replacements != 1:
+        raise ValueError("pyproject.toml must contain one project version")
+    pyproject_path.write_text(updated_project, encoding="utf-8")
+
+    changelog_path = repository_root / "CHANGELOG.md"
+    changelog = changelog_path.read_text(encoding="utf-8")
+    marker = "## [Unreleased]"
+    if changelog.count(marker) != 1:
+        raise ValueError("CHANGELOG.md must contain one Unreleased section")
+    changelog_sections = "\n".join(
+        f"### {title}\n\n" + "\n".join(f"* {item}" for item in items)
+        for title, items in sections
+    )
+    replacement = (
+        f"{marker}\n\n## [{version}] - {release_date.isoformat()}\n\n"
+        f"{changelog_sections}\n"
+    )
+    updated_changelog = changelog.replace(marker, replacement, 1)
+    changelog_path.write_text(updated_changelog, encoding="utf-8")
+
+    note_sections = "\n\n".join(
+        f"## {title}\n\n" + "\n".join(f"* {item}" for item in items)
+        for title, items in sections
+    )
+    release_note = f"# data-olympus {version}\n\n{note_sections}\n"
+    note_path = repository_root / "docs" / "releases" / f"v{version}.md"
+    if note_path.exists():
+        raise ValueError(f"release note already exists for {version}")
+    note_path.parent.mkdir(parents=True, exist_ok=True)
+    note_path.write_text(release_note, encoding="utf-8")
+    note_hash = _sha256_text(release_note)
+    return {
+        "changelog_hash": _sha256_text(updated_changelog),
+        "content_hash": note_hash,
+        "release_note_hash": note_hash,
+    }
+
+
+def completed_check_evidence(
+    payload: dict[str, Any],
+    *,
+    required: set[str],
+) -> dict[str, Any]:
+    """Require an exact complete GitHub check set, allowing optional skips."""
+    check_runs = payload.get("check_runs")
+    if type(check_runs) is not list or any(type(item) is not dict for item in check_runs):
+        raise ValueError("GitHub check runs response is invalid")
+    evidence = evaluate_ci_status(check_runs, sorted(required))
+    if not evidence["all_success"]:
+        raise ValueError("GitHub check runs did not succeed")
+    return evidence
+
+
+def _asset_names(release: dict[str, Any]) -> set[str]:
+    assets = release.get("assets")
+    if type(assets) is not list:
+        raise ValueError("GitHub release assets are unavailable")
+    names: set[str] = set()
+    for raw_asset in assets:
+        asset = _object(raw_asset, "GitHub release asset")
+        name = asset.get("name")
+        if type(name) is not str or not name:
+            raise ValueError("GitHub release asset name is unavailable")
+        names.add(name)
+    return names
+
+
+def candidate_release_evidence(
+    release: dict[str, Any],
+    provenance: dict[str, Any],
+    *,
+    source_revision: str,
+    version: str,
+    candidate_tag: str,
+    registry_digest: str,
+) -> dict[str, Any]:
+    """Bind the complete public candidate transaction to one source and digest."""
+    if type(source_revision) is not str or _SHA40.fullmatch(source_revision) is None:
+        raise ValueError("candidate source revision is invalid")
+    if type(registry_digest) is not str or _DIGEST.fullmatch(registry_digest) is None:
+        raise ValueError("candidate registry digest is invalid")
+    if (
+        release.get("tag_name") != candidate_tag
+        or release.get("target_commitish") != source_revision
+        or release.get("draft") is not False
+        or release.get("prerelease") is not True
+    ):
+        raise ValueError("GitHub candidate release identity does not match")
+    candidate = _object(provenance.get("candidate"), "candidate provenance")
+    expected_python_version = version + "rc" + candidate_tag.rsplit(".", 1)[-1]
+    if (
+        provenance.get("source_sha") != source_revision
+        or provenance.get("candidate_tag") != candidate_tag
+        or provenance.get("image_digest") != registry_digest
+        or candidate.get("source_sha") != source_revision
+        or candidate.get("version") != expected_python_version
+    ):
+        raise ValueError("candidate provenance identity does not match")
+    wheel = candidate.get("wheel")
+    sdist = candidate.get("sdist")
+    if type(wheel) is not str or type(sdist) is not str:
+        raise ValueError("candidate provenance artifact names are unavailable")
+    required_assets = {wheel, sdist, "release-provenance.json"}
+    if not required_assets.issubset(_asset_names(release)):
+        raise ValueError("GitHub candidate release is incomplete")
+    return {
+        "candidate_tag": candidate_tag,
+        "image_digest": registry_digest,
+        "pypi_version": expected_python_version,
+        "source_revision": source_revision,
+    }
+
+
+def stable_release_evidence(
+    release: dict[str, Any],
+    provenance: dict[str, Any],
+    pypi: dict[str, Any],
+    *,
+    source_revision: str,
+    version: str,
+) -> dict[str, Any]:
+    """Bind stable GitHub and PyPI artifacts to the reviewed source."""
+    if type(source_revision) is not str or _SHA40.fullmatch(source_revision) is None:
+        raise ValueError("stable source revision is invalid")
+    if (
+        release.get("tag_name") != f"v{version}"
+        or release.get("target_commitish") != source_revision
+        or release.get("draft") is not False
+        or release.get("prerelease") is not False
+        or provenance.get("source_sha") != source_revision
+    ):
+        raise ValueError("stable GitHub release identity does not match")
+    stable = _object(provenance.get("stable"), "stable provenance")
+    if stable.get("source_sha") != source_revision or stable.get("version") != version:
+        raise ValueError("stable provenance identity does not match")
+    wheel = stable.get("wheel")
+    sdist = stable.get("sdist")
+    if type(wheel) is not str or type(sdist) is not str:
+        raise ValueError("stable provenance artifact names are unavailable")
+    required_assets = {wheel, sdist, "release-provenance.json"}
+    if not required_assets.issubset(_asset_names(release)):
+        raise ValueError("stable GitHub release is incomplete")
+    info = _object(pypi.get("info"), "PyPI info")
+    urls = pypi.get("urls")
+    if info.get("version") != version or type(urls) is not list:
+        raise ValueError("stable PyPI release identity does not match")
+    remote: dict[str, str] = {}
+    for raw_url in urls:
+        item = _object(raw_url, "PyPI artifact")
+        filename = item.get("filename")
+        digests = _object(item.get("digests"), "PyPI artifact digests")
+        digest = digests.get("sha256")
+        if type(filename) is str and type(digest) is str:
+            remote[filename] = digest
+    for name, field in ((wheel, "wheel_sha256"), (sdist, "sdist_sha256")):
+        expected_hash = stable.get(field)
+        if (
+            type(expected_hash) is not str
+            or re.fullmatch(r"[0-9a-f]{64}", expected_hash) is None
+            or remote.get(name) != expected_hash
+        ):
+            raise ValueError("stable PyPI artifact hash does not match provenance")
+    return {
+        "pypi_version": version,
+        "source_revision": source_revision,
+    }
+
+
+def _yaml_object(value: Any, name: str) -> dict[str, Any]:
+    if type(value) is str:
+        try:
+            value = yaml.safe_load(value)
+        except yaml.YAMLError as error:
+            raise ValueError(f"{name} is invalid YAML") from error
+    return _object(value, name)
+
+
+def deployment_state(value: Any) -> dict[str, Any]:
+    """Extract exact digest and rollout facts from the live StatefulSet."""
+    manifest = _yaml_object(value, "StatefulSet")
+    if manifest.get("apiVersion") != "apps/v1" or manifest.get("kind") != "StatefulSet":
+        raise ValueError("live deployment is not the Data Olympus StatefulSet")
+    metadata = _object(manifest.get("metadata"), "StatefulSet metadata")
+    if (
+        metadata.get("name") != "data-olympus-mcp"
+        or metadata.get("namespace") != "data-olympus"
+    ):
+        raise ValueError("live deployment identity does not match Data Olympus")
+    annotations = _object(metadata.get("annotations"), "StatefulSet annotations")
+    if annotations.get("keel.sh/policy") != "never":
+        raise ValueError("Data Olympus Keel policy must be never")
+    spec = _object(manifest.get("spec"), "StatefulSet spec")
+    pod_spec = _object(
+        _object(_object(spec.get("template"), "pod template").get("spec"), "pod spec"),
+        "pod spec",
+    )
+    images: dict[str, str] = {}
+    for collection_name in ("initContainers", "containers"):
+        collection = pod_spec.get(collection_name)
+        if type(collection) is not list:
+            raise ValueError(f"{collection_name} must be an array")
+        for raw_container in collection:
+            container = _object(raw_container, "container")
+            name = container.get("name")
+            if name in {"prepare-git", "data-olympus-mcp"}:
+                image = container.get("image")
+                if type(image) is not str or "@" not in image:
+                    raise ValueError(f"{name} image must be digest pinned")
+                repository, digest = image.rsplit("@", 1)
+                if repository != IMAGE_REPOSITORY or _DIGEST.fullmatch(digest) is None:
+                    raise ValueError(f"{name} image is invalid")
+                images[name] = digest
+    if set(images) != {"prepare-git", "data-olympus-mcp"}:
+        raise ValueError("both Data Olympus containers must be present")
+    if len(set(images.values())) != 1:
+        raise ValueError("both Data Olympus containers must use the same exact digest")
+    status = _object(manifest.get("status", {}), "StatefulSet status")
+    desired = spec.get("replicas", 1)
+    rollout_complete = (
+        type(desired) is int
+        and desired > 0
+        and status.get("readyReplicas") == desired
+        and status.get("updatedReplicas") == desired
+        and status.get("replicas") == desired
+        and (
+            status.get("currentRevision") is None
+            or status.get("currentRevision") == status.get("updateRevision")
+        )
+    )
+    return {
+        "digest": next(iter(images.values())),
+        "keel_policy": "never",
+        "rollout_complete": rollout_complete,
+    }
+
+
+def deployment_manifest_for_digest(
+    live: dict[str, Any],
+    digest: str,
+) -> dict[str, Any]:
+    """Build an apply-safe StatefulSet document with both images pinned."""
+    if type(digest) is not str or _DIGEST.fullmatch(digest) is None:
+        raise ValueError("deployment digest must be an OCI SHA256 digest")
+    manifest = deepcopy(_object(live, "StatefulSet"))
+    if manifest.get("apiVersion") != "apps/v1" or manifest.get("kind") != "StatefulSet":
+        raise ValueError("live deployment is not the Data Olympus StatefulSet")
+    metadata = _object(manifest.get("metadata"), "StatefulSet metadata")
+    if (
+        metadata.get("name") != "data-olympus-mcp"
+        or metadata.get("namespace") != "data-olympus"
+    ):
+        raise ValueError("live deployment identity does not match Data Olympus")
+    for field in (
+        "creationTimestamp",
+        "generation",
+        "managedFields",
+        "resourceVersion",
+        "selfLink",
+        "uid",
+    ):
+        metadata.pop(field, None)
+    annotations = _object(metadata.setdefault("annotations", {}), "annotations")
+    annotations["keel.sh/policy"] = "never"
+    manifest.pop("status", None)
+
+    spec = _object(manifest.get("spec"), "StatefulSet spec")
+    volume_claims = spec.get("volumeClaimTemplates", [])
+    if type(volume_claims) is not list:
+        raise ValueError("volumeClaimTemplates must be an array")
+    for raw_claim in volume_claims:
+        _object(raw_claim, "volume claim template").pop("status", None)
+
+    pod_spec = _object(
+        _object(spec.get("template"), "pod template").get("spec"),
+        "pod spec",
+    )
+    expected_image = f"{IMAGE_REPOSITORY}@{digest}"
+    matched = set()
+    for collection_name, expected_name in (
+        ("initContainers", "prepare-git"),
+        ("containers", "data-olympus-mcp"),
+    ):
+        collection = pod_spec.get(collection_name)
+        if type(collection) is not list:
+            raise ValueError(f"{collection_name} must be an array")
+        for raw_container in collection:
+            container = _object(raw_container, "container")
+            if container.get("name") == expected_name:
+                container["image"] = expected_image
+                matched.add(expected_name)
+    if matched != {"prepare-git", "data-olympus-mcp"}:
+        raise ValueError("both Data Olympus containers must be present")
+    return manifest
+
+
+class ReleaseRuntime:
+    """Collect live release evidence from the admitted managed worktree."""
+
+    def __init__(
+        self,
+        repository_root: Path,
+        *,
+        gateway: FastMCPGateway,
+        command_output: CommandOutput = _default_command_output,
+        fetch_json: JsonFetch = _default_json_fetch,
+        sleep: Callable[[float], None] = time.sleep,
+        today: Callable[[], dt.date] = dt.date.today,
+    ) -> None:
+        self.repository_root = repository_root.resolve()
+        self.gateway = gateway
+        self.command_output = command_output
+        self.fetch_json = fetch_json
+        self.sleep = sleep
+        self.today = today
+        self._heartbeat: Callable[[], None] = lambda: None
+        self._prepared: dict[str, Any] | None = None
+        self._delivery: dict[str, Any] | None = None
+
+    def set_heartbeat(self, heartbeat: Callable[[], None]) -> None:
+        self._heartbeat = heartbeat
+
+    def heartbeat(self) -> None:
+        self._heartbeat()
+
+    def command(self, arguments: list[str], timeout: int = 60) -> str:
+        self.heartbeat()
+        if self.command_output is not _default_command_output:
+            result = self.command_output(arguments, self.repository_root, timeout)
+            self.heartbeat()
+            return result.strip()
+        process = subprocess.Popen(
+            arguments,
+            cwd=self.repository_root,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        started = time.monotonic()
+        while True:
+            remaining = timeout - (time.monotonic() - started)
+            if remaining <= 0:
+                process.kill()
+                process.communicate()
+                raise subprocess.TimeoutExpired(arguments, timeout)
+            try:
+                stdout, _stderr = process.communicate(timeout=min(20.0, remaining))
+                break
+            except subprocess.TimeoutExpired:
+                self.heartbeat()
+        self.heartbeat()
+        if process.returncode != 0:
+            raise ValueError(f"command failed: {arguments[0]}")
+        return stdout.strip()
+
+    def gateway_object(self, name: str, arguments: dict[str, object]) -> dict[str, Any]:
+        self.heartbeat()
+        result = self.gateway.execute(name, arguments)
+        self.heartbeat()
+        return _object(result, f"{name} response")
+
+    def live_statefulset(self) -> dict[str, Any]:
+        self.heartbeat()
+        result = self.gateway.execute(
+            "k8s_kndev_resources_get",
+            {
+                "apiVersion": "apps/v1",
+                "kind": "StatefulSet",
+                "name": "data-olympus-mcp",
+                "namespace": "data-olympus",
+            },
+        )
+        self.heartbeat()
+        return _yaml_object(result, "live Data Olympus StatefulSet")
+
+    def source_revision(self) -> str:
+        revision = self.command(["git", "rev-parse", "HEAD"])
+        if _SHA40.fullmatch(revision) is None:
+            raise ValueError("managed worktree source revision is invalid")
+        return revision
+
+    def candidate_revision(self) -> str:
+        revision = self.command(["git", "rev-parse", "origin/main"])
+        if _SHA40.fullmatch(revision) is None:
+            raise ValueError("remote main revision is invalid")
+        return revision
+
+    def collect_admission(self, run_input: dict[str, Any]) -> dict[str, Any]:
+        admitted = run_input.get("source_revision")
+        if type(admitted) is not str or _SHA40.fullmatch(admitted) is None:
+            raise ValueError("admitted source revision is invalid")
+        self.command(["git", "fetch", "--tags", "origin", "main"], timeout=120)
+        if self.source_revision() != admitted:
+            raise ValueError("managed worktree changed after admission")
+        remote_main = self.candidate_revision()
+        if remote_main != admitted:
+            raise ValueError("remote main changed after admission")
+        raw_computation = self.command(
+            [
+                "uv",
+                "run",
+                "--python",
+                "3.13",
+                "python",
+                "scripts/compute_release.py",
+            ],
+            timeout=120,
+        )
+        try:
+            computation = _object(
+                json.loads(raw_computation),
+                "release computation",
+            )
+        except json.JSONDecodeError as error:
+            raise ValueError("release computation returned invalid JSON") from error
+        return {
+            "branch": "main",
+            "source_revision": admitted,
+            "remote_main_revision": remote_main,
+            "computed_release": computation,
+        }
+
+    def _wait_pull_request(self, number: int, head_revision: str) -> dict[str, Any]:
+        last_error = "pull request checks did not appear"
+        for _attempt in range(120):
+            checks = self.gateway_object(
+                "pull_request_read",
+                {
+                    "method": "get_check_runs",
+                    "owner": GITHUB_OWNER,
+                    "repo": GITHUB_REPOSITORY,
+                    "pullNumber": number,
+                },
+            )
+            try:
+                check_evidence = completed_check_evidence(
+                    checks,
+                    required=REQUIRED_PULL_REQUEST_CHECKS,
+                )
+            except ValueError as error:
+                last_error = str(error)
+                runs = checks.get("check_runs")
+                if type(runs) is list and any(
+                    type(run) is dict
+                    and run.get("status") == "completed"
+                    and run.get("conclusion") not in {"success", "skipped"}
+                    for run in runs
+                ):
+                    raise
+                self.sleep(10)
+                self.heartbeat()
+                continue
+            pull = self.gateway_object(
+                "pull_request_read",
+                {
+                    "method": "get",
+                    "owner": GITHUB_OWNER,
+                    "repo": GITHUB_REPOSITORY,
+                    "pullNumber": number,
+                },
+            )
+            head = _object(pull.get("head"), "pull request head")
+            if (
+                head.get("sha") != head_revision
+                or pull.get("draft") is not False
+                or pull.get("state") != "open"
+                or pull.get("mergeable_state") not in {"clean", "unstable"}
+            ):
+                raise ValueError("release pull request identity or merge state changed")
+            return {"checks": check_evidence, "pull": pull}
+        raise ValueError(last_error)
+
+    def _wait_main_checks(self, source_revision: str) -> dict[str, Any]:
+        required = ",".join(sorted(REQUIRED_MAIN_CHECKS))
+        for _attempt in range(120):
+            try:
+                raw = self.command(
+                    [
+                        "uv",
+                        "run",
+                        "--python",
+                        "3.13",
+                        "python",
+                        "scripts/ci_status.py",
+                        "--sha",
+                        source_revision,
+                        "--required",
+                        required,
+                        "--json",
+                    ],
+                    timeout=60,
+                )
+                evidence = _object(json.loads(raw), "main CI evidence")
+                if evidence.get("sha") != source_revision:
+                    raise ValueError("main CI evidence source changed")
+                return evidence
+            except (ValueError, json.JSONDecodeError):
+                self.sleep(10)
+                self.heartbeat()
+        raise ValueError("exact main CI did not become green")
+
+    def _final_local_gates(self, source_revision: str, version: str) -> dict[str, Any]:
+        scratch = self.repository_root / "to-delete" / "aiops-release-build"
+        shutil.rmtree(scratch, ignore_errors=True)
+        scratch.mkdir(parents=True, exist_ok=True)
+        outputs: list[str] = []
+        commands = [
+            ["uv", "run", "--python", "3.13", "ruff", "check", "."],
+            ["uv", "run", "--python", "3.13", "mypy", "src"],
+            [
+                "uv",
+                "run",
+                "--python",
+                "3.13",
+                "python",
+                "scripts/check_benchmark_docs.py",
+            ],
+            ["uv", "run", "--python", "3.13", "pytest", "-q"],
+            ["bats", "-r", "tests"],
+            ["uv", "run", "--python", "3.13", "data-olympus", "lint", "example-bundle"],
+            [
+                "uv",
+                "run",
+                "--python",
+                "3.13",
+                "python",
+                "scripts/check_doc_consistency.py",
+            ],
+            ["uv", "build", "--out-dir", str(scratch)],
+        ]
+        try:
+            for command in commands:
+                outputs.append(self.command(command, timeout=900))
+            artifacts = sorted([*scratch.glob("*.whl"), *scratch.glob("*.tar.gz")])
+            if len(artifacts) != 2:
+                raise ValueError("release build did not create one wheel and one sdist")
+            for artifact in artifacts:
+                outputs.append(
+                    self.command(
+                        [
+                            "uv",
+                            "run",
+                            "--python",
+                            "3.13",
+                            "python",
+                            "scripts/smoke_installed_wheel.py",
+                            "--artifact",
+                            str(artifact),
+                            "--expected-version",
+                            version,
+                        ],
+                        timeout=300,
+                    )
+                )
+            security_report = self.command(
+                [
+                    "uv",
+                    "run",
+                    "--python",
+                    "3.13",
+                    "python",
+                    "scripts/security_alerts.py",
+                ],
+                timeout=120,
+            )
+            outputs.append(security_report)
+            version_report = self.command(
+                [
+                    "uv",
+                    "run",
+                    "--python",
+                    "3.13",
+                    "python",
+                    "scripts/check_version_free.py",
+                    "--version",
+                    version,
+                ],
+                timeout=120,
+            )
+            outputs.append(version_report)
+            ci = self._wait_main_checks(source_revision)
+            evidence_hash = sha256(
+                "\n".join(outputs).encode("utf-8")
+                + json.dumps(ci, sort_keys=True).encode("utf-8")
+            ).hexdigest()
+            return {
+                "ci": ci,
+                "security": {
+                    "exit_code": 0,
+                    "report_hash": _sha256_text(security_report),
+                    "route": "direct-gh-gateway-security-tools-unavailable",
+                },
+                "tests": {
+                    "source_revision": source_revision,
+                    "passed": True,
+                    "evidence_hash": evidence_hash,
+                },
+                "version_free": {"version": version, "free": True},
+            }
+        finally:
+            shutil.rmtree(scratch, ignore_errors=True)
+
+    def prepare(
+        self,
+        run_input: dict[str, Any],
+        admission: dict[str, Any],
+    ) -> dict[str, Any]:
+        admitted = run_input["source_revision"]
+        candidate = _object(
+            _object(admission.get("outputs"), "admission outputs").get("candidate"),
+            "admitted candidate",
+        )
+        version = candidate.get("version")
+        if type(version) is not str:
+            raise ValueError("admitted candidate version is unavailable")
+        computed = _object(
+            _object(admission.get("evidence"), "admission evidence").get(
+                "computed_release"
+            ),
+            "computed release",
+        )
+        changes = _object(computed.get("changes"), "computed release changes")
+        if self.command(["git", "status", "--porcelain"]):
+            raise ValueError("managed release worktree is not clean")
+        run_suffix = str(run_input["run_id"]).split("-", 1)[0]
+        branch = f"chore/release-v{version}-{run_suffix}"
+        self.command(["git", "switch", "-c", branch, admitted])
+        document_evidence = render_release_documents(
+            self.repository_root,
+            version,
+            changes,
+            self.today(),
+        )
+        self.command(["uv", "lock"], timeout=300)
+        release_note = f"docs/releases/v{version}.md"
+        self.command(
+            [
+                "git",
+                "add",
+                "pyproject.toml",
+                "uv.lock",
+                "CHANGELOG.md",
+                release_note,
+            ]
+        )
+        self.command(["git", "diff", "--cached", "--check"])
+        self.command(["git", "commit", "-m", f"chore(release): prepare v{version}"])
+        head_revision = self.source_revision()
+        self.command(["git", "push", "origin", f"HEAD:refs/heads/{branch}"], timeout=180)
+        pull = self.gateway_object(
+            "create_pull_request",
+            {
+                "base": "main",
+                "body": (
+                    "## Outcome\n\n"
+                    f"Prepare immutable Data Olympus release v{version} from "
+                    f"exact source `{admitted}`.\n\n"
+                    "## Verification\n\n"
+                    "All repository checks must pass before the deterministic "
+                    "release commit is merged. Publication remains blocked until "
+                    "the resulting exact main SHA receives independent review and "
+                    "SHA bound standing approval."
+                ),
+                "draft": False,
+                "head": branch,
+                "maintainer_can_modify": False,
+                "owner": GITHUB_OWNER,
+                "repo": GITHUB_REPOSITORY,
+                "title": f"chore(release): prepare v{version}",
+            },
+        )
+        number = pull.get("number")
+        if type(number) is not int or number <= 0:
+            raise ValueError("release pull request number is invalid")
+        ready = self._wait_pull_request(number, head_revision)
+        self.command(["git", "fetch", "origin", "main"], timeout=120)
+        if self.candidate_revision() != admitted:
+            raise ValueError("remote main changed before release merge")
+        merged = self.gateway_object(
+            "merge_pull_request",
+            {
+                "commit_title": f"chore(release): prepare v{version}",
+                "merge_method": "squash",
+                "owner": GITHUB_OWNER,
+                "pullNumber": number,
+                "repo": GITHUB_REPOSITORY,
+            },
+        )
+        final_revision = merged.get("sha")
+        if merged.get("merged") is not True or not isinstance(final_revision, str):
+            raise ValueError("release pull request did not merge")
+        if _SHA40.fullmatch(final_revision) is None:
+            raise ValueError("release merge returned an invalid source revision")
+        self.command(["git", "fetch", "origin", "main"], timeout=120)
+        if self.candidate_revision() != final_revision:
+            raise ValueError("release merge SHA does not match remote main")
+        self.command(["git", "switch", "--detach", final_revision])
+        if self.command(["git", "rev-parse", f"{final_revision}^"]) != admitted:
+            raise ValueError("release squash merge parent does not match admission")
+        if self.command(["git", "status", "--porcelain"]):
+            raise ValueError("release candidate worktree is not clean")
+        gates = self._final_local_gates(final_revision, version)
+        live = self.live_statefulset()
+        rollback = deployment_state(live)
+        if not rollback["rollout_complete"]:
+            raise ValueError("current Data Olympus rollback point is not ready")
+        final_candidate = {
+            "version": version,
+            "source_revision": final_revision,
+        }
+        raw = {
+            "candidate": final_candidate,
+            "extra_context": run_input["extra_context"],
+            "changelog": {
+                "source_revision": final_revision,
+                "content_hash": document_evidence["changelog_hash"],
+            },
+            "security": gates["security"],
+            "tests": gates["tests"],
+            "rollback_point": {
+                "digest": rollback["digest"],
+                "image": f"{IMAGE_REPOSITORY}@{rollback['digest']}",
+                "keel_policy": "never",
+            },
+            "release_pr": {
+                "number": number,
+                "url": f"https://github.com/{GITHUB_OWNER}/{GITHUB_REPOSITORY}/pull/{number}",
+                "merged": True,
+                "base_source_revision": admitted,
+                "head_revision": head_revision,
+                "source_revision": final_revision,
+                "candidate_version": version,
+            },
+        }
+        self._prepared = {
+            "raw": raw,
+            "gates": gates,
+            "document_evidence": document_evidence,
+            "pull_checks": ready["checks"],
+        }
+        return raw
+
+    def validate(
+        self,
+        _run_input: dict[str, Any],
+        _admission: dict[str, Any],
+        _prepared: dict[str, Any],
+    ) -> dict[str, Any]:
+        if self._prepared is None:
+            raise ValueError("release preparation evidence is unavailable")
+        candidate = _object(self._prepared["raw"]["candidate"], "candidate")
+        source_revision = candidate["source_revision"]
+        if (
+            self.candidate_revision() != source_revision
+            or self.source_revision() != source_revision
+        ):
+            raise ValueError("release candidate changed before validation")
+        gates = self._prepared["gates"]
+        return {
+            "candidate": candidate,
+            "current_source_revision": source_revision,
+            "ci": {
+                "source_revision": source_revision,
+                "all_success": gates["ci"]["all_success"],
+                "missing_required": gates["ci"]["missing_required"],
+            },
+            "security": {"exit_code": gates["security"]["exit_code"]},
+            "version_free": gates["version_free"],
+            "tests": gates["tests"],
+        }
+
+    def _workflow_run(
+        self,
+        workflow_id: str,
+        source_revision: str,
+        inputs: dict[str, object],
+    ) -> dict[str, Any]:
+        listed = self.gateway_object(
+            "actions_list",
+            {
+                "method": "list_workflow_runs",
+                "owner": GITHUB_OWNER,
+                "per_page": 100,
+                "repo": GITHUB_REPOSITORY,
+                "resource_id": workflow_id,
+                "workflow_runs_filter": {"event": "workflow_dispatch"},
+            },
+        )
+        existing_runs = listed.get("workflow_runs")
+        if type(existing_runs) is not list:
+            raise ValueError("existing workflow runs are unavailable")
+        existing_ids = {
+            run.get("id")
+            for run in existing_runs
+            if type(run) is dict and type(run.get("id")) is int
+        }
+        self.heartbeat()
+        self.gateway.execute(
+            "actions_run_trigger",
+            {
+                "inputs": inputs,
+                "method": "run_workflow",
+                "owner": GITHUB_OWNER,
+                "ref": "main",
+                "repo": GITHUB_REPOSITORY,
+                "workflow_id": workflow_id,
+            },
+        )
+        self.heartbeat()
+        for _attempt in range(180):
+            listed = self.gateway_object(
+                "actions_list",
+                {
+                    "method": "list_workflow_runs",
+                    "owner": GITHUB_OWNER,
+                    "per_page": 30,
+                    "repo": GITHUB_REPOSITORY,
+                    "resource_id": workflow_id,
+                    "workflow_runs_filter": {"event": "workflow_dispatch"},
+                },
+            )
+            runs = listed.get("workflow_runs")
+            if type(runs) is not list:
+                raise ValueError(f"{workflow_id} workflow runs are unavailable")
+            matches = [
+                run
+                for run in runs
+                if type(run) is dict
+                and run.get("id") not in existing_ids
+                and run.get("head_sha") == source_revision
+                and run.get("event") == "workflow_dispatch"
+            ]
+            if matches:
+                run = max(matches, key=lambda item: int(item.get("id", 0)))
+                if run.get("status") == "completed":
+                    if run.get("conclusion") != "success":
+                        raise ValueError(f"{workflow_id} did not succeed")
+                    run_id = run.get("id")
+                    if type(run_id) is not int:
+                        raise ValueError(f"{workflow_id} run identifier is invalid")
+                    exact = self.gateway_object(
+                        "actions_get",
+                        {
+                            "method": "get_workflow_run",
+                            "owner": GITHUB_OWNER,
+                            "repo": GITHUB_REPOSITORY,
+                            "resource_id": str(run_id),
+                        },
+                    )
+                    if (
+                        exact.get("id") != run_id
+                        or exact.get("head_sha") != source_revision
+                        or exact.get("conclusion") != "success"
+                    ):
+                        raise ValueError(f"{workflow_id} exact receipt changed")
+                    return {
+                        "conclusion": "success",
+                        "run_id": run_id,
+                        "source_revision": source_revision,
+                    }
+            self.sleep(10)
+            self.heartbeat()
+        raise ValueError(f"{workflow_id} did not complete before timeout")
+
+    def _release(self, tag: str) -> dict[str, Any]:
+        return self.gateway_object(
+            "get_release_by_tag",
+            {"owner": GITHUB_OWNER, "repo": GITHUB_REPOSITORY, "tag": tag},
+        )
+
+    def _release_asset_json(
+        self,
+        release: dict[str, Any],
+        asset_name: str,
+    ) -> dict[str, Any]:
+        assets = release.get("assets")
+        if type(assets) is not list:
+            raise ValueError("GitHub release assets are unavailable")
+        matches = [
+            asset
+            for asset in assets
+            if type(asset) is dict and asset.get("name") == asset_name
+        ]
+        if len(matches) != 1:
+            raise ValueError(f"GitHub release must contain one {asset_name}")
+        url = matches[0].get("browser_download_url")
+        allowed_prefix = (
+            f"https://github.com/{GITHUB_OWNER}/{GITHUB_REPOSITORY}/releases/download/"
+        )
+        if type(url) is not str or not url.startswith(allowed_prefix):
+            raise ValueError("GitHub release asset URL is invalid")
+        self.heartbeat()
+        result = self.fetch_json(url, 30)
+        self.heartbeat()
+        return result
+
+    def _registry_digest(self, tag: str) -> str:
+        raw = self.command(
+            [
+                "uv",
+                "run",
+                "--python",
+                "3.13",
+                "python",
+                "scripts/deployed_digest.py",
+                "--target",
+                tag,
+                "--json",
+            ],
+            timeout=120,
+        )
+        try:
+            evidence = _object(json.loads(raw), "GHCR digest evidence")
+        except json.JSONDecodeError as error:
+            raise ValueError("GHCR digest evidence is invalid") from error
+        digest = evidence.get("digest")
+        if type(digest) is not str or _DIGEST.fullmatch(digest) is None:
+            raise ValueError(f"GHCR tag {tag} does not resolve to one exact digest")
+        return digest
+
+    def _apply_digest(self, digest: str) -> dict[str, Any]:
+        live = self.live_statefulset()
+        manifest = deployment_manifest_for_digest(live, digest)
+        self.heartbeat()
+        self.gateway.execute(
+            "k8s_kndev_resources_create_or_update",
+            {
+                "resource": yaml.safe_dump(
+                    manifest,
+                    allow_unicode=True,
+                    sort_keys=False,
+                )
+            },
+        )
+        self.heartbeat()
+        for _attempt in range(90):
+            current = deployment_state(self.live_statefulset())
+            if current["digest"] == digest and current["rollout_complete"]:
+                return current
+            self.sleep(10)
+            self.heartbeat()
+        raise ValueError("Data Olympus exact digest rollout did not complete")
+
+    def _service_acceptance(self) -> dict[str, bool]:
+        raw = self.command(
+            [
+                "uv",
+                "run",
+                "--python",
+                "3.13",
+                "data-olympus",
+                "verify",
+                "--target",
+                DATA_OLYMPUS_URL,
+                "--json",
+            ],
+            timeout=120,
+        )
+        try:
+            result = _object(json.loads(raw), "Data Olympus acceptance evidence")
+        except json.JSONDecodeError as error:
+            raise ValueError("Data Olympus acceptance evidence is invalid") from error
+        checks = result.get("checks")
+        if result.get("ok") is not True or type(checks) is not list:
+            raise ValueError("Data Olympus external acceptance did not pass")
+        by_name = {
+            check.get("name"): check.get("ok")
+            for check in checks
+            if type(check) is dict
+        }
+        required = {"health", "readiness", "search", "enforcement"}
+        if any(by_name.get(name) is not True for name in required):
+            raise ValueError("Data Olympus external acceptance is incomplete")
+        documentation_raw = self.command(
+            [
+                "fastmcp",
+                "call",
+                "--server-spec",
+                f"{DATA_OLYMPUS_URL}/mcp",
+                "--target",
+                "kb_get",
+                "--input-json",
+                json.dumps({"id": "projects-data-olympus-release-contract"}),
+                "--json",
+                "--timeout",
+                "30",
+                "--auth",
+                "none",
+            ],
+            timeout=60,
+        )
+        try:
+            documentation = _object(
+                json.loads(documentation_raw),
+                "Data Olympus documentation evidence",
+            )
+        except json.JSONDecodeError as error:
+            raise ValueError("Data Olympus documentation evidence is invalid") from error
+        structured = documentation.get("structured_content")
+        if (
+            documentation.get("is_error") is not False
+            or type(structured) is not dict
+            or structured.get("id") != "projects-data-olympus-release-contract"
+        ):
+            raise ValueError("Data Olympus documentation read did not pass")
+        return {
+            "documentation": True,
+            "enforcement": True,
+            "healthy": True,
+            "mcp_search": True,
+            "ready": True,
+        }
+
+    def _candidate_publication(
+        self,
+        source_revision: str,
+        version: str,
+        candidate_tag: str,
+    ) -> dict[str, Any]:
+        release = self._release(candidate_tag)
+        provenance = self._release_asset_json(release, "release-provenance.json")
+        digest = self._registry_digest(candidate_tag)
+        return candidate_release_evidence(
+            release,
+            provenance,
+            source_revision=source_revision,
+            version=version,
+            candidate_tag=candidate_tag,
+            registry_digest=digest,
+        )
+
+    def _stable_publication(
+        self,
+        source_revision: str,
+        version: str,
+    ) -> dict[str, Any]:
+        release = self._release(f"v{version}")
+        provenance = self._release_asset_json(release, "release-provenance.json")
+        pypi_url = f"https://pypi.org/pypi/data-olympus/{version}/json"
+        pypi = self.fetch_json(pypi_url, 30)
+        return stable_release_evidence(
+            release,
+            provenance,
+            pypi,
+            source_revision=source_revision,
+            version=version,
+        )
+
+    def deliver(
+        self,
+        _run_input: dict[str, Any],
+        _admission: dict[str, Any],
+        _prepared: dict[str, Any],
+        _reviewed: dict[str, Any],
+    ) -> dict[str, Any]:
+        if self._prepared is None:
+            raise ValueError("release preparation evidence is unavailable")
+        candidate = _object(self._prepared["raw"]["candidate"], "candidate")
+        source_revision = candidate["source_revision"]
+        version = candidate["version"]
+        tags = self.gateway.execute(
+            "list_tags",
+            {
+                "owner": GITHUB_OWNER,
+                "page": 1,
+                "perPage": 100,
+                "repo": GITHUB_REPOSITORY,
+            },
+        )
+        if type(tags) is not list:
+            raise ValueError("GitHub tags are unavailable")
+        tag_names: list[str] = []
+        for raw_tag in tags:
+            if type(raw_tag) is dict and type(raw_tag.get("name")) is str:
+                tag_names.append(raw_tag["name"])
+        rc_number = next_rc_number(version, tag_names)
+        candidate_tag = f"{version}-rc.{rc_number}"
+        rollback_digest = self._prepared["raw"]["rollback_point"]["digest"]
+        deployment_started = False
+        try:
+            rc_receipt = self._workflow_run(
+                "rc-publish.yml",
+                source_revision,
+                {"number": rc_number, "ref": source_revision},
+            )
+            publication = self._candidate_publication(
+                source_revision,
+                version,
+                candidate_tag,
+            )
+            digest = publication["image_digest"]
+            deployment_started = True
+            canary_rollout = self._apply_digest(digest)
+            canary_acceptance = self._service_acceptance()
+            tag_receipt = self._workflow_run(
+                "tag-release.yml",
+                source_revision,
+                {"candidate_tag": candidate_tag},
+            )
+            stable = self._stable_publication(source_revision, version)
+            stable_digest = self._registry_digest(f"v{version}")
+            if stable_digest != digest:
+                raise ValueError("stable GHCR tag rebuilt or changed the candidate digest")
+            channel_receipt = self._workflow_run(
+                "set-channel.yml",
+                source_revision,
+                {"channel": "kndev", "source": f"v{version}"},
+            )
+            stable_rollout = self._apply_digest(digest)
+            stable_acceptance = self._service_acceptance()
+        except (OSError, subprocess.SubprocessError, ValueError) as error:
+            if deployment_started:
+                try:
+                    self._apply_digest(rollback_digest)
+                    self._service_acceptance()
+                except (OSError, subprocess.SubprocessError, ValueError) as rollback_error:
+                    raise ValueError(
+                        "release delivery failed and exact digest rollback also failed"
+                    ) from rollback_error
+            raise error
+        final_candidate = {
+            **candidate,
+            "candidate_tag": candidate_tag,
+            "image_digest": digest,
+        }
+        raw = {
+            "candidate": final_candidate,
+            "current_source_revision": source_revision,
+            "workflows": [
+                {
+                    **rc_receipt,
+                    "name": "rc-publish.yml",
+                    "candidate_tag": candidate_tag,
+                },
+                {
+                    **tag_receipt,
+                    "name": "tag-release.yml",
+                    "candidate_tag": candidate_tag,
+                },
+                {
+                    **channel_receipt,
+                    "name": "set-channel.yml",
+                    "source_tag": f"v{version}",
+                },
+            ],
+            "canary": {
+                "candidate_tag": candidate_tag,
+                "source_revision": source_revision,
+                "digest": digest,
+                "keel_policy": canary_rollout["keel_policy"],
+                "rollout_complete": canary_rollout["rollout_complete"],
+                **canary_acceptance,
+            },
+            "deployment": {
+                "keel_policy": stable_rollout["keel_policy"],
+                "source_revision": source_revision,
+                "image_digest": digest,
+                "rollout_complete": stable_rollout["rollout_complete"],
+            },
+        }
+        self._delivery = {
+            "raw": raw,
+            "acceptance": stable_acceptance,
+            "candidate_publication": publication,
+            "stable_publication": stable,
+        }
+        return raw
+
+    def verify(
+        self,
+        _run_input: dict[str, Any],
+        _admission: dict[str, Any],
+        _delivery: dict[str, Any],
+    ) -> dict[str, Any]:
+        if self._delivery is None:
+            raise ValueError("release delivery evidence is unavailable")
+        candidate = _object(self._delivery["raw"]["candidate"], "candidate")
+        source_revision = candidate["source_revision"]
+        version = candidate["version"]
+        digest = candidate["image_digest"]
+        stable = self._stable_publication(source_revision, version)
+        if self._registry_digest(f"v{version}") != digest:
+            raise ValueError("stable GHCR digest changed after delivery")
+        deployment = deployment_state(self.live_statefulset())
+        if deployment["digest"] != digest or not deployment["rollout_complete"]:
+            raise ValueError("kn dev deployment changed after delivery")
+        acceptance = self._service_acceptance()
+        return {
+            "candidate": candidate,
+            "github_release": {
+                "tag": f"v{version}",
+                "source_revision": stable["source_revision"],
+            },
+            "pypi": {
+                "version": stable["pypi_version"],
+                "provenance_source_revision": stable["source_revision"],
+            },
+            "image": {"tag": f"v{version}", "digest": digest},
+            "deployment": {
+                "source_revision": source_revision,
+                "digest": digest,
+                **acceptance,
+            },
+        }
+
+    def rollback(self, recovery: dict[str, Any]) -> dict[str, Any]:
+        source_revision = recovery.get("source_revision")
+        if type(source_revision) is not str or _SHA40.fullmatch(source_revision) is None:
+            raise ValueError("recovery source revision is invalid")
+        outcome = _object(recovery.get("outcome_evidence"), "recovery evidence")
+        failed_digest = outcome.get("digest")
+        rollback_digest = outcome.get("rollback_digest")
+        if type(failed_digest) is not str or _DIGEST.fullmatch(failed_digest) is None:
+            raise ValueError("failed release digest is unavailable")
+        if (
+            type(rollback_digest) is not str
+            or _DIGEST.fullmatch(rollback_digest) is None
+        ):
+            raise ValueError("release rollback digest is unavailable")
+        restored = self._apply_digest(rollback_digest)
+        acceptance = self._service_acceptance()
+        from scripts.operations.release import evaluate_stage
+
+        evaluated = evaluate_stage(
+            "rollback",
+            {
+                "failed_digest": failed_digest,
+                "rollback_point": {
+                    "digest": rollback_digest,
+                    "image": f"{IMAGE_REPOSITORY}@{rollback_digest}",
+                    "intended_keel_policy": "never",
+                },
+                "events": [
+                    {"name": "keel-paused", "policy": "never"},
+                    {
+                        "name": "digest-restored",
+                        "digest": rollback_digest,
+                        "containers": ["data-olympus-mcp", "prepare-git"],
+                    },
+                    {
+                        "name": "deployment-verified",
+                        "digest": rollback_digest,
+                        "healthy": acceptance["healthy"],
+                        "ready": restored["rollout_complete"],
+                    },
+                    {"name": "keel-policy-restored", "policy": "never"},
+                ],
+            },
+        )
+        return {
+            "status": evaluated["status"],
+            "reason": evaluated["reason"],
+            "evidence": evaluated["evidence"],
+            "source_revision": source_revision,
+        }
+
+
+def default_release_dependencies() -> dict[str, Any]:
+    """Wire the one project command to its complete live release runtime."""
+    runtime = ReleaseRuntime(
+        Path.cwd(),
+        gateway=FastMCPGateway(),
+    )
+    return {
+        "workspace": runtime.repository_root,
+        "source_revision": runtime.source_revision,
+        "candidate_revision": runtime.candidate_revision,
+        "collect_admission": runtime.collect_admission,
+        "prepare": runtime.prepare,
+        "validate": runtime.validate,
+        "deliver": runtime.deliver,
+        "verify": runtime.verify,
+        "rollback": runtime.rollback,
+        "set_heartbeat": runtime.set_heartbeat,
+    }

--- a/scripts/operations/release_runtime.py
+++ b/scripts/operations/release_runtime.py
@@ -1052,6 +1052,8 @@ class ReleaseRuntime:
         workflow_id: str,
         source_revision: str,
         inputs: dict[str, object],
+        *,
+        on_dispatch: Callable[[], None] | None = None,
     ) -> dict[str, Any]:
         listed = self.gateway_object(
             "actions_list",
@@ -1073,6 +1075,8 @@ class ReleaseRuntime:
             if type(run) is dict and type(run.get("id")) is int
         }
         self.heartbeat()
+        if on_dispatch is not None:
+            on_dispatch()
         self.gateway.execute(
             "actions_run_trigger",
             {
@@ -1357,13 +1361,19 @@ class ReleaseRuntime:
         deployment_started = False
         external_state_changed = False
         rollback_completed = False
-        try:
+
+        def mark_external_state_changed() -> None:
+            nonlocal external_state_changed
             external_state_changed = True
+
+        try:
             rc_receipt = self._workflow_run(
                 "rc-publish.yml",
                 source_revision,
                 {"number": rc_number, "ref": source_revision},
+                on_dispatch=mark_external_state_changed,
             )
+            external_state_changed = True
             publication = self._candidate_publication(
                 source_revision,
                 version,
@@ -1377,6 +1387,7 @@ class ReleaseRuntime:
                 "tag-release.yml",
                 source_revision,
                 {"candidate_tag": candidate_tag},
+                on_dispatch=mark_external_state_changed,
             )
             stable = self._stable_publication(source_revision, version)
             stable_digest = self._registry_digest(f"v{version}")
@@ -1386,6 +1397,7 @@ class ReleaseRuntime:
                 "set-channel.yml",
                 source_revision,
                 {"channel": "kndev", "source": f"v{version}"},
+                on_dispatch=mark_external_state_changed,
             )
             stable_rollout = self._apply_digest(digest)
             stable_acceptance = self._service_acceptance()

--- a/scripts/operations/release_runtime.py
+++ b/scripts/operations/release_runtime.py
@@ -60,7 +60,7 @@ JsonFetch = Callable[[str, int], dict[str, Any]]
 
 
 class ReleaseDeliveryError(ValueError):
-    """A delivery failure after externally visible release side effects."""
+    """A release failure after externally visible side effects."""
 
     external_state_changed = True
 
@@ -913,10 +913,60 @@ class ReleaseRuntime:
         self.command(["git", "fetch", "origin", "main"], timeout=120)
         if self.candidate_revision() != admitted:
             raise ValueError("remote main changed before release merge")
-        merged = self._merge_exact(number, version, head_revision)
+        try:
+            merged = self._merge_exact(number, version, head_revision)
+        except (OSError, subprocess.SubprocessError, ValueError) as error:
+            raise ReleaseDeliveryError(
+                "release merge outcome could not be confirmed",
+                {
+                    "external_state_changed": True,
+                    "merge_confirmed": False,
+                    "merge_outcome": "unknown",
+                    "release_pr_head_revision": head_revision,
+                    "release_pr_number": number,
+                    "rollback_completed": False,
+                },
+            ) from error
         final_revision = merged.get("sha")
         if merged.get("merged") is not True or not isinstance(final_revision, str):
             raise ValueError("release pull request did not merge")
+        try:
+            return self._finish_preparation_after_merge(
+                run_input=run_input,
+                admitted=admitted,
+                version=version,
+                head_revision=head_revision,
+                final_revision=final_revision,
+                number=number,
+                ready=ready,
+                document_evidence=document_evidence,
+            )
+        except (OSError, subprocess.SubprocessError, ValueError) as error:
+            raise ReleaseDeliveryError(
+                str(error),
+                {
+                    "external_state_changed": True,
+                    "merge_confirmed": True,
+                    "merge_outcome": "merged",
+                    "merged_revision": final_revision,
+                    "release_pr_head_revision": head_revision,
+                    "release_pr_number": number,
+                    "rollback_completed": False,
+                },
+            ) from error
+
+    def _finish_preparation_after_merge(
+        self,
+        *,
+        run_input: dict[str, Any],
+        admitted: str,
+        version: str,
+        head_revision: str,
+        final_revision: str,
+        number: int,
+        ready: dict[str, Any],
+        document_evidence: dict[str, Any],
+    ) -> dict[str, Any]:
         if _SHA40.fullmatch(final_revision) is None:
             raise ValueError("release merge returned an invalid source revision")
         self.command(["git", "fetch", "origin", "main"], timeout=120)

--- a/scripts/operations/release_runtime.py
+++ b/scripts/operations/release_runtime.py
@@ -707,6 +707,30 @@ class ReleaseRuntime:
         except json.JSONDecodeError as error:
             raise ValueError("release merge result is invalid") from error
 
+    def _confirmed_merge_revision(
+        self,
+        merged: dict[str, Any],
+        *,
+        number: int,
+        head_revision: str,
+    ) -> str:
+        if merged.get("merged") is not True:
+            raise ValueError("release pull request did not merge")
+        final_revision = merged.get("sha")
+        if type(final_revision) is not str or _SHA40.fullmatch(final_revision) is None:
+            raise ReleaseDeliveryError(
+                "confirmed release merge returned no usable source revision",
+                {
+                    "external_state_changed": True,
+                    "merge_confirmed": True,
+                    "merge_outcome": "merged",
+                    "release_pr_head_revision": head_revision,
+                    "release_pr_number": number,
+                    "rollback_completed": False,
+                },
+            )
+        return final_revision
+
     def _wait_main_checks(self, source_revision: str) -> dict[str, Any]:
         required = ",".join(sorted(REQUIRED_MAIN_CHECKS))
         for _attempt in range(120):
@@ -927,9 +951,11 @@ class ReleaseRuntime:
                     "rollback_completed": False,
                 },
             ) from error
-        final_revision = merged.get("sha")
-        if merged.get("merged") is not True or not isinstance(final_revision, str):
-            raise ValueError("release pull request did not merge")
+        final_revision = self._confirmed_merge_revision(
+            merged,
+            number=number,
+            head_revision=head_revision,
+        )
         try:
             return self._finish_preparation_after_merge(
                 run_input=run_input,
@@ -1200,10 +1226,17 @@ class ReleaseRuntime:
             raise ValueError(f"GHCR tag {tag} does not resolve to one exact digest")
         return digest
 
-    def _apply_digest(self, digest: str) -> dict[str, Any]:
+    def _apply_digest(
+        self,
+        digest: str,
+        *,
+        on_apply: Callable[[], None] | None = None,
+    ) -> dict[str, Any]:
         live = self.live_statefulset()
         manifest = deployment_manifest_for_digest(live, digest)
         self.heartbeat()
+        if on_apply is not None:
+            on_apply()
         self.gateway.execute(
             "k8s_kndev_resources_create_or_update",
             {
@@ -1366,6 +1399,11 @@ class ReleaseRuntime:
             nonlocal external_state_changed
             external_state_changed = True
 
+        def mark_deployment_started() -> None:
+            nonlocal deployment_started
+            mark_external_state_changed()
+            deployment_started = True
+
         try:
             rc_receipt = self._workflow_run(
                 "rc-publish.yml",
@@ -1380,8 +1418,10 @@ class ReleaseRuntime:
                 candidate_tag,
             )
             digest = publication["image_digest"]
-            deployment_started = True
-            canary_rollout = self._apply_digest(digest)
+            canary_rollout = self._apply_digest(
+                digest,
+                on_apply=mark_deployment_started,
+            )
             canary_acceptance = self._service_acceptance()
             tag_receipt = self._workflow_run(
                 "tag-release.yml",
@@ -1399,7 +1439,10 @@ class ReleaseRuntime:
                 {"channel": "kndev", "source": f"v{version}"},
                 on_dispatch=mark_external_state_changed,
             )
-            stable_rollout = self._apply_digest(digest)
+            stable_rollout = self._apply_digest(
+                digest,
+                on_apply=mark_deployment_started,
+            )
             stable_acceptance = self._service_acceptance()
         except (OSError, subprocess.SubprocessError, ValueError) as error:
             if deployment_started:
@@ -1525,8 +1568,45 @@ class ReleaseRuntime:
             or _DIGEST.fullmatch(rollback_digest) is None
         ):
             raise ValueError("release rollback digest is unavailable")
-        restored = self._apply_digest(rollback_digest)
-        acceptance = self._service_acceptance()
+        apply_started = False
+
+        def mark_apply_started() -> None:
+            nonlocal apply_started
+            apply_started = True
+
+        try:
+            restored = self._apply_digest(
+                rollback_digest,
+                on_apply=mark_apply_started,
+            )
+        except (OSError, subprocess.SubprocessError, ValueError) as error:
+            if apply_started:
+                raise ReleaseDeliveryError(
+                    str(error),
+                    {
+                        "acceptance_completed": False,
+                        "digest_apply_confirmed": False,
+                        "external_state_changed": True,
+                        "rollback_completed": False,
+                        "rollback_digest": rollback_digest,
+                        "rollout_complete": False,
+                    },
+                ) from error
+            raise
+        try:
+            acceptance = self._service_acceptance()
+        except (OSError, subprocess.SubprocessError, ValueError) as error:
+            raise ReleaseDeliveryError(
+                str(error),
+                {
+                    "acceptance_completed": False,
+                    "digest_apply_confirmed": True,
+                    "external_state_changed": True,
+                    "rollback_completed": False,
+                    "rollback_digest": rollback_digest,
+                    "rollout_complete": restored["rollout_complete"],
+                },
+            ) from error
         from scripts.operations.release import evaluate_stage
 
         evaluated = evaluate_stage(

--- a/tests/test_operations_release.py
+++ b/tests/test_operations_release.py
@@ -324,6 +324,7 @@ def test_review_requires_independent_claude_and_exact_ledger_approval() -> None:
     "mutate",
     [
         lambda value: value["companion_review"].__setitem__("family", "local"),
+        lambda value: value["companion_review"].__setitem__("family", "codex"),
         lambda value: value["companion_review"].__setitem__(
             "verdict",
             "BLOCK",
@@ -1031,6 +1032,42 @@ def test_release_blocks_when_ledger_approval_is_not_bound_to_candidate() -> None
     assert events[-1]["status"] == "blocked"
     assert events[-1]["candidate_revision"] == CANDIDATE_SHA
     assert "candidate approval revision does not match" in events[-1]["reason"]
+
+
+def test_release_blocks_when_review_ticket_is_not_the_qualified_claude_route() -> None:
+    dependencies = _release_dependencies()
+    dependencies["request_model_ticket"] = lambda request: {
+        "model_use_id": 71,
+        "purpose": request["purpose"],
+        "route_id": "codex",
+        "source_revision": request["source_revision"],
+        "ticket": "opaque-run-scoped-ticket",
+    }
+
+    events = execute_release_run(json.dumps(RUN_INPUT), dependencies)
+
+    assert events[-1]["status"] == "blocked"
+    assert "qualified Claude route" in events[-1]["reason"]
+
+
+def test_release_marks_external_delivery_failure_as_failed_with_recovery_evidence() -> None:
+    dependencies = _release_dependencies()
+
+    class ExternalFailure(ValueError):
+        external_state_changed = True
+        evidence = {
+            "external_state_changed": True,
+            "rollback_completed": True,
+        }
+
+    dependencies["deliver"] = lambda *_arguments: (_ for _ in ()).throw(
+        ExternalFailure("stable publication failed")
+    )
+
+    events = execute_release_run(json.dumps(RUN_INPUT), dependencies)
+
+    assert events[-1]["status"] == "failed"
+    assert events[-1]["evidence"] == ExternalFailure.evidence
 
 
 def test_release_cli_default_invocation_reads_complete_run_input(

--- a/tests/test_operations_release.py
+++ b/tests/test_operations_release.py
@@ -7,10 +7,14 @@ import pytest
 from scripts.operations.release import (
     DEFAULT_EXTRA_CONTEXT,
     evaluate_stage,
+    execute_release_run,
     main,
+    parse_release_run_input,
 )
 
 SOURCE_SHA = "a" * 40
+CANDIDATE_SHA = "f" * 40
+BRANCH_SHA = "9" * 40
 AUTHORITY_SHA = "b" * 40
 CONTRACT_SHA = "c" * 64
 IMAGE_DIGEST = "sha256:" + "d" * 64
@@ -149,7 +153,7 @@ def test_admission_blocks_unmerged_changed_or_v060_candidate(
     assert reason in result["reason"]
 
 
-def test_prepare_confirms_one_private_issue_and_hashes_extra_context() -> None:
+def test_prepare_confirms_one_merged_release_pr_and_hashes_extra_context() -> None:
     result = evaluate_stage(
         "prepare",
         {
@@ -170,14 +174,14 @@ def test_prepare_confirms_one_private_issue_and_hashes_extra_context() -> None:
                 "digest": PREVIOUS_DIGEST,
                 "keel_policy": "never",
             },
-            "release_issue": {
-                "count": 1,
-                "private": True,
-                "number": 177,
-                "url": "https://github.com/knaisoma/data-olympus/issues/177",
+            "release_pr": {
+                "number": 178,
+                "url": "https://github.com/knaisoma/data-olympus/pull/178",
+                "merged": True,
+                "base_source_revision": "8" * 40,
+                "head_revision": BRANCH_SHA,
                 "source_revision": SOURCE_SHA,
                 "candidate_version": "0.6.1",
-                "body_hash": "4" * 64,
             },
         },
     )
@@ -188,10 +192,10 @@ def test_prepare_confirms_one_private_issue_and_hashes_extra_context() -> None:
     assert context["length"] == len(DEFAULT_EXTRA_CONTEXT)
     assert len(context["sha256"]) == 64
     assert DEFAULT_EXTRA_CONTEXT not in json.dumps(result)
-    assert result["outputs"]["release_issue_number"] == 177
+    assert result["outputs"]["release_pr_number"] == 178
 
 
-def test_prepare_blocks_when_the_private_release_issue_is_missing() -> None:
+def test_prepare_blocks_when_the_release_pr_is_not_merged() -> None:
     input_document = {
         "candidate": _candidate(),
         "extra_context": DEFAULT_EXTRA_CONTEXT,
@@ -210,21 +214,21 @@ def test_prepare_blocks_when_the_private_release_issue_is_missing() -> None:
             "digest": PREVIOUS_DIGEST,
             "keel_policy": "never",
         },
-        "release_issue": {
-            "count": 0,
-            "private": True,
-            "number": 177,
-            "url": "https://github.com/knaisoma/data-olympus/issues/177",
+        "release_pr": {
+            "number": 178,
+            "url": "https://github.com/knaisoma/data-olympus/pull/178",
+            "merged": False,
+            "base_source_revision": "8" * 40,
+            "head_revision": BRANCH_SHA,
             "source_revision": SOURCE_SHA,
             "candidate_version": "0.6.1",
-            "body_hash": "4" * 64,
         },
     }
 
     result = evaluate_stage("prepare", input_document)
 
     assert result["status"] == "blocked"
-    assert "exactly one private release issue" in result["reason"]
+    assert "release_pr.merged" in result["reason"]
 
 
 def test_validate_requires_unchanged_candidate_and_all_exact_gates() -> None:
@@ -284,39 +288,42 @@ def test_validate_fails_closed_when_any_gate_changes(mutate) -> None:
     assert result["status"] == "blocked"
 
 
-def test_review_requires_crossed_claude_codex_families_and_sha_approval() -> None:
+def test_review_requires_independent_claude_and_exact_ledger_approval() -> None:
     result = evaluate_stage(
         "review",
         {
             "candidate": _candidate(),
             "current_source_revision": SOURCE_SHA,
-            "executor": {"family": "codex", "source_revision": SOURCE_SHA},
+            "contract_revision": CONTRACT_SHA,
+            "run_id": "11111111-2222-4333-8444-555555555555",
+            "executor": {"family": "deterministic", "source_revision": SOURCE_SHA},
             "companion_review": {
                 "family": "claude",
                 "verdict": "APPROVE",
                 "reviewed_source_revision": SOURCE_SHA,
                 "evidence_hash": "5" * 64,
             },
-            "operator_approval": {
-                "approved": True,
-                "source_revision": SOURCE_SHA,
-                "approval_id": "approval-0.6.1",
+            "candidate_approval": {
+                "authority": "standing-delegation",
+                "candidate_revision": SOURCE_SHA,
+                "contract_digest": CONTRACT_SHA,
+                "approval_id_hash": "6" * 64,
+                "review_model_use_id": 71,
+                "run_id": "11111111-2222-4333-8444-555555555555",
             },
+            "review_model_use_id": 71,
         },
     )
 
     assert result["status"] == "pass"
     assert result["evidence"]["reviewer_family"] == "claude"
-    assert result["evidence"]["executor_family"] == "codex"
+    assert result["evidence"]["executor_family"] == "deterministic"
 
 
 @pytest.mark.parametrize(
     "mutate",
     [
-        lambda value: value["companion_review"].__setitem__(
-            "family",
-            "codex",
-        ),
+        lambda value: value["companion_review"].__setitem__("family", "local"),
         lambda value: value["companion_review"].__setitem__(
             "verdict",
             "BLOCK",
@@ -325,12 +332,12 @@ def test_review_requires_crossed_claude_codex_families_and_sha_approval() -> Non
             "reviewed_source_revision",
             "f" * 40,
         ),
-        lambda value: value["operator_approval"].__setitem__(
-            "approved",
-            False,
+        lambda value: value["candidate_approval"].__setitem__(
+            "authority",
+            "forged",
         ),
-        lambda value: value["operator_approval"].__setitem__(
-            "source_revision",
+        lambda value: value["candidate_approval"].__setitem__(
+            "candidate_revision",
             "f" * 40,
         ),
     ],
@@ -341,18 +348,24 @@ def test_review_blocks_self_review_changed_sha_or_missing_approval(
     input_document = {
         "candidate": _candidate(),
         "current_source_revision": SOURCE_SHA,
-        "executor": {"family": "codex", "source_revision": SOURCE_SHA},
+        "contract_revision": CONTRACT_SHA,
+        "run_id": "11111111-2222-4333-8444-555555555555",
+        "executor": {"family": "deterministic", "source_revision": SOURCE_SHA},
         "companion_review": {
             "family": "claude",
             "verdict": "APPROVE",
             "reviewed_source_revision": SOURCE_SHA,
             "evidence_hash": "5" * 64,
         },
-        "operator_approval": {
-            "approved": True,
-            "source_revision": SOURCE_SHA,
-            "approval_id": "approval-0.6.1",
+        "candidate_approval": {
+            "authority": "standing-delegation",
+            "candidate_revision": SOURCE_SHA,
+            "contract_digest": CONTRACT_SHA,
+            "approval_id_hash": "6" * 64,
+            "review_model_use_id": 71,
+            "run_id": "11111111-2222-4333-8444-555555555555",
         },
+        "review_model_use_id": 71,
     }
     mutate(input_document)
 
@@ -676,46 +689,397 @@ def test_cli_emits_one_failed_json_object_when_input_is_missing(
     monkeypatch,
     capsys,
 ) -> None:
-    monkeypatch.delenv("AI_OPERATIONS_STAGE_INPUT", raising=False)
+    monkeypatch.delenv("AI_OPERATIONS_RUN_INPUT", raising=False)
 
-    exit_code = main(["authority"])
+    exit_code = main([], dependencies={})
     output = json.loads(capsys.readouterr().out)
 
     assert exit_code == 2
     assert output == {
         "status": "failed",
-        "reason": "AI_OPERATIONS_STAGE_INPUT is required",
+        "reason": "AI_OPERATIONS_RUN_INPUT is required",
         "evidence": {},
         "outputs": {},
     }
 
 
-def test_cli_rejects_wrong_argument_count(capsys) -> None:
-    exit_code = main([])
-    output = json.loads(capsys.readouterr().out)
-
-    assert exit_code == 2
-    assert output["status"] == "failed"
-    assert output["reason"] == "exactly one release stage is required"
-
-
-def test_cli_rejects_malformed_json(monkeypatch, capsys) -> None:
-    monkeypatch.setenv("AI_OPERATIONS_STAGE_INPUT", "{")
-
+def test_cli_rejects_retired_stage_invocation(capsys) -> None:
     exit_code = main(["authority"])
     output = json.loads(capsys.readouterr().out)
 
     assert exit_code == 2
     assert output["status"] == "failed"
-    assert output["reason"] == "AI_OPERATIONS_STAGE_INPUT must be valid JSON"
+    assert output["reason"] == "unsupported Data Olympus release operation"
 
 
-def test_cli_rejects_unknown_stage(monkeypatch, capsys) -> None:
-    monkeypatch.setenv("AI_OPERATIONS_STAGE_INPUT", "{}")
+def test_cli_rejects_malformed_json(monkeypatch, capsys) -> None:
+    monkeypatch.setenv("AI_OPERATIONS_RUN_INPUT", "{")
 
-    exit_code = main(["not-a-stage"])
+    exit_code = main([], dependencies={})
     output = json.loads(capsys.readouterr().out)
 
     assert exit_code == 1
     assert output["status"] == "failed"
-    assert output["reason"] == "unknown release stage: not-a-stage"
+    assert output["reason"] == "AI_OPERATIONS_RUN_INPUT must be valid JSON"
+
+
+def test_cli_rejects_unknown_operation(capsys) -> None:
+    exit_code = main(["not-a-stage"])
+    output = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 2
+    assert output["status"] == "failed"
+    assert output["reason"] == "unsupported Data Olympus release operation"
+
+
+RUN_INPUT = {
+    "authority_revision": AUTHORITY_SHA,
+    "contract_id": "data-olympus-release",
+    "contract_revision": CONTRACT_SHA,
+    "executor_capability": "deterministic-release-execution",
+    "extra_context": DEFAULT_EXTRA_CONTEXT,
+    "model_request": {
+        "command": [
+            "/usr/bin/python3",
+            "-m",
+            "ai_operations",
+            "models",
+            "request",
+        ],
+        "control_environment": "AI_OPERATIONS_RUN_CONTROL",
+        "ticket_environment": "AI_OPERATIONS_MODEL_TICKET",
+    },
+    "notification": {
+        "confirmation": "send_and_readback",
+        "destination": "data-olympus-operations",
+        "transport": "telegram",
+    },
+    "outcome": (
+        "One immutable reviewed release is published and every channel and "
+        "deployment matches its source revision."
+    ),
+    "project": "data-olympus",
+    "reviewer_capability": "high-risk-review",
+    "run_id": "11111111-2222-4333-8444-555555555555",
+    "source_revision": SOURCE_SHA,
+}
+
+
+def _approved_review(request: dict[str, object]) -> dict[str, object]:
+    assert request["purpose"] == "review"
+    ticket = request["ticket"]
+    assert isinstance(ticket, dict)
+    return {
+        "model_use_id": ticket["model_use_id"],
+        "route_id": ticket["route_id"],
+        "status": "approved",
+        "verdict": "APPROVE",
+    }
+
+
+def _release_dependencies(*, source_revision: str = SOURCE_SHA) -> dict[str, object]:
+    state = {"head": source_revision}
+    prepared_candidate = {
+        "version": "0.6.1",
+        "source_revision": CANDIDATE_SHA,
+    }
+    artifact_candidate = {
+        **prepared_candidate,
+        "candidate_tag": "0.6.1-rc.1",
+        "image_digest": IMAGE_DIGEST,
+    }
+
+    def prepare(run, _admitted):
+        state["head"] = CANDIDATE_SHA
+        return {
+            "candidate": prepared_candidate,
+            "extra_context": run["extra_context"],
+            "changelog": {
+                "source_revision": CANDIDATE_SHA,
+                "content_hash": "1" * 64,
+            },
+            "security": {"exit_code": 0, "report_hash": "2" * 64},
+            "tests": {
+                "source_revision": CANDIDATE_SHA,
+                "passed": True,
+                "evidence_hash": "3" * 64,
+            },
+            "rollback_point": {
+                "image": f"ghcr.io/knaisoma/data-olympus@{PREVIOUS_DIGEST}",
+                "digest": PREVIOUS_DIGEST,
+                "keel_policy": "never",
+            },
+            "release_pr": {
+                "number": 178,
+                "url": "https://github.com/knaisoma/data-olympus/pull/178",
+                "merged": True,
+                "base_source_revision": SOURCE_SHA,
+                "head_revision": BRANCH_SHA,
+                "source_revision": CANDIDATE_SHA,
+                "candidate_version": "0.6.1",
+            },
+        }
+
+    return {
+        "source_revision": lambda: source_revision,
+        "candidate_revision": lambda: state["head"],
+        "collect_admission": lambda _run: _admission_input(),
+        "prepare": prepare,
+        "validate": lambda _run, _admitted, _prepared: {
+            "candidate": prepared_candidate,
+            "current_source_revision": CANDIDATE_SHA,
+            "ci": {
+                "source_revision": CANDIDATE_SHA,
+                "all_success": True,
+                "missing_required": [],
+            },
+            "security": {"exit_code": 0},
+            "version_free": {"version": "0.6.1", "free": True},
+            "tests": {"source_revision": CANDIDATE_SHA, "passed": True},
+        },
+        "request_model_ticket": lambda request: {
+            "model_use_id": 71,
+            "purpose": request["purpose"],
+            "route_id": "claude-code",
+            "source_revision": request["source_revision"],
+            "ticket": "opaque-run-scoped-ticket",
+        },
+        "invoke_model": _approved_review,
+        "collect_candidate_approval": lambda run, _candidate, review: {
+            "approval_id_hash": "6" * 64,
+            "authority": "standing-delegation",
+            "candidate_revision": CANDIDATE_SHA,
+            "contract_digest": run["contract_revision"],
+            "review_model_use_id": review["model_use_id"],
+            "run_id": run["run_id"],
+        },
+        "deliver": lambda _run, _admitted, _prepared, _review: {
+            "candidate": artifact_candidate,
+            "current_source_revision": CANDIDATE_SHA,
+            "workflows": [
+                {
+                    "name": "rc-publish.yml",
+                    "conclusion": "success",
+                    "source_revision": CANDIDATE_SHA,
+                    "candidate_tag": "0.6.1-rc.1",
+                },
+                {
+                    "name": "tag-release.yml",
+                    "conclusion": "success",
+                    "source_revision": CANDIDATE_SHA,
+                    "candidate_tag": "0.6.1-rc.1",
+                },
+                {
+                    "name": "set-channel.yml",
+                    "conclusion": "success",
+                    "source_revision": CANDIDATE_SHA,
+                    "source_tag": "v0.6.1",
+                },
+            ],
+            "canary": {
+                "candidate_tag": "0.6.1-rc.1",
+                "source_revision": CANDIDATE_SHA,
+                "digest": IMAGE_DIGEST,
+                "keel_policy": "never",
+                "rollout_complete": True,
+                "healthy": True,
+                "ready": True,
+                "mcp_search": True,
+                "enforcement": True,
+            },
+            "deployment": {
+                "keel_policy": "never",
+                "image_digest": IMAGE_DIGEST,
+                "source_revision": CANDIDATE_SHA,
+                "rollout_complete": True,
+            },
+        },
+        "verify": lambda _run, _admitted, _delivery: {
+            "candidate": artifact_candidate,
+            "github_release": {
+                "tag": "v0.6.1",
+                "source_revision": CANDIDATE_SHA,
+            },
+            "pypi": {
+                "version": "0.6.1",
+                "provenance_source_revision": CANDIDATE_SHA,
+            },
+            "image": {"tag": "v0.6.1", "digest": IMAGE_DIGEST},
+            "deployment": {
+                "source_revision": CANDIDATE_SHA,
+                "digest": IMAGE_DIGEST,
+                "healthy": True,
+                "ready": True,
+                "mcp_search": True,
+                "enforcement": True,
+                "documentation": True,
+            },
+        },
+    }
+
+
+def test_run_input_matches_the_current_runner_boundary() -> None:
+    parsed = parse_release_run_input(json.dumps(RUN_INPUT))
+
+    assert parsed["model_request"]["ticket_environment"] == (
+        "AI_OPERATIONS_MODEL_TICKET"
+    )
+    forged = dict(RUN_INPUT)
+    forged["model_tickets"] = []
+
+    with pytest.raises(ValueError, match="unknown run input field: model_tickets"):
+        parse_release_run_input(json.dumps(forged))
+
+
+def test_one_release_command_emits_the_exact_runner_protocol() -> None:
+    events = execute_release_run(json.dumps(RUN_INPUT), _release_dependencies())
+
+    assert [event["name"] for event in events[:-1]] == [
+        "admission",
+        "prepare",
+        "validate",
+        "domain_review",
+        "deliver",
+        "verify",
+    ]
+    assert events[-1] == {
+        "type": "result",
+        "sequence": 7,
+        "status": "delivered",
+        "reason": "release 0.6.1 and kn dev match the reviewed source",
+        "evidence": {
+            "published_version": "0.6.1",
+            "source_revision": CANDIDATE_SHA,
+            "version": "0.6.1",
+            "digest": IMAGE_DIGEST,
+            "health": "verified",
+                "mcp": "verified",
+                "documentation": "verified",
+                "rollback_digest": PREVIOUS_DIGEST,
+                "release_pr_number": 178,
+            },
+        "source_revision": SOURCE_SHA,
+        "candidate_revision": CANDIDATE_SHA,
+        "review_model_use_id": 71,
+    }
+
+
+def test_runtime_heartbeats_keep_one_contiguous_protocol_sequence() -> None:
+    dependencies = _release_dependencies()
+    original_prepare = dependencies["prepare"]
+    heartbeat = None
+
+    def set_heartbeat(callback):
+        nonlocal heartbeat
+        heartbeat = callback
+
+    def prepare(run, admitted):
+        assert heartbeat is not None
+        heartbeat()
+        heartbeat()
+        return original_prepare(run, admitted)
+
+    dependencies["set_heartbeat"] = set_heartbeat
+    dependencies["prepare"] = prepare
+    emitted: list[dict[str, object]] = []
+
+    events = execute_release_run(
+        json.dumps(RUN_INPUT),
+        dependencies,
+        emit=emitted.append,
+    )
+
+    assert events == emitted
+    assert [event["sequence"] for event in events] == list(
+        range(1, len(events) + 1)
+    )
+    assert [event["type"] for event in events[:4]] == [
+        "milestone",
+        "heartbeat",
+        "heartbeat",
+        "milestone",
+    ]
+
+
+def test_no_action_is_reviewed_and_has_no_candidate_revision() -> None:
+    dependencies = _release_dependencies()
+    dependencies["collect_admission"] = lambda _run: _admission_input(
+        releasable=False
+    )
+
+    events = execute_release_run(json.dumps(RUN_INPUT), dependencies)
+
+    assert [event["type"] for event in events] == ["milestone", "result"]
+    assert events[-1]["status"] == "no_action"
+    assert events[-1]["candidate_revision"] is None
+    assert events[-1]["review_model_use_id"] == 71
+
+
+def test_release_blocks_when_ledger_approval_is_not_bound_to_candidate() -> None:
+    dependencies = _release_dependencies()
+    dependencies["collect_candidate_approval"] = lambda run, _candidate, review: {
+        "approval_id_hash": "6" * 64,
+        "authority": "standing-delegation",
+        "candidate_revision": SOURCE_SHA,
+        "contract_digest": run["contract_revision"],
+        "review_model_use_id": review["model_use_id"],
+        "run_id": run["run_id"],
+    }
+
+    events = execute_release_run(json.dumps(RUN_INPUT), dependencies)
+
+    assert events[-1]["status"] == "blocked"
+    assert events[-1]["candidate_revision"] == CANDIDATE_SHA
+    assert "candidate approval revision does not match" in events[-1]["reason"]
+
+
+def test_release_cli_default_invocation_reads_complete_run_input(
+    monkeypatch,
+    capsys,
+) -> None:
+    monkeypatch.setenv("AI_OPERATIONS_RUN_INPUT", json.dumps(RUN_INPUT))
+
+    exit_code = main([], dependencies=_release_dependencies())
+    lines = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
+
+    assert exit_code == 0
+    assert lines[-1]["status"] == "delivered"
+    assert "candidate_revision" in lines[-1]
+
+
+def test_release_cli_rollback_failure_is_one_closed_recovery_result(
+    monkeypatch,
+    capsys,
+) -> None:
+    recovery_input = {
+        "authority_revision": AUTHORITY_SHA,
+        "candidate_revision": CANDIDATE_SHA,
+        "contract_id": "data-olympus-release",
+        "contract_revision": CONTRACT_SHA,
+        "failure_reason": "notification failed",
+        "outcome_evidence": {
+            "digest": IMAGE_DIGEST,
+            "rollback_digest": PREVIOUS_DIGEST,
+        },
+        "run_id": RUN_INPUT["run_id"],
+        "source_revision": SOURCE_SHA,
+    }
+    monkeypatch.setenv(
+        "AI_OPERATIONS_RECOVERY_INPUT",
+        json.dumps(recovery_input),
+    )
+    dependencies = _release_dependencies()
+    dependencies["rollback"] = lambda _recovery: (_ for _ in ()).throw(
+        ValueError("gateway unavailable")
+    )
+
+    exit_code = main(["rollback"], dependencies=dependencies)
+    output = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 1
+    assert output == {
+        "status": "failed",
+        "reason": "gateway unavailable",
+        "evidence": {},
+        "source_revision": SOURCE_SHA,
+    }

--- a/tests/test_operations_release.py
+++ b/tests/test_operations_release.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from hashlib import sha256
 
 import pytest
 
@@ -965,6 +966,31 @@ def test_one_release_command_emits_the_exact_runner_protocol() -> None:
     }
 
 
+def test_review_evidence_hash_binds_the_packet_and_claude_response() -> None:
+    dependencies = _release_dependencies()
+    captured: dict[str, object] = {}
+
+    def invoke_model(request: dict[str, object]) -> dict[str, object]:
+        response = _approved_review(request)
+        captured["packet"] = request["packet"]
+        captured["response"] = response
+        return response
+
+    dependencies["invoke_model"] = invoke_model
+
+    events = execute_release_run(json.dumps(RUN_INPUT), dependencies)
+
+    review_event = next(event for event in events if event.get("name") == "domain_review")
+    expected_hash = sha256(
+        json.dumps(
+            {"packet": captured["packet"], "response": captured["response"]},
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode()
+    ).hexdigest()
+    assert review_event["evidence"]["review_hash"] == expected_hash
+
+
 def test_runtime_heartbeats_keep_one_contiguous_protocol_sequence() -> None:
     dependencies = _release_dependencies()
     original_prepare = dependencies["prepare"]
@@ -1050,7 +1076,10 @@ def test_release_blocks_when_review_ticket_is_not_the_qualified_claude_route() -
     assert "qualified Claude route" in events[-1]["reason"]
 
 
-def test_release_marks_external_delivery_failure_as_failed_with_recovery_evidence() -> None:
+@pytest.mark.parametrize("stage", ["prepare", "deliver"])
+def test_release_marks_external_release_failure_as_failed_with_recovery_evidence(
+    stage: str,
+) -> None:
     dependencies = _release_dependencies()
 
     class ExternalFailure(ValueError):
@@ -1060,7 +1089,7 @@ def test_release_marks_external_delivery_failure_as_failed_with_recovery_evidenc
             "rollback_completed": True,
         }
 
-    dependencies["deliver"] = lambda *_arguments: (_ for _ in ()).throw(
+    dependencies[stage] = lambda *_arguments: (_ for _ in ()).throw(
         ExternalFailure("stable publication failed")
     )
 

--- a/tests/test_operations_release.py
+++ b/tests/test_operations_release.py
@@ -1113,7 +1113,7 @@ def test_release_cli_default_invocation_reads_complete_run_input(
     assert "candidate_revision" in lines[-1]
 
 
-def test_release_cli_rollback_failure_is_one_closed_recovery_result(
+def test_release_cli_rollback_preflight_failure_is_one_blocked_recovery_result(
     monkeypatch,
     capsys,
 ) -> None:
@@ -1144,7 +1144,7 @@ def test_release_cli_rollback_failure_is_one_closed_recovery_result(
 
     assert exit_code == 1
     assert output == {
-        "status": "failed",
+        "status": "blocked",
         "reason": "gateway unavailable",
         "evidence": {},
         "source_revision": SOURCE_SHA,
@@ -1165,6 +1165,7 @@ def test_release_cli_preserves_rollback_failure_evidence(monkeypatch, capsys) ->
     )
 
     class RecoveryFailure(ValueError):
+        external_state_changed = True
         evidence = {
             "digest_apply_confirmed": True,
             "external_state_changed": True,
@@ -1180,4 +1181,5 @@ def test_release_cli_preserves_rollback_failure_evidence(monkeypatch, capsys) ->
     output = json.loads(capsys.readouterr().out)
 
     assert exit_code == 1
+    assert output["status"] == "failed"
     assert output["evidence"] == RecoveryFailure.evidence

--- a/tests/test_operations_release.py
+++ b/tests/test_operations_release.py
@@ -1149,3 +1149,35 @@ def test_release_cli_rollback_failure_is_one_closed_recovery_result(
         "evidence": {},
         "source_revision": SOURCE_SHA,
     }
+
+
+def test_release_cli_preserves_rollback_failure_evidence(monkeypatch, capsys) -> None:
+    recovery_input = {
+        "outcome_evidence": {
+            "digest": IMAGE_DIGEST,
+            "rollback_digest": PREVIOUS_DIGEST,
+        },
+        "source_revision": SOURCE_SHA,
+    }
+    monkeypatch.setenv(
+        "AI_OPERATIONS_RECOVERY_INPUT",
+        json.dumps(recovery_input),
+    )
+
+    class RecoveryFailure(ValueError):
+        evidence = {
+            "digest_apply_confirmed": True,
+            "external_state_changed": True,
+            "rollback_completed": False,
+        }
+
+    dependencies = _release_dependencies()
+    dependencies["rollback"] = lambda _recovery: (_ for _ in ()).throw(
+        RecoveryFailure("acceptance failed")
+    )
+
+    exit_code = main(["rollback"], dependencies=dependencies)
+    output = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 1
+    assert output["evidence"] == RecoveryFailure.evidence

--- a/tests/test_operations_release_runtime.py
+++ b/tests/test_operations_release_runtime.py
@@ -598,6 +598,50 @@ def test_prepare_reports_failed_recovery_evidence_after_merge_boundary(
         assert raised.value.evidence["merged_revision"] == final_revision
 
 
+@pytest.mark.parametrize("dispatch_started", [False, True])
+def test_delivery_failure_classification_tracks_the_workflow_dispatch_boundary(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    dispatch_started: bool,
+) -> None:
+    previous = "sha256:" + "e" * 64
+    runtime = ReleaseRuntime(tmp_path, gateway=StubGateway({"list_tags": []}))
+    runtime._prepared = {
+        "raw": {
+            "candidate": {"version": "0.7.0", "source_revision": SOURCE_SHA},
+            "rollback_point": {"digest": previous},
+        }
+    }
+
+    def workflow_run(
+        _name: str,
+        _source: str,
+        _inputs: dict[str, object],
+        *,
+        on_dispatch: object = None,
+    ) -> dict[str, object]:
+        if dispatch_started:
+            assert callable(on_dispatch)
+            on_dispatch()
+        raise ValueError("workflow preflight or dispatch failed")
+
+    monkeypatch.setattr(runtime, "_workflow_run", workflow_run)
+
+    with pytest.raises(ValueError) as raised:
+        runtime.deliver({}, {}, {}, {})
+
+    if dispatch_started:
+        assert isinstance(raised.value, ReleaseDeliveryError)
+        assert raised.value.evidence == {
+            "deployment_started": False,
+            "external_state_changed": True,
+            "rollback_completed": False,
+        }
+    else:
+        assert type(raised.value) is ValueError
+        assert getattr(raised.value, "external_state_changed", False) is False
+
+
 def test_partial_delivery_failure_restores_the_exact_previous_digest(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -619,15 +663,22 @@ def test_partial_delivery_failure_restores_the_exact_previous_digest(
         "mcp_search": True,
         "ready": True,
     }
-    monkeypatch.setattr(
-        runtime,
-        "_workflow_run",
-        lambda _name, source, _inputs: {
+    def workflow_run(
+        _name: str,
+        source: str,
+        _inputs: dict[str, object],
+        *,
+        on_dispatch: object = None,
+    ) -> dict[str, object]:
+        assert callable(on_dispatch)
+        on_dispatch()
+        return {
             "conclusion": "success",
             "run_id": 1,
             "source_revision": source,
-        },
-    )
+        }
+
+    monkeypatch.setattr(runtime, "_workflow_run", workflow_run)
     monkeypatch.setattr(
         runtime,
         "_candidate_publication",

--- a/tests/test_operations_release_runtime.py
+++ b/tests/test_operations_release_runtime.py
@@ -1,0 +1,539 @@
+from __future__ import annotations
+
+import json
+from datetime import date
+from typing import TYPE_CHECKING
+
+import pytest
+
+from scripts.operations.release_runtime import (
+    FastMCPGateway,
+    ReleaseRuntime,
+    candidate_release_evidence,
+    completed_check_evidence,
+    default_release_dependencies,
+    deployment_manifest_for_digest,
+    deployment_state,
+    render_release_documents,
+    stable_release_evidence,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+SOURCE_SHA = "a" * 40
+DIGEST = "sha256:" + "b" * 64
+
+
+class StubGateway:
+    def __init__(self, responses: dict[str, object] | None = None) -> None:
+        self.responses = responses or {}
+        self.calls: list[tuple[str, dict[str, object]]] = []
+
+    def execute(self, name: str, arguments: dict[str, object]) -> object:
+        self.calls.append((name, arguments))
+        response = self.responses[name]
+        if type(response) is tuple:
+            next_response, *remaining = response
+            self.responses[name] = tuple(remaining)
+            return next_response
+        return response
+
+
+def test_fastmcp_gateway_uses_the_gateway_control_plane() -> None:
+    calls: list[list[str]] = []
+
+    def run_command(command: list[str], _cwd: Path, _timeout: int) -> str:
+        calls.append(command)
+        return json.dumps(
+            {
+                "is_error": False,
+                "structured_content": {
+                    "result": json.dumps(
+                        {"tool": "get_latest_release", "result": "{\"tag\":\"v1\"}"}
+                    )
+                },
+            }
+        )
+
+    gateway = FastMCPGateway(run_command=run_command)
+
+    result = gateway.execute(
+        "get_latest_release",
+        {"owner": "knaisoma", "repo": "data-olympus"},
+    )
+
+    assert result == {"tag": "v1"}
+    assert calls[0][:5] == [
+        "fastmcp",
+        "call",
+        "--server-spec",
+        "http://fastmcp-gateway.mcp-gateway.apps.172.30.1.2.nip.io/mcp",
+        "--target",
+    ]
+    assert calls[0][5] == "execute_tool"
+
+
+def test_collect_admission_binds_exact_remote_main_and_governed_computation(
+    tmp_path: Path,
+) -> None:
+    commands: list[tuple[str, ...]] = []
+
+    def command_output(command: list[str], _cwd: Path, _timeout: int) -> str:
+        commands.append(tuple(command))
+        if command[:2] == ["git", "fetch"]:
+            return ""
+        if command == ["git", "rev-parse", "HEAD"]:
+            return SOURCE_SHA
+        if command == ["git", "rev-parse", "origin/main"]:
+            return SOURCE_SHA
+        if command[0] == "uv":
+            return json.dumps(
+                {
+                    "releasable": True,
+                    "bump": "minor",
+                    "current_version": "0.6.0",
+                    "next_version": "0.7.0",
+                    "functional_changed": False,
+                    "changes": {
+                        "features": [
+                            "feat(automation): make weekly releases outcome based"
+                        ],
+                        "fixes": [],
+                        "breaking": [],
+                    },
+                }
+            )
+        raise AssertionError(command)
+
+    runtime = ReleaseRuntime(
+        repository_root=tmp_path,
+        gateway=StubGateway(),
+        command_output=command_output,
+    )
+
+    evidence = runtime.collect_admission({"source_revision": SOURCE_SHA})
+
+    assert evidence["branch"] == "main"
+    assert evidence["source_revision"] == SOURCE_SHA
+    assert evidence["remote_main_revision"] == SOURCE_SHA
+    assert evidence["computed_release"]["next_version"] == "0.7.0"
+    assert commands[0] == ("git", "fetch", "--tags", "origin", "main")
+
+
+def test_collect_admission_fails_when_the_managed_worktree_is_stale(
+    tmp_path: Path,
+) -> None:
+    def command_output(command: list[str], _cwd: Path, _timeout: int) -> str:
+        if command[:2] == ["git", "fetch"]:
+            return ""
+        if command == ["git", "rev-parse", "HEAD"]:
+            return SOURCE_SHA
+        if command == ["git", "rev-parse", "origin/main"]:
+            return "f" * 40
+        raise AssertionError(command)
+
+    runtime = ReleaseRuntime(
+        repository_root=tmp_path,
+        gateway=StubGateway(),
+        command_output=command_output,
+    )
+
+    with pytest.raises(ValueError, match="remote main changed after admission"):
+        runtime.collect_admission({"source_revision": SOURCE_SHA})
+
+
+def test_render_release_documents_updates_only_the_governed_release_files(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / "docs" / "releases").mkdir(parents=True)
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "data-olympus"\nversion = "0.6.0"\n',
+        encoding="utf-8",
+    )
+    (tmp_path / "CHANGELOG.md").write_text(
+        "# Changelog\n\n## [Unreleased]\n\n## [0.6.0] - 2026-07-18\n",
+        encoding="utf-8",
+    )
+
+    evidence = render_release_documents(
+        tmp_path,
+        "0.7.0",
+        {
+            "features": ["feat(automation): make releases outcome based"],
+            "fixes": ["fix(mcp): preserve exact source evidence"],
+            "breaking": [],
+        },
+        date(2026, 8, 1),
+    )
+
+    assert 'version = "0.7.0"' in (tmp_path / "pyproject.toml").read_text()
+    changelog = (tmp_path / "CHANGELOG.md").read_text()
+    assert changelog.index("## [Unreleased]") < changelog.index(
+        "## [0.7.0] - 2026-08-01"
+    )
+    assert "feat(automation): make releases outcome based" in changelog
+    note = (tmp_path / "docs" / "releases" / "v0.7.0.md").read_text()
+    assert note.startswith("# data-olympus 0.7.0")
+    assert evidence["content_hash"] == evidence["release_note_hash"]
+    assert len(evidence["changelog_hash"]) == 64
+
+
+def test_completed_check_evidence_requires_every_expected_check_and_no_failures() -> None:
+    payload = {
+        "check_runs": [
+            {"name": "test", "status": "completed", "conclusion": "success"},
+            {
+                "name": "version-free-guard",
+                "status": "completed",
+                "conclusion": "success",
+            },
+            {"name": "CodeQL", "status": "completed", "conclusion": "success"},
+        ]
+    }
+
+    evidence = completed_check_evidence(
+        payload,
+        required={"test", "version-free-guard"},
+    )
+
+    assert evidence["all_success"] is True
+    assert evidence["missing_required"] == []
+
+    payload["check_runs"][2]["conclusion"] = "failure"
+    with pytest.raises(ValueError, match="did not succeed"):
+        completed_check_evidence(
+            payload,
+            required={"test", "version-free-guard"},
+        )
+
+
+def test_deployment_state_parses_gateway_yaml_and_binds_both_images() -> None:
+    state = deployment_state(
+        f"""
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: data-olympus-mcp
+  namespace: data-olympus
+  annotations:
+    keel.sh/policy: never
+spec:
+  template:
+    spec:
+      initContainers:
+        - name: prepare-git
+          image: ghcr.io/knaisoma/data-olympus@{DIGEST}
+      containers:
+        - name: data-olympus-mcp
+          image: ghcr.io/knaisoma/data-olympus@{DIGEST}
+status:
+  observedGeneration: 7
+  readyReplicas: 1
+  replicas: 1
+  updatedReplicas: 1
+"""
+    )
+
+    assert state["digest"] == DIGEST
+    assert state["keel_policy"] == "never"
+    assert state["rollout_complete"] is True
+
+
+def test_deployment_state_rejects_mixed_container_digests() -> None:
+    document = {
+        "apiVersion": "apps/v1",
+        "kind": "StatefulSet",
+        "metadata": {
+            "name": "data-olympus-mcp",
+            "namespace": "data-olympus",
+            "annotations": {"keel.sh/policy": "never"},
+        },
+        "spec": {
+            "volumeClaimTemplates": [
+                {
+                    "metadata": {"name": "kb-main"},
+                    "spec": {"accessModes": ["ReadWriteOnce"]},
+                    "status": {"phase": "Pending"},
+                }
+            ],
+            "template": {
+                "spec": {
+                    "initContainers": [
+                        {
+                            "name": "prepare-git",
+                            "image": f"ghcr.io/knaisoma/data-olympus@{DIGEST}",
+                        }
+                    ],
+                    "containers": [
+                        {
+                            "name": "data-olympus-mcp",
+                            "image": (
+                                "ghcr.io/knaisoma/data-olympus@sha256:"
+                                + "c" * 64
+                            ),
+                        }
+                    ],
+                }
+            }
+        },
+        "status": {"readyReplicas": 1, "replicas": 1, "updatedReplicas": 1},
+    }
+
+    with pytest.raises(ValueError, match="same exact digest"):
+        deployment_state(document)
+
+
+def test_candidate_release_evidence_binds_assets_source_and_digest() -> None:
+    tag = "0.7.0-rc.1"
+    evidence = candidate_release_evidence(
+        {
+            "tag_name": tag,
+            "target_commitish": SOURCE_SHA,
+            "draft": False,
+            "prerelease": True,
+            "assets": [
+                {"name": "data_olympus-0.7.0rc1-py3-none-any.whl"},
+                {"name": "data_olympus-0.7.0rc1.tar.gz"},
+                {"name": "release-provenance.json"},
+            ],
+        },
+        {
+            "source_sha": SOURCE_SHA,
+            "candidate_tag": tag,
+            "image_digest": DIGEST,
+            "candidate": {
+                "version": "0.7.0rc1",
+                "source_sha": SOURCE_SHA,
+                "wheel": "data_olympus-0.7.0rc1-py3-none-any.whl",
+                "sdist": "data_olympus-0.7.0rc1.tar.gz",
+            },
+        },
+        source_revision=SOURCE_SHA,
+        version="0.7.0",
+        candidate_tag=tag,
+        registry_digest=DIGEST,
+    )
+
+    assert evidence["candidate_tag"] == tag
+    assert evidence["image_digest"] == DIGEST
+
+
+def test_stable_release_evidence_requires_exact_pypi_hashes() -> None:
+    stable = {
+        "version": "0.7.0",
+        "source_sha": SOURCE_SHA,
+        "wheel": "data_olympus-0.7.0-py3-none-any.whl",
+        "wheel_sha256": "d" * 64,
+        "sdist": "data_olympus-0.7.0.tar.gz",
+        "sdist_sha256": "e" * 64,
+    }
+    evidence = stable_release_evidence(
+        {
+            "tag_name": "v0.7.0",
+            "target_commitish": SOURCE_SHA,
+            "draft": False,
+            "prerelease": False,
+            "assets": [
+                {"name": stable["wheel"]},
+                {"name": stable["sdist"]},
+                {"name": "release-provenance.json"},
+            ],
+        },
+        {"source_sha": SOURCE_SHA, "stable": stable},
+        {
+            "info": {"version": "0.7.0"},
+            "urls": [
+                {
+                    "filename": stable["wheel"],
+                    "digests": {"sha256": stable["wheel_sha256"]},
+                },
+                {
+                    "filename": stable["sdist"],
+                    "digests": {"sha256": stable["sdist_sha256"]},
+                },
+            ],
+        },
+        source_revision=SOURCE_SHA,
+        version="0.7.0",
+    )
+
+    assert evidence["source_revision"] == SOURCE_SHA
+    assert evidence["pypi_version"] == "0.7.0"
+
+
+def test_default_dependencies_exposes_every_release_lifecycle_operation() -> None:
+    dependencies = default_release_dependencies()
+
+    for name in (
+        "collect_admission",
+        "prepare",
+        "validate",
+        "deliver",
+        "verify",
+        "rollback",
+        "set_heartbeat",
+    ):
+        assert callable(dependencies[name])
+    assert "collect_operator_approval" not in dependencies
+
+
+def test_deployment_manifest_pins_both_containers_and_keeps_keel_disabled() -> None:
+    live = {
+        "apiVersion": "apps/v1",
+        "kind": "StatefulSet",
+        "metadata": {
+            "name": "data-olympus-mcp",
+            "namespace": "data-olympus",
+            "annotations": {
+                "keel.sh/policy": "never",
+                "keel.sh/trigger": "poll",
+            },
+            "resourceVersion": "123",
+            "uid": "server-owned",
+        },
+        "spec": {
+            "volumeClaimTemplates": [
+                {
+                    "metadata": {"name": "kb-main"},
+                    "spec": {"accessModes": ["ReadWriteOnce"]},
+                    "status": {"phase": "Pending"},
+                }
+            ],
+            "template": {
+                "spec": {
+                    "initContainers": [
+                        {"name": "prepare-git", "image": "old-init"}
+                    ],
+                    "containers": [
+                        {"name": "data-olympus-mcp", "image": "old-main"}
+                    ],
+                }
+            }
+        },
+        "status": {"readyReplicas": 1},
+    }
+
+    manifest = deployment_manifest_for_digest(live, DIGEST)
+
+    expected_image = f"ghcr.io/knaisoma/data-olympus@{DIGEST}"
+    assert manifest["metadata"]["annotations"]["keel.sh/policy"] == "never"
+    assert "resourceVersion" not in manifest["metadata"]
+    assert "uid" not in manifest["metadata"]
+    assert "status" not in manifest
+    assert "status" not in manifest["spec"]["volumeClaimTemplates"][0]
+    assert manifest["spec"]["template"]["spec"]["initContainers"][0][
+        "image"
+    ] == expected_image
+    assert manifest["spec"]["template"]["spec"]["containers"][0][
+        "image"
+    ] == expected_image
+
+
+def test_workflow_receipt_is_new_completed_and_bound_to_exact_source(
+    tmp_path: Path,
+) -> None:
+    gateway = StubGateway(
+        {
+            "actions_list": (
+                {"workflow_runs": [{"id": 4, "head_sha": SOURCE_SHA}]},
+                {
+                    "workflow_runs": [
+                        {
+                            "id": 5,
+                            "head_sha": SOURCE_SHA,
+                            "event": "workflow_dispatch",
+                            "status": "completed",
+                            "conclusion": "success",
+                        }
+                    ]
+                },
+            ),
+            "actions_run_trigger": {},
+            "actions_get": {
+                "id": 5,
+                "head_sha": SOURCE_SHA,
+                "conclusion": "success",
+            },
+        }
+    )
+    runtime = ReleaseRuntime(tmp_path, gateway=gateway, sleep=lambda _seconds: None)
+
+    receipt = runtime._workflow_run(
+        "rc-publish.yml",
+        SOURCE_SHA,
+        {"number": 1, "ref": SOURCE_SHA},
+    )
+
+    assert receipt == {
+        "conclusion": "success",
+        "run_id": 5,
+        "source_revision": SOURCE_SHA,
+    }
+    assert gateway.calls[1] == (
+        "actions_run_trigger",
+        {
+            "inputs": {"number": 1, "ref": SOURCE_SHA},
+            "method": "run_workflow",
+            "owner": "knaisoma",
+            "ref": "main",
+            "repo": "data-olympus",
+            "workflow_id": "rc-publish.yml",
+        },
+    )
+
+
+def test_partial_delivery_failure_restores_the_exact_previous_digest(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    previous = "sha256:" + "e" * 64
+    gateway = StubGateway({"list_tags": []})
+    runtime = ReleaseRuntime(tmp_path, gateway=gateway)
+    runtime._prepared = {
+        "raw": {
+            "candidate": {"version": "0.7.0", "source_revision": SOURCE_SHA},
+            "rollback_point": {"digest": previous},
+        }
+    }
+    applied: list[str] = []
+    acceptance = {
+        "documentation": True,
+        "enforcement": True,
+        "healthy": True,
+        "mcp_search": True,
+        "ready": True,
+    }
+    monkeypatch.setattr(
+        runtime,
+        "_workflow_run",
+        lambda _name, source, _inputs: {
+            "conclusion": "success",
+            "run_id": 1,
+            "source_revision": source,
+        },
+    )
+    monkeypatch.setattr(
+        runtime,
+        "_candidate_publication",
+        lambda _source, _version, _tag: {"image_digest": DIGEST},
+    )
+    monkeypatch.setattr(
+        runtime,
+        "_apply_digest",
+        lambda digest: (
+            applied.append(digest)
+            or {"digest": digest, "keel_policy": "never", "rollout_complete": True}
+        ),
+    )
+    monkeypatch.setattr(runtime, "_service_acceptance", lambda: acceptance)
+    monkeypatch.setattr(
+        runtime,
+        "_stable_publication",
+        lambda _source, _version: (_ for _ in ()).throw(ValueError("stable failed")),
+    )
+
+    with pytest.raises(ValueError, match="stable failed"):
+        runtime.deliver({}, {}, {}, {})
+
+    assert applied == [DIGEST, previous]

--- a/tests/test_operations_release_runtime.py
+++ b/tests/test_operations_release_runtime.py
@@ -8,6 +8,7 @@ import pytest
 
 from scripts.operations.release_runtime import (
     FastMCPGateway,
+    ReleaseDeliveryError,
     ReleaseRuntime,
     candidate_release_evidence,
     completed_check_evidence,
@@ -483,6 +484,39 @@ def test_workflow_receipt_is_new_completed_and_bound_to_exact_source(
     )
 
 
+def test_merge_uses_github_expected_head_precondition(tmp_path: Path) -> None:
+    commands: list[list[str]] = []
+
+    def command_output(command: list[str], _cwd: Path, _timeout: int) -> str:
+        commands.append(command)
+        return json.dumps({"merged": True, "sha": SOURCE_SHA})
+
+    runtime = ReleaseRuntime(
+        tmp_path,
+        gateway=StubGateway(),
+        command_output=command_output,
+    )
+
+    result = runtime._merge_exact(182, "0.7.0", "f" * 40)
+
+    assert result == {"merged": True, "sha": SOURCE_SHA}
+    assert commands == [
+        [
+            "gh",
+            "api",
+            "--method",
+            "PUT",
+            "repos/knaisoma/data-olympus/pulls/182/merge",
+            "--field",
+            "merge_method=squash",
+            "--field",
+            "commit_title=chore(release): prepare v0.7.0",
+            "--field",
+            "sha=" + "f" * 40,
+        ]
+    ]
+
+
 def test_partial_delivery_failure_restores_the_exact_previous_digest(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -533,7 +567,13 @@ def test_partial_delivery_failure_restores_the_exact_previous_digest(
         lambda _source, _version: (_ for _ in ()).throw(ValueError("stable failed")),
     )
 
-    with pytest.raises(ValueError, match="stable failed"):
+    with pytest.raises(ReleaseDeliveryError, match="stable failed") as raised:
         runtime.deliver({}, {}, {}, {})
 
     assert applied == [DIGEST, previous]
+    assert raised.value.external_state_changed is True
+    assert raised.value.evidence == {
+        "deployment_started": True,
+        "external_state_changed": True,
+        "rollback_completed": True,
+    }

--- a/tests/test_operations_release_runtime.py
+++ b/tests/test_operations_release_runtime.py
@@ -517,6 +517,38 @@ def test_merge_uses_github_expected_head_precondition(tmp_path: Path) -> None:
     ]
 
 
+def test_merge_response_distinguishes_no_merge_from_confirmed_missing_identity(
+    tmp_path: Path,
+) -> None:
+    runtime = ReleaseRuntime(tmp_path, gateway=StubGateway())
+
+    with pytest.raises(ValueError) as unmerged:
+        runtime._confirmed_merge_revision(
+            {"merged": False, "message": "head changed"},
+            number=182,
+            head_revision="f" * 40,
+        )
+
+    assert type(unmerged.value) is ValueError
+    assert getattr(unmerged.value, "external_state_changed", False) is False
+
+    with pytest.raises(ReleaseDeliveryError) as confirmed:
+        runtime._confirmed_merge_revision(
+            {"merged": True},
+            number=182,
+            head_revision="f" * 40,
+        )
+
+    assert confirmed.value.evidence == {
+        "external_state_changed": True,
+        "merge_confirmed": True,
+        "merge_outcome": "merged",
+        "release_pr_head_revision": "f" * 40,
+        "release_pr_number": 182,
+        "rollback_completed": False,
+    }
+
+
 @pytest.mark.parametrize("merge_confirmed", [False, True])
 def test_prepare_reports_failed_recovery_evidence_after_merge_boundary(
     tmp_path: Path,
@@ -684,14 +716,18 @@ def test_partial_delivery_failure_restores_the_exact_previous_digest(
         "_candidate_publication",
         lambda _source, _version, _tag: {"image_digest": DIGEST},
     )
-    monkeypatch.setattr(
-        runtime,
-        "_apply_digest",
-        lambda digest: (
-            applied.append(digest)
-            or {"digest": digest, "keel_policy": "never", "rollout_complete": True}
-        ),
-    )
+    def apply_digest(
+        digest: str,
+        *,
+        on_apply: object = None,
+    ) -> dict[str, object]:
+        if on_apply is not None:
+            assert callable(on_apply)
+            on_apply()
+        applied.append(digest)
+        return {"digest": digest, "keel_policy": "never", "rollout_complete": True}
+
+    monkeypatch.setattr(runtime, "_apply_digest", apply_digest)
     monkeypatch.setattr(runtime, "_service_acceptance", lambda: acceptance)
     monkeypatch.setattr(
         runtime,
@@ -709,3 +745,56 @@ def test_partial_delivery_failure_restores_the_exact_previous_digest(
         "external_state_changed": True,
         "rollback_completed": True,
     }
+
+
+@pytest.mark.parametrize("failure_point", ["preflight", "apply", "acceptance"])
+def test_rollback_failure_evidence_tracks_the_digest_apply_boundary(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    failure_point: str,
+) -> None:
+    rollback_digest = "sha256:" + "e" * 64
+    runtime = ReleaseRuntime(tmp_path, gateway=StubGateway())
+
+    def apply_digest(
+        digest: str,
+        *,
+        on_apply: object = None,
+    ) -> dict[str, object]:
+        assert digest == rollback_digest
+        if failure_point != "preflight":
+            assert callable(on_apply)
+            on_apply()
+        if failure_point in {"preflight", "apply"}:
+            raise ValueError(f"{failure_point} failed")
+        return {"digest": digest, "keel_policy": "never", "rollout_complete": True}
+
+    monkeypatch.setattr(runtime, "_apply_digest", apply_digest)
+    monkeypatch.setattr(
+        runtime,
+        "_service_acceptance",
+        lambda: (_ for _ in ()).throw(ValueError("acceptance failed")),
+    )
+    recovery = {
+        "source_revision": SOURCE_SHA,
+        "outcome_evidence": {
+            "digest": DIGEST,
+            "rollback_digest": rollback_digest,
+        },
+    }
+
+    with pytest.raises(ValueError) as raised:
+        runtime.rollback(recovery)
+
+    if failure_point == "preflight":
+        assert type(raised.value) is ValueError
+        assert getattr(raised.value, "external_state_changed", False) is False
+        return
+
+    assert isinstance(raised.value, ReleaseDeliveryError)
+    assert raised.value.evidence["external_state_changed"] is True
+    assert raised.value.evidence["digest_apply_confirmed"] is (
+        failure_point == "acceptance"
+    )
+    assert raised.value.evidence["rollback_completed"] is False
+    assert raised.value.evidence["rollback_digest"] == rollback_digest

--- a/tests/test_operations_release_runtime.py
+++ b/tests/test_operations_release_runtime.py
@@ -517,6 +517,87 @@ def test_merge_uses_github_expected_head_precondition(tmp_path: Path) -> None:
     ]
 
 
+@pytest.mark.parametrize("merge_confirmed", [False, True])
+def test_prepare_reports_failed_recovery_evidence_after_merge_boundary(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    merge_confirmed: bool,
+) -> None:
+    head_revision = "c" * 40
+    final_revision = "d" * 40
+    gateway = StubGateway({"create_pull_request": {"number": 182}})
+    runtime = ReleaseRuntime(
+        tmp_path,
+        gateway=gateway,
+        command_output=lambda _command, _cwd, _timeout: "",
+    )
+    monkeypatch.setattr(
+        "scripts.operations.release_runtime.render_release_documents",
+        lambda *_arguments: {
+            "changelog_hash": "1" * 64,
+            "content_hash": "2" * 64,
+            "release_note_hash": "2" * 64,
+        },
+    )
+    monkeypatch.setattr(runtime, "source_revision", lambda: head_revision)
+    remote_revisions = iter([SOURCE_SHA, final_revision])
+    monkeypatch.setattr(runtime, "candidate_revision", lambda: next(remote_revisions))
+    monkeypatch.setattr(
+        runtime,
+        "_wait_pull_request",
+        lambda _number, _head: {"checks": {}, "pull": {}},
+    )
+    if merge_confirmed:
+        monkeypatch.setattr(
+            runtime,
+            "_merge_exact",
+            lambda _number, _version, _head: {
+                "merged": True,
+                "sha": final_revision,
+            },
+        )
+        monkeypatch.setattr(
+            runtime,
+            "_final_local_gates",
+            lambda _source, _version: (_ for _ in ()).throw(
+                ValueError("post merge gates failed")
+            ),
+        )
+    else:
+        monkeypatch.setattr(
+            runtime,
+            "_merge_exact",
+            lambda _number, _version, _head: (_ for _ in ()).throw(
+                ValueError("merge response lost")
+            ),
+        )
+
+    with pytest.raises(ReleaseDeliveryError) as raised:
+        runtime.prepare(
+            {
+                "extra_context": "No extra context for this run",
+                "run_id": "11111111-2222-4333-8444-555555555555",
+                "source_revision": SOURCE_SHA,
+            },
+            {
+                "evidence": {
+                    "computed_release": {
+                        "changes": {"breaking": [], "features": [], "fixes": []}
+                    }
+                },
+                "outputs": {"candidate": {"version": "0.7.0"}},
+            },
+        )
+
+    assert raised.value.external_state_changed is True
+    assert raised.value.evidence["external_state_changed"] is True
+    assert raised.value.evidence["merge_confirmed"] is merge_confirmed
+    assert raised.value.evidence["release_pr_number"] == 182
+    assert raised.value.evidence["rollback_completed"] is False
+    if merge_confirmed:
+        assert raised.value.evidence["merged_revision"] == final_revision
+
+
 def test_partial_delivery_failure_restores_the_exact_previous_digest(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_release_contract_docs.py
+++ b/tests/test_release_contract_docs.py
@@ -63,8 +63,8 @@ def test_versioning_rule_uses_one_linear_release_change() -> None:
     versioning = _read(".rules/versioning.md")
     routine = _read(".rules/release-routine.md")
 
-    assert "`chore/release-vX.Y.Z`" in versioning
-    assert "`chore/release-vX.Y.Z`" in routine
+    assert "`chore/release-vX.Y.Z-RUN`" in versioning
+    assert "`chore/release-vX.Y.Z-RUN`" in routine
     assert "linear history" in versioning
     assert "squash merged" in versioning
     assert "feature/<release-epic-id>" not in versioning


### PR DESCRIPTION
## Outcome

Replace the fragmented release planning stages with one project owned Monday outcome command. The command computes the next version dynamically, prepares one public release pull request, binds review and standing approval to the exact resulting main SHA, publishes one immutable candidate and stable release, deploys an exact digest to kn dev, verifies the service, and returns truthful recovery evidence.

All schedules remain disabled until company certification completes.

## Safety

FastMCP remains the primary control plane. Direct GitHub calls are limited to the three documented gateway capability gaps: security alert enumeration, container package digest lookup, and a pull request merge carrying GitHub's expected head SHA precondition.

Every mutation boundary distinguishes safe preflight blocking from ambiguous or confirmed external state failure. Rollback evidence survives through the CLI.

## Verification

The complete suite passed after the final behavior change: Ruff, mypy across 73 source files, documentation guards, the complete pytest suite with only two documented optional dependency skips, all 74 Bats tests, example bundle lint, package build, installed wheel smoke, and installed source distribution smoke.

Claude Opus independently reviewed and approved the exact combined range from cb079fd10413e19db2795464f29dd63f9d155552 through 7113c83ed6923a5d4ca5089ce866dc9711fe9c1e.