### PR TITLE
fix(release): isolate prereview model evidence

### DIFF
--- a/.rules/release-routine.md
+++ b/.rules/release-routine.md
@@ -147,7 +147,11 @@ The release host requires:
    immutable delivery procedure.
 8. The deterministic executor requests one central, run controlled Claude
    review of `H`. Self review is prohibited. Review evidence hashes both the
-   exact submitted packet and the ticket bound Claude response.
+   exact submitted packet and the ticket bound Claude response. The packet
+   states the compact runner response contract and includes only controls that
+   require model judgment. The native `REVIEW_REQUIRED` value is validated
+   deterministically before review and is omitted from the model packet because
+   it is the expected prereview state, not a release finding.
 9. Require the candidate approval ledger entry to bind the run, contract
    digest, `H`, and consumed Claude review. The approved standing delegation
    may materialize that exact entry only after the review passes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+* **Separated deterministic release controls from model review.** The release
+  review packet now carries an explicit compact response contract and omits the
+  already validated native prereview decision, which is not a model judged
+  release gate. A failed model subprocess is now reported as an invocation
+  failure instead of being misclassified as invalid JSON.
 * **Made the GHCR immutability guard exact and credential independent.** The
   release gate now inspects the public `vX.Y.Z` registry tag directly instead
   of requiring GitHub Packages API scope or scanning a bounded version list.

--- a/scripts/operations/release.py
+++ b/scripts/operations/release.py
@@ -1225,6 +1225,8 @@ def _invoke_ticketed_model_from_runner(
         try:
             response = json.loads(process.stdout.strip())
         except json.JSONDecodeError as error:
+            if process.returncode != 0:
+                raise ReleaseInputError("review model invocation failed") from error
             raise ReleaseInputError("review model invocation returned invalid JSON") from error
         parsed = _approved_model_response(response, ticket)
         if process.returncode != 0:
@@ -1425,10 +1427,22 @@ def execute_release_run(
             "instruction": (
                 "Independently review the exact deterministic Data Olympus release "
                 "candidate. Approve only when source identity, tests, security, "
-                "version, rollback point, and immutable release procedures pass."
+                "version, rollback point, and immutable release procedures pass. "
+                "Return exactly one compact JSON object matching "
+                "response_contract with no markdown or prose."
             ),
             "prepared_evidence": prepared["evidence"],
-            "release_controls": prepared_input["release_controls"],
+            "release_controls": {
+                key: value
+                for key, value in prepared_input["release_controls"].items()
+                if key != "review_decision"
+            },
+            "response_contract": {
+                "actual_model": "exact invoked model identifier",
+                "verdict": "pass or fail",
+                "reason": "nonempty concise string",
+                "evidence": "JSON object",
+            },
             "source_revision": candidate_revision,
             "validation_evidence": validation["evidence"],
         }

--- a/tests/test_operations_release.py
+++ b/tests/test_operations_release.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import json
+import subprocess
 from hashlib import sha256
 
 import pytest
 
+from scripts.operations import release as release_module
 from scripts.operations.release import (
     DEFAULT_EXTRA_CONTEXT,
     evaluate_stage,
@@ -1046,6 +1048,149 @@ def test_review_evidence_hash_binds_the_packet_and_claude_response() -> None:
         ).encode()
     ).hexdigest()
     assert review_event["evidence"]["review_hash"] == expected_hash
