### PR TITLE
fix(release): inspect exact GHCR version tag

### DIFF
--- a/.rules/release-routine.md
+++ b/.rules/release-routine.md
@@ -75,6 +75,18 @@ exact Telegram readback.
 Rollback is the same executable with the `rollback` argument. It reads
 `AI_OPERATIONS_RECOVERY_INPUT` and returns one closed recovery result.
 
+## Runtime prerequisites
+
+The release host requires:
+
+* Python 3.13 and `uv` for project gates and artifact builds.
+* GitHub CLI authentication for supported GitHub reads and mutations.
+* Docker CLI with the Buildx plugin for exact public GHCR tag inspection and
+  release digest verification. Registry inspection is bounded and
+  noninteractive.
+* Bats for the shell test suite.
+* Explicit access to the kn dev kubeconfig and the FastMCP gateway.
+
 ## Monday sequence
 
 1. Bind the authority revision, contract digest, run identifier, and exact
@@ -117,6 +129,12 @@ Rollback is the same executable with the `rollback` argument. It reads
 
    Ruff, mypy, and pytest run through `uv` with the declared `dev` extra so the
    release can never select an unrelated global executable.
+
+   GHCR availability uses an exact public registry tag inspection for
+   `ghcr.io/knaisoma/data-olympus:vX.Y.Z`. Only an explicit missing manifest
+   proves the tag is free. Client, permission, registry, and unrecognized
+   failures block the release. This check does not depend on GitHub Packages
+   API scopes or a truncated package version listing.
 
    Each isolated wheel or sdist smoke gets one fresh retry because environment
    creation and dependency retrieval can fail transiently. A second failure

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+* **Made the GHCR immutability guard exact and credential independent.** The
+  release gate now inspects the public `vX.Y.Z` registry tag directly instead
+  of requiring GitHub Packages API scope or scanning a bounded version list.
+  Only an explicit missing manifest proves the version is free; every other
+  client, timeout, or registry failure still blocks the bounded, noninteractive
+  check without exposing command diagnostics.
 * **Isolated autonomous release quality tools.** The release runtime now installs
   the declared `dev` extra when it runs Ruff, mypy, and pytest. This prevents a
   missing project executable from falling through to an unrelated global Python

--- a/scripts/check_version_free.py
+++ b/scripts/check_version_free.py
@@ -121,22 +121,41 @@ def _gh_json(path: str) -> object:
 
 
 def _on_ghcr(version: str, repo: str) -> bool:
