### PR TITLE
fix(release): isolate development quality tools

### DIFF
--- a/.rules/release-routine.md
+++ b/.rules/release-routine.md
@@ -115,6 +115,9 @@ Rollback is the same executable with the `rollback` argument. It reads
    * `scripts/ci_status.py`.
    * Version availability across PyPI, GHCR, GitHub tags, and GitHub releases.
 
+   Ruff, mypy, and pytest run through `uv` with the declared `dev` extra so the
+   release can never select an unrelated global executable.
+
    Each isolated wheel or sdist smoke gets one fresh retry because environment
    creation and dependency retrieval can fail transiently. A second failure
    blocks the release. The other local gates remain single attempt so a real

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+* **Isolated autonomous release quality tools.** The release runtime now installs
+  the declared `dev` extra when it runs Ruff, mypy, and pytest. This prevents a
+  missing project executable from falling through to an unrelated global Python
+  environment and validating the wrong installed Data Olympus version.
 * **Moved autonomous release approval before merge.** The release routine now
   reviews and approves the exact unmerged candidate, rederives every control
   replaced by the deliberate GitHub ruleset bypass, conditionally merges the

--- a/scripts/operations/release_runtime.py
+++ b/scripts/operations/release_runtime.py
@@ -1268,8 +1268,18 @@ class ReleaseRuntime:
         scratch.mkdir(parents=True, exist_ok=True)
         outputs: list[str] = []
         commands = [
-            ["uv", "run", "--python", "3.13", "ruff", "check", "."],
-            ["uv", "run", "--python", "3.13", "mypy", "src"],
+            [
+                "uv",
+                "run",
+                "--extra",
+                "dev",
+                "--python",
+                "3.13",
+                "ruff",
+                "check",
+                ".",
+            ],
+            ["uv", "run", "--extra", "dev", "--python", "3.13", "mypy", "src"],
             [
                 "uv",
                 "run",
@@ -1278,7 +1288,7 @@ class ReleaseRuntime:
                 "python",
                 "scripts/check_benchmark_docs.py",
             ],
-            ["uv", "run", "--python", "3.13", "pytest", "-q"],
+            ["uv", "run", "--extra", "dev", "--python", "3.13", "pytest", "-q"],
             ["bats", "-r", "tests"],
             ["uv", "run", "--python", "3.13", "data-olympus", "lint", "example-bundle"],
             [

--- a/tests/test_operations_release_runtime.py
+++ b/tests/test_operations_release_runtime.py
@@ -763,6 +763,46 @@ def test_distribution_smoke_stops_after_one_retry(
     assert len(commands) == 2
 
 
+def test_final_local_gates_install_declared_dev_extra_for_python_test_tools(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    commands: list[list[str]] = []
+
+    def command_output(command: list[str], _cwd: Path, _timeout: int) -> str:
+        commands.append(command)
+        if command[:2] == ["uv", "build"]:
+            output_directory = tmp_path / "to-delete" / "aiops-release-build"
+            (output_directory / "data_olympus-0.7.0-py3-none-any.whl").touch()
+            (output_directory / "data_olympus-0.7.0.tar.gz").touch()
+        return "ok"
+
+    runtime = ReleaseRuntime(
+        repository_root=tmp_path,
+        gateway=StubGateway(),
+        command_output=command_output,
+    )
+    monkeypatch.setattr(runtime, "_smoke_distribution", lambda *_arguments: "ok")
+    monkeypatch.setattr(
+        runtime,
+        "_wait_main_checks",
+        lambda _revision: {"all_success": True, "missing_required": []},
+    )
+
+    runtime._final_local_gates(SOURCE_SHA, "0.7.0")
+
+    expected_prefix = ["uv", "run", "--extra", "dev", "--python", "3.13"]
+    expected_tools = {"ruff", "mypy", "pytest"}
+    actual = {
+        command[len(expected_prefix)]
+        for command in commands
+        if command[: len(expected_prefix)] == expected_prefix
+        and len(command) > len(expected_prefix)
+        and command[len(expected_prefix)] in expected_tools
+    }
+    assert actual == expected_tools
+
+
 def test_render_release_documents_updates_only_the_governed_release_files(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Outcome

The autonomous release runtime now installs the declared `dev` extra before invoking Ruff, mypy, and pytest. This prevents `uv` from falling through to unrelated global executables and validating a stale installed Data Olympus package.

## Evidence

* Source: `ed15ffcce5a26fd93638bd14a4c9de2926364dd9`
* Candidate: `e84214fcd54000b86e9f5878d069c4b55018b8fe`
* Candidate tree: `d2d172dbf1f0242080424f4e2797fc7bb01b4ddf`
* Diff SHA256: `1dcfaebe5c477db3eb5069f890b7f3d819eb74d15984363e486844b72b3e0e24`
* Test driven regression observed failing before the implementation and passing afterwards.
* Ruff, mypy, benchmark documentation, 74 Bats tests, bundle lint, documentation consistency, and the complete pytest suite passed.
* Both built distributions passed isolated installed artifact smoke tests.
* Claude Sonnet 5 returned an explicit `APPROVE` verdict on the exact diff.

## Safety

This pull request does not publish, deploy, schedule, or notify.