+
+
+def test_release_review_packet_omits_the_validated_prereview_state() -> None:
+    dependencies = _release_dependencies()
+    captured: dict[str, object] = {}
+
+    def invoke_model(request: dict[str, object]) -> dict[str, object]:
+        captured["packet"] = request["packet"]
+        return _approved_review(request)
+
+    dependencies["invoke_model"] = invoke_model
+
+    events = execute_release_run(json.dumps(RUN_INPUT), dependencies)
+
+    packet = captured["packet"]
+    assert isinstance(packet, dict)
+    assert packet["response_contract"] == {
+        "actual_model": "exact invoked model identifier",
+        "verdict": "pass or fail",
+        "reason": "nonempty concise string",
+        "evidence": "JSON object",
+    }
+    instruction = packet["instruction"]
+    assert isinstance(instruction, str)
+    assert "exactly one compact JSON object" in instruction
+    release_controls = packet["release_controls"]
+    assert isinstance(release_controls, dict)
+    assert "review_decision" not in release_controls
+    assert events[-1]["status"] == "delivered"
+
+
+def test_failed_model_process_is_not_misreported_as_invalid_json(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    monkeypatch.setattr(
+        release_module.subprocess,
+        "run",
+        lambda *_arguments, **_keywords: subprocess.CompletedProcess(
+            args=[],
+            returncode=1,
+            stdout="",
+            stderr="error: qualified routes exhausted\n",
+        ),
+    )
+    ticket = {
+        "model_use_id": 71,
+        "purpose": "review",
+        "route_id": "claude-code",
+        "source_revision": SOURCE_SHA,
+        "ticket": "opaque-run-scoped-ticket",
+    }
+
+    with pytest.raises(
+        ValueError,
+        match="^review model invocation failed$",
+    ):
+        release_module._invoke_ticketed_model_from_runner(
+            RUN_INPUT,
+            ticket,
+            {"instruction": "review"},
+            tmp_path,
+        )
+
+
+def test_nonzero_model_block_remains_an_independent_review_block(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    response = {
+        "model_use_id": 71,
+        "route_id": "claude-code",
+        "status": "blocked",
+        "verdict": "BLOCK",
+    }
+    monkeypatch.setattr(
+        release_module.subprocess,
+        "run",
+        lambda *_arguments, **_keywords: subprocess.CompletedProcess(
+            args=[],
+            returncode=1,
+            stdout=json.dumps(response),
+            stderr="",
+        ),
+    )
+    ticket = {
+        "model_use_id": 71,
+        "purpose": "review",
+        "route_id": "claude-code",
+        "source_revision": SOURCE_SHA,
+        "ticket": "opaque-run-scoped-ticket",
+    }
+
+    with pytest.raises(
+        ValueError,
+        match="^independent review blocked the release$",
+    ):
+        release_module._invoke_ticketed_model_from_runner(
+            RUN_INPUT,
+            ticket,
+            {"instruction": "review"},
+            tmp_path,
+        )
+
+
+def test_nonzero_model_approval_is_still_an_invocation_failure(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    response = {
+        "model_use_id": 71,
+        "route_id": "claude-code",
+        "status": "approved",
+        "verdict": "APPROVE",
+    }
+    monkeypatch.setattr(
+        release_module.subprocess,
+        "run",
+        lambda *_arguments, **_keywords: subprocess.CompletedProcess(
+            args=[],
+            returncode=1,
+            stdout=json.dumps(response),
+            stderr="",
+        ),
+    )
+    ticket = {
+        "model_use_id": 71,
+        "purpose": "review",
+        "route_id": "claude-code",
+        "source_revision": SOURCE_SHA,
+        "ticket": "opaque-run-scoped-ticket",
+    }
+
+    with pytest.raises(
+        ValueError,
+        match="^review model invocation failed$",
+    ):
+        release_module._invoke_ticketed_model_from_runner(
+            RUN_INPUT,
+            ticket,
+            {"instruction": "review"},
+            tmp_path,
+        )
 
 
 def test_runtime_heartbeats_keep_one_contiguous_protocol_sequence() -> None:


### PR DESCRIPTION
## Outcome

Keeps the GitHub review state as a deterministic release control, omits that already validated field from model judgment, adds an explicit compact model response contract, and preserves fail closed subprocess handling.

## Verification

* Ruff: passed
* mypy: passed across 73 source files
* Full pytest: passed with the two documented optional dependency skips
* Bats: 74 passed
* Example bundle lint: 0 errors across 14 bundles
* Documentation consistency: passed
* Wheel and sdist build: passed
* Installed artifact smoke tests: passed for both artifacts
* Dependabot and CodeQL: 0 open alerts
* Release availability checks: `v0.7.0` remains free on PyPI, GHCR, and GitHub
* Targeted release tests: 61 passed

## Independent review

* Claude Sonnet 5 verdict: `APPROVE`
* Reviewed commit: `d6a54dc1fc7e54a893ae474fa15a07f54dcfdfca`
* Reviewed diff SHA256: `e6e69dbe90c20fcffae0c61eb1dab80d418c1db33d7548018e8acaf8add0e0dd`
* Earlier budget exhausted attempts returned no verdict and are not counted as reviews.