### PR TITLE
fix(release): remove unavailable quality gate

### DIFF
--- a/.rules/release-routine.md
+++ b/.rules/release-routine.md
@@ -95,11 +95,12 @@ Rollback is the same executable with the `rollback` argument. It reads
    new empty `[Unreleased]` block, and write `docs/releases/vX.Y.Z.md`.
 6. Open one public pull request through FastMCP. Keep it open and unmerged.
    Require every observed repository check to reach a successful terminal
-   conclusion. Require the exact `CodeQL - Code Quality` check, all three
-   CodeQL language analyses with zero results, no open CodeQL alert for the
-   pull request, no unresolved review thread, and the complete active default
-   branch ruleset fingerprint. Code Quality must be configured. Missing or
-   unverifiable evidence blocks before review or merge.
+   conclusion. Require the aggregate `CodeQL` check, all three CodeQL language
+   analyses with zero results, no open CodeQL alert for the pull request, no
+   unresolved review thread, and the complete active default branch ruleset
+   fingerprint. GitHub Code Quality is not a dependency because it is not
+   available on the approved GitHub Free plan. Missing or unverifiable
+   evidence blocks before review or merge.
 7. Bind the review candidate to the exact pull request head SHA `H`, its Git
    tree `T`, and admitted main SHA `B`. Require `H` to have sole parent `B`.
    Rerun all local release gates against `H`:
@@ -125,10 +126,10 @@ Rollback is the same executable with the `rollback` argument. It reads
    digest, `H`, and consumed Claude review. The approved standing delegation
    may materialize that exact entry only after the review passes.
 10. In the same execution, rederive `H`, `T`, `B`, remote `main`, every check
-    and security result, every review thread, Code Quality setup and result,
-    and the complete ruleset fingerprint. Any change requires a new run and
-    review. The deliberate team bypass bypasses the entire GitHub ruleset, not
-    only native approval, so these routine owned controls are load bearing.
+    and CodeQL result, every review thread, and the complete ruleset
+    fingerprint. Any change requires a new run and review. The deliberate team
+    bypass bypasses the entire GitHub ruleset, not only native approval, so
+    these routine owned controls are load bearing.
 11. Submit a conditional squash merge naming expected head `H`. Reconcile an
     ambiguous response only from the same pull request and current remote
     `main`. An open unchanged pull request stops safely. Every other ambiguous

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,9 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   reviews and approves the exact unmerged candidate, rederives every control
   replaced by the deliberate GitHub ruleset bypass, conditionally merges the
   expected head, and proves exact parent and tree transfer before any
-  publication or deployment. An unavailable Code Quality result blocks the
-  release instead of being treated as satisfied.
+  publication or deployment. The routine preserves exact CodeQL, alert,
+  review, ruleset, and tree transfer evidence without depending on the paid
+  GitHub Code Quality product, which is unavailable on the approved Free plan.
 * **Accepted the canonical FastMCP pull request receipt.** The automated
   release routine now derives the new pull request number from the exact
   repository URL when the gateway receipt omits a separate numeric field.