-    """True if the ghcr image tag :vX.Y.Z exists for the org's container package."""
-    org = repo.split("/", 1)[0]
-    versions = _gh_json(
-        f"/orgs/{org}/packages/container/data-olympus/versions?per_page=100"
+    """True if the exact public ghcr image tag :vX.Y.Z exists.
+
+    Only an explicit missing-manifest response means the tag is free. Registry
+    and client failures raise RegistryError so the release remains fail closed.
+    """
+    reference = f"ghcr.io/{repo}:v{version}"
+    command = ["docker", "buildx", "imagetools", "inspect", reference]
+    try:
+        result = subprocess.run(
+            command,
+            capture_output=True,
+            stdin=subprocess.DEVNULL,
+            text=True,
+            timeout=30,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise RegistryError(f"ghcr query for {reference} timed out") from exc
+    except OSError as exc:
+        raise RegistryError(
+            f"ghcr registry client unavailable for {reference}"
+        ) from exc
+
+    if result.returncode == 0:
+        return True
+
+    diagnostic = f"{result.stdout}\n{result.stderr}".lower()
+    explicit_missing = (
+        "manifest unknown" in diagnostic
+        or "no such manifest" in diagnostic
+        or f"{reference.lower()}: not found" in diagnostic
     )
-    if versions is None:
-        # Package does not exist yet: the version cannot be published there.
+    if explicit_missing:
         return False
-    if not isinstance(versions, list):
-        raise RegistryError("unexpected ghcr package versions payload")
-    wanted = f"v{version}"
-    for entry in versions:
-        tags = (((entry or {}).get("metadata") or {}).get("container") or {}).get("tags") or []
-        if wanted in tags:
-            return True
-    return False
+
+    raise RegistryError(f"ghcr query for {reference} failed")
 
 
 def _on_github(version: str, repo: str) -> bool:

--- a/tests/test_check_version_free.py
+++ b/tests/test_check_version_free.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import pytest
 
+import scripts.check_version_free as version_guard
 from scripts.check_version_free import (
     RegistryError,
     VersionTaken,
@@ -57,6 +58,152 @@ def test_idempotent_rerun_false_when_tag_elsewhere() -> None:
 
 def test_idempotent_rerun_false_when_tag_absent() -> None:
     assert idempotent_rerun("0.5.0", tag_commit=None, head_commit="new456") is False
+
+
+def test_ghcr_checks_the_exact_public_registry_tag(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[list[str], dict[str, object]]] = []
+
+    def run(command: list[str], **kwargs: object) -> object:
+        calls.append((command, kwargs))
+        return version_guard.subprocess.CompletedProcess(
+            command,
+            0,
+            stdout="Name: ghcr.io/knaisoma/data-olympus:v0.7.0",
+            stderr="",
+        )
+
+    monkeypatch.setattr(version_guard.subprocess, "run", run)
+
+    assert version_guard._on_ghcr("0.7.0", "knaisoma/data-olympus") is True
+    assert calls == [
+        (
+            [
+                "docker",
+                "buildx",
+                "imagetools",
+                "inspect",
+                "ghcr.io/knaisoma/data-olympus:v0.7.0",
+            ],
+            {
+                "capture_output": True,
+                "stdin": version_guard.subprocess.DEVNULL,
+                "text": True,
+                "timeout": 30,
+            },
+        )
+    ]
+
+
+@pytest.mark.parametrize(
+    "diagnostic",
+    [
+        "manifest unknown",
+        "no such manifest",
+        "ERROR: ghcr.io/knaisoma/data-olympus:v0.7.0: not found",
+    ],
+)
+def test_ghcr_treats_only_an_explicit_missing_manifest_as_free(
+    monkeypatch: pytest.MonkeyPatch,
+    diagnostic: str,
+) -> None:
+    monkeypatch.setattr(
+        version_guard.subprocess,
+        "run",
+        lambda command, **_kwargs: version_guard.subprocess.CompletedProcess(
+            command,
+            1,
+            stdout="",
+            stderr=diagnostic,
+        ),
+    )
+
+    assert version_guard._on_ghcr("0.7.0", "knaisoma/data-olympus") is False
+
+
+@pytest.mark.parametrize(
+    "diagnostic",
+    [
+        'error getting credentials: executable file not found in $PATH',
+        "",
+    ],
+)
+def test_ghcr_does_not_misclassify_client_or_unknown_errors_as_free(
+    monkeypatch: pytest.MonkeyPatch,
+    diagnostic: str,
+) -> None:
+    monkeypatch.setattr(
+        version_guard.subprocess,
+        "run",
+        lambda command, **_kwargs: version_guard.subprocess.CompletedProcess(
+            command,
+            1,
+            stdout="",
+            stderr=diagnostic,
+        ),
+    )
+
+    with pytest.raises(RegistryError):
+        version_guard._on_ghcr("0.7.0", "knaisoma/data-olympus")
+
+
+def test_ghcr_timeout_fails_closed(monkeypatch: pytest.MonkeyPatch) -> None:
+    def timeout(command: list[str], **_kwargs: object) -> object:
+        raise version_guard.subprocess.TimeoutExpired(command, timeout=30)
+
+    monkeypatch.setattr(version_guard.subprocess, "run", timeout)
+
+    with pytest.raises(RegistryError, match="timed out"):
+        version_guard._on_ghcr("0.7.0", "knaisoma/data-olympus")
+
+
+def test_ghcr_registry_failure_does_not_leak_diagnostics(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sensitive_diagnostic = "denied with credential marker do-not-expose"
+    monkeypatch.setattr(
+        version_guard.subprocess,
+        "run",
+        lambda command, **_kwargs: version_guard.subprocess.CompletedProcess(
+            command,
+            1,
+            stdout="",
+            stderr=sensitive_diagnostic,
+        ),
+    )
+
+    with pytest.raises(RegistryError) as captured:
+        version_guard._on_ghcr("0.7.0", "knaisoma/data-olympus")
+    assert sensitive_diagnostic not in str(captured.value)
+
+
+def test_ghcr_fails_closed_when_registry_client_is_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def missing_executable(*_args: object, **_kwargs: object) -> object:
+        raise FileNotFoundError("docker")
+
+    monkeypatch.setattr(version_guard.subprocess, "run", missing_executable)
+    with pytest.raises(RegistryError, match="registry client unavailable"):
+        version_guard._on_ghcr("0.7.0", "knaisoma/data-olympus")
+
+
+def test_ghcr_fails_closed_on_registry_authorization_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        version_guard.subprocess,
+        "run",
+        lambda command, **_kwargs: version_guard.subprocess.CompletedProcess(
+            command,
+            1,
+            stdout="",
+            stderr="denied: requested access to the resource is denied",
+        ),
+    )
+    with pytest.raises(RegistryError, match="ghcr.io/knaisoma/data-olympus:v0.7.0"):
+        version_guard._on_ghcr("0.7.0", "knaisoma/data-olympus")
 
 
 def _patch_registry(


### PR DESCRIPTION
## Summary

* Replace the paginated GitHub Packages version lookup with exact public GHCR tag inspection.
* Bound the registry call to 30 seconds and disable interactive input.
* Treat only explicit manifest missing diagnostics as free and fail closed on every other result.
* Add regression coverage, release prerequisites, and changelog documentation.

## Candidate

* Head commit: `75d22d7a194cba22f1dc444923a166de13de3b94`
* Tree: `29190ff6908d5fddc766a561db749e5438cdf0c6`
* Base: `47267011f751f8968a89f40a4497e6ab446dc4bd`
* Diff SHA256: `53bb58f5bd40297b4abf3cfc6757caf284a3ec26aebad39c7cdbd79bf6743bab`

## Verification

* Ruff passed.
* mypy passed across 73 source files.
* Benchmark documentation guard passed.
* Complete pytest suite passed with two documented optional dependency skips.
* All 74 Bats tests passed.
* Bundle lint and documentation consistency passed.
* Wheel and source distribution build and installed artifact smokes passed.
* Security gate reported zero open Dependabot and CodeQL alerts.
* Live version check reported 0.7.0 free across PyPI, GHCR, and GitHub.
* Live version check reported 0.6.0 present across all three registries.

## Companion review

Claude Opus 5 initially returned BLOCK for timeout and false free risks. Those findings were corrected with test driven changes. Opus then returned APPROVE. After one documentation wording clarification, Claude Sonnet 5 reviewed this exact candidate diff and returned APPROVE.