### PR TITLE
fix(security): update setuptools to 83.0.0

### DIFF
--- a/benchmarks/results/receipt.json
+++ b/benchmarks/results/receipt.json
@@ -35,7 +35,7 @@
       }
     ],
     "path": "uv.lock",
-    "sha256": "b8f39d5183c1a26561bb549cd866a4d40e278f042f54e62f508286b1e0c90363"
+    "sha256": "b108a6c64cb2abe227d70716983d54b9c681cedfc4609845401449003e8dd2cc"
   },
   "environment": {
     "platform": "macOS-26.5.2-arm64-arm-64bit-Mach-O",

--- a/uv.lock
+++ b/uv.lock
@@ -2317,11 +2317,11 @@ wheels = [
 
 [[package]]
 name = "setuptools"
-version = "81.0.0"
+version = "83.0.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0d/1c/73e719955c59b8e424d015ab450f51c0af856ae46ea2da83eba51cc88de1/setuptools-81.0.0.tar.gz", hash = "sha256:487b53915f52501f0a79ccfd0c02c165ffe06631443a886740b91af4b7a5845a", size = 1198299, upload-time = "2026-02-06T21:10:39.601Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/26/f5d29e25ffdb535afef2d35cdb55b325298f96debd670da4c325e08d70f4/setuptools-83.0.0.tar.gz", hash = "sha256:025bccbbf0fa05b6192bc64ae1e7b16e001fd6d6d4d5de03c97b1c1ade523bef", size = 1154254, upload-time = "2026-07-04T15:31:22.699Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e1/e3/c164c88b2e5ce7b24d667b9bd83589cf4f3520d97cad01534cd3c4f55fdb/setuptools-81.0.0-py3-none-any.whl", hash = "sha256:fdd925d5c5d9f62e4b74b30d6dd7828ce236fd6ed998a08d81de62ce5a6310d6", size = 1062021, upload-time = "2026-02-06T21:10:37.175Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/40/e1e72872c6354b306daef1703549e8e83b4d43cfea356311bf722a043752/setuptools-83.0.0-py3-none-any.whl", hash = "sha256:29b23c360f22f414dc7336bb39178cc7bcbf6021ed2733cde173f09dba19abb3", size = 1008090, upload-time = "2026-07-04T15:31:20.885Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Security outcome

Resolve Dependabot alert 20 for CVE 2026 59890 and GHSA h35f 9h28 mq5c by updating the transitive benchmark dependency from setuptools 81.0.0 to the first patched version, 83.0.0.

The benchmark provenance receipt is regenerated only for the resulting lockfile hash. No source or manifest dependency changed.

## Verification

Lock integrity and exact dependency resolution passed. Ruff, mypy, documentation guards, the complete pytest suite, all 74 Bats tests, bundle lint, package build, installed wheel smoke, and installed source distribution smoke passed. Claude Sonnet independently approved exact commit 4840183306d88a9928f35c0c9051489bf73473de.