### PR TITLE
fix(release): wait for complete check matrix

### DIFF
--- a/scripts/operations/release_runtime.py
+++ b/scripts/operations/release_runtime.py
@@ -340,6 +340,24 @@ def completed_check_evidence(
     return evidence
 
 
+def _check_matrix_concluded(
+    check_runs: list[dict[str, Any]],
+    required: set[str],
+) -> bool:
+    """Return true only after every observed check has a final conclusion."""
+    if not check_runs:
+        return False
+    names = {run.get("name") for run in check_runs}
+    if not required <= names:
+        return False
+    return all(
+        run.get("status") == "completed"
+        and type(run.get("conclusion")) is str
+        and bool(run.get("conclusion"))
+        for run in check_runs
+    )
+
+
 def _asset_names(release: dict[str, Any]) -> set[str]:
     assets = release.get("assets")
     if type(assets) is not list:
@@ -734,13 +752,11 @@ class ReleaseRuntime:
             except ValueError as error:
                 last_error = str(error)
                 runs = checks.get("check_runs")
-                if type(runs) is list and any(
-                    type(run) is dict
-                    and run.get("status") == "completed"
-                    and type(run.get("conclusion")) is str
-                    and run.get("conclusion") not in {"success", "skipped"}
-                    for run in runs
+                if type(runs) is not list or any(
+                    type(run) is not dict for run in runs
                 ):
+                    raise
+                if _check_matrix_concluded(runs, REQUIRED_PULL_REQUEST_CHECKS):
                     raise
                 self.sleep(10)
                 self.heartbeat()

--- a/tests/test_operations_release_runtime.py
+++ b/tests/test_operations_release_runtime.py
@@ -522,15 +522,19 @@ def test_completed_check_evidence_requires_every_expected_check_and_no_failures(
         )
 
 
-def test_pull_request_waiter_polls_completed_check_without_conclusion(
+def test_pull_request_waiter_waits_for_complete_check_matrix(
     tmp_path: Path,
 ) -> None:
     pending = {
         "check_runs": [
             {
                 "name": name,
-                "status": "completed",
-                "conclusion": None if name == "CodeQL" else "success",
+                "status": "in_progress" if name == "test" else "completed",
+                "conclusion": (
+                    "failure"
+                    if name == "CodeQL"
+                    else None if name == "test" else "success"
+                ),
             }
             for name in sorted(REQUIRED_PULL_REQUEST_CHECKS)
         ]
@@ -568,6 +572,32 @@ def test_pull_request_waiter_polls_completed_check_without_conclusion(
         required=REQUIRED_PULL_REQUEST_CHECKS,
     ), "pull": pull}
     assert sleeps == [10]
+
+
+def test_pull_request_waiter_fails_when_complete_matrix_is_not_green(
+    tmp_path: Path,
+) -> None:
+    failed = {
+        "check_runs": [
+            {
+                "name": name,
+                "status": "completed",
+                "conclusion": "failure" if name == "CodeQL" else "success",
+            }
+            for name in sorted(REQUIRED_PULL_REQUEST_CHECKS)
+        ]
+    }
+    sleeps: list[float] = []
+    runtime = ReleaseRuntime(
+        tmp_path,
+        gateway=StubGateway({"pull_request_read": failed}),
+        sleep=sleeps.append,
+    )
+
+    with pytest.raises(ValueError, match="GitHub check runs did not succeed"):
+        runtime._wait_pull_request(192, SOURCE_SHA)
+
+    assert sleeps == []
 
 
 def test_deployment_state_parses_gateway_yaml_and_binds_both_images() -> None:


### PR DESCRIPTION
## Summary

* Wait until every observed GitHub check has a terminal conclusion and every required check name is present.
* Preserve the existing fail closed evaluator once the check matrix is complete.
* Add regressions for an early failure reported while another required check is still running and for a terminal failed matrix.

## Operational context

Release run `54947310-de36-48c7-b795-18dc3eab80e1` stopped before merge while PR 192 still had required checks in progress. No release, deployment, or notification occurred. PR 192 will be audit commented and closed unmerged after this correction is approved and merged.

## Verification

* Full pytest suite
* Ruff
* mypy
* benchmark and documentation guards
* example bundle lint
* Bats suite
* lock check
* source and wheel build
* strict Twine artifact checks
* focused isolated waiter regressions