### PR TITLE
fix(release): require approval before merge

### DIFF
--- a/.rules/release-routine.md
+++ b/.rules/release-routine.md
@@ -7,9 +7,10 @@ Automation status: disabled until baseline certification
 
 ## Outcome
 
-Publish one immutable release from already merged, reviewed, green,
-unreleased work, then prove that every artifact and the kn dev service match
-one exact reviewed source revision.
+Publish one immutable release from already merged, green, unreleased work.
+Review the deterministic release candidate before it can merge, prove that the
+squash merge transferred the exact reviewed tree, then prove that every
+artifact and the kn dev service name the resulting delivery revision.
 
 The routine is outcome based. It is not a weekly cutter and has no obligation
 to release when the evidence says no release is due.
@@ -45,11 +46,13 @@ The fixed milestones are:
 * `verify`
 
 The project command owns Git, release artifact, workflow, registry, and kn dev
-evidence. Supported external mutations and reads go through FastMCP. The three
-current GitHub capability gaps are security alert enumeration, container
-package digest lookup, and a pull request merge with an expected head SHA
-precondition. They reuse governed repository commands and record the direct
-GitHub fallback because the gateway exposes none of those exact operations.
+evidence. Supported external mutations and reads go through FastMCP. Current
+gateway capability gaps are CodeQL analysis and alert enumeration, Code
+Quality setup, ruleset details, GraphQL review threads, container package
+digest lookup, and a pull request merge with an expected head SHA precondition.
+They reuse governed repository commands and record the direct GitHub fallback
+because the gateway exposes none of those exact operations. These gaps remain
+tracked platform work and do not weaken the release gates.
 An unconditional gateway merge is not an acceptable substitute for the
 expected head precondition.
 After the conditional merge mutation begins, an unknown merge outcome or any
@@ -90,12 +93,16 @@ Rollback is the same executable with the `rollback` argument. It reads
 5. Set `pyproject.toml` to `X.Y.Z`, update `uv.lock`, close the matching
    changelog block, open a
    new empty `[Unreleased]` block, and write `docs/releases/vX.Y.Z.md`.
-6. Open one public pull request through FastMCP. Require every repository check
-   to complete successfully. Confirm that remote `main` still equals the
-   admitted SHA, then squash merge the one deterministic release change.
-7. Bind the candidate to the resulting exact `main` SHA and require its parent
-   to equal the admitted SHA. A concurrent main change blocks the run.
-8. Rerun all release gates against that final SHA:
+6. Open one public pull request through FastMCP. Keep it open and unmerged.
+   Require every observed repository check to reach a successful terminal
+   conclusion. Require the exact `CodeQL - Code Quality` check, all three
+   CodeQL language analyses with zero results, no open CodeQL alert for the
+   pull request, no unresolved review thread, and the complete active default
+   branch ruleset fingerprint. Code Quality must be configured. Missing or
+   unverifiable evidence blocks before review or merge.
+7. Bind the review candidate to the exact pull request head SHA `H`, its Git
+   tree `T`, and admitted main SHA `B`. Require `H` to have sole parent `B`.
+   Rerun all local release gates against `H`:
 
    * Complete test suite.
    * Ruff.
@@ -108,19 +115,32 @@ Rollback is the same executable with the `rollback` argument. It reads
    * Version availability across PyPI, GHCR, GitHub tags, and GitHub releases.
 
    Pull request checks require the aggregate `CodeQL` signal and all three
-   language analyses. Default branch pushes do not emit the aggregate signal,
-   so final main CI requires the three successful language analyses directly.
-
-9. The deterministic executor requests one central, run controlled Claude
-   review of the exact final SHA. Self review is prohibited. Review evidence
-   hashes both the submitted packet and the ticket bound Claude response.
-10. Require the candidate approval ledger entry to bind the run, contract
-    digest, final SHA, and consumed Claude review. The approved standing
-    delegation may materialize that exact entry only after the review passes.
-11. Dispatch `rc-publish.yml` for that SHA and the next unused candidate
+   language analyses. The review packet includes `H`, `T`, `B`, exact checks,
+   security evidence, release gates, rollback point, ruleset fingerprint, and
+   immutable delivery procedure.
+8. The deterministic executor requests one central, run controlled Claude
+   review of `H`. Self review is prohibited. Review evidence hashes both the
+   exact submitted packet and the ticket bound Claude response.
+9. Require the candidate approval ledger entry to bind the run, contract
+   digest, `H`, and consumed Claude review. The approved standing delegation
+   may materialize that exact entry only after the review passes.
+10. In the same execution, rederive `H`, `T`, `B`, remote `main`, every check
+    and security result, every review thread, Code Quality setup and result,
+    and the complete ruleset fingerprint. Any change requires a new run and
+    review. The deliberate team bypass bypasses the entire GitHub ruleset, not
+    only native approval, so these routine owned controls are load bearing.
+11. Submit a conditional squash merge naming expected head `H`. Reconcile an
+    ambiguous response only from the same pull request and current remote
+    `main`. An open unchanged pull request stops safely. Every other ambiguous
+    state fails closed.
+12. Fetch resulting remote main SHA `M`. Require `M` to have sole parent `B`
+    and exact tree `T`. Rerun final CI and every release gate against `M`.
+    Publication is a direct continuation after these freshly derived proofs,
+    never a replay from stored evidence.
+13. Dispatch `rc-publish.yml` for `M` and the next unused candidate
     number. Do not reproduce version computation or publication logic in the
     runner.
-12. Verify the complete candidate transaction:
+14. Verify the complete candidate transaction:
 
     * GitHub prerelease.
     * Candidate wheel.
@@ -129,32 +149,36 @@ Rollback is the same executable with the `rollback` argument. It reads
     * `release-provenance.json`.
     * GHCR image digest.
 
-13. Keep Keel at `never`. Deploy the candidate exact digest to both StatefulSet
+15. Keep Keel at `never`. Deploy the candidate exact digest to both StatefulSet
     containers through the kn dev FastMCP gateway, wait for rollout, and verify
     health, readiness, MCP search, enforcement, and documentation.
-14. If canary verification passes, dispatch `tag-release.yml` with the exact
+16. If canary verification passes, dispatch `tag-release.yml` with the exact
     candidate tag. The workflow promotes the existing candidate and must not
     rebuild the OCI image.
-15. Dispatch `set-channel.yml` with `source=vX.Y.Z` for registry channel
+17. Dispatch `set-channel.yml` with `source=vX.Y.Z` for registry channel
     traceability. The moving channel does not drive the kn dev deployment while
     Keel is `never`.
-16. Deploy the same stable digest explicitly to kn dev and run the full
+18. Deploy the same stable digest explicitly to kn dev and run the full
     external verification stage.
-17. Return a delivered project result with the release pull request, previous
-   rollback digest, published version, exact candidate SHA, image digest, and
-   verification receipts.
-18. The central runner sends one Telegram completion message to the semantic
+19. Return a delivered project result whose immutable candidate revision is
+   `H`. Evidence separately records `B`, `T`, `M`, exact tree equality, the
+   previous rollback digest, published version, image digest, and verification
+   receipts.
+20. The central runner sends one Telegram completion message to the semantic
    destination `data-olympus-operations`. Completion requires exact independent
    readback of the destination, message identifier, run marker, and content.
-19. The durable runner ledger records the truthful terminal state. No private
+21. The durable runner ledger records the truthful terminal state. No private
    issue is an authority or completion dependency.
 
 ## Exact source rule
 
-The release branch SHA is premerge evidence only because squash merge produces
-a new commit. Final review, exact approval, workflow receipts, provenance,
-tags, artifacts, deployment, verification, and notification all name the same
-resulting `main` source SHA.
+The release branch head `H` is the immutable reviewed candidate. The approval
+stays bound to `H`. The squash merge produces delivery revision `M`, which is
+authorized only when its sole parent is admitted SHA `B` and its tree exactly
+equals reviewed tree `T`. Workflow receipts, provenance, tags, artifacts,
+deployment, verification, and notification all name `M`. Project and central
+candidate fields remain `H`; delivery evidence records both revisions and the
+content transfer proof.
 
 Any source change invalidates approval and restarts the release assessment.
 
@@ -186,8 +210,8 @@ is never relabeled as complete because a workflow started.
 
 The release is complete only when:
 
-* GitHub release `vX.Y.Z` points at the reviewed SHA.
-* PyPI `X.Y.Z` provenance points at the reviewed SHA.
+* GitHub release `vX.Y.Z` points at the proven delivery SHA.
+* PyPI `X.Y.Z` provenance points at the proven delivery SHA.
 * GHCR `vX.Y.Z` points at the reviewed candidate digest.
 * kn dev runs that exact digest in both containers.
 * Health, readiness, MCP search, enforcement, and documentation pass.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+* **Moved autonomous release approval before merge.** The release routine now
+  reviews and approves the exact unmerged candidate, rederives every control
+  replaced by the deliberate GitHub ruleset bypass, conditionally merges the
+  expected head, and proves exact parent and tree transfer before any
+  publication or deployment. An unavailable Code Quality result blocks the
+  release instead of being treated as satisfied.
 * **Accepted the canonical FastMCP pull request receipt.** The automated
   release routine now derives the new pull request number from the exact
   repository URL when the gateway receipt omits a separate numeric field.

--- a/scripts/operations/release.py
+++ b/scripts/operations/release.py
@@ -186,6 +186,63 @@ def _extra_context(value: Any) -> dict[str, Any]:
     }
 
 
+def _release_control_evidence(value: Any, source_revision: str) -> dict[str, Any]:
+    controls = _object(value, "release_controls")
+    _same_source(
+        source_revision,
+        controls.get("candidate_revision"),
+        "release_controls.candidate_revision",
+    )
+    checks = _object(controls.get("check_evidence"), "release_controls.check_evidence")
+    _true(checks.get("all_success"), "release_controls.check_evidence.all_success")
+    if checks.get("missing_required") != []:
+        raise ReleaseInputError(
+            "release_controls.check_evidence.missing_required must be empty"
+        )
+    if controls.get("code_quality_check") not in {
+        "CodeQL - Code Quality",
+        "CodeQL - Code Quality / Analyze",
+    }:
+        raise ReleaseInputError("release_controls.code_quality_check is invalid")
+    if controls.get("code_quality_state") != "configured":
+        raise ReleaseInputError("release_controls.code_quality_state must be configured")
+    codeql_hash = _hash(
+        controls.get("codeql_analysis_hash"),
+        "release_controls.codeql_analysis_hash",
+    )
+    if controls.get("codeql_languages") != [
+        "actions",
+        "javascript-typescript",
+        "python",
+    ]:
+        raise ReleaseInputError("release_controls.codeql_languages is incomplete")
+    if controls.get("open_codeql_alerts") != 0:
+        raise ReleaseInputError("release_controls.open_codeql_alerts must be zero")
+    if controls.get("review_decision") != "REVIEW_REQUIRED":
+        raise ReleaseInputError("release_controls.review_decision changed")
+    if controls.get("unresolved_review_threads") != 0:
+        raise ReleaseInputError(
+            "release_controls.unresolved_review_threads must be zero"
+        )
+    fingerprint = _hash(
+        controls.get("ruleset_fingerprint"),
+        "release_controls.ruleset_fingerprint",
+    )
+    ruleset_ids = controls.get("ruleset_ids")
+    if (
+        type(ruleset_ids) is not list
+        or not ruleset_ids
+        or any(type(ruleset_id) is not int or ruleset_id <= 0 for ruleset_id in ruleset_ids)
+    ):
+        raise ReleaseInputError("release_controls.ruleset_ids is invalid")
+    return {
+        "code_quality_check": controls["code_quality_check"],
+        "codeql_analysis_hash": codeql_hash,
+        "ruleset_fingerprint": fingerprint,
+        "ruleset_ids": ruleset_ids,
+    }
+
+
 def _authority(input_document: dict[str, Any]) -> StageResult:
     authority_revision = _sha40(
         input_document.get("authority_revision"),
@@ -294,6 +351,10 @@ def _prepare(input_document: dict[str, Any]) -> StageResult:
         require_artifact=False,
     )
     context = _extra_context(input_document.get("extra_context"))
