### PR TITLE
fix(release): resume unpublished preparation

### DIFF
--- a/.rules/release-routine.md
+++ b/.rules/release-routine.md
@@ -105,6 +105,20 @@ The release host requires:
 5. Set `pyproject.toml` to `X.Y.Z`, update `uv.lock`, close the matching
    changelog block, open a
    new empty `[Unreleased]` block, and write `docs/releases/vX.Y.Z.md`.
+   A prepared version that merged but has no public tag, release, package,
+   image, or candidate may roll forward that same version exactly once per new
+   computed release item. Recovery requires the existing release note items to
+   be a heading preserving subset of the current computation and the existing
+   changelog target to begin with their exact canonical rendering. It rebuilds
+   both canonical sections from the full current computation, preserves prior
+   detailed target prose, moves current Unreleased prose under the target,
+   records the actual preparation date, and leaves one empty Unreleased block.
+   Every document state check and output render completes in memory before the
+   first file write. A missing counterpart, mismatch, duplicate target, or
+   replay without a new item blocks there. The unchanged version availability
+   gate blocks every public collision before review or merge. The resulting
+   commit then follows the complete ordinary review, merge, publication,
+   deployment, and notification sequence without a special delivery path.
 6. Open one public pull request through FastMCP. Keep it open and unmerged.
    Require every observed repository check to reach a successful terminal
    conclusion. Require the aggregate `CodeQL` check, all three CodeQL language

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+* Resume a merged but still unpublished release preparation by validating its
+  prior canonical documents, rebuilding them atomically from the complete
+  current computation, and then reusing the ordinary reviewed release path.
 * Retry one transient unbound FastMCP response during the idempotent postmerge
   tag inventory, while preserving strict tool binding and exact merge evidence
   when the bounded retry still fails.

--- a/scripts/operations/release_runtime.py
+++ b/scripts/operations/release_runtime.py
@@ -280,6 +280,71 @@ def _release_sections(changes: dict[str, Any]) -> list[tuple[str, list[str]]]:
     return sections
 
 
