### PR TITLE
fix(automation): make release imports deterministic

### DIFF
--- a/.rules/release-routine.md
+++ b/.rules/release-routine.md
@@ -18,7 +18,7 @@ to release when the evidence says no release is due.
 
 The complete project command is:
 
-`python3.13 scripts/operations/release.py`
+`python3.13 -m scripts.operations.release`
 
 It reads the bounded run document from `AI_OPERATIONS_RUN_INPUT`. It emits
 newline delimited JSON with contiguous sequence numbers. The only event types

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Repository owned build, release, and verification scripts."""

--- a/tests/test_operations_package.py
+++ b/tests/test_operations_package.py
@@ -1,0 +1,31 @@
+import subprocess
+import sys
+from pathlib import Path
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_release_runtime_imports_from_the_repository_scripts_package() -> None:
+    process = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "from pathlib import Path; "
+                "import scripts; "
+                "from scripts.operations import release_runtime; "
+                "print(Path(scripts.__file__).resolve()); "
+                "print(Path(release_runtime.__file__).resolve())"
+            ),
+        ],
+        cwd=REPOSITORY_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert process.returncode == 0, process.stderr
+    assert process.stdout.splitlines() == [
+        str(REPOSITORY_ROOT / "scripts" / "__init__.py"),
+        str(REPOSITORY_ROOT / "scripts" / "operations" / "release_runtime.py"),
+    ]


### PR DESCRIPTION
## Summary

Make the repository owned `scripts` directory an explicit local package and document the module entrypoint used by the release routine. This prevents an unrelated installed `scripts` package from shadowing the Data Olympus release runtime.

## Verification

The package resolution regression test failed with `ModuleNotFoundError` on the former tree and now passes. The complete pytest suite reached 100 percent with zero failures and two expected optional dependency skips. Ruff, mypy, both documentation guards, 74 Bats tests, example bundle lint, wheel and source distribution build, strict metadata validation, and both installed artifact smokes pass.

Hatch explicitly packages only `src/data_olympus` in the wheel and excludes `scripts` from the source distribution, so this local marker is not published as a top level downstream package.

## Companion review (Claude Opus)

The focused review covered exact commit `857f46ea2648f4de80f6712126e671ca9ee4773e` together with AI Operations commit `2d259b311fc51a455243e461c9fe39f60e842d7e`. The current Claude Opus alias reported actual model `claude-opus-4-8` and returned `VERDICT: APPROVE`. Fable was not used. The reviewer confirmed correct import semantics, rollback parity, fail closed behavior, test adequacy, and unchanged release mutation boundaries.