### PR TITLE
fix(release): retry bound tag inventory read

### DIFF
--- a/.rules/release-routine.md
+++ b/.rules/release-routine.md
@@ -141,6 +141,13 @@ The release host requires:
    blocks the release. The other local gates remain single attempt so a real
    validation failure is never hidden.
 
+   The first postmerge GitHub tag inventory is an idempotent FastMCP read. It
+   gets one retry only when text content omits the required gateway tool binding.
+   A mismatched tool, malformed result, different gateway failure, or second
+   omission still fails closed. A final failure preserves the already proven
+   merge parent and tree evidence and is never misclassified as a premerge
+   block. No mutation call is retried by this rule.
+
    Pull request checks require the aggregate `CodeQL` signal and all three
    language analyses. The review packet includes `H`, `T`, `B`, exact checks,
    security evidence, release gates, rollback point, ruleset fingerprint, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+* Retry one transient unbound FastMCP response during the idempotent postmerge
+  tag inventory, while preserving strict tool binding and exact merge evidence
+  when the bounded retry still fails.
+
 ## [0.7.0] - 2026-08-01
 
 ### New features

--- a/scripts/operations/release_runtime.py
+++ b/scripts/operations/release_runtime.py
@@ -82,6 +82,10 @@ class ReleaseDeliveryError(ValueError):
         self.evidence = evidence
 
 
+class UnboundGatewayResultError(ValueError):
+    """A text fallback omitted the gateway's requested tool binding."""
+
+
 def _default_command_output(command: list[str], cwd: Path, timeout: int) -> str:
     process = subprocess.run(
         command,
@@ -244,7 +248,9 @@ class FastMCPGateway:
         if used_text_content and not (
             type(result) is dict and set(result) >= {"tool", "result"}
         ):
-            raise ValueError("FastMCP text content omitted gateway result")
+            raise UnboundGatewayResultError(
+                "FastMCP text content omitted gateway result"
+            )
         if type(result) is dict and set(result) >= {"tool", "result"}:
             if result["tool"] != name:
                 raise ValueError("FastMCP result tool does not match request")
@@ -1663,6 +1669,27 @@ class ReleaseRuntime:
             {"owner": GITHUB_OWNER, "repo": GITHUB_REPOSITORY, "tag": tag},
         )
 
+    def _list_tags(self) -> list[Any]:
+        arguments = {
+            "owner": GITHUB_OWNER,
+            "page": 1,
+            "perPage": 100,
+            "repo": GITHUB_REPOSITORY,
+        }
+        for attempt in range(2):
+            try:
+                tags = self.gateway.execute("list_tags", arguments)
+            except UnboundGatewayResultError:
+                if attempt != 0:
+                    raise
+                self.sleep(1.0)
+                self.heartbeat()
+                continue
+            if type(tags) is not list:
+                raise ValueError("GitHub tags are unavailable")
+            return tags
+        raise AssertionError("list tags retry loop exhausted")
+
     def _release_asset_json(
         self,
         release: dict[str, Any],
@@ -2029,6 +2056,7 @@ class ReleaseRuntime:
         )
         try:
             final_gates = self._final_local_gates(source_revision, version)
+            tags = self._list_tags()
         except (OSError, subprocess.SubprocessError, ValueError) as error:
             raise ReleaseDeliveryError(
                 str(error),
@@ -2039,17 +2067,6 @@ class ReleaseRuntime:
                     "rollback_completed": False,
                 },
             ) from error
-        tags = self.gateway.execute(
-            "list_tags",
-            {
-                "owner": GITHUB_OWNER,
-                "page": 1,
-                "perPage": 100,
-                "repo": GITHUB_REPOSITORY,
-            },
-        )
-        if type(tags) is not list:
-            raise ValueError("GitHub tags are unavailable")
         tag_names: list[str] = []
         for raw_tag in tags:
             if type(raw_tag) is dict and type(raw_tag.get("name")) is str:

--- a/tests/test_operations_release_runtime.py
+++ b/tests/test_operations_release_runtime.py
@@ -12,6 +12,7 @@ from scripts.operations.release_runtime import (
     FastMCPGateway,
     ReleaseDeliveryError,
     ReleaseRuntime,
+    UnboundGatewayResultError,
     _authority_consult,
     _authority_gate_check,
     candidate_release_evidence,
@@ -481,7 +482,7 @@ def test_fastmcp_gateway_rejects_unbound_text_content() -> None:
             }
         )
 
-    with pytest.raises(ValueError, match="omitted gateway result"):
+    with pytest.raises(UnboundGatewayResultError, match="omitted gateway result"):
         FastMCPGateway(run_command=run_command).execute(
             "create_pull_request",
             {"owner": "knaisoma", "repo": "data-olympus"},
@@ -509,6 +510,93 @@ def test_fastmcp_gateway_rejects_a_different_tool_result() -> None:
             "create_pull_request",
             {"owner": "knaisoma", "repo": "data-olympus"},
         )
