### PR TITLE
fix(automation): align final main checks

### DIFF
--- a/.rules/release-routine.md
+++ b/.rules/release-routine.md
@@ -102,6 +102,10 @@ Rollback is the same executable with the `rollback` argument. It reads
    * `scripts/ci_status.py`.
    * Version availability across PyPI, GHCR, GitHub tags, and GitHub releases.
 
+   Pull request checks require the aggregate `CodeQL` signal and all three
+   language analyses. Default branch pushes do not emit the aggregate signal,
+   so final main CI requires the three successful language analyses directly.
+
 9. The deterministic executor requests one central, run controlled Claude
    review of the exact final SHA. Self review is prohibited. Review evidence
    hashes both the submitted packet and the ticket bound Claude response.

--- a/scripts/operations/release_runtime.py
+++ b/scripts/operations/release_runtime.py
@@ -47,7 +47,6 @@ REQUIRED_MAIN_CHECKS = {
     "Analyze (actions)",
     "Analyze (javascript-typescript)",
     "Analyze (python)",
-    "CodeQL",
     "doc-consistency-guard",
     "test",
 }

--- a/tests/test_operations_release_runtime.py
+++ b/tests/test_operations_release_runtime.py
@@ -7,6 +7,8 @@ from typing import TYPE_CHECKING
 import pytest
 
 from scripts.operations.release_runtime import (
+    REQUIRED_MAIN_CHECKS,
+    REQUIRED_PULL_REQUEST_CHECKS,
     FastMCPGateway,
     ReleaseDeliveryError,
     ReleaseRuntime,
@@ -24,6 +26,19 @@ if TYPE_CHECKING:
 
 SOURCE_SHA = "a" * 40
 DIGEST = "sha256:" + "b" * 64
+
+
+def test_required_checks_match_pull_request_and_main_github_surfaces() -> None:
+    codeql_analyses = {
+        "Analyze (actions)",
+        "Analyze (javascript-typescript)",
+        "Analyze (python)",
+    }
+
+    assert codeql_analyses <= REQUIRED_PULL_REQUEST_CHECKS
+    assert codeql_analyses <= REQUIRED_MAIN_CHECKS
+    assert "CodeQL" in REQUIRED_PULL_REQUEST_CHECKS
+    assert "CodeQL" not in REQUIRED_MAIN_CHECKS
 
 
 class StubGateway:


### PR DESCRIPTION
## Outcome

Align the final release main CI gate with the exact checks GitHub emits on default branch pushes. All three CodeQL language analyses remain mandatory. The aggregate CodeQL signal remains mandatory on pull requests, where GitHub emits it, and is removed only from final main checks, where two live commits prove it is absent.

## Verification

A regression test encodes the distinct pull request and main surfaces. The corrected gate passes against live main commit c79ff838e4ec397009e07f31fe6851c1d70bc338. The complete suite, all 74 Bats tests, documentation guards, package build, and both installed artifact smoke tests passed. Claude Sonnet independently approved exact commit 5b57d136e5e5edcd0c7e119e1184916fdb52a540.