### PR TITLE
fix(automation): bind release consultation to run

### DIFF
--- a/.rules/release-routine.md
+++ b/.rules/release-routine.md
@@ -80,8 +80,13 @@ Rollback is the same executable with the `rollback` argument. It reads
 3. If the repository proves that no unreleased work exists, close the
    candidate as `No action`. Never manufacture a release to satisfy the
    schedule.
-4. Prepare the version change and release notes on one short lived
-   `chore/release-vX.Y.Z-RUN` branch from the admitted source SHA.
+4. Before branch creation or file mutation, record a fresh explicit Data
+   Olympus consultation under the runner identifier and workspace
+   `data-olympus`. Require `kb_gate_check` to return `allow` for that exact
+   session and workspace. Then prepare the version change and release notes on
+   one short lived `chore/release-vX.Y.Z-RUN` branch from the admitted source
+   SHA. The unchanged repository precommit hook remains the final staged
+   authority gate.
 5. Set `pyproject.toml` to `X.Y.Z`, update `uv.lock`, close the matching
    changelog block, open a
    new empty `[Unreleased]` block, and write `docs/releases/vX.Y.Z.md`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * **Accepted the FastMCP standard text content envelope.** Release automation
   now reads the gateway's legacy tool bound text result when optional
   structured content is absent, while rejecting unbound or mismatched output.
+* **Made release commits satisfy the governance gate autonomously.** Before
+  changing release files, the routine now records a run scoped Data Olympus
+  MCP consultation and validates its bounded receipt.
 
 ## [0.6.0] - 2026-07-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,9 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   structured content is absent, while rejecting unbound or mismatched output.
 * **Made release commits satisfy the governance gate autonomously.** Before
   changing release files, the routine now records a run scoped Data Olympus
-  MCP consultation and validates its bounded receipt.
+  MCP consultation, validates receipt freshness, and requires a server side
+  gate receipt bound to the exact run and workspace. The unchanged precommit
+  audit gate still verifies the staged governed change.
 
 ## [0.6.0] - 2026-07-18
 

--- a/scripts/operations/release_runtime.py
+++ b/scripts/operations/release_runtime.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import datetime as dt
 import json
+import math
 import re
 import shutil
 import subprocess
