### PR TITLE
fix(release): wait for complete check conclusions

### DIFF
--- a/scripts/operations/release_runtime.py
+++ b/scripts/operations/release_runtime.py
@@ -737,6 +737,7 @@ class ReleaseRuntime:
                 if type(runs) is list and any(
                     type(run) is dict
                     and run.get("status") == "completed"
+                    and type(run.get("conclusion")) is str
                     and run.get("conclusion") not in {"success", "skipped"}
                     for run in runs
                 ):

--- a/tests/test_operations_release_runtime.py
+++ b/tests/test_operations_release_runtime.py
@@ -522,6 +522,54 @@ def test_completed_check_evidence_requires_every_expected_check_and_no_failures(
         )
 
 
+def test_pull_request_waiter_polls_completed_check_without_conclusion(
+    tmp_path: Path,
+) -> None:
+    pending = {
+        "check_runs": [
+            {
+                "name": name,
+                "status": "completed",
+                "conclusion": None if name == "CodeQL" else "success",
+            }
+            for name in sorted(REQUIRED_PULL_REQUEST_CHECKS)
+        ]
+    }
+    completed = {
+        "check_runs": [
+            {
+                "name": name,
+                "status": "completed",
+                "conclusion": "success",
+            }
+            for name in sorted(REQUIRED_PULL_REQUEST_CHECKS)
+        ]
+    }
+    pull = {
+        "draft": False,
+        "head": {"sha": SOURCE_SHA},
+        "mergeable_state": "clean",
+        "state": "open",
+    }
+    gateway = StubGateway(
+        {"pull_request_read": (pending, completed, pull)}
+    )
+    sleeps: list[float] = []
+    runtime = ReleaseRuntime(
+        tmp_path,
+        gateway=gateway,
+        sleep=sleeps.append,
+    )
+
+    result = runtime._wait_pull_request(190, SOURCE_SHA)
+
+    assert result == {"checks": completed_check_evidence(
+        completed,
+        required=REQUIRED_PULL_REQUEST_CHECKS,
+    ), "pull": pull}
+    assert sleeps == [10]
+
+
 def test_deployment_state_parses_gateway_yaml_and_binds_both_images() -> None:
     state = deployment_state(
         f"""


### PR DESCRIPTION
## Outcome

Keep polling when GitHub transiently reports a completed check run without a conclusion. Stop immediately only for an explicit terminal non-success conclusion.

## Evidence

Fresh runner run 7de598d4-acf5-4df4-95e7-db6bae054e05 stopped while PR 190 had required checks still in progress. Every check later completed successfully. The regression test reproduces the transient completed plus null conclusion state, fails on the old behavior, and passes with this one-condition correction.

## Verification

The complete repository test suite, Ruff, mypy, benchmark and documentation guards, example bundle lint, all 74 Bats tests, lock check, package build, and strict Twine checks pass. This correction is isolated so a fresh runner run can own v0.7.0 end to end.