### PR TITLE
fix(automation): read pull number from gateway receipt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+* **Accepted the canonical FastMCP pull request receipt.** The automated
+  release routine now derives the new pull request number from the exact
+  repository URL when the gateway receipt omits a separate numeric field.
+
 ## [0.6.0] - 2026-07-18
 
 ### Added

--- a/scripts/operations/release_runtime.py
+++ b/scripts/operations/release_runtime.py
@@ -53,6 +53,9 @@ REQUIRED_MAIN_CHECKS = {
 
 _SHA40 = re.compile(r"^[0-9a-f]{40}$")
 _DIGEST = re.compile(r"^sha256:[0-9a-f]{64}$")
+_PULL_REQUEST_URL = re.compile(
+    r"^https://github[.]com/knaisoma/data-olympus/pull/([1-9][0-9]*)$"
+)
 
 CommandOutput = Callable[[list[str], Path, int], str]
 JsonFetch = Callable[[str, int], dict[str, Any]]
@@ -930,6 +933,11 @@ class ReleaseRuntime:
             },
         )
         number = pull.get("number")
+        if type(number) is not int:
+            url = pull.get("url")
+            match = _PULL_REQUEST_URL.fullmatch(url) if type(url) is str else None
+            if match is not None:
+                number = int(match.group(1))
         if type(number) is not int or number <= 0:
             raise ValueError("release pull request number is invalid")
         ready = self._wait_pull_request(number, head_revision)

--- a/tests/test_operations_release_runtime.py
+++ b/tests/test_operations_release_runtime.py
@@ -572,7 +572,14 @@ def test_prepare_reports_failed_recovery_evidence_after_merge_boundary(
 ) -> None:
     head_revision = "c" * 40
     final_revision = "d" * 40
-    gateway = StubGateway({"create_pull_request": {"number": 182}})
+    gateway = StubGateway(
+        {
+            "create_pull_request": {
+                "id": "PR_kwDOQFQYxM6Yxw",
+                "url": "https://github.com/knaisoma/data-olympus/pull/182",
+            }
+        }
+    )
     runtime = ReleaseRuntime(
         tmp_path,
         gateway=gateway,


### PR DESCRIPTION
## Outcome

Accept the canonical FastMCP pull request creation receipt and derive the positive pull number only from the exact Data Olympus GitHub URL when the separate numeric field is absent.

## Verification

* Complete pytest suite passed with two expected optional dependency skips.
* Ruff, mypy, 74 Bats tests, documentation guards, example bundle lint, strict Twine checks, and isolated wheel plus source distribution smokes passed.
* Claude Opus exact packet review returned `VERDICT: APPROVE` for commit `6678d73`.
* All schedules remain disabled.