@@ -60,6 +61,10 @@ _PULL_REQUEST_URL = re.compile(
 CommandOutput = Callable[[list[str], Path, int], str]
 JsonFetch = Callable[[str, int], dict[str, Any]]
 AuthorityConsult = Callable[[dict[str, object]], dict[str, Any]]
+AuthorityGateCheck = Callable[[dict[str, object]], dict[str, Any]]
+
+MAX_AUTHORITY_CONSULT_AGE_SECONDS = 300.0
+MAX_AUTHORITY_CLOCK_SKEW_SECONDS = 5.0
 
 
 class ReleaseDeliveryError(ValueError):
@@ -105,6 +110,13 @@ def _object(value: Any, name: str) -> dict[str, Any]:
     return value
 
 
+def _positive_finite_number(value: Any) -> float | None:
+    if type(value) not in {int, float}:
+        return None
+    number = float(value)
+    return number if number > 0 and math.isfinite(number) else None
+
+
 def _parse_nested_json(value: Any) -> Any:
     current = value
     for _ in range(4):
@@ -117,9 +129,10 @@ def _parse_nested_json(value: Any) -> Any:
     return current
 
 
-def _authority_consult(
+def _data_olympus_call(
+    target: str,
     arguments: dict[str, object],
-    run_command: CommandOutput = _default_command_output,
+    run_command: CommandOutput,
 ) -> dict[str, Any]:
     command = [
         "fastmcp",
@@ -127,7 +140,7 @@ def _authority_consult(
         "--server-spec",
         f"{DATA_OLYMPUS_URL}/mcp",
         "--target",
-        "kb_consult",
+        target,
         "--input-json",
         json.dumps(arguments, separators=(",", ":"), sort_keys=True),
         "--json",
@@ -143,11 +156,25 @@ def _authority_consult(
         raise ValueError("Data Olympus MCP returned invalid JSON") from error
     is_error = envelope.get("is_error")
     if type(is_error) is not bool or is_error:
-        raise ValueError("Data Olympus MCP consultation failed")
+        raise ValueError(f"Data Olympus MCP {target} failed")
     return _object(
         envelope.get("structured_content"),
         "Data Olympus MCP structured content",
     )
+
+
+def _authority_consult(
+    arguments: dict[str, object],
+    run_command: CommandOutput = _default_command_output,
+) -> dict[str, Any]:
+    return _data_olympus_call("kb_consult", arguments, run_command)
+
+
+def _authority_gate_check(
+    arguments: dict[str, object],
+    run_command: CommandOutput = _default_command_output,
+) -> dict[str, Any]:
+    return _data_olympus_call("kb_gate_check", arguments, run_command)
 
 
 class FastMCPGateway:
@@ -565,17 +592,21 @@ class ReleaseRuntime:
         gateway: FastMCPGateway,
         command_output: CommandOutput = _default_command_output,
         authority_consult: AuthorityConsult = _authority_consult,
+        authority_gate_check: AuthorityGateCheck = _authority_gate_check,
         fetch_json: JsonFetch = _default_json_fetch,
         sleep: Callable[[float], None] = time.sleep,
         today: Callable[[], dt.date] = dt.date.today,
+        clock: Callable[[], float] = time.time,
     ) -> None:
         self.repository_root = repository_root.resolve()
         self.gateway = gateway
         self.command_output = command_output
         self.authority_consult = authority_consult
+        self.authority_gate_check = authority_gate_check
         self.fetch_json = fetch_json
         self.sleep = sleep
         self.today = today
+        self.clock = clock
         self._heartbeat: Callable[[], None] = lambda: None
         self._prepared: dict[str, Any] | None = None
         self._delivery: dict[str, Any] | None = None
@@ -938,28 +969,48 @@ class ReleaseRuntime:
         changes = _object(computed.get("changes"), "computed release changes")
         if self.command(["git", "status", "--porcelain"]):
             raise ValueError("managed release worktree is not clean")
+        run_id = str(run_input["run_id"])
+        authority_intent = (
+            f"Prepare governed Data Olympus release v{version} from "
+            f"exact source {admitted}."
+        )
         consultation = self.authority_consult(
             {
                 "agent_identity": "ai-operations-release",
-                "intent": (
-                    f"Prepare governed Data Olympus release v{version} from "
-                    f"exact source {admitted}."
-                ),
-                "source_session": str(run_input["run_id"]),
+                "intent": authority_intent,
+                "source_session": run_id,
                 "trigger": "explicit",
                 "workspace": GITHUB_REPOSITORY,
             }
         )
-        consulted_at = consultation.get("consulted_at")
-        ttl_seconds = consultation.get("ttl_seconds")
-        if (
-            type(consulted_at) not in {int, float}
-            or consulted_at <= 0
-            or type(ttl_seconds) not in {int, float}
-            or ttl_seconds <= 0
-        ):
+        consulted_at = _positive_finite_number(consultation.get("consulted_at"))
+        ttl_seconds = _positive_finite_number(consultation.get("ttl_seconds"))
+        if consulted_at is None or ttl_seconds is None:
             raise ValueError("authority consultation receipt is invalid")
-        run_suffix = str(run_input["run_id"]).split("-", 1)[0]
+        consultation_age = self.clock() - consulted_at
+        if (
+            not math.isfinite(consultation_age)
+            or consultation_age < -MAX_AUTHORITY_CLOCK_SKEW_SECONDS
+            or consultation_age
+            > min(ttl_seconds, MAX_AUTHORITY_CONSULT_AGE_SECONDS)
+        ):
+            raise ValueError("authority consultation is not fresh")
+        gate_receipt = self.authority_gate_check(
+            {
+                "action_diff": authority_intent,
+                "action_path": "pyproject.toml",
+                "session_id": run_id,
+                "tool_name": "git commit",
+                "workspace": GITHUB_REPOSITORY,
+            }
+        )
+        if (
+            gate_receipt.get("verdict") != "allow"
+            or gate_receipt.get("session_id") != run_id
+            or gate_receipt.get("workspace") != GITHUB_REPOSITORY
+        ):
+            raise ValueError("authority gate receipt is invalid")
+        run_suffix = run_id.split("-", 1)[0]
         branch = f"chore/release-v{version}-{run_suffix}"
         self.command(["git", "switch", "-c", branch, admitted])
         document_evidence = render_release_documents(

--- a/scripts/operations/release_runtime.py
+++ b/scripts/operations/release_runtime.py
@@ -59,6 +59,7 @@ _PULL_REQUEST_URL = re.compile(
 
 CommandOutput = Callable[[list[str], Path, int], str]
 JsonFetch = Callable[[str, int], dict[str, Any]]
+AuthorityConsult = Callable[[dict[str, object]], dict[str, Any]]
 
 
 class ReleaseDeliveryError(ValueError):
@@ -114,6 +115,39 @@ def _parse_nested_json(value: Any) -> Any:
         except json.JSONDecodeError:
             break
     return current
+
+
+def _authority_consult(
+    arguments: dict[str, object],
+    run_command: CommandOutput = _default_command_output,
+) -> dict[str, Any]:
+    command = [
+        "fastmcp",
+        "call",
+        "--server-spec",
+        f"{DATA_OLYMPUS_URL}/mcp",
+        "--target",
+        "kb_consult",
+        "--input-json",
+        json.dumps(arguments, separators=(",", ":"), sort_keys=True),
+        "--json",
+        "--timeout",
+        "30",
+        "--auth",
+        "none",
+    ]
+    raw = run_command(command, Path.cwd(), 40)
+    try:
+        envelope = _object(json.loads(raw), "Data Olympus MCP response")
+    except json.JSONDecodeError as error:
+        raise ValueError("Data Olympus MCP returned invalid JSON") from error
+    is_error = envelope.get("is_error")
+    if type(is_error) is not bool or is_error:
+        raise ValueError("Data Olympus MCP consultation failed")
+    return _object(
+        envelope.get("structured_content"),
+        "Data Olympus MCP structured content",
+    )
 
 
 class FastMCPGateway:
@@ -530,6 +564,7 @@ class ReleaseRuntime:
         *,
         gateway: FastMCPGateway,
         command_output: CommandOutput = _default_command_output,
+        authority_consult: AuthorityConsult = _authority_consult,
         fetch_json: JsonFetch = _default_json_fetch,
         sleep: Callable[[float], None] = time.sleep,
         today: Callable[[], dt.date] = dt.date.today,
@@ -537,6 +572,7 @@ class ReleaseRuntime:
         self.repository_root = repository_root.resolve()
         self.gateway = gateway
         self.command_output = command_output
+        self.authority_consult = authority_consult
         self.fetch_json = fetch_json
         self.sleep = sleep
         self.today = today
@@ -902,6 +938,27 @@ class ReleaseRuntime:
         changes = _object(computed.get("changes"), "computed release changes")
         if self.command(["git", "status", "--porcelain"]):
             raise ValueError("managed release worktree is not clean")
+        consultation = self.authority_consult(
+            {
+                "agent_identity": "ai-operations-release",
+                "intent": (
+                    f"Prepare governed Data Olympus release v{version} from "
+                    f"exact source {admitted}."
+                ),
+                "source_session": str(run_input["run_id"]),
+                "trigger": "explicit",
+                "workspace": GITHUB_REPOSITORY,
+            }
+        )
+        consulted_at = consultation.get("consulted_at")
+        ttl_seconds = consultation.get("ttl_seconds")
+        if (
+            type(consulted_at) not in {int, float}
+            or consulted_at <= 0
+            or type(ttl_seconds) not in {int, float}
+            or ttl_seconds <= 0
+        ):
+            raise ValueError("authority consultation receipt is invalid")
         run_suffix = str(run_input["run_id"]).split("-", 1)[0]
         branch = f"chore/release-v{version}-{run_suffix}"
         self.command(["git", "switch", "-c", branch, admitted])

--- a/tests/test_operations_release_runtime.py
+++ b/tests/test_operations_release_runtime.py
@@ -13,6 +13,7 @@ from scripts.operations.release_runtime import (
     ReleaseDeliveryError,
     ReleaseRuntime,
     _authority_consult,
+    _authority_gate_check,
     candidate_release_evidence,
     completed_check_evidence,
     default_release_dependencies,
@@ -131,6 +132,50 @@ def test_authority_consult_calls_data_olympus_mcp_directly() -> None:
     assert json.loads(calls[0][7]) == arguments
 
 
+def test_authority_gate_check_binds_session_and_workspace_directly() -> None:
+    calls: list[list[str]] = []
+    arguments = {
+        "action_diff": "Prepare governed release v0.7.0.",
+        "action_path": "pyproject.toml",
+        "session_id": "run-id",
+        "tool_name": "git commit",
+        "workspace": "data-olympus",
+    }
+    receipt = {
+        "verdict": "allow",
+        "reason": "fresh explicit consultation on record",
+        "rules": [],
+        "session_id": "run-id",
+        "workspace": "data-olympus",
+    }
+
+    def run_command(command: list[str], _cwd: Path, _timeout: int) -> str:
+        calls.append(command)
+        return json.dumps(
+            {
+                "content": [{"type": "text", "text": "allowed"}],
+                "is_error": False,
+                "structured_content": receipt,
+            }
+        )
+
+    result = _authority_gate_check(arguments, run_command)
+
+    assert result == receipt
+    assert calls[0][:6] == [
+        "fastmcp",
+        "call",
+        "--server-spec",
+        (
+            "http://data-olympus-mcp.data-olympus."
+            "apps.172.30.1.2.nip.io/mcp"
+        ),
+        "--target",
+        "kb_gate_check",
+    ]
+    assert json.loads(calls[0][7]) == arguments
+
+
 def test_fastmcp_gateway_accepts_the_standard_text_content_envelope() -> None:
     def run_command(_command: list[str], _cwd: Path, _timeout: int) -> str:
         return json.dumps(
@@ -232,6 +277,98 @@ def test_prepare_fails_before_mutation_without_authority_consult_receipt(
     )
 
     with pytest.raises(ValueError, match="authority consultation receipt"):
+        runtime.prepare(
+            {
+                "extra_context": "No extra context for this run",
+                "run_id": "11111111-2222-4333-8444-555555555555",
+                "source_revision": SOURCE_SHA,
+            },
+            {
+                "evidence": {
+                    "computed_release": {
+                        "changes": {"breaking": [], "features": [], "fixes": []}
+                    }
+                },
+                "outputs": {"candidate": {"version": "0.7.0"}},
+            },
+        )
+
+    assert commands == [["git", "status", "--porcelain"]]
+
+
+def test_prepare_fails_before_mutation_on_stale_authority_consultation(
+    tmp_path: Path,
+) -> None:
+    commands: list[list[str]] = []
+
+    def command_output(command: list[str], _cwd: Path, _timeout: int) -> str:
+        commands.append(command)
+        if command == ["git", "status", "--porcelain"]:
+            return ""
+        raise AssertionError(command)
+
+    runtime = ReleaseRuntime(
+        tmp_path,
+        gateway=StubGateway(),
+        command_output=command_output,
+        authority_consult=lambda _arguments: {
+            "consulted_at": 100.0,
+            "ttl_seconds": 300,
+        },
+        authority_gate_check=lambda _arguments: pytest.fail(
+            "stale consultation must not reach the gate check"
+        ),
+        clock=lambda: 401.0,
+    )
+
+    with pytest.raises(ValueError, match="authority consultation is not fresh"):
+        runtime.prepare(
+            {
+                "extra_context": "No extra context for this run",
+                "run_id": "11111111-2222-4333-8444-555555555555",
+                "source_revision": SOURCE_SHA,
+            },
+            {
+                "evidence": {
+                    "computed_release": {
+                        "changes": {"breaking": [], "features": [], "fixes": []}
+                    }
+                },
+                "outputs": {"candidate": {"version": "0.7.0"}},
+            },
+        )
+
+    assert commands == [["git", "status", "--porcelain"]]
+
+
+def test_prepare_fails_before_mutation_on_unbound_authority_gate_receipt(
+    tmp_path: Path,
+) -> None:
+    commands: list[list[str]] = []
+
+    def command_output(command: list[str], _cwd: Path, _timeout: int) -> str:
+        commands.append(command)
+        if command == ["git", "status", "--porcelain"]:
+            return ""
+        raise AssertionError(command)
+
+    runtime = ReleaseRuntime(
+        tmp_path,
+        gateway=StubGateway(),
+        command_output=command_output,
+        authority_consult=lambda _arguments: {
+            "consulted_at": 100.0,
+            "ttl_seconds": 300,
+        },
+        authority_gate_check=lambda _arguments: {
+            "verdict": "allow",
+            "session_id": "different-run",
+            "workspace": "data-olympus",
+        },
+        clock=lambda: 100.0,
+    )
+
+    with pytest.raises(ValueError, match="authority gate receipt is invalid"):
         runtime.prepare(
             {
                 "extra_context": "No extra context for this run",
@@ -734,6 +871,7 @@ def test_prepare_reports_failed_recovery_evidence_after_merge_boundary(
     head_revision = "c" * 40
     final_revision = "d" * 40
     consultations: list[dict[str, object]] = []
+    gate_checks: list[dict[str, object]] = []
     gateway = StubGateway(
         {
             "create_pull_request": {
@@ -750,6 +888,15 @@ def test_prepare_reports_failed_recovery_evidence_after_merge_boundary(
             consultations.append(arguments)
             or {"consulted_at": 1.0, "ttl_seconds": 300}
         ),
+        authority_gate_check=lambda arguments: (
+            gate_checks.append(arguments)
+            or {
+                "verdict": "allow",
+                "session_id": "11111111-2222-4333-8444-555555555555",
+                "workspace": "data-olympus",
+            }
+        ),
+        clock=lambda: 1.0,
     )
     monkeypatch.setattr(
         "scripts.operations.release_runtime.render_release_documents",
@@ -823,6 +970,18 @@ def test_prepare_reports_failed_recovery_evidence_after_merge_boundary(
             ),
             "source_session": "11111111-2222-4333-8444-555555555555",
             "trigger": "explicit",
+            "workspace": "data-olympus",
+        }
+    ]
+    assert gate_checks == [
+        {
+            "action_diff": (
+                "Prepare governed Data Olympus release v0.7.0 from exact "
+                f"source {SOURCE_SHA}."
+            ),
+            "action_path": "pyproject.toml",
+            "session_id": "11111111-2222-4333-8444-555555555555",
+            "tool_name": "git commit",
             "workspace": "data-olympus",
         }
     ]

--- a/tests/test_operations_release_runtime.py
+++ b/tests/test_operations_release_runtime.py
@@ -12,6 +12,7 @@ from scripts.operations.release_runtime import (
     FastMCPGateway,
     ReleaseDeliveryError,
     ReleaseRuntime,
+    _authority_consult,
     candidate_release_evidence,
     completed_check_evidence,
     default_release_dependencies,
@@ -88,6 +89,46 @@ def test_fastmcp_gateway_uses_the_gateway_control_plane() -> None:
         "--target",
     ]
     assert calls[0][5] == "execute_tool"
+
+
+def test_authority_consult_calls_data_olympus_mcp_directly() -> None:
+    calls: list[list[str]] = []
+    arguments = {
+        "agent_identity": "ai-operations-release",
+        "intent": "Prepare governed release.",
+        "source_session": "run-id",
+        "trigger": "explicit",
+        "workspace": "data-olympus",
+    }
+
+    def run_command(command: list[str], _cwd: Path, _timeout: int) -> str:
+        calls.append(command)
+        return json.dumps(
+            {
+                "content": [{"type": "text", "text": "consulted"}],
+                "is_error": False,
+                "structured_content": {
+                    "consulted_at": 1.0,
+                    "ttl_seconds": 300,
+                },
+            }
+        )
+
+    result = _authority_consult(arguments, run_command)
+
+    assert result == {"consulted_at": 1.0, "ttl_seconds": 300}
+    assert calls[0][:6] == [
+        "fastmcp",
+        "call",
+        "--server-spec",
+        (
+            "http://data-olympus-mcp.data-olympus."
+            "apps.172.30.1.2.nip.io/mcp"
+        ),
+        "--target",
+        "kb_consult",
+    ]
+    assert json.loads(calls[0][7]) == arguments
 
 
 def test_fastmcp_gateway_accepts_the_standard_text_content_envelope() -> None:
@@ -170,6 +211,44 @@ def test_fastmcp_gateway_rejects_a_different_tool_result() -> None:
             "create_pull_request",
             {"owner": "knaisoma", "repo": "data-olympus"},
         )
+
+
+def test_prepare_fails_before_mutation_without_authority_consult_receipt(
+    tmp_path: Path,
+) -> None:
+    commands: list[list[str]] = []
+
+    def command_output(command: list[str], _cwd: Path, _timeout: int) -> str:
+        commands.append(command)
+        if command == ["git", "status", "--porcelain"]:
+            return ""
+        raise AssertionError(command)
+
+    runtime = ReleaseRuntime(
+        tmp_path,
+        gateway=StubGateway(),
+        command_output=command_output,
+        authority_consult=lambda _arguments: {},
+    )
+
+    with pytest.raises(ValueError, match="authority consultation receipt"):
+        runtime.prepare(
+            {
+                "extra_context": "No extra context for this run",
+                "run_id": "11111111-2222-4333-8444-555555555555",
+                "source_revision": SOURCE_SHA,
+            },
+            {
+                "evidence": {
+                    "computed_release": {
+                        "changes": {"breaking": [], "features": [], "fixes": []}
+                    }
+                },
+                "outputs": {"candidate": {"version": "0.7.0"}},
+            },
+        )
+
+    assert commands == [["git", "status", "--porcelain"]]
 
 
 def test_collect_admission_binds_exact_remote_main_and_governed_computation(
@@ -654,6 +733,7 @@ def test_prepare_reports_failed_recovery_evidence_after_merge_boundary(
 ) -> None:
     head_revision = "c" * 40
     final_revision = "d" * 40
+    consultations: list[dict[str, object]] = []
     gateway = StubGateway(
         {
             "create_pull_request": {
@@ -666,6 +746,10 @@ def test_prepare_reports_failed_recovery_evidence_after_merge_boundary(
         tmp_path,
         gateway=gateway,
         command_output=lambda _command, _cwd, _timeout: "",
+        authority_consult=lambda arguments: (
+            consultations.append(arguments)
+            or {"consulted_at": 1.0, "ttl_seconds": 300}
+        ),
     )
     monkeypatch.setattr(
         "scripts.operations.release_runtime.render_release_documents",
@@ -730,6 +814,18 @@ def test_prepare_reports_failed_recovery_evidence_after_merge_boundary(
     assert raised.value.evidence["merge_confirmed"] is merge_confirmed
     assert raised.value.evidence["release_pr_number"] == 182
     assert raised.value.evidence["rollback_completed"] is False
+    assert consultations == [
+        {
+            "agent_identity": "ai-operations-release",
+            "intent": (
+                "Prepare governed Data Olympus release v0.7.0 from exact "
+                f"source {SOURCE_SHA}."
+            ),
+            "source_session": "11111111-2222-4333-8444-555555555555",
+            "trigger": "explicit",
+            "workspace": "data-olympus",
+        }
+    ]
     if merge_confirmed:
         assert raised.value.evidence["merged_revision"] == final_revision
 


### PR DESCRIPTION
## Outcome

Make the autonomous Data Olympus release routine satisfy governance before creating a branch or changing release files.

The routine now records an explicit run scoped consultation, rejects stale receipts, requires a server side `kb_gate_check` receipt bound to the exact runner UUID and `data-olympus` workspace, and retains the unchanged precommit audit gate.

## Verification

* Claude Opus companion review: `VERDICT: APPROVE` for exact head `219e24de311ab90c3812bb9f48e8c068bdaf46ac`.
* Full pytest suite at 100 percent with two expected optional skips.
* Ruff and mypy across 73 source files.
* Benchmark and documentation guards.
* Example bundle lint and all 74 Bats tests.
* Wheel and source distribution build, strict Twine checks, and isolated artifact smokes.
* Live consultation, exact gate check, and unchanged staged report canary.
* Zero open Dependabot and CodeQL alerts.