### PR TITLE
chore(release): prepare v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,30 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-08-01
+
+### New features
+
+* feat(automation): execute weekly release outcome
+* feat(automation): make weekly releases outcome based
+### Fixed
+
+* fix(release): isolate development quality tools
+* fix(release): retry transient artifact smoke (#198)
+* fix(release): remove unavailable quality gate (#196)
+* fix(release): require approval before merge (#195)
+* fix(release): wait for complete check matrix (#193)
+* fix(release): wait for complete check conclusions (#191)
+* fix(release): allow metadata-only lock version bump (#189)
+* fix(automation): bind release consultation to run
+* fix(automation): accept FastMCP text content
+* fix(automation): read pull number from gateway receipt
+* fix(automation): make release imports deterministic (#182)
+* fix(automation): align final main checks
+* fix(security): update setuptools to 83.0.0
+* fix(ci): allow immutable history reconciliation
+
+
 ### Fixed
 
 * **Isolated autonomous release quality tools.** The release runtime now installs

--- a/docs/releases/v0.7.0.md
+++ b/docs/releases/v0.7.0.md
@@ -1,0 +1,23 @@
+# data-olympus 0.7.0
+
+## New features
+
+* feat(automation): execute weekly release outcome
+* feat(automation): make weekly releases outcome based
+
+## Fixed
+
+* fix(release): isolate development quality tools
+* fix(release): retry transient artifact smoke (#198)
+* fix(release): remove unavailable quality gate (#196)
+* fix(release): require approval before merge (#195)
+* fix(release): wait for complete check matrix (#193)
+* fix(release): wait for complete check conclusions (#191)
+* fix(release): allow metadata-only lock version bump (#189)
+* fix(automation): bind release consultation to run
+* fix(automation): accept FastMCP text content
+* fix(automation): read pull number from gateway receipt
+* fix(automation): make release imports deterministic (#182)
+* fix(automation): align final main checks
+* fix(security): update setuptools to 83.0.0
+* fix(ci): allow immutable history reconciliation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "data-olympus"
-version = "0.6.0"
+version = "0.7.0"
 description = "Governance-grade knowledge-base format (OKF-compatible) plus CLI and single-writer MCP server"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -475,7 +475,7 @@ wheels = [
 
 [[package]]
 name = "data-olympus"
-version = "0.6.0"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Outcome

Prepare immutable Data Olympus release v0.7.0 from exact source `47267011f751f8968a89f40a4497e6ab446dc4bd`.

## Verification

All repository checks must pass before the deterministic release commit is merged. Publication remains blocked until the resulting exact main SHA receives independent review and SHA bound standing approval.