### PR TITLE
fix(automation): accept FastMCP text content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * **Accepted the canonical FastMCP pull request receipt.** The automated
   release routine now derives the new pull request number from the exact
   repository URL when the gateway receipt omits a separate numeric field.
+* **Accepted the FastMCP standard text content envelope.** Release automation
+  now reads the gateway's legacy tool bound text result when optional
+  structured content is absent, while rejecting unbound or mismatched output.
 
 ## [0.6.0] - 2026-07-18
 

--- a/scripts/operations/release_runtime.py
+++ b/scripts/operations/release_runtime.py
@@ -157,14 +157,31 @@ class FastMCPGateway:
             raise ValueError("FastMCP returned invalid JSON") from error
         if envelope.get("is_error") is True:
             raise ValueError("FastMCP returned an error result")
-        structured = _object(
-            envelope.get("structured_content"),
-            "FastMCP structured content",
-        )
-        if "result" not in structured:
-            raise ValueError("FastMCP structured content omitted result")
-        result = _parse_nested_json(structured["result"])
+        structured = envelope.get("structured_content")
+        used_text_content = structured is None
+        if structured is None:
+            content = envelope.get("content")
+            if type(content) is not list or len(content) != 1:
+                raise ValueError("FastMCP content must contain one item")
+            item = _object(content[0], "FastMCP content item")
+            if item.get("type") != "text" or type(item.get("text")) is not str:
+                raise ValueError("FastMCP content item must be text")
+            result = _parse_nested_json(item["text"])
+        else:
+            structured_object = _object(
+                structured,
+                "FastMCP structured content",
+            )
+            if "result" not in structured_object:
+                raise ValueError("FastMCP structured content omitted result")
+            result = _parse_nested_json(structured_object["result"])
+        if used_text_content and not (
+            type(result) is dict and set(result) >= {"tool", "result"}
+        ):
+            raise ValueError("FastMCP text content omitted gateway result")
         if type(result) is dict and set(result) >= {"tool", "result"}:
+            if result["tool"] != name:
+                raise ValueError("FastMCP result tool does not match request")
             result = _parse_nested_json(result["result"])
         return result
 

--- a/tests/test_operations_release_runtime.py
+++ b/tests/test_operations_release_runtime.py
@@ -90,6 +90,88 @@ def test_fastmcp_gateway_uses_the_gateway_control_plane() -> None:
     assert calls[0][5] == "execute_tool"
 
 
+def test_fastmcp_gateway_accepts_the_standard_text_content_envelope() -> None:
+    def run_command(_command: list[str], _cwd: Path, _timeout: int) -> str:
+        return json.dumps(
+            {
+                "content": [
+                    {
+                        "type": "text",
+                        "text": json.dumps(
+                            {
+                                "tool": "create_pull_request",
+                                "result": json.dumps(
+                                    {
+                                        "id": "PR_kwDOQFQYxM6Yxw",
+                                        "url": (
+                                            "https://github.com/knaisoma/"
+                                            "data-olympus/pull/185"
+                                        ),
+                                    }
+                                ),
+                            }
+                        ),
+                    }
+                ],
+                "is_error": False,
+            }
+        )
+
+    result = FastMCPGateway(run_command=run_command).execute(
+        "create_pull_request",
+        {"owner": "knaisoma", "repo": "data-olympus"},
+    )
+
+    assert result == {
+        "id": "PR_kwDOQFQYxM6Yxw",
+        "url": "https://github.com/knaisoma/data-olympus/pull/185",
+    }
+
+
+def test_fastmcp_gateway_rejects_unbound_text_content() -> None:
+    def run_command(_command: list[str], _cwd: Path, _timeout: int) -> str:
+        return json.dumps(
+            {
+                "content": [
+                    {
+                        "type": "text",
+                        "text": json.dumps({"id": "unbound-result"}),
+                    }
+                ],
+                "is_error": False,
+            }
+        )
+
+    with pytest.raises(ValueError, match="omitted gateway result"):
+        FastMCPGateway(run_command=run_command).execute(
+            "create_pull_request",
+            {"owner": "knaisoma", "repo": "data-olympus"},
+        )
+
+
+def test_fastmcp_gateway_rejects_a_different_tool_result() -> None:
+    def run_command(_command: list[str], _cwd: Path, _timeout: int) -> str:
+        return json.dumps(
+            {
+                "content": [
+                    {
+                        "type": "text",
+                        "text": json.dumps(
+                            {"tool": "list_tags", "result": "[]"}
+                        ),
+                    }
+                ],
+                "is_error": False,
+            }
+        )
+
+    with pytest.raises(ValueError, match="tool does not match request"):
+        FastMCPGateway(run_command=run_command).execute(
+            "create_pull_request",
+            {"owner": "knaisoma", "repo": "data-olympus"},
+        )
+
+
 def test_collect_admission_binds_exact_remote_main_and_governed_computation(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Outcome

Accept FastMCP's standard single text content envelope when optional structured content is absent. Require the gateway wrapper and bind its tool identity to the exact requested operation.

## Production evidence

Certification run `ea922107-edef-4a27-b403-be99548cb75f` reproduced the exact envelope after creating PR 185. PR 185 was audit commented and closed. No merge, publication, deployment, or Telegram send occurred.

## Verification

* Complete pytest suite passed with two expected optional dependency skips.
* Ruff, mypy, 74 Bats tests, documentation guards, example bundle lint, strict Twine checks, and isolated wheel plus source distribution smokes passed.
* Live read only FastMCP parsing returned PR 185 through the corrected adapter.
* Claude Opus exact packet review returned `VERDICT: APPROVE` for `d6a14bb`.
* All schedules remain disabled.