### PR TITLE
fix(release): retry transient artifact smoke

### DIFF
--- a/.rules/release-routine.md
+++ b/.rules/release-routine.md
@@ -115,6 +115,11 @@ Rollback is the same executable with the `rollback` argument. It reads
    * `scripts/ci_status.py`.
    * Version availability across PyPI, GHCR, GitHub tags, and GitHub releases.
 
+   Each isolated wheel or sdist smoke gets one fresh retry because environment
+   creation and dependency retrieval can fail transiently. A second failure
+   blocks the release. The other local gates remain single attempt so a real
+   validation failure is never hidden.
+
    Pull request checks require the aggregate `CodeQL` signal and all three
    language analyses. The review packet includes `H`, `T`, `B`, exact checks,
    security evidence, release gates, rollback point, ruleset fingerprint, and

--- a/scripts/operations/release_runtime.py
+++ b/scripts/operations/release_runtime.py
@@ -1239,6 +1239,29 @@ class ReleaseRuntime:
                 self.heartbeat()
         raise ValueError("exact main CI did not become green")
 
+    def _smoke_distribution(self, artifact: Path, version: str) -> str:
+        command = [
+            "uv",
+            "run",
+            "--python",
+            "3.13",
+            "python",
+            "scripts/smoke_installed_wheel.py",
+            "--artifact",
+            str(artifact),
+            "--expected-version",
+            version,
+        ]
+        for attempt in range(2):
+            try:
+                return self.command(command, timeout=300)
+            except (ValueError, subprocess.TimeoutExpired):
+                if attempt == 1:
+                    raise
+                self.sleep(2.0)
+                self.heartbeat()
+        raise AssertionError("distribution smoke retry loop exhausted")
+
     def _final_local_gates(self, source_revision: str, version: str) -> dict[str, Any]:
         scratch = self.repository_root / "to-delete" / "aiops-release-build"
         shutil.rmtree(scratch, ignore_errors=True)
@@ -1275,23 +1298,7 @@ class ReleaseRuntime:
             if len(artifacts) != 2:
                 raise ValueError("release build did not create one wheel and one sdist")
             for artifact in artifacts:
-                outputs.append(
-                    self.command(
-                        [
-                            "uv",
-                            "run",
-                            "--python",
-                            "3.13",
-                            "python",
-                            "scripts/smoke_installed_wheel.py",
-                            "--artifact",
-                            str(artifact),
-                            "--expected-version",
-                            version,
-                        ],
-                        timeout=300,
-                    )
-                )
+                outputs.append(self._smoke_distribution(artifact, version))
             security_report = self.command(
                 [
                     "uv",

--- a/tests/test_operations_release_runtime.py
+++ b/tests/test_operations_release_runtime.py
@@ -710,6 +710,59 @@ def test_collect_admission_fails_when_the_managed_worktree_is_stale(
         runtime.collect_admission({"source_revision": SOURCE_SHA})
 
 
+def test_distribution_smoke_retries_one_transient_failure(
+    tmp_path: Path,
+) -> None:
+    commands: list[list[str]] = []
+    sleeps: list[float] = []
+
+    def command_output(command: list[str], _cwd: Path, _timeout: int) -> str:
+        commands.append(command)
+        if len(commands) == 1:
+            raise ValueError("command failed: uv")
+        return "installed artifact smoke: ok"
+
+    runtime = ReleaseRuntime(
+        repository_root=tmp_path,
+        gateway=StubGateway(),
+        command_output=command_output,
+        sleep=sleeps.append,
+    )
+    artifact = tmp_path / "data_olympus-0.7.0.tar.gz"
+
+    output = runtime._smoke_distribution(artifact, "0.7.0")
+
+    assert output == "installed artifact smoke: ok"
+    assert len(commands) == 2
+    assert commands[0] == commands[1]
+    assert sleeps == [2.0]
+
+
+def test_distribution_smoke_stops_after_one_retry(
+    tmp_path: Path,
+) -> None:
+    commands: list[list[str]] = []
+
+    def command_output(command: list[str], _cwd: Path, _timeout: int) -> str:
+        commands.append(command)
+        raise ValueError("command failed: uv")
+
+    runtime = ReleaseRuntime(
+        repository_root=tmp_path,
+        gateway=StubGateway(),
+        command_output=command_output,
+        sleep=lambda _seconds: None,
+    )
+
+    with pytest.raises(ValueError, match="command failed: uv"):
+        runtime._smoke_distribution(
+            tmp_path / "data_olympus-0.7.0.tar.gz",
+            "0.7.0",
+        )
+
+    assert len(commands) == 2
+
+
 def test_render_release_documents_updates_only_the_governed_release_files(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Outcome

Allow exactly one fresh retry for each isolated wheel or sdist smoke test so a transient environment setup failure does not require operator follow up. A second failure still blocks, and every other local release gate remains single attempt.

## Incident

The first autonomous v0.7.0 run stopped before review, merge, or deployment when an installed sdist smoke returned `command failed: uv`. The exact unchanged smoke passed on immediate independent reproduction.

## Verification

* Ruff across the repository
* `mypy src`
* Benchmark documentation guard
* Full Python test suite
* 74 Bats tests
* Example bundle lint
* Document consistency guard
* Diff check

## Companion review

Claude Sonnet 5 returned `APPROVE` for exact candidate `fa0e2b8d92b3c144ea0b7fedf7c3ef2f0c1fded7`, tree `5dc9c65d719655f99c50eb10371ecaae8a7aaf4c`, and diff SHA256 `b760853d4d997833ac281bfb740d0d5e0a96097ca1f17921f7fc641b2e881a96`.