+
+
+def test_list_tags_retries_one_unbound_fastmcp_text_response(
+    tmp_path: Path,
+) -> None:
+    class FlakyReadGateway:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def execute(self, name: str, arguments: dict[str, object]) -> object:
+            assert name == "list_tags"
+            assert arguments == {
+                "owner": "knaisoma",
+                "page": 1,
+                "perPage": 100,
+                "repo": "data-olympus",
+            }
+            self.calls += 1
+            if self.calls == 1:
+                raise UnboundGatewayResultError(
+                    "FastMCP text content omitted gateway result"
+                )
+            return [{"name": "v0.6.0"}]
+
+    sleeps: list[float] = []
+    gateway = FlakyReadGateway()
+    runtime = ReleaseRuntime(
+        tmp_path,
+        gateway=gateway,
+        sleep=sleeps.append,
+    )
+
+    assert runtime._list_tags() == [{"name": "v0.6.0"}]
+    assert gateway.calls == 2
+    assert sleeps == [1.0]
+
+
+def test_list_tags_does_not_retry_other_gateway_failures(tmp_path: Path) -> None:
+    class InvalidGateway:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def execute(self, _name: str, _arguments: dict[str, object]) -> object:
+            self.calls += 1
+            raise ValueError("FastMCP result tool does not match request")
+
+    sleeps: list[float] = []
+    gateway = InvalidGateway()
+    runtime = ReleaseRuntime(
+        tmp_path,
+        gateway=gateway,
+        sleep=sleeps.append,
+    )
+
+    with pytest.raises(ValueError, match="tool does not match request"):
+        runtime._list_tags()
+
+    assert gateway.calls == 1
+    assert sleeps == []
+
+
+def test_list_tags_stops_after_one_unbound_response_retry(
+    tmp_path: Path,
+) -> None:
+    class UnboundGateway:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def execute(self, _name: str, _arguments: dict[str, object]) -> object:
+            self.calls += 1
+            raise UnboundGatewayResultError(
+                "FastMCP text content omitted gateway result"
+            )
+
+    sleeps: list[float] = []
+    gateway = UnboundGateway()
+    runtime = ReleaseRuntime(
+        tmp_path,
+        gateway=gateway,
+        sleep=sleeps.append,
+    )
+
+    with pytest.raises(ValueError, match="omitted gateway result"):
+        runtime._list_tags()
+
+    assert gateway.calls == 2
+    assert sleeps == [1.0]
 
 
 def test_prepare_fails_before_mutation_without_authority_consult_receipt(
@@ -1773,6 +1861,36 @@ def _prime_approved_delivery(
             "reviewer_family": "claude",
             "source_revision": CANDIDATE_SHA,
         },
+    }
+
+
+def test_postmerge_tag_inventory_failure_preserves_delivery_proof(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    previous = "sha256:" + "e" * 64
+    runtime = ReleaseRuntime(tmp_path, gateway=StubGateway())
+    reviewed = _prime_approved_delivery(runtime, monkeypatch, previous)
+
+    def fail_tags() -> list[object]:
+        raise ValueError("FastMCP text content omitted gateway result")
+
+    monkeypatch.setattr(runtime, "_list_tags", fail_tags)
+
+    with pytest.raises(ReleaseDeliveryError, match="omitted gateway result") as raised:
+        runtime.deliver({}, {}, {}, reviewed)
+
+    assert raised.value.evidence == {
+        "admitted_revision": SOURCE_SHA,
+        "approved_candidate_revision": CANDIDATE_SHA,
+        "delivery_revision": DELIVERY_SHA,
+        "delivery_tree_revision": CANDIDATE_TREE,
+        "external_state_changed": True,
+        "merge_confirmed": True,
+        "release_pr_number": 182,
+        "reviewed_tree_revision": CANDIDATE_TREE,
+        "rollback_completed": False,
+        "sole_parent_revision": SOURCE_SHA,
     }
 
 


### PR DESCRIPTION
## Outcome

Retries only one typed unbound FastMCP response during the idempotent postmerge `list_tags` inventory. All other gateway failures remain fail closed and mutation calls are never retried. A final failure now preserves the exact reviewed merge proof as a postmerge delivery error.

## Incident evidence

* Release run `91e7e659-eafc-4ba6-8f37-1a3075020539` safely merged reviewed PR 207, then failed before publication and deployment when the first postmerge tag inventory received unbound text content.
* Direct replay of the same `list_tags` call returned the normal tool bound gateway envelope.
* Merged release commit `3a62219b2ed5ee648fc10cac3462543d9105a66b` has the exact reviewed candidate tree and expected sole parent.
* Version `0.7.0` remains absent from PyPI, GHCR, and GitHub tags and releases.

## Verification

* Five focused retry, binding, and postmerge classification regressions: passed
* Complete focused release suites: passed
* Ruff: passed
* mypy: passed across 73 source files
* Full pytest: passed with only the two documented optional dependency skips
* Bats: 74 passed
* Example bundle lint: 0 errors across 14 bundles
* Documentation consistency: passed
* Wheel and sdist build and installed smokes: passed
* Security: 0 open Dependabot and 0 open CodeQL alerts
* Live `0.7.0` availability guard: passed

## Independent review

* Claude Sonnet 5 verdict: `APPROVE`
* Reviewed commit: `98669e3302b6adb5d20cea6a1e0e4de90cf0f7d2`
* Reviewed diff SHA256: `82840ad6e88bcade8eca246c6bb5c3821ff3639b79f0b8955c0f284380272215`