+    release_controls = _release_control_evidence(
+        input_document.get("release_controls"),
+        source_revision,
+    )
 
     changelog = _object(input_document.get("changelog"), "changelog")
     _same_source(
@@ -349,7 +410,8 @@ def _prepare(input_document: dict[str, Any]) -> StageResult:
     url = _string(release_pr.get("url"), "release_pr.url")
     if url != f"https://github.com/knaisoma/data-olympus/pull/{number}":
         raise ReleaseInputError("release_pr.url is outside the Data Olympus repository")
-    _true(release_pr.get("merged"), "release_pr.merged")
+    if release_pr.get("merged") is not False:
+        raise ReleaseInputError("release pull request must remain unmerged before review")
     base_revision = _sha40(
         release_pr.get("base_source_revision"),
         "release_pr.base_source_revision",
@@ -358,8 +420,12 @@ def _prepare(input_document: dict[str, Any]) -> StageResult:
         release_pr.get("head_revision"),
         "release_pr.head_revision",
     )
-    if base_revision == head_revision or head_revision == source_revision:
-        raise ReleaseInputError("release_pr revisions do not prove a squash merge")
+    if base_revision == head_revision or head_revision != source_revision:
+        raise ReleaseInputError("release_pr revisions do not bind the unmerged candidate")
+    head_tree_revision = _sha40(
+        release_pr.get("head_tree_revision"),
+        "release_pr.head_tree_revision",
+    )
     _same_source(
         source_revision,
         release_pr.get("source_revision"),
@@ -370,7 +436,7 @@ def _prepare(input_document: dict[str, Any]) -> StageResult:
 
     return _result(
         "pass",
-        f"release pull request {number} produced candidate {version}",
+        f"release pull request {number} prepared candidate {version} for review",
         {
             "source_revision": source_revision,
             "version": version,
@@ -380,7 +446,9 @@ def _prepare(input_document: dict[str, Any]) -> StageResult:
             "tests_hash": tests_hash,
             "rollback_digest": rollback_digest,
             "release_pr_head_revision": head_revision,
+            "release_pr_head_tree_revision": head_tree_revision,
             "release_pr_base_revision": base_revision,
+            **release_controls,
         },
         {
             "release_pr_number": number,
@@ -547,6 +615,43 @@ def _deliver(input_document: dict[str, Any]) -> StageResult:
         input_document.get("current_source_revision"),
         "current_source_revision",
     )
+    delivery_proof = _object(
+        input_document.get("delivery_proof"),
+        "delivery_proof",
+    )
+    admitted_revision = _sha40(
+        delivery_proof.get("admitted_revision"),
+        "delivery_proof.admitted_revision",
+    )
+    approved_candidate_revision = _sha40(
+        delivery_proof.get("approved_candidate_revision"),
+        "delivery_proof.approved_candidate_revision",
+    )
+    delivery_revision = _sha40(
+        delivery_proof.get("delivery_revision"),
+        "delivery_proof.delivery_revision",
+    )
+    reviewed_tree_revision = _sha40(
+        delivery_proof.get("reviewed_tree_revision"),
+        "delivery_proof.reviewed_tree_revision",
+    )
+    delivery_tree_revision = _sha40(
+        delivery_proof.get("delivery_tree_revision"),
+        "delivery_proof.delivery_tree_revision",
+    )
+    sole_parent_revision = _sha40(
+        delivery_proof.get("sole_parent_revision"),
+        "delivery_proof.sole_parent_revision",
+    )
+    _true(delivery_proof.get("merge_confirmed"), "delivery_proof.merge_confirmed")
+    if delivery_revision != source_revision:
+        raise ReleaseInputError("delivery proof revision does not match delivered source")
+    if approved_candidate_revision == delivery_revision:
+        raise ReleaseInputError("approved candidate and squash delivery revisions must differ")
+    if reviewed_tree_revision != delivery_tree_revision:
+        raise ReleaseInputError("delivery tree does not match the reviewed candidate tree")
+    if sole_parent_revision != admitted_revision:
+        raise ReleaseInputError("delivery parent does not match the admitted revision")
     candidate_tag = candidate["candidate_tag"]
 
     workflows = input_document.get("workflows")
@@ -627,12 +732,22 @@ def _deliver(input_document: dict[str, Any]) -> StageResult:
         "pass",
         f"release {version} was delivered by the approved workflows",
         {
+            "admitted_revision": admitted_revision,
+            "approved_candidate_revision": approved_candidate_revision,
             "source_revision": source_revision,
             "candidate_tag": candidate_tag,
+            "delivery_revision": delivery_revision,
+            "delivery_tree_revision": delivery_tree_revision,
             "digest": digest,
             "workflows": sorted(required),
         },
-        {"published_version": version},
+        {
+            "admitted_revision": admitted_revision,
+            "approved_candidate_revision": approved_candidate_revision,
+            "delivery_revision": delivery_revision,
+            "delivery_tree_revision": delivery_tree_revision,
+            "published_version": version,
+        },
     )
 
 
@@ -692,7 +807,7 @@ def _verify(input_document: dict[str, Any]) -> StageResult:
 
     return _result(
         "pass",
-        f"release {version} and kn dev match the reviewed source",
+        f"release {version} and kn dev match the approved release content",
         {
             "source_revision": source_revision,
             "version": version,
@@ -1321,6 +1436,7 @@ def execute_release_run(
                 "version, rollback point, and immutable release procedures pass."
             ),
             "prepared_evidence": prepared["evidence"],
+            "release_controls": prepared_input["release_controls"],
             "source_revision": candidate_revision,
             "validation_evidence": validation["evidence"],
         }

--- a/scripts/operations/release_runtime.py
+++ b/scripts/operations/release_runtime.py
@@ -51,6 +51,15 @@ REQUIRED_MAIN_CHECKS = {
     "doc-consistency-guard",
     "test",
 }
+CODE_QUALITY_CHECK_NAMES = {
+    "CodeQL - Code Quality",
+    "CodeQL - Code Quality / Analyze",
+}
+EXPECTED_CODEQL_LANGUAGES = {
+    "actions",
+    "javascript-typescript",
+    "python",
+}
 
 _SHA40 = re.compile(r"^[0-9a-f]{40}$")
 _DIGEST = re.compile(r"^sha256:[0-9a-f]{64}$")
@@ -356,6 +365,257 @@ def _check_matrix_concluded(
         and bool(run.get("conclusion"))
         for run in check_runs
     )
+
+
+def governed_release_controls(
+    *,
+    admitted_revision: str,
+    candidate_revision: str,
+    checks: dict[str, Any],
+    code_quality_setup: dict[str, Any],
+    codeql_alerts: list[dict[str, Any]],
+    codeql_analyses: list[dict[str, Any]],
+    review_state: dict[str, Any],
+    rulesets: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Rederive every control replaced by the deliberate ruleset bypass."""
+    if _SHA40.fullmatch(admitted_revision) is None:
+        raise ValueError("admitted release revision is invalid")
+    if _SHA40.fullmatch(candidate_revision) is None:
+        raise ValueError("release candidate revision is invalid")
+
+    if code_quality_setup.get("state") != "configured":
+        raise ValueError("GitHub Code Quality is not configured")
+    quality_languages = code_quality_setup.get("languages")
+    if type(quality_languages) is not list or not {
+        "javascript-typescript",
+        "python",
+    } <= set(quality_languages):
+        raise ValueError("GitHub Code Quality languages are incomplete")
+
+    check_evidence = completed_check_evidence(
+        checks,
+        required=REQUIRED_PULL_REQUEST_CHECKS,
+    )
+    check_evidence = {
+        **check_evidence,
+        "checks": sorted(
+            check_evidence["checks"],
+            key=lambda check: str(check.get("name")),
+        ),
+    }
+    check_runs = checks["check_runs"]
+    quality_checks = [
+        run
+        for run in check_runs
+        if run.get("name") in CODE_QUALITY_CHECK_NAMES
+    ]
+    if len(quality_checks) != 1:
+        raise ValueError("exact GitHub Code Quality check is unavailable")
+    quality_check = quality_checks[0]
+    if (
+        quality_check.get("status") != "completed"
+        or quality_check.get("conclusion") != "success"
+    ):
+        raise ValueError("GitHub Code Quality check did not succeed")
+
+    pull = _object(
+        _object(
+            _object(review_state.get("data"), "review state data").get(
+                "repository"
+            ),
+            "review state repository",
+        ).get("pullRequest"),
+        "review state pull request",
+    )
+    if (
+        pull.get("baseRefOid") != admitted_revision
+        or pull.get("headRefOid") != candidate_revision
+        or pull.get("isDraft") is not False
+        or pull.get("merged") is not False
+        or pull.get("state") != "OPEN"
+    ):
+        raise ValueError("release pull request identity changed")
+    if (
+        pull.get("mergeStateStatus") != "BLOCKED"
+        or pull.get("reviewDecision") != "REVIEW_REQUIRED"
+    ):
+        raise ValueError("release pull request review state changed")
+    threads = _object(pull.get("reviewThreads"), "review threads")
+    page_info = _object(threads.get("pageInfo"), "review thread page info")
+    nodes = threads.get("nodes")
+    if (
+        page_info.get("hasNextPage") is not False
+        or type(nodes) is not list
+        or any(type(node) is not dict for node in nodes)
+    ):
+        raise ValueError("release review thread evidence is incomplete")
+    unresolved_threads = sum(node.get("isResolved") is not True for node in nodes)
+    if unresolved_threads:
+        raise ValueError("release pull request has unresolved review threads")
+
+    if type(codeql_alerts) is not list or codeql_alerts:
+        raise ValueError("release pull request has open CodeQL alerts")
+    if type(codeql_analyses) is not list:
+        raise ValueError("CodeQL analysis evidence is invalid")
+    matched_analyses = [
+        analysis
+        for analysis in codeql_analyses
+        if type(analysis) is dict
+        and analysis.get("commit_sha") == candidate_revision
+        and analysis.get("analysis_key")
+        == "dynamic/github-code-scanning/codeql:analyze"
+    ]
+    languages = {
+        str(analysis.get("category", "")).removeprefix("/language:")
+        for analysis in matched_analyses
+    }
+    if languages != EXPECTED_CODEQL_LANGUAGES:
+        raise ValueError("exact candidate CodeQL language matrix is incomplete")
+    if any(
+        analysis.get("error") not in {None, ""}
+        or analysis.get("results_count") != 0
+        for analysis in matched_analyses
+    ):
+        raise ValueError("exact candidate CodeQL analysis did not pass")
+
+    active_rulesets = []
+    for ruleset in rulesets:
+        if type(ruleset) is not dict:
+            raise ValueError("GitHub ruleset evidence is invalid")
+        conditions = ruleset.get("conditions")
+        ref_name = conditions.get("ref_name") if type(conditions) is dict else None
+        includes = ref_name.get("include") if type(ref_name) is dict else None
+        if (
+            ruleset.get("target") == "branch"
+            and ruleset.get("enforcement") == "active"
+            and type(includes) is list
+            and "~DEFAULT_BRANCH" in includes
+        ):
+            active_rulesets.append(ruleset)
+    if not active_rulesets:
+        raise ValueError("active default branch ruleset is unavailable")
+    all_rules = [
+        rule
+        for ruleset in active_rulesets
+        for rule in ruleset.get("rules", [])
+        if type(rule) is dict
+    ]
+    rule_types = {rule.get("type") for rule in all_rules}
+    for required_type, description in (
+        ("deletion", "deletion protection"),
+        ("non_fast_forward", "non fast forward protection"),
+        ("required_linear_history", "required linear history"),
+    ):
+        if required_type not in rule_types:
+            raise ValueError(f"GitHub ruleset lost {description}")
+
+    pull_rules = [rule for rule in all_rules if rule.get("type") == "pull_request"]
+    if not any(
+        type(rule.get("parameters")) is dict
+        and rule["parameters"].get("required_approving_review_count", 0) >= 1
+        and rule["parameters"].get("require_code_owner_review") is True
+        and rule["parameters"].get("require_last_push_approval") is True
+        and rule["parameters"].get("required_review_thread_resolution") is True
+        for rule in pull_rules
+    ):
+        raise ValueError("GitHub pull request review rules changed")
+    status_rules = [
+        rule for rule in all_rules if rule.get("type") == "required_status_checks"
+    ]
+    if not any(
+        type(rule.get("parameters")) is dict
+        and any(
+            type(item) is dict and item.get("context") == "test"
+            for item in rule["parameters"].get("required_status_checks", [])
+        )
+        for rule in status_rules
+    ):
+        raise ValueError("GitHub ruleset lost the required test status")
+    scanning_rules = [rule for rule in all_rules if rule.get("type") == "code_scanning"]
+    if not any(
+        type(rule.get("parameters")) is dict
+        and any(
+            type(tool) is dict
+            and tool.get("tool") == "CodeQL"
+            and tool.get("security_alerts_threshold") == "high_or_higher"
+            and tool.get("alerts_threshold") == "errors"
+            for tool in rule["parameters"].get("code_scanning_tools", [])
+        )
+        for rule in scanning_rules
+    ):
+        raise ValueError("GitHub CodeQL ruleset thresholds changed")
+    quality_rules = [rule for rule in all_rules if rule.get("type") == "code_quality"]
+    if not any(
+        type(rule.get("parameters")) is dict
+        and rule["parameters"].get("severity") == "errors"
+        for rule in quality_rules
+    ):
+        raise ValueError("GitHub Code Quality ruleset threshold changed")
+    if not any(
+        ruleset.get("current_user_can_bypass") == "always"
+        and type(ruleset.get("bypass_actors")) is list
+        and any(
+            type(actor) is dict
+            and actor.get("actor_type") == "Team"
+            and actor.get("bypass_mode") == "always"
+            for actor in ruleset["bypass_actors"]
+        )
+        for ruleset in active_rulesets
+    ):
+        raise ValueError("authorized release ruleset bypass is unavailable")
+
+    canonical_rulesets = sorted(
+        (
+            {
+                field: ruleset.get(field)
+                for field in (
+                    "id",
+                    "target",
+                    "source_type",
+                    "source",
+                    "enforcement",
+                    "conditions",
+                    "rules",
+                    "bypass_actors",
+                    "current_user_can_bypass",
+                )
+            }
+            for ruleset in active_rulesets
+        ),
+        key=lambda ruleset: int(ruleset.get("id", 0)),
+    )
+    ruleset_fingerprint = sha256(
+        json.dumps(canonical_rulesets, separators=(",", ":"), sort_keys=True).encode()
+    ).hexdigest()
+    analysis_summary = sorted(
+        (
+            {
+                "analysis_key": analysis["analysis_key"],
+                "category": analysis["category"],
+                "commit_sha": analysis["commit_sha"],
+                "error": analysis.get("error", ""),
+                "results_count": analysis["results_count"],
+            }
+            for analysis in matched_analyses
+        ),
+        key=lambda analysis: analysis["category"],
+    )
+    return {
+        "candidate_revision": candidate_revision,
+        "check_evidence": check_evidence,
+        "code_quality_check": quality_check["name"],
+        "code_quality_state": "configured",
+        "codeql_analysis_hash": sha256(
+            json.dumps(analysis_summary, separators=(",", ":"), sort_keys=True).encode()
+        ).hexdigest(),
+        "codeql_languages": sorted(languages),
+        "open_codeql_alerts": 0,
+        "review_decision": pull["reviewDecision"],
+        "ruleset_fingerprint": ruleset_fingerprint,
+        "ruleset_ids": sorted(ruleset["id"] for ruleset in active_rulesets),
+        "unresolved_review_threads": unresolved_threads,
+    }
 
 
 def _asset_names(release: dict[str, Any]) -> set[str]:
@@ -691,11 +951,40 @@ class ReleaseRuntime:
             raise ValueError("managed worktree source revision is invalid")
         return revision
 
-    def candidate_revision(self) -> str:
+    def remote_main_revision(self) -> str:
         revision = self.command(["git", "rev-parse", "origin/main"])
         if _SHA40.fullmatch(revision) is None:
             raise ValueError("remote main revision is invalid")
         return revision
+
+    def candidate_revision(self) -> str:
+        if self._prepared is None:
+            return self.source_revision()
+        candidate = _object(self._prepared["raw"].get("candidate"), "candidate")
+        revision = candidate.get("source_revision")
+        if type(revision) is not str or _SHA40.fullmatch(revision) is None:
+            raise ValueError("prepared candidate revision is invalid")
+        return revision
+
+    def _tree_revision(self, revision: str) -> str:
+        if _SHA40.fullmatch(revision) is None:
+            raise ValueError("git tree source revision is invalid")
+        tree = self.command(["git", "rev-parse", f"{revision}^{{tree}}"])
+        if _SHA40.fullmatch(tree) is None:
+            raise ValueError("git tree revision is invalid")
+        return tree
+
+    def _parent_revisions(self, revision: str) -> list[str]:
+        if _SHA40.fullmatch(revision) is None:
+            raise ValueError("git parent source revision is invalid")
+        parts = self.command(
+            ["git", "rev-list", "--parents", "-n", "1", revision]
+        ).split()
+        if not parts or parts[0] != revision or any(
+            _SHA40.fullmatch(part) is None for part in parts
+        ):
+            raise ValueError("git parent evidence is invalid")
+        return parts[1:]
 
     def collect_admission(self, run_input: dict[str, Any]) -> dict[str, Any]:
         admitted = run_input.get("source_revision")
@@ -704,7 +993,7 @@ class ReleaseRuntime:
         self.command(["git", "fetch", "--tags", "origin", "main"], timeout=120)
         if self.source_revision() != admitted:
             raise ValueError("managed worktree changed after admission")
-        remote_main = self.candidate_revision()
+        remote_main = self.remote_main_revision()
         if remote_main != admitted:
             raise ValueError("remote main changed after admission")
         raw_computation = self.command(
@@ -732,7 +1021,134 @@ class ReleaseRuntime:
             "computed_release": computation,
         }
 
-    def _wait_pull_request(self, number: int, head_revision: str) -> dict[str, Any]:
+    def _github_json(self, arguments: list[str], *, timeout: int = 60) -> Any:
+        raw = self.command(["gh", "api", *arguments], timeout=timeout)
+        try:
+            return json.loads(raw)
+        except json.JSONDecodeError as error:
+            raise ValueError("GitHub API returned invalid JSON") from error
+
+    @staticmethod
+    def _flatten_pages(value: Any, name: str) -> list[dict[str, Any]]:
+        if type(value) is not list:
+            raise ValueError(f"{name} is invalid")
+        pages = value if all(type(page) is list for page in value) else [value]
+        flattened = [item for page in pages for item in page]
+        if any(type(item) is not dict for item in flattened):
+            raise ValueError(f"{name} is invalid")
+        return flattened
+
+    def _review_state(self, number: int) -> dict[str, Any]:
+        query = (
+            "query($owner:String!,$repo:String!,$number:Int!){"
+            "repository(owner:$owner,name:$repo){pullRequest(number:$number){"
+            "baseRefOid headRefOid isDraft mergeStateStatus merged reviewDecision "
+            "state reviewThreads(first:100){totalCount pageInfo{hasNextPage} "
+            "nodes{isResolved}}}}}"
+        )
+        value = self._github_json(
+            [
+                "graphql",
+                "-f",
+                f"query={query}",
+                "-F",
+                f"owner={GITHUB_OWNER}",
+                "-F",
+                f"repo={GITHUB_REPOSITORY}",
+                "-F",
+                f"number={number}",
+            ]
+        )
+        return _object(value, "GitHub pull request review state")
+
+    def _active_rulesets(self) -> list[dict[str, Any]]:
+        summaries = self._github_json(
+            [
+                f"repos/{GITHUB_OWNER}/{GITHUB_REPOSITORY}/rulesets"
+                "?includes_parents=true&targets=branch&per_page=100",
+            ]
+        )
+        if type(summaries) is not list or any(
+            type(summary) is not dict for summary in summaries
+        ):
+            raise ValueError("GitHub ruleset list is invalid")
+        details = []
+        for summary in summaries:
+            ruleset_id = summary.get("id")
+            if type(ruleset_id) is not int:
+                raise ValueError("GitHub ruleset identity is invalid")
+            details.append(
+                _object(
+                    self._github_json(
+                        [
+                            f"repos/{GITHUB_OWNER}/{GITHUB_REPOSITORY}/rulesets/"
+                            f"{ruleset_id}"
+                        ]
+                    ),
+                    "GitHub ruleset",
+                )
+            )
+        return details
+
+    def _collect_release_controls(
+        self,
+        *,
+        number: int,
+        head_revision: str,
+        base_revision: str,
+        checks: dict[str, Any],
+    ) -> dict[str, Any]:
+        setup = _object(
+            self._github_json(
+                [
+                    "-H",
+                    "X-GitHub-Api-Version: 2026-03-10",
+                    f"repos/{GITHUB_OWNER}/{GITHUB_REPOSITORY}/code-quality/setup",
+                ]
+            ),
+            "GitHub Code Quality setup",
+        )
+        analyses = self._flatten_pages(
+            self._github_json(
+                [
+                    "--paginate",
+                    "--slurp",
+                    f"repos/{GITHUB_OWNER}/{GITHUB_REPOSITORY}/"
+                    "code-scanning/analyses?per_page=100",
+                ],
+                timeout=120,
+            ),
+            "CodeQL analyses",
+        )
+        alerts = self._flatten_pages(
+            self._github_json(
+                [
+                    "--paginate",
+                    "--slurp",
+                    f"repos/{GITHUB_OWNER}/{GITHUB_REPOSITORY}/"
+                    f"code-scanning/alerts?state=open&pr={number}&per_page=100",
+                ],
+                timeout=120,
+            ),
+            "CodeQL alerts",
+        )
+        return governed_release_controls(
+            admitted_revision=base_revision,
+            candidate_revision=head_revision,
+            checks=checks,
+            code_quality_setup=setup,
+            codeql_alerts=alerts,
+            codeql_analyses=analyses,
+            review_state=self._review_state(number),
+            rulesets=self._active_rulesets(),
+        )
+
+    def _wait_pull_request(
+        self,
+        number: int,
+        head_revision: str,
+        base_revision: str,
+    ) -> dict[str, Any]:
         last_error = "pull request checks did not appear"
         for _attempt in range(120):
             checks = self.gateway_object(
@@ -771,14 +1187,23 @@ class ReleaseRuntime:
                 },
             )
             head = _object(pull.get("head"), "pull request head")
+            base = _object(pull.get("base"), "pull request base")
             if (
                 head.get("sha") != head_revision
+                or base.get("sha") != base_revision
                 or pull.get("draft") is not False
                 or pull.get("state") != "open"
-                or pull.get("mergeable_state") not in {"clean", "unstable"}
+                or pull.get("merged") is not False
+                or pull.get("mergeable_state") != "blocked"
             ):
                 raise ValueError("release pull request identity or merge state changed")
-            return {"checks": check_evidence, "pull": pull}
+            controls = self._collect_release_controls(
+                number=number,
+                head_revision=head_revision,
+                base_revision=base_revision,
+                checks=checks,
+            )
+            return {"checks": check_evidence, "controls": controls, "pull": pull}
         raise ValueError(last_error)
 
     def _merge_exact(
@@ -1082,90 +1507,30 @@ class ReleaseRuntime:
                 number = int(match.group(1))
         if type(number) is not int or number <= 0:
             raise ValueError("release pull request number is invalid")
-        ready = self._wait_pull_request(number, head_revision)
+        head_tree_revision = self._tree_revision(head_revision)
+        if self._parent_revisions(head_revision) != [admitted]:
+            raise ValueError("release candidate parent does not match admission")
+        ready = self._wait_pull_request(number, head_revision, admitted)
         self.command(["git", "fetch", "origin", "main"], timeout=120)
-        if self.candidate_revision() != admitted:
-            raise ValueError("remote main changed before release merge")
-        try:
-            merged = self._merge_exact(number, version, head_revision)
-        except (OSError, subprocess.SubprocessError, ValueError) as error:
-            raise ReleaseDeliveryError(
-                "release merge outcome could not be confirmed",
-                {
-                    "external_state_changed": True,
-                    "merge_confirmed": False,
-                    "merge_outcome": "unknown",
-                    "release_pr_head_revision": head_revision,
-                    "release_pr_number": number,
-                    "rollback_completed": False,
-                },
-            ) from error
-        final_revision = self._confirmed_merge_revision(
-            merged,
-            number=number,
-            head_revision=head_revision,
-        )
-        try:
-            return self._finish_preparation_after_merge(
-                run_input=run_input,
-                admitted=admitted,
-                version=version,
-                head_revision=head_revision,
-                final_revision=final_revision,
-                number=number,
-                ready=ready,
-                document_evidence=document_evidence,
-            )
-        except (OSError, subprocess.SubprocessError, ValueError) as error:
-            raise ReleaseDeliveryError(
-                str(error),
-                {
-                    "external_state_changed": True,
-                    "merge_confirmed": True,
-                    "merge_outcome": "merged",
-                    "merged_revision": final_revision,
-                    "release_pr_head_revision": head_revision,
-                    "release_pr_number": number,
-                    "rollback_completed": False,
-                },
-            ) from error
-
-    def _finish_preparation_after_merge(
-        self,
-        *,
-        run_input: dict[str, Any],
-        admitted: str,
-        version: str,
-        head_revision: str,
-        final_revision: str,
-        number: int,
-        ready: dict[str, Any],
-        document_evidence: dict[str, Any],
-    ) -> dict[str, Any]:
-        if _SHA40.fullmatch(final_revision) is None:
-            raise ValueError("release merge returned an invalid source revision")
-        self.command(["git", "fetch", "origin", "main"], timeout=120)
-        if self.candidate_revision() != final_revision:
-            raise ValueError("release merge SHA does not match remote main")
-        self.command(["git", "switch", "--detach", final_revision])
-        if self.command(["git", "rev-parse", f"{final_revision}^"]) != admitted:
-            raise ValueError("release squash merge parent does not match admission")
+        if self.remote_main_revision() != admitted:
+            raise ValueError("remote main changed before release review")
         if self.command(["git", "status", "--porcelain"]):
             raise ValueError("release candidate worktree is not clean")
-        gates = self._final_local_gates(final_revision, version)
+        gates = self._final_local_gates(head_revision, version)
         live = self.live_statefulset()
         rollback = deployment_state(live)
         if not rollback["rollout_complete"]:
             raise ValueError("current Data Olympus rollback point is not ready")
-        final_candidate = {
+        review_candidate = {
             "version": version,
-            "source_revision": final_revision,
+            "source_revision": head_revision,
         }
         raw = {
-            "candidate": final_candidate,
+            "candidate": review_candidate,
             "extra_context": run_input["extra_context"],
+            "release_controls": ready["controls"],
             "changelog": {
-                "source_revision": final_revision,
+                "source_revision": head_revision,
                 "content_hash": document_evidence["changelog_hash"],
             },
             "security": gates["security"],
@@ -1178,10 +1543,11 @@ class ReleaseRuntime:
             "release_pr": {
                 "number": number,
                 "url": f"https://github.com/{GITHUB_OWNER}/{GITHUB_REPOSITORY}/pull/{number}",
-                "merged": True,
+                "merged": False,
                 "base_source_revision": admitted,
                 "head_revision": head_revision,
-                "source_revision": final_revision,
+                "head_tree_revision": head_tree_revision,
+                "source_revision": head_revision,
                 "candidate_version": version,
             },
         }
@@ -1190,6 +1556,7 @@ class ReleaseRuntime:
             "gates": gates,
             "document_evidence": document_evidence,
             "pull_checks": ready["checks"],
+            "release_controls": ready["controls"],
         }
         return raw
 
@@ -1203,9 +1570,12 @@ class ReleaseRuntime:
             raise ValueError("release preparation evidence is unavailable")
         candidate = _object(self._prepared["raw"]["candidate"], "candidate")
         source_revision = candidate["source_revision"]
+        base_revision = self._prepared["raw"]["release_pr"]["base_source_revision"]
         if (
-            self.candidate_revision() != source_revision
+            self.remote_main_revision() != base_revision
             or self.source_revision() != source_revision
+            or self._tree_revision(source_revision)
+            != self._prepared["raw"]["release_pr"]["head_tree_revision"]
         ):
             raise ValueError("release candidate changed before validation")
         gates = self._prepared["gates"]
@@ -1510,6 +1880,135 @@ class ReleaseRuntime:
             version=version,
         )
 
+    def _reconcile_merge_result(
+        self,
+        *,
+        number: int,
+        head_revision: str,
+        base_revision: str,
+    ) -> str | None:
+        pull = self.gateway_object(
+            "pull_request_read",
+            {
+                "method": "get",
+                "owner": GITHUB_OWNER,
+                "repo": GITHUB_REPOSITORY,
+                "pullNumber": number,
+            },
+        )
+        head = _object(pull.get("head"), "pull request head")
+        base = _object(pull.get("base"), "pull request base")
+        self.command(["git", "fetch", "origin", "main"], timeout=120)
+        remote_main = self.remote_main_revision()
+        if head.get("sha") != head_revision or base.get("sha") != base_revision:
+            raise ReleaseDeliveryError(
+                "release merge reconciliation found changed pull request identity",
+                {
+                    "external_state_changed": True,
+                    "merge_confirmed": False,
+                    "merge_outcome": "unknown",
+                    "release_pr_head_revision": head_revision,
+                    "release_pr_number": number,
+                    "rollback_completed": False,
+                },
+            )
+        merge_revision = pull.get("merge_commit_sha")
+        if (
+            pull.get("merged") is True
+            and type(merge_revision) is str
+            and _SHA40.fullmatch(merge_revision) is not None
+            and remote_main == merge_revision
+        ):
+            return merge_revision
+        if (
+            pull.get("merged") is False
+            and pull.get("state") == "open"
+            and remote_main == base_revision
+        ):
+            return None
+        raise ReleaseDeliveryError(
+            "release merge outcome could not be reconciled",
+            {
+                "external_state_changed": True,
+                "merge_confirmed": False,
+                "merge_outcome": "unknown",
+                "release_pr_head_revision": head_revision,
+                "release_pr_number": number,
+                "rollback_completed": False,
+            },
+        )
+
+    def _merge_and_prove_delivery(
+        self,
+        *,
+        number: int,
+        version: str,
+        head_revision: str,
+        head_tree_revision: str,
+        base_revision: str,
+    ) -> tuple[str, dict[str, Any]]:
+        try:
+            merged = self._merge_exact(number, version, head_revision)
+        except (OSError, subprocess.SubprocessError, ValueError):
+            final_revision = self._reconcile_merge_result(
+                number=number,
+                head_revision=head_revision,
+                base_revision=base_revision,
+            )
+            if final_revision is None:
+                raise ValueError("release pull request did not merge") from None
+        else:
+            try:
+                final_revision = self._confirmed_merge_revision(
+                    merged,
+                    number=number,
+                    head_revision=head_revision,
+                )
+            except ValueError:
+                final_revision = self._reconcile_merge_result(
+                    number=number,
+                    head_revision=head_revision,
+                    base_revision=base_revision,
+                )
+                if final_revision is None:
+                    raise ValueError("release pull request did not merge") from None
+
+        try:
+            self.command(["git", "fetch", "origin", "main"], timeout=120)
+            if self.remote_main_revision() != final_revision:
+                raise ValueError("release merge SHA does not match remote main")
+            if self._parent_revisions(final_revision) != [base_revision]:
+                raise ValueError("release squash merge parent does not match admission")
+            final_tree_revision = self._tree_revision(final_revision)
+            if final_tree_revision != head_tree_revision:
+                raise ValueError("release squash merge tree does not match reviewed content")
+            self.command(["git", "switch", "--detach", final_revision])
+            if self.command(["git", "status", "--porcelain"]):
+                raise ValueError("delivered release worktree is not clean")
+        except (OSError, subprocess.SubprocessError, ValueError) as error:
+            raise ReleaseDeliveryError(
+                str(error),
+                {
+                    "external_state_changed": True,
+                    "merge_confirmed": True,
+                    "merge_outcome": "merged",
+                    "merged_revision": final_revision,
+                    "release_pr_head_revision": head_revision,
+                    "release_pr_number": number,
+                    "rollback_completed": False,
+                },
+            ) from error
+        proof = {
+            "admitted_revision": base_revision,
+            "approved_candidate_revision": head_revision,
+            "delivery_revision": final_revision,
+            "delivery_tree_revision": final_tree_revision,
+            "merge_confirmed": True,
+            "reviewed_tree_revision": head_tree_revision,
+            "sole_parent_revision": base_revision,
+        }
+        return final_revision, proof
+
     def deliver(
         self,
         _run_input: dict[str, Any],
@@ -1519,9 +2018,59 @@ class ReleaseRuntime:
     ) -> dict[str, Any]:
         if self._prepared is None:
             raise ValueError("release preparation evidence is unavailable")
-        candidate = _object(self._prepared["raw"]["candidate"], "candidate")
-        source_revision = candidate["source_revision"]
-        version = candidate["version"]
+        prepared_candidate = _object(
+            self._prepared["raw"]["candidate"],
+            "candidate",
+        )
+        candidate_revision = prepared_candidate["source_revision"]
+        version = prepared_candidate["version"]
+        review_evidence = _object(_reviewed.get("evidence"), "release review evidence")
+        if (
+            _reviewed.get("status") != "pass"
+            or review_evidence.get("reviewer_family") != "claude"
+            or review_evidence.get("source_revision") != candidate_revision
+        ):
+            raise ValueError("independent candidate approval is unavailable")
+        release_pr = _object(
+            self._prepared["raw"].get("release_pr"),
+            "release pull request",
+        )
+        number = release_pr["number"]
+        base_revision = release_pr["base_source_revision"]
+        head_tree_revision = release_pr["head_tree_revision"]
+        ready = self._wait_pull_request(
+            number,
+            candidate_revision,
+            base_revision,
+        )
+        if ready["controls"] != self._prepared["release_controls"]:
+            raise ValueError("release controls changed after independent review")
+        self.command(["git", "fetch", "origin", "main"], timeout=120)
+        if (
+            self.remote_main_revision() != base_revision
+            or self.source_revision() != candidate_revision
+            or self._tree_revision(candidate_revision) != head_tree_revision
+        ):
+            raise ValueError("release candidate changed before approved merge")
+        source_revision, delivery_proof = self._merge_and_prove_delivery(
+            number=number,
+            version=version,
+            head_revision=candidate_revision,
+            head_tree_revision=head_tree_revision,
+            base_revision=base_revision,
+        )
+        try:
+            final_gates = self._final_local_gates(source_revision, version)
+        except (OSError, subprocess.SubprocessError, ValueError) as error:
+            raise ReleaseDeliveryError(
+                str(error),
+                {
+                    **delivery_proof,
+                    "external_state_changed": True,
+                    "release_pr_number": number,
+                    "rollback_completed": False,
+                },
+            ) from error
         tags = self.gateway.execute(
             "list_tags",
             {
@@ -1619,13 +2168,15 @@ class ReleaseRuntime:
                 ) from error
             raise
         final_candidate = {
-            **candidate,
+            "source_revision": source_revision,
+            "version": version,
             "candidate_tag": candidate_tag,
             "image_digest": digest,
         }
         raw = {
             "candidate": final_candidate,
             "current_source_revision": source_revision,
+            "delivery_proof": delivery_proof,
             "workflows": [
                 {
                     **rc_receipt,
@@ -1662,6 +2213,7 @@ class ReleaseRuntime:
             "raw": raw,
             "acceptance": stable_acceptance,
             "candidate_publication": publication,
+            "final_gates": final_gates,
             "stable_publication": stable,
         }
         return raw

--- a/tests/test_operations_release.py
+++ b/tests/test_operations_release.py
@@ -15,6 +15,7 @@ from scripts.operations.release import (
 
 SOURCE_SHA = "a" * 40
 CANDIDATE_SHA = "f" * 40
+DELIVERY_SHA = "7" * 40
 BRANCH_SHA = "9" * 40
 AUTHORITY_SHA = "b" * 40
 CONTRACT_SHA = "c" * 64
@@ -58,6 +59,22 @@ def _admission_input(*, releasable: bool = True) -> dict[str, object]:
                 "breaking": [],
             },
         },
+    }
+
+
+def _release_controls(candidate_revision: str) -> dict[str, object]:
+    return {
+        "candidate_revision": candidate_revision,
+        "check_evidence": {"all_success": True, "missing_required": []},
+        "code_quality_check": "CodeQL - Code Quality",
+        "code_quality_state": "configured",
+        "codeql_analysis_hash": "4" * 64,
+        "codeql_languages": ["actions", "javascript-typescript", "python"],
+        "open_codeql_alerts": 0,
+        "review_decision": "REVIEW_REQUIRED",
+        "ruleset_fingerprint": "5" * 64,
+        "ruleset_ids": [18080131],
+        "unresolved_review_threads": 0,
     }
 
 
@@ -154,19 +171,21 @@ def test_admission_blocks_unmerged_changed_or_v060_candidate(
     assert reason in result["reason"]
 
 
-def test_prepare_confirms_one_merged_release_pr_and_hashes_extra_context() -> None:
+def test_prepare_confirms_one_unmerged_release_candidate_and_hashes_extra_context() -> None:
+    candidate = {**_candidate(), "source_revision": CANDIDATE_SHA}
     result = evaluate_stage(
         "prepare",
         {
-            "candidate": _candidate(),
+            "candidate": candidate,
+            "release_controls": _release_controls(CANDIDATE_SHA),
             "extra_context": DEFAULT_EXTRA_CONTEXT,
             "changelog": {
-                "source_revision": SOURCE_SHA,
+                "source_revision": CANDIDATE_SHA,
                 "content_hash": "1" * 64,
             },
             "security": {"exit_code": 0, "report_hash": "2" * 64},
             "tests": {
-                "source_revision": SOURCE_SHA,
+                "source_revision": CANDIDATE_SHA,
                 "passed": True,
                 "evidence_hash": "3" * 64,
             },
@@ -178,10 +197,11 @@ def test_prepare_confirms_one_merged_release_pr_and_hashes_extra_context() -> No
             "release_pr": {
                 "number": 178,
                 "url": "https://github.com/knaisoma/data-olympus/pull/178",
-                "merged": True,
-                "base_source_revision": "8" * 40,
-                "head_revision": BRANCH_SHA,
-                "source_revision": SOURCE_SHA,
+                "merged": False,
+                "base_source_revision": SOURCE_SHA,
+                "head_revision": CANDIDATE_SHA,
+                "head_tree_revision": BRANCH_SHA,
+                "source_revision": CANDIDATE_SHA,
                 "candidate_version": "0.6.1",
             },
         },
@@ -194,19 +214,23 @@ def test_prepare_confirms_one_merged_release_pr_and_hashes_extra_context() -> No
     assert len(context["sha256"]) == 64
     assert DEFAULT_EXTRA_CONTEXT not in json.dumps(result)
     assert result["outputs"]["release_pr_number"] == 178
+    assert result["evidence"]["release_pr_head_tree_revision"] == BRANCH_SHA
+    assert result["evidence"]["ruleset_fingerprint"] == "5" * 64
 
 
-def test_prepare_blocks_when_the_release_pr_is_not_merged() -> None:
+def test_prepare_blocks_when_the_release_pr_was_merged_before_review() -> None:
+    candidate = {**_candidate(), "source_revision": CANDIDATE_SHA}
     input_document = {
-        "candidate": _candidate(),
+        "candidate": candidate,
+        "release_controls": _release_controls(CANDIDATE_SHA),
         "extra_context": DEFAULT_EXTRA_CONTEXT,
         "changelog": {
-            "source_revision": SOURCE_SHA,
+            "source_revision": CANDIDATE_SHA,
             "content_hash": "1" * 64,
         },
         "security": {"exit_code": 0, "report_hash": "2" * 64},
         "tests": {
-            "source_revision": SOURCE_SHA,
+            "source_revision": CANDIDATE_SHA,
             "passed": True,
             "evidence_hash": "3" * 64,
         },
@@ -218,10 +242,11 @@ def test_prepare_blocks_when_the_release_pr_is_not_merged() -> None:
         "release_pr": {
             "number": 178,
             "url": "https://github.com/knaisoma/data-olympus/pull/178",
-            "merged": False,
-            "base_source_revision": "8" * 40,
-            "head_revision": BRANCH_SHA,
-            "source_revision": SOURCE_SHA,
+            "merged": True,
+            "base_source_revision": SOURCE_SHA,
+            "head_revision": CANDIDATE_SHA,
+            "head_tree_revision": BRANCH_SHA,
+            "source_revision": CANDIDATE_SHA,
             "candidate_version": "0.6.1",
         },
     }
@@ -229,7 +254,7 @@ def test_prepare_blocks_when_the_release_pr_is_not_merged() -> None:
     result = evaluate_stage("prepare", input_document)
 
     assert result["status"] == "blocked"
-    assert "release_pr.merged" in result["reason"]
+    assert "must remain unmerged" in result["reason"]
 
 
 def test_validate_requires_unchanged_candidate_and_all_exact_gates() -> None:
@@ -382,6 +407,15 @@ def test_deliver_accepts_only_existing_workflows_bound_to_candidate() -> None:
         {
             "candidate": _candidate(),
             "current_source_revision": SOURCE_SHA,
+            "delivery_proof": {
+                "admitted_revision": "8" * 40,
+                "approved_candidate_revision": CANDIDATE_SHA,
+                "delivery_revision": SOURCE_SHA,
+                "delivery_tree_revision": BRANCH_SHA,
+                "merge_confirmed": True,
+                "reviewed_tree_revision": BRANCH_SHA,
+                "sole_parent_revision": "8" * 40,
+            },
             "workflows": [
                 {
                     "name": "rc-publish.yml",
@@ -430,6 +464,15 @@ def test_deliver_fails_stable_promotion_without_verified_canary() -> None:
     input_document = {
         "candidate": _candidate(),
         "current_source_revision": SOURCE_SHA,
+        "delivery_proof": {
+            "admitted_revision": "8" * 40,
+            "approved_candidate_revision": CANDIDATE_SHA,
+            "delivery_revision": SOURCE_SHA,
+            "delivery_tree_revision": BRANCH_SHA,
+            "merge_confirmed": True,
+            "reviewed_tree_revision": BRANCH_SHA,
+            "sole_parent_revision": "8" * 40,
+        },
         "workflows": [
             {
                 "name": "rc-publish.yml",
@@ -786,7 +829,8 @@ def _release_dependencies(*, source_revision: str = SOURCE_SHA) -> dict[str, obj
         "source_revision": CANDIDATE_SHA,
     }
     artifact_candidate = {
-        **prepared_candidate,
+        "version": "0.6.1",
+        "source_revision": DELIVERY_SHA,
         "candidate_tag": "0.6.1-rc.1",
         "image_digest": IMAGE_DIGEST,
     }
@@ -795,6 +839,7 @@ def _release_dependencies(*, source_revision: str = SOURCE_SHA) -> dict[str, obj
         state["head"] = CANDIDATE_SHA
         return {
             "candidate": prepared_candidate,
+            "release_controls": _release_controls(CANDIDATE_SHA),
             "extra_context": run["extra_context"],
             "changelog": {
                 "source_revision": CANDIDATE_SHA,
@@ -814,9 +859,10 @@ def _release_dependencies(*, source_revision: str = SOURCE_SHA) -> dict[str, obj
             "release_pr": {
                 "number": 178,
                 "url": "https://github.com/knaisoma/data-olympus/pull/178",
-                "merged": True,
+                "merged": False,
                 "base_source_revision": SOURCE_SHA,
-                "head_revision": BRANCH_SHA,
+                "head_revision": CANDIDATE_SHA,
+                "head_tree_revision": BRANCH_SHA,
                 "source_revision": CANDIDATE_SHA,
                 "candidate_version": "0.6.1",
             },
@@ -857,30 +903,39 @@ def _release_dependencies(*, source_revision: str = SOURCE_SHA) -> dict[str, obj
         },
         "deliver": lambda _run, _admitted, _prepared, _review: {
             "candidate": artifact_candidate,
-            "current_source_revision": CANDIDATE_SHA,
+            "current_source_revision": DELIVERY_SHA,
+            "delivery_proof": {
+                "admitted_revision": SOURCE_SHA,
+                "approved_candidate_revision": CANDIDATE_SHA,
+                "delivery_revision": DELIVERY_SHA,
+                "delivery_tree_revision": BRANCH_SHA,
+                "merge_confirmed": True,
+                "reviewed_tree_revision": BRANCH_SHA,
+                "sole_parent_revision": SOURCE_SHA,
+            },
             "workflows": [
                 {
                     "name": "rc-publish.yml",
                     "conclusion": "success",
-                    "source_revision": CANDIDATE_SHA,
+                    "source_revision": DELIVERY_SHA,
                     "candidate_tag": "0.6.1-rc.1",
                 },
                 {
                     "name": "tag-release.yml",
                     "conclusion": "success",
-                    "source_revision": CANDIDATE_SHA,
+                    "source_revision": DELIVERY_SHA,
                     "candidate_tag": "0.6.1-rc.1",
                 },
                 {
                     "name": "set-channel.yml",
                     "conclusion": "success",
-                    "source_revision": CANDIDATE_SHA,
+                    "source_revision": DELIVERY_SHA,
                     "source_tag": "v0.6.1",
                 },
             ],
             "canary": {
                 "candidate_tag": "0.6.1-rc.1",
-                "source_revision": CANDIDATE_SHA,
+                "source_revision": DELIVERY_SHA,
                 "digest": IMAGE_DIGEST,
                 "keel_policy": "never",
                 "rollout_complete": True,
@@ -892,7 +947,7 @@ def _release_dependencies(*, source_revision: str = SOURCE_SHA) -> dict[str, obj
             "deployment": {
                 "keel_policy": "never",
                 "image_digest": IMAGE_DIGEST,
-                "source_revision": CANDIDATE_SHA,
+                "source_revision": DELIVERY_SHA,
                 "rollout_complete": True,
             },
         },
@@ -900,15 +955,15 @@ def _release_dependencies(*, source_revision: str = SOURCE_SHA) -> dict[str, obj
             "candidate": artifact_candidate,
             "github_release": {
                 "tag": "v0.6.1",
-                "source_revision": CANDIDATE_SHA,
+                "source_revision": DELIVERY_SHA,
             },
             "pypi": {
                 "version": "0.6.1",
-                "provenance_source_revision": CANDIDATE_SHA,
+                "provenance_source_revision": DELIVERY_SHA,
             },
             "image": {"tag": "v0.6.1", "digest": IMAGE_DIGEST},
             "deployment": {
-                "source_revision": CANDIDATE_SHA,
+                "source_revision": DELIVERY_SHA,
                 "digest": IMAGE_DIGEST,
                 "healthy": True,
                 "ready": True,
@@ -948,10 +1003,14 @@ def test_one_release_command_emits_the_exact_runner_protocol() -> None:
         "type": "result",
         "sequence": 7,
         "status": "delivered",
-        "reason": "release 0.6.1 and kn dev match the reviewed source",
+        "reason": "release 0.6.1 and kn dev match the approved release content",
         "evidence": {
+            "admitted_revision": SOURCE_SHA,
+            "approved_candidate_revision": CANDIDATE_SHA,
+            "delivery_revision": DELIVERY_SHA,
+            "delivery_tree_revision": BRANCH_SHA,
             "published_version": "0.6.1",
-            "source_revision": CANDIDATE_SHA,
+            "source_revision": DELIVERY_SHA,
             "version": "0.6.1",
             "digest": IMAGE_DIGEST,
             "health": "verified",

--- a/tests/test_operations_release_runtime.py
+++ b/tests/test_operations_release_runtime.py
@@ -19,6 +19,7 @@ from scripts.operations.release_runtime import (
     default_release_dependencies,
     deployment_manifest_for_digest,
     deployment_state,
+    governed_release_controls,
     render_release_documents,
     stable_release_evidence,
 )
@@ -28,6 +29,104 @@ if TYPE_CHECKING:
 
 SOURCE_SHA = "a" * 40
 DIGEST = "sha256:" + "b" * 64
+CANDIDATE_SHA = "c" * 40
+CANDIDATE_TREE = "1" * 40
+DELIVERY_SHA = "d" * 40
+
+
+def _release_ruleset() -> dict[str, object]:
+    return {
+        "id": 18080131,
+        "name": "main protection",
+        "target": "branch",
+        "enforcement": "active",
+        "conditions": {
+            "ref_name": {"exclude": [], "include": ["~DEFAULT_BRANCH"]}
+        },
+        "rules": [
+            {"type": "deletion"},
+            {"type": "non_fast_forward"},
+            {
+                "type": "pull_request",
+                "parameters": {
+                    "required_approving_review_count": 1,
+                    "require_code_owner_review": True,
+                    "require_last_push_approval": True,
+                    "required_review_thread_resolution": True,
+                },
+            },
+            {
+                "type": "required_status_checks",
+                "parameters": {
+                    "required_status_checks": [{"context": "test"}]
+                },
+            },
+            {"type": "required_linear_history"},
+            {
+                "type": "code_scanning",
+                "parameters": {
+                    "code_scanning_tools": [
+                        {
+                            "tool": "CodeQL",
+                            "security_alerts_threshold": "high_or_higher",
+                            "alerts_threshold": "errors",
+                        }
+                    ]
+                },
+            },
+            {"type": "code_quality", "parameters": {"severity": "errors"}},
+        ],
+        "bypass_actors": [
+            {"actor_id": 18280424, "actor_type": "Team", "bypass_mode": "always"}
+        ],
+        "current_user_can_bypass": "always",
+    }
+
+
+def _successful_pull_checks() -> dict[str, object]:
+    names = REQUIRED_PULL_REQUEST_CHECKS | {"CodeQL - Code Quality"}
+    return {
+        "check_runs": [
+            {"name": name, "status": "completed", "conclusion": "success"}
+            for name in sorted(names)
+        ]
+    }
+
+
+def _review_state() -> dict[str, object]:
+    return {
+        "data": {
+            "repository": {
+                "pullRequest": {
+                    "baseRefOid": SOURCE_SHA,
+                    "headRefOid": CANDIDATE_SHA,
+                    "isDraft": False,
+                    "mergeStateStatus": "BLOCKED",
+                    "merged": False,
+                    "reviewDecision": "REVIEW_REQUIRED",
+                    "state": "OPEN",
+                    "reviewThreads": {
+                        "nodes": [],
+                        "pageInfo": {"hasNextPage": False},
+                        "totalCount": 0,
+                    },
+                }
+            }
+        }
+    }
+
+
+def _codeql_analyses() -> list[dict[str, object]]:
+    return [
+        {
+            "analysis_key": "dynamic/github-code-scanning/codeql:analyze",
+            "category": f"/language:{language}",
+            "commit_sha": CANDIDATE_SHA,
+            "error": "",
+            "results_count": 0,
+        }
+        for language in ("actions", "javascript-typescript", "python")
+    ]
 
 
 def test_required_checks_match_pull_request_and_main_github_surfaces() -> None:
@@ -41,6 +140,111 @@ def test_required_checks_match_pull_request_and_main_github_surfaces() -> None:
     assert codeql_analyses <= REQUIRED_MAIN_CHECKS
     assert "CodeQL" in REQUIRED_PULL_REQUEST_CHECKS
     assert "CodeQL" not in REQUIRED_MAIN_CHECKS
+
+
+def test_governed_release_controls_rederive_every_bypassed_rule() -> None:
+    evidence = governed_release_controls(
+        admitted_revision=SOURCE_SHA,
+        candidate_revision=CANDIDATE_SHA,
+        checks=_successful_pull_checks(),
+        code_quality_setup={
+            "state": "configured",
+            "languages": ["javascript-typescript", "python"],
+        },
+        codeql_alerts=[],
+        codeql_analyses=_codeql_analyses(),
+        review_state=_review_state(),
+        rulesets=[_release_ruleset()],
+    )
+
+    assert evidence["candidate_revision"] == CANDIDATE_SHA
+    assert evidence["code_quality_check"] == "CodeQL - Code Quality"
+    assert evidence["codeql_languages"] == [
+        "actions",
+        "javascript-typescript",
+        "python",
+    ]
+    assert evidence["review_decision"] == "REVIEW_REQUIRED"
+    assert evidence["unresolved_review_threads"] == 0
+    assert len(evidence["ruleset_fingerprint"]) == 64
+
+
+def test_governed_release_controls_block_unconfigured_code_quality() -> None:
+    with pytest.raises(ValueError, match="Code Quality is not configured"):
+        governed_release_controls(
+            admitted_revision=SOURCE_SHA,
+            candidate_revision=CANDIDATE_SHA,
+            checks=_successful_pull_checks(),
+            code_quality_setup={
+                "state": "not-configured",
+                "languages": ["javascript-typescript", "python"],
+            },
+            codeql_alerts=[],
+            codeql_analyses=_codeql_analyses(),
+            review_state=_review_state(),
+            rulesets=[_release_ruleset()],
+        )
+
+
+def test_governed_release_controls_block_ruleset_or_candidate_drift() -> None:
+    changed = _release_ruleset()
+    changed["rules"] = [
+        rule
+        for rule in changed["rules"]
+        if rule["type"] != "required_linear_history"
+    ]
+
+    with pytest.raises(ValueError, match="required linear history"):
+        governed_release_controls(
+            admitted_revision=SOURCE_SHA,
+            candidate_revision=CANDIDATE_SHA,
+            checks=_successful_pull_checks(),
+            code_quality_setup={
+                "state": "configured",
+                "languages": ["javascript-typescript", "python"],
+            },
+            codeql_alerts=[],
+            codeql_analyses=_codeql_analyses(),
+            review_state=_review_state(),
+            rulesets=[changed],
+        )
+
+
+def test_ruleset_fingerprint_excludes_transport_metadata() -> None:
+    original = _release_ruleset()
+    original.update(
+        {
+            "_links": {"self": {"href": "https://api.github.test/old"}},
+            "created_at": "2026-06-24T18:47:03Z",
+            "node_id": "old-node",
+            "updated_at": "2026-07-01T09:08:06Z",
+        }
+    )
+    refreshed = {**original}
+    refreshed.update(
+        {
+            "_links": {"self": {"href": "https://api.github.test/new"}},
+            "node_id": "new-node",
+            "updated_at": "2026-08-01T16:00:00Z",
+        }
+    )
+    arguments = {
+        "admitted_revision": SOURCE_SHA,
+        "candidate_revision": CANDIDATE_SHA,
+        "checks": _successful_pull_checks(),
+        "code_quality_setup": {
+            "state": "configured",
+            "languages": ["javascript-typescript", "python"],
+        },
+        "codeql_alerts": [],
+        "codeql_analyses": _codeql_analyses(),
+        "review_state": _review_state(),
+    }
+
+    first = governed_release_controls(**arguments, rulesets=[original])
+    second = governed_release_controls(**arguments, rulesets=[refreshed])
+
+    assert first["ruleset_fingerprint"] == second["ruleset_fingerprint"]
 
 
 class StubGateway:
@@ -550,9 +754,11 @@ def test_pull_request_waiter_waits_for_complete_check_matrix(
         ]
     }
     pull = {
+        "base": {"sha": "b" * 40},
         "draft": False,
         "head": {"sha": SOURCE_SHA},
-        "mergeable_state": "clean",
+        "mergeable_state": "blocked",
+        "merged": False,
         "state": "open",
     }
     gateway = StubGateway(
@@ -564,13 +770,15 @@ def test_pull_request_waiter_waits_for_complete_check_matrix(
         gateway=gateway,
         sleep=sleeps.append,
     )
+    controls = {"ruleset_fingerprint": "4" * 64}
+    runtime._collect_release_controls = lambda **_arguments: controls
 
-    result = runtime._wait_pull_request(190, SOURCE_SHA)
+    result = runtime._wait_pull_request(190, SOURCE_SHA, "b" * 40)
 
     assert result == {"checks": completed_check_evidence(
         completed,
         required=REQUIRED_PULL_REQUEST_CHECKS,
-    ), "pull": pull}
+    ), "controls": controls, "pull": pull}
     assert sleeps == [10]
 
 
@@ -595,7 +803,7 @@ def test_pull_request_waiter_fails_when_complete_matrix_is_not_green(
     )
 
     with pytest.raises(ValueError, match="GitHub check runs did not succeed"):
-        runtime._wait_pull_request(192, SOURCE_SHA)
+        runtime._wait_pull_request(192, SOURCE_SHA, "b" * 40)
 
     assert sleeps == []
 
@@ -940,14 +1148,10 @@ def test_merge_response_distinguishes_no_merge_from_confirmed_missing_identity(
     }
 
 
-@pytest.mark.parametrize("merge_confirmed", [False, True])
-def test_prepare_reports_failed_recovery_evidence_after_merge_boundary(
+def test_prepare_stops_at_the_unmerged_review_candidate(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
-    merge_confirmed: bool,
 ) -> None:
-    head_revision = "c" * 40
-    final_revision = "d" * 40
     consultations: list[dict[str, object]] = []
     gate_checks: list[dict[str, object]] = []
     gateway = StubGateway(
@@ -984,61 +1188,88 @@ def test_prepare_reports_failed_recovery_evidence_after_merge_boundary(
             "release_note_hash": "2" * 64,
         },
     )
-    monkeypatch.setattr(runtime, "source_revision", lambda: head_revision)
-    remote_revisions = iter([SOURCE_SHA, final_revision])
-    monkeypatch.setattr(runtime, "candidate_revision", lambda: next(remote_revisions))
+    monkeypatch.setattr(runtime, "source_revision", lambda: CANDIDATE_SHA)
+    monkeypatch.setattr(runtime, "remote_main_revision", lambda: SOURCE_SHA)
+    monkeypatch.setattr(runtime, "_tree_revision", lambda _revision: CANDIDATE_TREE)
+    monkeypatch.setattr(runtime, "_parent_revisions", lambda _revision: [SOURCE_SHA])
     monkeypatch.setattr(
         runtime,
         "_wait_pull_request",
-        lambda _number, _head: {"checks": {}, "pull": {}},
+        lambda _number, _head, _base: {
+            "checks": completed_check_evidence(
+                _successful_pull_checks(),
+                required=REQUIRED_PULL_REQUEST_CHECKS,
+            ),
+            "controls": {
+                "candidate_revision": CANDIDATE_SHA,
+                "code_quality_state": "configured",
+                "ruleset_fingerprint": "4" * 64,
+            },
+            "pull": {},
+        },
     )
-    if merge_confirmed:
-        monkeypatch.setattr(
-            runtime,
-            "_merge_exact",
-            lambda _number, _version, _head: {
-                "merged": True,
-                "sha": final_revision,
+    monkeypatch.setattr(
+        runtime,
+        "_final_local_gates",
+        lambda _source, _version: {
+            "ci": {"all_success": True, "missing_required": []},
+            "security": {"exit_code": 0, "report_hash": "5" * 64},
+            "tests": {
+                "source_revision": CANDIDATE_SHA,
+                "passed": True,
+                "evidence_hash": "6" * 64,
             },
-        )
-        monkeypatch.setattr(
-            runtime,
-            "_final_local_gates",
-            lambda _source, _version: (_ for _ in ()).throw(
-                ValueError("post merge gates failed")
-            ),
-        )
-    else:
-        monkeypatch.setattr(
-            runtime,
-            "_merge_exact",
-            lambda _number, _version, _head: (_ for _ in ()).throw(
-                ValueError("merge response lost")
-            ),
-        )
+            "version_free": {"version": "0.7.0", "free": True},
+        },
+    )
+    monkeypatch.setattr(
+        "scripts.operations.release_runtime.deployment_state",
+        lambda _statefulset: {
+            "digest": DIGEST,
+            "keel_policy": "never",
+            "rollout_complete": True,
+        },
+    )
+    monkeypatch.setattr(runtime, "live_statefulset", lambda: {})
+    monkeypatch.setattr(
+        runtime,
+        "_merge_exact",
+        lambda *_arguments: (_ for _ in ()).throw(
+            AssertionError("prepare must not merge")
+        ),
+    )
 
-    with pytest.raises(ReleaseDeliveryError) as raised:
-        runtime.prepare(
-            {
-                "extra_context": "No extra context for this run",
-                "run_id": "11111111-2222-4333-8444-555555555555",
-                "source_revision": SOURCE_SHA,
+    result = runtime.prepare(
+        {
+            "extra_context": "No extra context for this run",
+            "run_id": "11111111-2222-4333-8444-555555555555",
+            "source_revision": SOURCE_SHA,
+        },
+        {
+            "evidence": {
+                "computed_release": {
+                    "changes": {"breaking": [], "features": [], "fixes": []}
+                }
             },
-            {
-                "evidence": {
-                    "computed_release": {
-                        "changes": {"breaking": [], "features": [], "fixes": []}
-                    }
-                },
-                "outputs": {"candidate": {"version": "0.7.0"}},
-            },
-        )
+            "outputs": {"candidate": {"version": "0.7.0"}},
+        },
+    )
 
-    assert raised.value.external_state_changed is True
-    assert raised.value.evidence["external_state_changed"] is True
-    assert raised.value.evidence["merge_confirmed"] is merge_confirmed
-    assert raised.value.evidence["release_pr_number"] == 182
-    assert raised.value.evidence["rollback_completed"] is False
+    assert result["candidate"] == {
+        "source_revision": CANDIDATE_SHA,
+        "version": "0.7.0",
+    }
+    assert result["release_pr"] == {
+        "base_source_revision": SOURCE_SHA,
+        "candidate_version": "0.7.0",
+        "head_revision": CANDIDATE_SHA,
+        "head_tree_revision": CANDIDATE_TREE,
+        "merged": False,
+        "number": 182,
+        "source_revision": CANDIDATE_SHA,
+        "url": "https://github.com/knaisoma/data-olympus/pull/182",
+    }
+    assert runtime.candidate_revision() == CANDIDATE_SHA
     assert consultations == [
         {
             "agent_identity": "ai-operations-release",
@@ -1063,8 +1294,346 @@ def test_prepare_reports_failed_recovery_evidence_after_merge_boundary(
             "workspace": "data-olympus",
         }
     ]
-    if merge_confirmed:
-        assert raised.value.evidence["merged_revision"] == final_revision
+
+
+def test_deliver_merges_only_after_review_and_proves_exact_tree_transfer(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    previous = "sha256:" + "e" * 64
+    order: list[str] = []
+    controls = {
+        "candidate_revision": CANDIDATE_SHA,
+        "code_quality_state": "configured",
+        "ruleset_fingerprint": "4" * 64,
+    }
+    runtime = ReleaseRuntime(
+        tmp_path,
+        gateway=StubGateway({"list_tags": []}),
+        command_output=lambda _command, _cwd, _timeout: "",
+    )
+    runtime._prepared = {
+        "raw": {
+            "candidate": {
+                "source_revision": CANDIDATE_SHA,
+                "version": "0.7.0",
+            },
+            "release_pr": {
+                "base_source_revision": SOURCE_SHA,
+                "head_revision": CANDIDATE_SHA,
+                "head_tree_revision": CANDIDATE_TREE,
+                "number": 182,
+            },
+            "rollback_point": {"digest": previous},
+        },
+        "release_controls": controls,
+    }
+    monkeypatch.setattr(
+        runtime,
+        "_wait_pull_request",
+        lambda _number, _head, _base: (
+            order.append("controls")
+            or {
+                "checks": {},
+                "controls": controls,
+                "pull": {},
+            }
+        ),
+    )
+    remote_revisions = iter([SOURCE_SHA, DELIVERY_SHA])
+    monkeypatch.setattr(
+        runtime,
+        "remote_main_revision",
+        lambda: next(remote_revisions),
+    )
+    monkeypatch.setattr(runtime, "source_revision", lambda: CANDIDATE_SHA)
+    monkeypatch.setattr(
+        runtime,
+        "_tree_revision",
+        lambda revision: (
+            order.append(f"tree:{revision}") or CANDIDATE_TREE
+        ),
+    )
+    monkeypatch.setattr(
+        runtime,
+        "_parent_revisions",
+        lambda revision: (
+            order.append(f"parents:{revision}") or [SOURCE_SHA]
+        ),
+    )
+    monkeypatch.setattr(
+        runtime,
+        "_merge_exact",
+        lambda _number, _version, _head: (
+            order.append("merge")
+            or {"merged": True, "sha": DELIVERY_SHA}
+        ),
+    )
+    monkeypatch.setattr(
+        runtime,
+        "_final_local_gates",
+        lambda revision, version: (
+            order.append("final-gates")
+            or {
+                "ci": {"all_success": True, "missing_required": []},
+                "security": {"exit_code": 0},
+                "tests": {"source_revision": revision, "passed": True},
+                "version_free": {"version": version, "free": True},
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        runtime,
+        "_workflow_run",
+        lambda name, revision, _inputs, **_kwargs: (
+            order.append(f"workflow:{name}")
+            or {
+                "conclusion": "success",
+                "run_id": len(order),
+                "source_revision": revision,
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        runtime,
+        "_candidate_publication",
+        lambda revision, _version, tag: {
+            "candidate_tag": tag,
+            "image_digest": DIGEST,
+            "source_revision": revision,
+        },
+    )
+    monkeypatch.setattr(
+        runtime,
+        "_stable_publication",
+        lambda revision, version: {
+            "pypi_version": version,
+            "source_revision": revision,
+        },
+    )
+    monkeypatch.setattr(runtime, "_registry_digest", lambda _tag: DIGEST)
+    monkeypatch.setattr(
+        runtime,
+        "_apply_digest",
+        lambda _digest, **_kwargs: {
+            "keel_policy": "never",
+            "rollout_complete": True,
+        },
+    )
+    monkeypatch.setattr(
+        runtime,
+        "_service_acceptance",
+        lambda: {
+            "enforcement": True,
+            "healthy": True,
+            "mcp_search": True,
+            "ready": True,
+        },
+    )
+
+    result = runtime.deliver(
+        {},
+        {},
+        {},
+        {
+            "status": "pass",
+            "evidence": {
+                "reviewer_family": "claude",
+                "source_revision": CANDIDATE_SHA,
+            },
+        },
+    )
+
+    assert result["candidate"]["source_revision"] == DELIVERY_SHA
+    assert result["delivery_proof"] == {
+        "admitted_revision": SOURCE_SHA,
+        "approved_candidate_revision": CANDIDATE_SHA,
+        "delivery_revision": DELIVERY_SHA,
+        "delivery_tree_revision": CANDIDATE_TREE,
+        "merge_confirmed": True,
+        "reviewed_tree_revision": CANDIDATE_TREE,
+        "sole_parent_revision": SOURCE_SHA,
+    }
+    assert order.index("controls") < order.index("merge")
+    assert order.index("merge") < order.index(f"tree:{DELIVERY_SHA}")
+    assert order.index(f"tree:{DELIVERY_SHA}") < order.index("final-gates")
+    assert order.index("final-gates") < order.index("workflow:rc-publish.yml")
+
+
+def test_delivery_blocks_ruleset_drift_without_attempting_merge(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime = ReleaseRuntime(
+        tmp_path,
+        gateway=StubGateway({"list_tags": []}),
+    )
+    reviewed = _prime_approved_delivery(
+        runtime,
+        monkeypatch,
+        "sha256:" + "e" * 64,
+    )
+    changed_controls = {"ruleset_fingerprint": "9" * 64}
+    monkeypatch.setattr(
+        runtime,
+        "_wait_pull_request",
+        lambda *_arguments: {
+            "checks": {},
+            "controls": changed_controls,
+            "pull": {},
+        },
+    )
+    merge_attempted = False
+
+    def merge(**_arguments):
+        nonlocal merge_attempted
+        merge_attempted = True
+        return DELIVERY_SHA, {}
+
+    monkeypatch.setattr(runtime, "_merge_and_prove_delivery", merge)
+
+    with pytest.raises(ValueError, match="controls changed"):
+        runtime.deliver({}, {}, {}, reviewed)
+
+    assert merge_attempted is False
+
+
+def test_merge_proof_rejects_a_different_delivery_tree(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime = ReleaseRuntime(
+        tmp_path,
+        gateway=StubGateway(),
+        command_output=lambda _command, _cwd, _timeout: "",
+    )
+    monkeypatch.setattr(
+        runtime,
+        "_merge_exact",
+        lambda *_arguments: {"merged": True, "sha": DELIVERY_SHA},
+    )
+    monkeypatch.setattr(runtime, "remote_main_revision", lambda: DELIVERY_SHA)
+    monkeypatch.setattr(
+        runtime,
+        "_parent_revisions",
+        lambda _revision: [SOURCE_SHA],
+    )
+    monkeypatch.setattr(runtime, "_tree_revision", lambda _revision: "8" * 40)
+
+    with pytest.raises(ReleaseDeliveryError, match="tree does not match") as raised:
+        runtime._merge_and_prove_delivery(
+            number=182,
+            version="0.7.0",
+            head_revision=CANDIDATE_SHA,
+            head_tree_revision=CANDIDATE_TREE,
+            base_revision=SOURCE_SHA,
+        )
+
+    assert raised.value.evidence["merge_confirmed"] is True
+    assert raised.value.evidence["merged_revision"] == DELIVERY_SHA
+
+
+def test_ambiguous_merge_response_reconciles_only_the_same_confirmed_pull(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    gateway = StubGateway(
+        {
+            "pull_request_read": {
+                "base": {"sha": SOURCE_SHA},
+                "head": {"sha": CANDIDATE_SHA},
+                "merge_commit_sha": DELIVERY_SHA,
+                "merged": True,
+            }
+        }
+    )
+    runtime = ReleaseRuntime(
+        tmp_path,
+        gateway=gateway,
+        command_output=lambda _command, _cwd, _timeout: "",
+    )
+    monkeypatch.setattr(
+        runtime,
+        "_merge_exact",
+        lambda *_arguments: (_ for _ in ()).throw(ValueError("response lost")),
+    )
+    monkeypatch.setattr(runtime, "remote_main_revision", lambda: DELIVERY_SHA)
+    monkeypatch.setattr(
+        runtime,
+        "_parent_revisions",
+        lambda _revision: [SOURCE_SHA],
+    )
+    monkeypatch.setattr(runtime, "_tree_revision", lambda _revision: CANDIDATE_TREE)
+
+    revision, proof = runtime._merge_and_prove_delivery(
+        number=182,
+        version="0.7.0",
+        head_revision=CANDIDATE_SHA,
+        head_tree_revision=CANDIDATE_TREE,
+        base_revision=SOURCE_SHA,
+    )
+
+    assert revision == DELIVERY_SHA
+    assert proof["delivery_revision"] == DELIVERY_SHA
+
+
+def _prime_approved_delivery(
+    runtime: ReleaseRuntime,
+    monkeypatch: pytest.MonkeyPatch,
+    previous: str,
+) -> dict[str, object]:
+    controls = {"ruleset_fingerprint": "4" * 64}
+    runtime._prepared = {
+        "raw": {
+            "candidate": {
+                "version": "0.7.0",
+                "source_revision": CANDIDATE_SHA,
+            },
+            "release_pr": {
+                "base_source_revision": SOURCE_SHA,
+                "head_revision": CANDIDATE_SHA,
+                "head_tree_revision": CANDIDATE_TREE,
+                "number": 182,
+            },
+            "rollback_point": {"digest": previous},
+        },
+        "release_controls": controls,
+    }
+    monkeypatch.setattr(
+        runtime,
+        "_wait_pull_request",
+        lambda *_arguments: {"checks": {}, "controls": controls, "pull": {}},
+    )
+    monkeypatch.setattr(runtime, "remote_main_revision", lambda: SOURCE_SHA)
+    monkeypatch.setattr(runtime, "source_revision", lambda: CANDIDATE_SHA)
+    monkeypatch.setattr(runtime, "command", lambda *_arguments, **_kwargs: "")
+    monkeypatch.setattr(runtime, "_tree_revision", lambda _revision: CANDIDATE_TREE)
+    proof = {
+        "admitted_revision": SOURCE_SHA,
+        "approved_candidate_revision": CANDIDATE_SHA,
+        "delivery_revision": DELIVERY_SHA,
+        "delivery_tree_revision": CANDIDATE_TREE,
+        "merge_confirmed": True,
+        "reviewed_tree_revision": CANDIDATE_TREE,
+        "sole_parent_revision": SOURCE_SHA,
+    }
+    monkeypatch.setattr(
+        runtime,
+        "_merge_and_prove_delivery",
+        lambda **_arguments: (DELIVERY_SHA, proof),
+    )
+    monkeypatch.setattr(
+        runtime,
+        "_final_local_gates",
+        lambda _revision, _version: {},
+    )
+    return {
+        "status": "pass",
+        "evidence": {
+            "reviewer_family": "claude",
+            "source_revision": CANDIDATE_SHA,
+        },
+    }
 
 
 @pytest.mark.parametrize("dispatch_started", [False, True])
@@ -1075,12 +1644,7 @@ def test_delivery_failure_classification_tracks_the_workflow_dispatch_boundary(
 ) -> None:
     previous = "sha256:" + "e" * 64
     runtime = ReleaseRuntime(tmp_path, gateway=StubGateway({"list_tags": []}))
-    runtime._prepared = {
-        "raw": {
-            "candidate": {"version": "0.7.0", "source_revision": SOURCE_SHA},
-            "rollback_point": {"digest": previous},
-        }
-    }
+    reviewed = _prime_approved_delivery(runtime, monkeypatch, previous)
 
     def workflow_run(
         _name: str,
@@ -1097,7 +1661,7 @@ def test_delivery_failure_classification_tracks_the_workflow_dispatch_boundary(
     monkeypatch.setattr(runtime, "_workflow_run", workflow_run)
 
     with pytest.raises(ValueError) as raised:
-        runtime.deliver({}, {}, {}, {})
+        runtime.deliver({}, {}, {}, reviewed)
 
     if dispatch_started:
         assert isinstance(raised.value, ReleaseDeliveryError)
@@ -1118,12 +1682,7 @@ def test_partial_delivery_failure_restores_the_exact_previous_digest(
     previous = "sha256:" + "e" * 64
     gateway = StubGateway({"list_tags": []})
     runtime = ReleaseRuntime(tmp_path, gateway=gateway)
-    runtime._prepared = {
-        "raw": {
-            "candidate": {"version": "0.7.0", "source_revision": SOURCE_SHA},
-            "rollback_point": {"digest": previous},
-        }
-    }
+    reviewed = _prime_approved_delivery(runtime, monkeypatch, previous)
     applied: list[str] = []
     acceptance = {
         "documentation": True,
@@ -1173,7 +1732,7 @@ def test_partial_delivery_failure_restores_the_exact_previous_digest(
     )
 
     with pytest.raises(ReleaseDeliveryError, match="stable failed") as raised:
-        runtime.deliver({}, {}, {}, {})
+        runtime.deliver({}, {}, {}, reviewed)
 
     assert applied == [DIGEST, previous]
     assert raised.value.external_state_changed is True

--- a/tests/test_release_contract_docs.py
+++ b/tests/test_release_contract_docs.py
@@ -71,6 +71,26 @@ def test_versioning_rule_uses_one_linear_release_change() -> None:
     assert "feature/<release-epic-id>" not in routine
 
 
+def test_release_routine_reviews_before_merge_and_proves_content_transfer() -> None:
+    routine = _read(".rules/release-routine.md")
+    normalized = " ".join(routine.split())
+
+    for required in (
+        "Keep it open and unmerged",
+        "Code Quality must be configured",
+        "review of `H`",
+        "expected head `H`",
+        "sole parent `B`",
+        "tree exactly equals reviewed tree `T`",
+        "entire GitHub ruleset",
+        "direct continuation",
+        "candidate fields remain `H`",
+    ):
+        assert required in normalized
+    assert "review of the exact final SHA" not in normalized
+    assert "bypass only the native approval" not in normalized
+
+
 def test_release_planning_is_outcome_based() -> None:
     planning = _read(".rules/release-planning.md")
 


### PR DESCRIPTION
## Outcome

Move independent review and standing approval before the release pull request merge. Bind approval to candidate H and tree T, conditionally merge the expected head, prove delivered main M has admitted parent B and tree T, rerun final gates, and only then permit publication or deployment.

## Safety

* Rederives the complete ruleset, check, CodeQL, Code Quality, and review thread controls before merge.
* Blocks while GitHub Code Quality is not configured.
* Reconciles ambiguous merge outcomes only from the same pull request and remote main.
* Preserves H as the central candidate while delivery evidence records M.

## Verification

* Ruff passed.
* mypy passed for 73 source files.
* Benchmark documentation guard passed.
* Complete Python suite passed with two documented optional dependency skips.
* All 74 Bats tests passed.
* Example bundle lint passed.
* Live PR 194 probe failed closed at the expected Code Quality precondition.

## Companion review (Claude)

Claude Opus returned APPROVE for the complete high risk diff. Claude Sonnet returned APPROVE for the only post review delta, which canonicalizes the ruleset fingerprint to enforcement relevant fields.