+def _render_change_sections(
+    sections: list[tuple[str, list[str]]],
+    *,
+    heading_level: int,
+) -> str:
+    if heading_level not in {2, 3}:
+        raise ValueError("release section heading level must be 2 or 3")
+    separator = "\n\n" if heading_level == 2 else "\n"
+    heading = "#" * heading_level
+    return separator.join(
+        f"{heading} {title}\n\n" + "\n".join(f"* {item}" for item in items)
+        for title, items in sections
+    )
+
+
+def _parse_release_note(
+    document: str,
+    version: str,
+) -> list[tuple[str, list[str]]]:
+    title = f"# data-olympus {version}\n\n"
+    if not document.startswith(title):
+        raise ValueError("prepared release note title is invalid")
+    lines = document[len(title) :].splitlines()
+    allowed = ["Breaking changes", "New features", "Fixed"]
+    sections: list[tuple[str, list[str]]] = []
+    index = 0
+    last_order = -1
+    while index < len(lines):
+        line = lines[index]
+        if not line.startswith("## ") or line[3:] not in allowed:
+            raise ValueError("prepared release note section is invalid")
+        section_title = line[3:]
+        section_order = allowed.index(section_title)
+        if section_order <= last_order:
+            raise ValueError("prepared release note section order is invalid")
+        last_order = section_order
+        index += 1
+        if index >= len(lines) or lines[index] != "":
+            raise ValueError("prepared release note section spacing is invalid")
+        index += 1
+        items: list[str] = []
+        while index < len(lines) and lines[index] != "":
+            if not lines[index].startswith("* ") or not lines[index][2:].strip():
+                raise ValueError("prepared release note item is invalid")
+            items.append(lines[index][2:])
+            index += 1
+        if not items:
+            raise ValueError("prepared release note section must contain an item")
+        sections.append((section_title, items))
+        if index < len(lines):
+            index += 1
+            if index >= len(lines):
+                raise ValueError("prepared release note has trailing whitespace")
+    canonical = f"{title}{_render_change_sections(sections, heading_level=2)}\n"
+    if document != canonical:
+        raise ValueError("prepared release note is not canonical")
+    return sections
+
+
+def _section_items(
+    sections: list[tuple[str, list[str]]],
+) -> dict[str, list[str]]:
+    return {title: items for title, items in sections}
+
+
 def render_release_documents(
     repository_root: Path,
     version: str,
@@ -292,6 +357,10 @@ def render_release_documents(
     sections = _release_sections(changes)
     pyproject_path = repository_root / "pyproject.toml"
     pyproject = pyproject_path.read_text(encoding="utf-8")
+    project_versions = re.findall(r'(?m)^version = "([^"]+)"\s*$', pyproject)
+    if len(project_versions) != 1:
+        raise ValueError("pyproject.toml must contain one project version")
+    current_version = project_versions[0]
     updated_project, replacements = re.subn(
         r'(?m)^(version = ")[^"]+("\s*)$',
         rf"\g<1>{version}\g<2>",
@@ -300,38 +369,103 @@ def render_release_documents(
     )
     if replacements != 1:
         raise ValueError("pyproject.toml must contain one project version")
-    pyproject_path.write_text(updated_project, encoding="utf-8")
 
     changelog_path = repository_root / "CHANGELOG.md"
     changelog = changelog_path.read_text(encoding="utf-8")
     marker = "## [Unreleased]"
     if changelog.count(marker) != 1:
         raise ValueError("CHANGELOG.md must contain one Unreleased section")
-    changelog_sections = "\n".join(
-        f"### {title}\n\n" + "\n".join(f"* {item}" for item in items)
-        for title, items in sections
-    )
-    replacement = (
-        f"{marker}\n\n## [{version}] - {release_date.isoformat()}\n\n"
-        f"{changelog_sections}\n"
-    )
-    updated_changelog = changelog.replace(marker, replacement, 1)
-    changelog_path.write_text(updated_changelog, encoding="utf-8")
-
-    note_sections = "\n\n".join(
-        f"## {title}\n\n" + "\n".join(f"* {item}" for item in items)
-        for title, items in sections
-    )
-    release_note = f"# data-olympus {version}\n\n{note_sections}\n"
     note_path = repository_root / "docs" / "releases" / f"v{version}.md"
-    if note_path.exists():
-        raise ValueError(f"release note already exists for {version}")
+    target_pattern = re.compile(
+        rf"(?m)^## \[{re.escape(version)}\] - [0-9]{{4}}-[0-9]{{2}}-[0-9]{{2}}$"
+    )
+    target_matches = list(target_pattern.finditer(changelog))
+    note_exists = note_path.exists()
+    changelog_sections = _render_change_sections(sections, heading_level=3)
+    note_sections = _render_change_sections(sections, heading_level=2)
+    release_note = f"# data-olympus {version}\n\n{note_sections}\n"
+
+    if current_version != version and not note_exists and not target_matches:
+        document_mode = "normal"
+        replacement = (
+            f"{marker}\n\n## [{version}] - {release_date.isoformat()}\n\n"
+            f"{changelog_sections}\n"
+        )
+        updated_changelog = changelog.replace(marker, replacement, 1)
+    elif current_version == version and note_exists and len(target_matches) == 1:
+        document_mode = "roll_forward"
+        prior_sections = _parse_release_note(
+            note_path.read_text(encoding="utf-8"),
+            version,
+        )
+        prior_items = _section_items(prior_sections)
+        current_items = _section_items(sections)
+        for title, items in prior_items.items():
+            available = current_items.get(title, [])
+            if any(item not in available for item in items):
+                raise ValueError(
+                    "prepared release note item is absent from current computation"
+                )
+        has_new_item = any(
+            item not in prior_items.get(title, [])
+            for title, items in sections
+            for item in items
+        )
+        if not has_new_item:
+            raise ValueError("roll forward requires at least one new release item")
+
+        target = target_matches[0]
+        marker_start = changelog.index(marker)
+        marker_end = marker_start + len(marker)
+        if target.start() <= marker_end:
+            raise ValueError("prepared changelog target must follow Unreleased")
+        release_header = re.compile(
+            r"(?m)^## \[[0-9]+\.[0-9]+\.[0-9]+\] - "
+            r"[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+        )
+        first_release = release_header.search(changelog, marker_end)
+        if first_release is None or first_release.start() != target.start():
+            raise ValueError("prepared changelog target must be the first release")
+        body_start = target.end()
+        if changelog[body_start : body_start + 2] != "\n\n":
+            raise ValueError("prepared changelog target spacing is invalid")
+        body_start += 2
+        next_release = release_header.search(changelog, body_start)
+        body_end = next_release.start() if next_release is not None else len(changelog)
+        target_body = changelog[body_start:body_end]
+        prior_changelog = _render_change_sections(prior_sections, heading_level=3)
+        prefix_boundary = target_body[len(prior_changelog) : len(prior_changelog) + 1]
+        if not target_body.startswith(prior_changelog) or prefix_boundary not in {
+            "",
+            "\n",
+        }:
+            raise ValueError("prepared changelog canonical prefix is invalid")
+
+        prior_detail = target_body[len(prior_changelog) :].strip("\n")
+        unreleased_detail = changelog[marker_end : target.start()].strip("\n")
+        target_parts = [changelog_sections]
+        if prior_detail:
+            target_parts.append(prior_detail)
+        if unreleased_detail:
+            target_parts.append(unreleased_detail)
+        suffix = changelog[body_end:]
+        updated_changelog = (
+            f"{changelog[:marker_start]}{marker}\n\n"
+            f"## [{version}] - {release_date.isoformat()}\n\n"
+            f"{'\n\n'.join(target_parts)}\n\n{suffix}"
+        )
+    else:
+        raise ValueError("release documents are in an inconsistent prepared state")
+
+    pyproject_path.write_text(updated_project, encoding="utf-8")
+    changelog_path.write_text(updated_changelog, encoding="utf-8")
     note_path.parent.mkdir(parents=True, exist_ok=True)
     note_path.write_text(release_note, encoding="utf-8")
     note_hash = _sha256_text(release_note)
     return {
         "changelog_hash": _sha256_text(updated_changelog),
         "content_hash": note_hash,
+        "document_mode": document_mode,
         "release_note_hash": note_hash,
     }
 
@@ -1506,6 +1640,7 @@ class ReleaseRuntime:
             "changelog": {
                 "source_revision": head_revision,
                 "content_hash": document_evidence["changelog_hash"],
+                "document_mode": document_evidence["document_mode"],
             },
             "security": gates["security"],
             "tests": gates["tests"],

--- a/tests/test_operations_release_runtime.py
+++ b/tests/test_operations_release_runtime.py
@@ -925,6 +925,169 @@ def test_render_release_documents_updates_only_the_governed_release_files(
     assert note.startswith("# data-olympus 0.7.0")
     assert evidence["content_hash"] == evidence["release_note_hash"]
     assert len(evidence["changelog_hash"]) == 64
+    assert evidence["document_mode"] == "normal"
+
+
+def _write_prepared_release_documents(
+    root: Path,
+    *,
+    changelog_fixed_item: str = "fix(mcp): preserve exact source evidence",
+    include_note: bool = True,
+    include_target: bool = True,
+) -> tuple[Path, Path, Path]:
+    note_path = root / "docs" / "releases" / "v0.7.0.md"
+    note_path.parent.mkdir(parents=True)
+    pyproject_path = root / "pyproject.toml"
+    pyproject_path.write_text(
+        '[project]\nname = "data-olympus"\nversion = "0.7.0"\n',
+        encoding="utf-8",
+    )
+    target = ""
+    if include_target:
+        target = (
+            "## [0.7.0] - 2026-08-01\n\n"
+            "### New features\n\n"
+            "* feat(automation): make releases outcome based\n"
+            "### Fixed\n\n"
+            f"* {changelog_fixed_item}\n\n\n"
+            "### Fixed\n\n"
+            "* **Preserved prior detailed release prose.** Exact details remain.\n\n"
+        )
+    changelog_path = root / "CHANGELOG.md"
+    changelog_path.write_text(
+        "# Changelog\n\n"
+        "## [Unreleased]\n\n"
+        "### Fixed\n\n"
+        "* Retry one transient bound tag inventory response.\n\n"
+        f"{target}"
+        "## [0.6.0] - 2026-07-18\n",
+        encoding="utf-8",
+    )
+    if include_note:
+        note_path.write_text(
+            "# data-olympus 0.7.0\n\n"
+            "## New features\n\n"
+            "* feat(automation): make releases outcome based\n\n"
+            "## Fixed\n\n"
+            "* fix(mcp): preserve exact source evidence\n",
+            encoding="utf-8",
+        )
+    return pyproject_path, changelog_path, note_path
+
+
+def _roll_forward_changes() -> dict[str, list[str]]:
+    return {
+        "breaking": [],
+        "features": ["feat(automation): make releases outcome based"],
+        "fixes": [
+            "fix(mcp): preserve exact source evidence",
+            "fix(release): retry bound tag inventory read (#208)",
+        ],
+    }
+
+
+def test_render_release_documents_rolls_forward_one_unpublished_preparation(
+    tmp_path: Path,
+) -> None:
+    _, changelog_path, note_path = _write_prepared_release_documents(tmp_path)
+
+    evidence = render_release_documents(
+        tmp_path,
+        "0.7.0",
+        _roll_forward_changes(),
+        date(2026, 8, 2),
+    )
+
+    changelog = changelog_path.read_text(encoding="utf-8")
+    note = note_path.read_text(encoding="utf-8")
+    assert evidence["document_mode"] == "roll_forward"
+    assert changelog.count("## [Unreleased]") == 1
+    assert "## [Unreleased]\n\n## [0.7.0] - 2026-08-02" in changelog
+    assert changelog.count("## [0.7.0] - 2026-08-02") == 1
+    assert changelog.count("fix(release): retry bound tag inventory read (#208)") == 1
+    assert note.count("fix(release): retry bound tag inventory read (#208)") == 1
+    assert "**Preserved prior detailed release prose.**" in changelog
+    assert "Retry one transient bound tag inventory response." in changelog
+    assert changelog.index("**Preserved prior detailed release prose.**") < (
+        changelog.index("Retry one transient bound tag inventory response.")
+    )
+
+
+@pytest.mark.parametrize(
+    ("include_note", "include_target", "current_fixed", "changelog_fixed"),
+    [
+        (True, False, "fix(mcp): preserve exact source evidence", None),
+        (False, True, "fix(mcp): preserve exact source evidence", None),
+        (True, True, "fix(other): absent from current computation", None),
+        (
+            True,
+            True,
+            "fix(mcp): preserve exact source evidence",
+            "fix(mcp): preserve exact source evidence but altered",
+        ),
+    ],
+)
+def test_render_release_documents_rejects_inconsistent_preparation_atomically(
+    tmp_path: Path,
+    include_note: bool,
+    include_target: bool,
+    current_fixed: str,
+    changelog_fixed: str | None,
+) -> None:
+    paths = _write_prepared_release_documents(
+        tmp_path,
+        include_note=include_note,
+        include_target=include_target,
+        changelog_fixed_item=(
+            changelog_fixed or "fix(mcp): preserve exact source evidence"
+        ),
+    )
+    note_path = paths[2]
+    if include_note and current_fixed != "fix(mcp): preserve exact source evidence":
+        note_path.write_text(
+            "# data-olympus 0.7.0\n\n"
+            "## New features\n\n"
+            "* feat(automation): make releases outcome based\n\n"
+            "## Fixed\n\n"
+            f"* {current_fixed}\n",
+            encoding="utf-8",
+        )
+    before = {
+        path: path.read_bytes() if path.exists() else None
+        for path in paths
+    }
+
+    with pytest.raises(ValueError):
+        render_release_documents(
+            tmp_path,
+            "0.7.0",
+            _roll_forward_changes(),
+            date(2026, 8, 2),
+        )
+
+    assert {
+        path: path.read_bytes() if path.exists() else None
+        for path in paths
+    } == before
+
+
+def test_render_release_documents_rejects_roll_forward_replay_atomically(
+    tmp_path: Path,
+) -> None:
+    paths = _write_prepared_release_documents(tmp_path)
+    before = {path: path.read_bytes() for path in paths}
+    changes = _roll_forward_changes()
+    changes["fixes"] = ["fix(mcp): preserve exact source evidence"]
+
+    with pytest.raises(ValueError, match="new release item"):
+        render_release_documents(
+            tmp_path,
+            "0.7.0",
+            changes,
+            date(2026, 8, 2),
+        )
+
+    assert {path: path.read_bytes() for path in paths} == before
 
 
 def test_completed_check_evidence_requires_every_expected_check_and_no_failures() -> None:
@@ -1415,6 +1578,7 @@ def test_prepare_stops_at_the_unmerged_review_candidate(
         lambda *_arguments: {
             "changelog_hash": "1" * 64,
             "content_hash": "2" * 64,
+            "document_mode": "normal",
             "release_note_hash": "2" * 64,
         },
     )
@@ -1497,6 +1661,11 @@ def test_prepare_stops_at_the_unmerged_review_candidate(
         "number": 182,
         "source_revision": CANDIDATE_SHA,
         "url": "https://github.com/knaisoma/data-olympus/pull/182",
+    }
+    assert result["changelog"] == {
+        "content_hash": "1" * 64,
+        "document_mode": "normal",
+        "source_revision": CANDIDATE_SHA,
     }
     assert runtime.candidate_revision() == CANDIDATE_SHA
     assert consultations == [


### PR DESCRIPTION
## Outcome

Resume a merged but still unpublished 0.7.0 preparation without skipping a version, duplicating release documents, or weakening the ordinary release path.

## Safety

All package, note, and changelog state is validated before writes. Recovery requires the prior canonical items under the same headings in the complete current computation, an exact changelog prefix boundary, and at least one new item. Inconsistent, altered, or replayed state fails before mutation.

## Verification

* Reviewed head: `61f70fdb125b50312d55b6bd4e8d46c2cf8918fa`
* Reviewed tree: `45d62351f49ec075bebaf43c773b9a17b1cd0b6f`
* Base: `4503ce50f407de00681d00857aec1f8b628a346a`
* Diff SHA256: `414d27955459ccd18fec5d83c4ba5a5e40b1cc03c27bb1207b69b07a82d83fec`
* Claude Opus 5: `APPROVE`
* Focused release suites: 116 passed
* Full pytest: passed with two documented optional dependency skips
* Ruff, mypy on 73 source files, benchmark docs, 74 Bats tests, example bundle lint, document consistency: passed
* Wheel and source distribution builds and installed smokes: passed
* Security: zero open Dependabot and CodeQL alerts
* Live version guard: 0.7.0 remains free on PyPI, GHCR, and GitHub

Merge remains conditional on this exact reviewed head and every remote check succeeding.