--- a/scripts/operations/release.py
+++ b/scripts/operations/release.py
@@ -199,13 +199,6 @@ def _release_control_evidence(value: Any, source_revision: str) -> dict[str, Any
         raise ReleaseInputError(
             "release_controls.check_evidence.missing_required must be empty"
         )
-    if controls.get("code_quality_check") not in {
-        "CodeQL - Code Quality",
-        "CodeQL - Code Quality / Analyze",
-    }:
-        raise ReleaseInputError("release_controls.code_quality_check is invalid")
-    if controls.get("code_quality_state") != "configured":
-        raise ReleaseInputError("release_controls.code_quality_state must be configured")
     codeql_hash = _hash(
         controls.get("codeql_analysis_hash"),
         "release_controls.codeql_analysis_hash",
@@ -236,7 +229,6 @@ def _release_control_evidence(value: Any, source_revision: str) -> dict[str, Any
     ):
         raise ReleaseInputError("release_controls.ruleset_ids is invalid")
     return {
-        "code_quality_check": controls["code_quality_check"],
         "codeql_analysis_hash": codeql_hash,
         "ruleset_fingerprint": fingerprint,
         "ruleset_ids": ruleset_ids,

--- a/scripts/operations/release_runtime.py
+++ b/scripts/operations/release_runtime.py
@@ -51,10 +51,6 @@ REQUIRED_MAIN_CHECKS = {
     "doc-consistency-guard",
     "test",
 }
-CODE_QUALITY_CHECK_NAMES = {
-    "CodeQL - Code Quality",
-    "CodeQL - Code Quality / Analyze",
-}
 EXPECTED_CODEQL_LANGUAGES = {
     "actions",
     "javascript-typescript",
@@ -372,7 +368,6 @@ def governed_release_controls(
     admitted_revision: str,
     candidate_revision: str,
     checks: dict[str, Any],
-    code_quality_setup: dict[str, Any],
     codeql_alerts: list[dict[str, Any]],
     codeql_analyses: list[dict[str, Any]],
     review_state: dict[str, Any],
@@ -383,15 +378,6 @@ def governed_release_controls(
         raise ValueError("admitted release revision is invalid")
     if _SHA40.fullmatch(candidate_revision) is None:
         raise ValueError("release candidate revision is invalid")
-
-    if code_quality_setup.get("state") != "configured":
-        raise ValueError("GitHub Code Quality is not configured")
-    quality_languages = code_quality_setup.get("languages")
-    if type(quality_languages) is not list or not {
-        "javascript-typescript",
-        "python",
-    } <= set(quality_languages):
-        raise ValueError("GitHub Code Quality languages are incomplete")
 
     check_evidence = completed_check_evidence(
         checks,
@@ -404,21 +390,6 @@ def governed_release_controls(
             key=lambda check: str(check.get("name")),
         ),
     }
-    check_runs = checks["check_runs"]
-    quality_checks = [
-        run
-        for run in check_runs
-        if run.get("name") in CODE_QUALITY_CHECK_NAMES
-    ]
-    if len(quality_checks) != 1:
-        raise ValueError("exact GitHub Code Quality check is unavailable")
-    quality_check = quality_checks[0]
-    if (
-        quality_check.get("status") != "completed"
-        or quality_check.get("conclusion") != "success"
-    ):
-        raise ValueError("GitHub Code Quality check did not succeed")
-
     pull = _object(
         _object(
             _object(review_state.get("data"), "review state data").get(
@@ -545,13 +516,6 @@ def governed_release_controls(
         for rule in scanning_rules
     ):
         raise ValueError("GitHub CodeQL ruleset thresholds changed")
-    quality_rules = [rule for rule in all_rules if rule.get("type") == "code_quality"]
-    if not any(
-        type(rule.get("parameters")) is dict
-        and rule["parameters"].get("severity") == "errors"
-        for rule in quality_rules
-    ):
-        raise ValueError("GitHub Code Quality ruleset threshold changed")
     if not any(
         ruleset.get("current_user_can_bypass") == "always"
         and type(ruleset.get("bypass_actors")) is list
@@ -604,8 +568,6 @@ def governed_release_controls(
     return {
         "candidate_revision": candidate_revision,
         "check_evidence": check_evidence,
-        "code_quality_check": quality_check["name"],
-        "code_quality_state": "configured",
         "codeql_analysis_hash": sha256(
             json.dumps(analysis_summary, separators=(",", ":"), sort_keys=True).encode()
         ).hexdigest(),
@@ -1098,16 +1060,6 @@ class ReleaseRuntime:
         base_revision: str,
         checks: dict[str, Any],
     ) -> dict[str, Any]:
-        setup = _object(
-            self._github_json(
-                [
-                    "-H",
-                    "X-GitHub-Api-Version: 2026-03-10",
-                    f"repos/{GITHUB_OWNER}/{GITHUB_REPOSITORY}/code-quality/setup",
-                ]
-            ),
-            "GitHub Code Quality setup",
-        )
         analyses = self._flatten_pages(
             self._github_json(
                 [
@@ -1136,7 +1088,6 @@ class ReleaseRuntime:
             admitted_revision=base_revision,
             candidate_revision=head_revision,
             checks=checks,
-            code_quality_setup=setup,
             codeql_alerts=alerts,
             codeql_analyses=analyses,
             review_state=self._review_state(number),

--- a/tests/test_operations_release.py
+++ b/tests/test_operations_release.py
@@ -66,8 +66,6 @@ def _release_controls(candidate_revision: str) -> dict[str, object]:
     return {
         "candidate_revision": candidate_revision,
         "check_evidence": {"all_success": True, "missing_required": []},
-        "code_quality_check": "CodeQL - Code Quality",
-        "code_quality_state": "configured",
         "codeql_analysis_hash": "4" * 64,
         "codeql_languages": ["actions", "javascript-typescript", "python"],
         "open_codeql_alerts": 0,

--- a/tests/test_operations_release_runtime.py
+++ b/tests/test_operations_release_runtime.py
@@ -74,7 +74,6 @@ def _release_ruleset() -> dict[str, object]:
                     ]
                 },
             },
-            {"type": "code_quality", "parameters": {"severity": "errors"}},
         ],
         "bypass_actors": [
             {"actor_id": 18280424, "actor_type": "Team", "bypass_mode": "always"}
@@ -84,11 +83,10 @@ def _release_ruleset() -> dict[str, object]:
 
 
 def _successful_pull_checks() -> dict[str, object]:
-    names = REQUIRED_PULL_REQUEST_CHECKS | {"CodeQL - Code Quality"}
     return {
         "check_runs": [
             {"name": name, "status": "completed", "conclusion": "success"}
-            for name in sorted(names)
+            for name in sorted(REQUIRED_PULL_REQUEST_CHECKS)
         ]
     }
 
@@ -147,10 +145,6 @@ def test_governed_release_controls_rederive_every_bypassed_rule() -> None:
         admitted_revision=SOURCE_SHA,
         candidate_revision=CANDIDATE_SHA,
         checks=_successful_pull_checks(),
-        code_quality_setup={
-            "state": "configured",
-            "languages": ["javascript-typescript", "python"],
-        },
         codeql_alerts=[],
         codeql_analyses=_codeql_analyses(),
         review_state=_review_state(),
@@ -158,7 +152,6 @@ def test_governed_release_controls_rederive_every_bypassed_rule() -> None:
     )
 
     assert evidence["candidate_revision"] == CANDIDATE_SHA
-    assert evidence["code_quality_check"] == "CodeQL - Code Quality"
     assert evidence["codeql_languages"] == [
         "actions",
         "javascript-typescript",
@@ -169,21 +162,45 @@ def test_governed_release_controls_rederive_every_bypassed_rule() -> None:
     assert len(evidence["ruleset_fingerprint"]) == 64
 
 
-def test_governed_release_controls_block_unconfigured_code_quality() -> None:
-    with pytest.raises(ValueError, match="Code Quality is not configured"):
+def test_governed_release_controls_block_missing_codeql_ruleset_threshold() -> None:
+    ruleset = _release_ruleset()
+    ruleset["rules"] = [
+        rule for rule in ruleset["rules"] if rule["type"] != "code_scanning"
+    ]
+
+    with pytest.raises(ValueError, match="CodeQL ruleset thresholds"):
         governed_release_controls(
             admitted_revision=SOURCE_SHA,
             candidate_revision=CANDIDATE_SHA,
             checks=_successful_pull_checks(),
-            code_quality_setup={
-                "state": "not-configured",
-                "languages": ["javascript-typescript", "python"],
-            },
             codeql_alerts=[],
             codeql_analyses=_codeql_analyses(),
             review_state=_review_state(),
-            rulesets=[_release_ruleset()],
+            rulesets=[ruleset],
         )
+
+
+def test_governed_release_controls_do_not_depend_on_paid_code_quality() -> None:
+    ruleset = _release_ruleset()
+    checks = _successful_pull_checks()
+
+    evidence = governed_release_controls(
+        admitted_revision=SOURCE_SHA,
+        candidate_revision=CANDIDATE_SHA,
+        checks=checks,
+        codeql_alerts=[],
+        codeql_analyses=_codeql_analyses(),
+        review_state=_review_state(),
+        rulesets=[ruleset],
+    )
+
+    assert "code_quality_check" not in evidence
+    assert "code_quality_state" not in evidence
+    assert evidence["codeql_languages"] == [
+        "actions",
+        "javascript-typescript",
+        "python",
+    ]
 
 
 def test_governed_release_controls_block_ruleset_or_candidate_drift() -> None:
@@ -199,10 +216,6 @@ def test_governed_release_controls_block_ruleset_or_candidate_drift() -> None:
             admitted_revision=SOURCE_SHA,
             candidate_revision=CANDIDATE_SHA,
             checks=_successful_pull_checks(),
-            code_quality_setup={
-                "state": "configured",
-                "languages": ["javascript-typescript", "python"],
-            },
             codeql_alerts=[],
             codeql_analyses=_codeql_analyses(),
             review_state=_review_state(),
@@ -232,10 +245,6 @@ def test_ruleset_fingerprint_excludes_transport_metadata() -> None:
         "admitted_revision": SOURCE_SHA,
         "candidate_revision": CANDIDATE_SHA,
         "checks": _successful_pull_checks(),
-        "code_quality_setup": {
-            "state": "configured",
-            "languages": ["javascript-typescript", "python"],
-        },
         "codeql_alerts": [],
         "codeql_analyses": _codeql_analyses(),
         "review_state": _review_state(),
@@ -245,6 +254,46 @@ def test_ruleset_fingerprint_excludes_transport_metadata() -> None:
     second = governed_release_controls(**arguments, rulesets=[refreshed])
 
     assert first["ruleset_fingerprint"] == second["ruleset_fingerprint"]
+
+
+def test_collect_release_controls_queries_codeql_without_code_quality(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    commands: list[list[str]] = []
+    runtime = ReleaseRuntime(
+        tmp_path,
+        gateway=StubGateway(),
+        command_output=lambda _command, _cwd, _timeout: "",
+    )
+
+    def github_json(arguments: list[str], *, timeout: int = 60) -> object:
+        del timeout
+        commands.append(arguments)
+        endpoint = arguments[-1]
+        if "analyses" in endpoint:
+            return [_codeql_analyses()]
+        if "alerts" in endpoint:
+            return [[]]
+        raise AssertionError(f"unexpected GitHub API call: {arguments}")
+
+    monkeypatch.setattr(runtime, "_github_json", github_json)
+    monkeypatch.setattr(runtime, "_review_state", lambda _number: _review_state())
+    monkeypatch.setattr(runtime, "_active_rulesets", lambda: [_release_ruleset()])
+
+    evidence = runtime._collect_release_controls(
+        number=195,
+        head_revision=CANDIDATE_SHA,
+        base_revision=SOURCE_SHA,
+        checks=_successful_pull_checks(),
+    )
+
+    assert evidence["codeql_languages"] == [
+        "actions",
+        "javascript-typescript",
+        "python",
+    ]
+    assert all("code-quality" not in " ".join(command) for command in commands)
 
 
 class StubGateway:
@@ -1202,7 +1251,6 @@ def test_prepare_stops_at_the_unmerged_review_candidate(
             ),
             "controls": {
                 "candidate_revision": CANDIDATE_SHA,
-                "code_quality_state": "configured",
                 "ruleset_fingerprint": "4" * 64,
             },
             "pull": {},
@@ -1304,7 +1352,6 @@ def test_deliver_merges_only_after_review_and_proves_exact_tree_transfer(
     order: list[str] = []
     controls = {
         "candidate_revision": CANDIDATE_SHA,
-        "code_quality_state": "configured",
         "ruleset_fingerprint": "4" * 64,
     }
     runtime = ReleaseRuntime(

--- a/tests/test_release_contract_docs.py
+++ b/tests/test_release_contract_docs.py
@@ -77,7 +77,8 @@ def test_release_routine_reviews_before_merge_and_proves_content_transfer() -> N
 
     for required in (
         "Keep it open and unmerged",
-        "Code Quality must be configured",
+        "GitHub Code Quality is not a dependency",
+        "aggregate `CodeQL` check",
         "review of `H`",
         "expected head `H`",
         "sole parent `B`",
@@ -87,6 +88,7 @@ def test_release_routine_reviews_before_merge_and_proves_content_transfer() -> N
         "candidate fields remain `H`",
     ):
         assert required in normalized
+    assert "Code Quality must be configured" not in normalized
     assert "review of the exact final SHA" not in normalized
     assert "bypass only the native approval" not in normalized
 


### PR DESCRIPTION
## Summary

* Remove the unavailable paid GitHub Code Quality dependency from release control collection and evidence validation.
* Preserve the complete check matrix, exact CodeQL analysis and alert evidence, review thread checks, active ruleset fingerprint, conditional expected head merge, and exact parent and tree transfer proof.
* Document that the approved GitHub Free plan does not depend on Code Quality.

## Verification

* Ruff passed.
* mypy passed for 73 source files.
* Benchmark documentation guard passed.
* Complete pytest suite passed with only the two declared optional dependency skips.
* All 74 Bats tests passed.
* Example bundle lint passed.
* git diff check passed.

## Companion review (Claude Opus)

APPROVE. The no cost architecture is sound, preserves CodeQL and the load bearing bypass compensation, and requires an exact single rule transition with preimage and postimage verification.

## Companion review (Claude Sonnet)

APPROVE. The exact seven file diff has no material blocker and does not weaken the retained CodeQL, review, ruleset, merge identity, or tree transfer controls.

## Rollout

Merge this code first. Keep every schedule absent. Then remove only the unavailable code_quality rule from ruleset 18080131 after exact preimage validation, verify the exact postimage and fingerprint, and restart certification from item 1.