### PR TITLE
chore(release): harden prepared publication recovery

### DIFF
--- a/.rules/release-routine.md
+++ b/.rules/release-routine.md
@@ -118,7 +118,7 @@ The release host requires:
    replay without a new item blocks there. The unchanged version availability
    gate blocks every public collision before review or merge. The resulting
    commit then follows the complete ordinary review, merge, publication,
-   deployment, and notification sequence without a special delivery path.
+   deployment, and notification sequence.
 6. Open one public pull request through FastMCP. Keep it open and unmerged.
    Require every observed repository check to reach a successful terminal
    conclusion. Require the aggregate `CodeQL` check, all three CodeQL language
@@ -221,6 +221,51 @@ The release host requires:
    readback of the destination, message identifier, run marker, and content.
 21. The durable runner ledger records the truthful terminal state. No private
    issue is an authority or completion dependency.
+
+## Prepared but unpublished recovery
+
+One narrow recovery state is supported when the exact release preparation is
+already on `origin/main`, but no candidate or stable public surface exists. It
+is not a generic resume engine.
+
+Any one of these indicators selects the recovery validator and prevents a
+fallback to ordinary preparation:
+
+* `pyproject.toml` already declares the computed target version.
+* `docs/releases/vX.Y.Z.md` already exists.
+* `CHANGELOG.md` already contains the computed target version.
+
+The state is valid only when all of these conditions hold:
+
+* The managed worktree, local source, and remote main are the same admitted
+  SHA.
+* The project version is exactly the computed target.
+* The release note is canonical and exactly matches the current deterministic
+  computation.
+* There is exactly one empty Unreleased block.
+* There is exactly one target release block, it is the first release, and its
+  canonical prefix exactly matches the current deterministic computation.
+* The document hashes and Git tree remain unchanged through validation and
+  delivery.
+* The full local gates and rollback point pass.
+
+This state creates no branch, commit, pull request, or merge. The current main
+SHA and tree become the review candidate. A fresh central Claude review and
+SHA bound standing approval are still mandatory. Delivery records
+`preparation_mode=prepared_unpublished`, `merge_skipped=true`, and
+`merge_confirmed=false`; it does not invent a pull request, merge parent, or
+different delivery revision.
+
+After review, the runner revalidates the source, tree, documents, full local
+gates, and public tag inventory. Before the first workflow dispatch, the exact
+candidate spelling must be confirmed absent from PyPI, public GHCR manifest
+inspection, and GitHub releases. Registry or client uncertainty blocks. The
+ordinary `rc-publish.yml`, canary, `tag-release.yml`, `set-channel.yml`, stable
+deployment, verification, Telegram readback, and ledger sequence then runs
+unchanged.
+
+Any other partially prepared, partially published, or mismatched state blocks
+for a separately reviewed recovery decision.
 
 ## Exact source rule
 

--- a/.rules/versioning.md
+++ b/.rules/versioning.md
@@ -55,6 +55,13 @@ When a release is due:
 4. Bind the candidate to the resulting exact main SHA.
 5. Publish and promote only through the existing release workflows.
 
+The only exception is the fail closed prepared but unpublished recovery in
+`.rules/release-routine.md`. It applies when the complete deterministic release
+preparation is already on the admitted `origin/main` SHA and every candidate
+and stable public surface is still absent. That recovery reviews the exact main
+SHA, creates no replacement branch or merge, and reuses the same publication
+and promotion workflows after all evidence is revalidated.
+
 ## Pull request discipline
 
 Feature and fix pull requests contain one logical change and are squash merged.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,9 +77,13 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
-* Resume a merged but still unpublished release preparation by validating its
-  prior canonical documents, rebuilding them atomically from the complete
-  current computation, and then reusing the ordinary reviewed release path.
+* Resume a merged but still unpublished release preparation only when its
+  version, empty Unreleased block, release note, canonical changelog prefix,
+  source SHA, and tree exactly match the current computation. The current main
+  SHA receives fresh independent review without inventing a branch, pull
+  request, merge, or parent. Candidate spelling is then confirmed absent from
+  PyPI, public GHCR manifest inspection, and GitHub releases before the
+  ordinary publication, deployment, verification, and notification tail runs.
 * Retry one transient unbound FastMCP response during the idempotent postmerge
   tag inventory, while preserving strict tool binding and exact merge evidence
   when the bounded retry still fails.

--- a/scripts/operations/release.py
+++ b/scripts/operations/release.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import datetime as dt
 import json
 import os
 import re
@@ -343,10 +344,9 @@ def _prepare(input_document: dict[str, Any]) -> StageResult:
         require_artifact=False,
     )
     context = _extra_context(input_document.get("extra_context"))
-    release_controls = _release_control_evidence(
-        input_document.get("release_controls"),
-        source_revision,
-    )
+    preparation_mode = input_document.get("preparation_mode", "pull_request")
+    if preparation_mode not in {"pull_request", "prepared_unpublished"}:
+        raise ReleaseInputError("preparation_mode is invalid")
 
     changelog = _object(input_document.get("changelog"), "changelog")
     _same_source(
@@ -391,6 +391,80 @@ def _prepare(input_document: dict[str, Any]) -> StageResult:
         raise ReleaseInputError("rollback_point.image does not match rollback_point.digest")
     if rollback.get("keel_policy") != "never":
         raise ReleaseInputError("rollback_point.keel_policy must be never")
+
+    if preparation_mode == "prepared_unpublished":
+        if "release_pr" in input_document or "release_controls" in input_document:
+            raise ReleaseInputError(
+                "prepared unpublished evidence must not contain pull request controls"
+            )
+        if changelog.get("document_mode") != "prepared_unpublished":
+            raise ReleaseInputError(
+                "prepared unpublished changelog document mode is invalid"
+            )
+        prepared_main = _object(
+            input_document.get("prepared_main"),
+            "prepared_main",
+        )
+        expected_fields = {
+            "changelog_hash",
+            "release_date",
+            "release_note_hash",
+            "source_revision",
+            "tree_revision",
+            "version",
+        }
+        if set(prepared_main) != expected_fields:
+            raise ReleaseInputError("prepared_main fields are invalid")
+        _same_source(
+            source_revision,
+            prepared_main.get("source_revision"),
+            "prepared_main.source_revision",
+        )
+        if prepared_main.get("version") != version:
+            raise ReleaseInputError("prepared_main.version does not match the candidate")
+        tree_revision = _sha40(
+            prepared_main.get("tree_revision"),
+            "prepared_main.tree_revision",
+        )
+        if _hash(
+            prepared_main.get("changelog_hash"),
+            "prepared_main.changelog_hash",
+        ) != changelog_hash:
+            raise ReleaseInputError("prepared_main changelog hash changed")
+        release_note_hash = _hash(
+            prepared_main.get("release_note_hash"),
+            "prepared_main.release_note_hash",
+        )
+        release_date = _string(
+            prepared_main.get("release_date"),
+            "prepared_main.release_date",
+        )
+        try:
+            dt.date.fromisoformat(release_date)
+        except ValueError as error:
+            raise ReleaseInputError("prepared_main.release_date is invalid") from error
+        return _result(
+            "pass",
+            f"prepared unpublished release {version} is bound to current main",
+            {
+                "source_revision": source_revision,
+                "version": version,
+                "preparation_mode": preparation_mode,
+                "prepared_tree_revision": tree_revision,
+                "release_note_hash": release_note_hash,
+                "extra_context": context,
+                "changelog_hash": changelog_hash,
+                "security_hash": security_hash,
+                "tests_hash": tests_hash,
+                "rollback_digest": rollback_digest,
+            },
+            {"preparation_reference": f"origin/main@{source_revision}"},
+        )
+
+    release_controls = _release_control_evidence(
+        input_document.get("release_controls"),
+        source_revision,
+    )
 
     release_pr = _object(
         input_document.get("release_pr"),
@@ -631,19 +705,48 @@ def _deliver(input_document: dict[str, Any]) -> StageResult:
         delivery_proof.get("delivery_tree_revision"),
         "delivery_proof.delivery_tree_revision",
     )
-    sole_parent_revision = _sha40(
-        delivery_proof.get("sole_parent_revision"),
-        "delivery_proof.sole_parent_revision",
-    )
-    _true(delivery_proof.get("merge_confirmed"), "delivery_proof.merge_confirmed")
     if delivery_revision != source_revision:
         raise ReleaseInputError("delivery proof revision does not match delivered source")
-    if approved_candidate_revision == delivery_revision:
-        raise ReleaseInputError("approved candidate and squash delivery revisions must differ")
     if reviewed_tree_revision != delivery_tree_revision:
         raise ReleaseInputError("delivery tree does not match the reviewed candidate tree")
-    if sole_parent_revision != admitted_revision:
-        raise ReleaseInputError("delivery parent does not match the admitted revision")
+    preparation_mode = delivery_proof.get("preparation_mode", "pull_request")
+    if preparation_mode == "prepared_unpublished":
+        if "sole_parent_revision" in delivery_proof:
+            raise ReleaseInputError(
+                "prepared unpublished delivery must not invent a merge parent"
+            )
+        if delivery_proof.get("merge_confirmed") is not False:
+            raise ReleaseInputError(
+                "prepared unpublished delivery must not claim a merge"
+            )
+        _true(delivery_proof.get("merge_skipped"), "delivery_proof.merge_skipped")
+        if not (
+            admitted_revision
+            == approved_candidate_revision
+            == delivery_revision
+        ):
+            raise ReleaseInputError(
+                "prepared unpublished delivery source identity changed"
+            )
+    elif preparation_mode == "pull_request":
+        sole_parent_revision = _sha40(
+            delivery_proof.get("sole_parent_revision"),
+            "delivery_proof.sole_parent_revision",
+        )
+        _true(
+            delivery_proof.get("merge_confirmed"),
+            "delivery_proof.merge_confirmed",
+        )
+        if approved_candidate_revision == delivery_revision:
+            raise ReleaseInputError(
+                "approved candidate and squash delivery revisions must differ"
+            )
+        if sole_parent_revision != admitted_revision:
+            raise ReleaseInputError(
+                "delivery parent does not match the admitted revision"
+            )
+    else:
+        raise ReleaseInputError("delivery_proof.preparation_mode is invalid")
     candidate_tag = candidate["candidate_tag"]
 
     workflows = input_document.get("workflows")
@@ -730,6 +833,7 @@ def _deliver(input_document: dict[str, Any]) -> StageResult:
             "candidate_tag": candidate_tag,
             "delivery_revision": delivery_revision,
             "delivery_tree_revision": delivery_tree_revision,
+            "preparation_mode": preparation_mode,
             "digest": digest,
             "workflows": sorted(required),
         },
@@ -1432,11 +1536,6 @@ def execute_release_run(
                 "response_contract with no markdown or prose."
             ),
             "prepared_evidence": prepared["evidence"],
-            "release_controls": {
-                key: value
-                for key, value in prepared_input["release_controls"].items()
-                if key != "review_decision"
-            },
             "response_contract": {
                 "actual_model": "exact invoked model identifier",
                 "verdict": "pass or fail",
@@ -1446,6 +1545,20 @@ def execute_release_run(
             "source_revision": candidate_revision,
             "validation_evidence": validation["evidence"],
         }
+        if prepared_input.get("preparation_mode") == "prepared_unpublished":
+            packet["preparation_controls"] = _object(
+                prepared_input.get("prepared_main"),
+                "prepared_main",
+            )
+        else:
+            packet["release_controls"] = {
+                key: value
+                for key, value in _object(
+                    prepared_input.get("release_controls"),
+                    "release_controls",
+                ).items()
+                if key != "review_decision"
+            }
         review = _invoke_review(run_input, dependencies, ticket, packet)
         approval = _collect_candidate_approval(
             run_input,
@@ -1508,6 +1621,15 @@ def execute_release_run(
         record(
             _milestone(6, "verify", verification["reason"], verification["evidence"])
         )
+        preparation_reference: dict[str, Any] = {}
+        if "release_pr_number" in prepared["outputs"]:
+            preparation_reference["release_pr_number"] = prepared["outputs"][
+                "release_pr_number"
+            ]
+        if "preparation_reference" in prepared["outputs"]:
+            preparation_reference["preparation_reference"] = prepared["outputs"][
+                "preparation_reference"
+            ]
         record(
             _project_result(
                 7,
@@ -1520,9 +1642,7 @@ def execute_release_run(
                     "rollback_digest": prepared["evidence"][
                         "rollback_digest"
                     ],
-                    "release_pr_number": prepared["outputs"][
-                        "release_pr_number"
-                    ],
+                    **preparation_reference,
                 },
                 candidate_revision=candidate_revision,
                 review_model_use_id=review["model_use_id"],

--- a/scripts/operations/release_runtime.py
+++ b/scripts/operations/release_runtime.py
@@ -470,6 +470,109 @@ def render_release_documents(
     }
 
 
+def validate_prepared_release_documents(
+    repository_root: Path,
+    version: str,
+    changes: dict[str, Any],
+) -> dict[str, str]:
+    """Prove an exact prepared release state without changing any file."""
+    if re.fullmatch(r"[0-9]+\.[0-9]+\.[0-9]+", version) is None:
+        raise ValueError("release version must be X.Y.Z")
+    sections = _release_sections(changes)
+
+    pyproject = (repository_root / "pyproject.toml").read_text(encoding="utf-8")
+    project_versions = re.findall(r'(?m)^version = "([^"]+)"\s*$', pyproject)
+    if project_versions != [version]:
+        raise ValueError("prepared pyproject version does not match the release")
+
+    note_path = repository_root / "docs" / "releases" / f"v{version}.md"
+    if not note_path.is_file():
+        raise ValueError("prepared release note is missing")
+    release_note = note_path.read_text(encoding="utf-8")
+    if _parse_release_note(release_note, version) != sections:
+        raise ValueError("prepared release note does not match current computation")
+
+    changelog = (repository_root / "CHANGELOG.md").read_text(encoding="utf-8")
+    marker = "## [Unreleased]"
+    if changelog.count(marker) != 1:
+        raise ValueError("prepared changelog must contain one Unreleased section")
+    target_pattern = re.compile(
+        rf"(?m)^## \[{re.escape(version)}\] - "
+        r"([0-9]{4}-[0-9]{2}-[0-9]{2})$"
+    )
+    target_matches = list(target_pattern.finditer(changelog))
+    if len(target_matches) != 1:
+        raise ValueError("prepared changelog must contain one target release")
+    target = target_matches[0]
+    marker_start = changelog.index(marker)
+    marker_end = marker_start + len(marker)
+    if target.start() <= marker_end:
+        raise ValueError("prepared changelog target must follow Unreleased")
+    if changelog[marker_end : target.start()] != "\n\n":
+        raise ValueError("prepared changelog Unreleased section must be empty")
+
+    release_header = re.compile(
+        r"(?m)^## \[[0-9]+\.[0-9]+\.[0-9]+\] - "
+        r"[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+    )
+    first_release = release_header.search(changelog, marker_end)
+    if first_release is None or first_release.start() != target.start():
+        raise ValueError("prepared changelog target must be the first release")
+    body_start = target.end()
+    if changelog[body_start : body_start + 2] != "\n\n":
+        raise ValueError("prepared changelog target spacing is invalid")
+    body_start += 2
+    next_release = release_header.search(changelog, body_start)
+    body_end = next_release.start() if next_release is not None else len(changelog)
+    target_body = changelog[body_start:body_end]
+    canonical = _render_change_sections(sections, heading_level=3)
+    boundary = target_body[len(canonical) : len(canonical) + 1]
+    if not target_body.startswith(canonical) or boundary not in {"", "\n"}:
+        raise ValueError("prepared changelog canonical prefix is invalid")
+
+    release_date = target.group(1)
+    try:
+        dt.date.fromisoformat(release_date)
+    except ValueError as error:
+        raise ValueError("prepared changelog release date is invalid") from error
+    note_hash = _sha256_text(release_note)
+    return {
+        "changelog_hash": _sha256_text(changelog),
+        "content_hash": note_hash,
+        "document_mode": "prepared_unpublished",
+        "release_date": release_date,
+        "release_note_hash": note_hash,
+    }
+
+
+def _has_prepared_release_indicators(
+    repository_root: Path,
+    version: str,
+) -> bool:
+    pyproject_path = repository_root / "pyproject.toml"
+    pyproject = (
+        pyproject_path.read_text(encoding="utf-8")
+        if pyproject_path.is_file()
+        else ""
+    )
+    declared_versions = re.findall(r'(?m)^version = "([^"]+)"\s*$', pyproject)
+    note_exists = (
+        repository_root / "docs" / "releases" / f"v{version}.md"
+    ).exists()
+    changelog_path = repository_root / "CHANGELOG.md"
+    changelog = (
+        changelog_path.read_text(encoding="utf-8")
+        if changelog_path.is_file()
+        else ""
+    )
+    target_exists = re.search(
+        rf"(?m)^## \[{re.escape(version)}\] - "
+        r"[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+        changelog,
+    ) is not None
+    return declared_versions == [version] or note_exists or target_exists
+
+
 def completed_check_evidence(
     payload: dict[str, Any],
     *,
@@ -1497,6 +1600,36 @@ class ReleaseRuntime:
         finally:
             shutil.rmtree(scratch, ignore_errors=True)
 
+    def _strict_version_free(self, version: str) -> dict[str, Any]:
+        raw = self.command(
+            [
+                "uv",
+                "run",
+                "--python",
+                "3.13",
+                "python",
+                "scripts/version_free.py",
+                "--version",
+                version,
+                "--json",
+            ],
+            timeout=120,
+        )
+        try:
+            evidence = _object(json.loads(raw), "candidate version evidence")
+        except json.JSONDecodeError as error:
+            raise ValueError("candidate version evidence is invalid") from error
+        expected = {
+            "free": True,
+            "ghcr_taken": False,
+            "github_release_taken": False,
+            "pypi_taken": False,
+            "unreachable": [],
+        }
+        if evidence != expected:
+            raise ValueError("candidate version is taken or a registry is unreachable")
+        return evidence
+
     def prepare(
         self,
         run_input: dict[str, Any],
@@ -1520,8 +1653,15 @@ class ReleaseRuntime:
         if self.command(["git", "status", "--porcelain"]):
             raise ValueError("managed release worktree is not clean")
         run_id = str(run_input["run_id"])
+        prepared_unpublished = _has_prepared_release_indicators(
+            self.repository_root,
+            version,
+        )
         authority_intent = (
-            f"Prepare governed Data Olympus release v{version} from "
+            f"Resume governed prepared unpublished Data Olympus release v{version} "
+            f"from exact source {admitted}."
+            if prepared_unpublished
+            else f"Prepare governed Data Olympus release v{version} from "
             f"exact source {admitted}."
         )
         consultation = self.authority_consult(
@@ -1548,9 +1688,17 @@ class ReleaseRuntime:
         gate_receipt = self.authority_gate_check(
             {
                 "action_diff": authority_intent,
-                "action_path": "pyproject.toml",
+                "action_path": (
+                    f"docs/releases/v{version}.md"
+                    if prepared_unpublished
+                    else "pyproject.toml"
+                ),
                 "session_id": run_id,
-                "tool_name": "git commit",
+                "tool_name": (
+                    "release prepared state validation"
+                    if prepared_unpublished
+                    else "git commit"
+                ),
                 "workspace": GITHUB_REPOSITORY,
             }
         )
@@ -1560,6 +1708,59 @@ class ReleaseRuntime:
             or gate_receipt.get("workspace") != GITHUB_REPOSITORY
         ):
             raise ValueError("authority gate receipt is invalid")
+        if prepared_unpublished:
+            document_evidence = validate_prepared_release_documents(
+                self.repository_root,
+                version,
+                changes,
+            )
+            self.command(["git", "fetch", "origin", "main"], timeout=120)
+            if (
+                self.source_revision() != admitted
+                or self.remote_main_revision() != admitted
+            ):
+                raise ValueError("prepared unpublished source changed")
+            tree_revision = self._tree_revision(admitted)
+            gates = self._final_local_gates(admitted, version)
+            live = self.live_statefulset()
+            rollback = deployment_state(live)
+            if not rollback["rollout_complete"]:
+                raise ValueError("current Data Olympus rollback point is not ready")
+            raw = {
+                "candidate": {
+                    "version": version,
+                    "source_revision": admitted,
+                },
+                "preparation_mode": "prepared_unpublished",
+                "extra_context": run_input["extra_context"],
+                "prepared_main": {
+                    "source_revision": admitted,
+                    "tree_revision": tree_revision,
+                    "version": version,
+                    "changelog_hash": document_evidence["changelog_hash"],
+                    "release_note_hash": document_evidence["release_note_hash"],
+                    "release_date": document_evidence["release_date"],
+                },
+                "changelog": {
+                    "source_revision": admitted,
+                    "content_hash": document_evidence["changelog_hash"],
+                    "document_mode": "prepared_unpublished",
+                },
+                "security": gates["security"],
+                "tests": gates["tests"],
+                "rollback_point": {
+                    "digest": rollback["digest"],
+                    "image": f"{IMAGE_REPOSITORY}@{rollback['digest']}",
+                    "keel_policy": "never",
+                },
+            }
+            self._prepared = {
+                "raw": raw,
+                "gates": gates,
+                "document_evidence": document_evidence,
+                "preparation_mode": "prepared_unpublished",
+            }
+            return raw
         run_suffix = run_id.split("-", 1)[0]
         branch = f"chore/release-v{version}-{run_suffix}"
         self.command(["git", "switch", "-c", branch, admitted])
@@ -1679,6 +1880,45 @@ class ReleaseRuntime:
             raise ValueError("release preparation evidence is unavailable")
         candidate = _object(self._prepared["raw"]["candidate"], "candidate")
         source_revision = candidate["source_revision"]
+        if self._prepared["raw"].get("preparation_mode") == "prepared_unpublished":
+            prepared_main = _object(
+                self._prepared["raw"].get("prepared_main"),
+                "prepared main",
+            )
+            self.command(["git", "fetch", "origin", "main"], timeout=120)
+            if (
+                self.remote_main_revision() != source_revision
+                or self.source_revision() != source_revision
+                or self._tree_revision(source_revision)
+                != prepared_main["tree_revision"]
+            ):
+                raise ValueError("prepared unpublished candidate changed")
+            computation = _object(
+                _object(_admission.get("evidence"), "admission evidence").get(
+                    "computed_release"
+                ),
+                "computed release",
+            )
+            current_documents = validate_prepared_release_documents(
+                self.repository_root,
+                candidate["version"],
+                _object(computation.get("changes"), "computed release changes"),
+            )
+            if current_documents != self._prepared["document_evidence"]:
+                raise ValueError("prepared unpublished documents changed")
+            gates = self._prepared["gates"]
+            return {
+                "candidate": candidate,
+                "current_source_revision": source_revision,
+                "ci": {
+                    "source_revision": source_revision,
+                    "all_success": gates["ci"]["all_success"],
+                    "missing_required": gates["ci"]["missing_required"],
+                },
+                "security": {"exit_code": gates["security"]["exit_code"]},
+                "version_free": gates["version_free"],
+                "tests": gates["tests"],
+            }
         base_revision = self._prepared["raw"]["release_pr"]["base_source_revision"]
         if (
             self.remote_main_revision() != base_revision
@@ -2161,38 +2401,85 @@ class ReleaseRuntime:
             or review_evidence.get("source_revision") != candidate_revision
         ):
             raise ValueError("independent candidate approval is unavailable")
-        release_pr = _object(
-            self._prepared["raw"].get("release_pr"),
-            "release pull request",
+        preparation_mode = self._prepared["raw"].get(
+            "preparation_mode",
+            "pull_request",
         )
-        number = release_pr["number"]
-        base_revision = release_pr["base_source_revision"]
-        head_tree_revision = release_pr["head_tree_revision"]
-        ready = self._wait_pull_request(
-            number,
-            candidate_revision,
-            base_revision,
-        )
-        if ready["controls"] != self._prepared["release_controls"]:
-            raise ValueError("release controls changed after independent review")
-        self.command(["git", "fetch", "origin", "main"], timeout=120)
-        if (
-            self.remote_main_revision() != base_revision
-            or self.source_revision() != candidate_revision
-            or self._tree_revision(candidate_revision) != head_tree_revision
-        ):
-            raise ValueError("release candidate changed before approved merge")
-        source_revision, delivery_proof = self._merge_and_prove_delivery(
-            number=number,
-            version=version,
-            head_revision=candidate_revision,
-            head_tree_revision=head_tree_revision,
-            base_revision=base_revision,
-        )
+        number: int | None = None
+        if preparation_mode == "prepared_unpublished":
+            prepared_main = _object(
+                self._prepared["raw"].get("prepared_main"),
+                "prepared main",
+            )
+            self.command(["git", "fetch", "origin", "main"], timeout=120)
+            if (
+                self.remote_main_revision() != candidate_revision
+                or self.source_revision() != candidate_revision
+                or self._tree_revision(candidate_revision)
+                != prepared_main["tree_revision"]
+            ):
+                raise ValueError("prepared unpublished candidate changed before delivery")
+            admission_changes = _object(
+                _object(_admission.get("evidence"), "admission evidence").get(
+                    "computed_release"
+                ),
+                "computed release",
+            ).get("changes")
+            documents = validate_prepared_release_documents(
+                self.repository_root,
+                version,
+                _object(admission_changes, "computed release changes"),
+            )
+            if documents != self._prepared["document_evidence"]:
+                raise ValueError("prepared unpublished documents changed before delivery")
+            source_revision = candidate_revision
+            delivery_proof = {
+                "preparation_mode": "prepared_unpublished",
+                "admitted_revision": candidate_revision,
+                "approved_candidate_revision": candidate_revision,
+                "delivery_revision": candidate_revision,
+                "delivery_tree_revision": prepared_main["tree_revision"],
+                "merge_confirmed": False,
+                "merge_skipped": True,
+                "reviewed_tree_revision": prepared_main["tree_revision"],
+            }
+        elif preparation_mode == "pull_request":
+            release_pr = _object(
+                self._prepared["raw"].get("release_pr"),
+                "release pull request",
+            )
+            number = release_pr["number"]
+            base_revision = release_pr["base_source_revision"]
+            head_tree_revision = release_pr["head_tree_revision"]
+            ready = self._wait_pull_request(
+                number,
+                candidate_revision,
+                base_revision,
+            )
+            if ready["controls"] != self._prepared["release_controls"]:
+                raise ValueError("release controls changed after independent review")
+            self.command(["git", "fetch", "origin", "main"], timeout=120)
+            if (
+                self.remote_main_revision() != base_revision
+                or self.source_revision() != candidate_revision
+                or self._tree_revision(candidate_revision) != head_tree_revision
+            ):
+                raise ValueError("release candidate changed before approved merge")
+            source_revision, delivery_proof = self._merge_and_prove_delivery(
+                number=number,
+                version=version,
+                head_revision=candidate_revision,
+                head_tree_revision=head_tree_revision,
+                base_revision=base_revision,
+            )
+        else:
+            raise ValueError("release preparation mode is invalid")
         try:
             final_gates = self._final_local_gates(source_revision, version)
             tags = self._list_tags()
         except (OSError, subprocess.SubprocessError, ValueError) as error:
+            if preparation_mode == "prepared_unpublished":
+                raise
             raise ReleaseDeliveryError(
                 str(error),
                 {
@@ -2208,6 +2495,20 @@ class ReleaseRuntime:
                 tag_names.append(raw_tag["name"])
         rc_number = next_rc_number(version, tag_names)
         candidate_tag = f"{version}-rc.{rc_number}"
+        try:
+            candidate_availability = self._strict_version_free(candidate_tag)
+        except (OSError, subprocess.SubprocessError, ValueError) as error:
+            if preparation_mode == "prepared_unpublished":
+                raise
+            raise ReleaseDeliveryError(
+                str(error),
+                {
+                    **delivery_proof,
+                    "external_state_changed": True,
+                    "release_pr_number": number,
+                    "rollback_completed": False,
+                },
+            ) from error
         rollback_digest = self._prepared["raw"]["rollback_point"]["digest"]
         deployment_started = False
         external_state_changed = False
@@ -2333,6 +2634,7 @@ class ReleaseRuntime:
             "raw": raw,
             "acceptance": stable_acceptance,
             "candidate_publication": publication,
+            "candidate_version_free": candidate_availability,
             "final_gates": final_gates,
             "stable_publication": stable,
         }

--- a/scripts/version_free.py
+++ b/scripts/version_free.py
@@ -102,19 +102,27 @@ def _pypi_present(version: str, package: str = "data-olympus") -> bool | None:
 
 
 def _ghcr_present(tag: str, package: str = "data-olympus") -> bool | None:
-    out = subprocess.run(
-        [
-            "gh", "api",
-            "--paginate",
-            f"/orgs/knaisoma/packages/container/{package}/versions",
-            "--jq", ".[].metadata.container.tags[]",
-        ],
-        capture_output=True, text=True,
-    )
-    if out.returncode != 0:
+    reference = f"ghcr.io/knaisoma/{package}:{tag}"
+    try:
+        out = subprocess.run(
+            ["docker", "buildx", "imagetools", "inspect", reference],
+            capture_output=True,
+            stdin=subprocess.DEVNULL,
+            text=True,
+            timeout=30,
+        )
+    except (OSError, subprocess.TimeoutExpired):
         return None
-    tags = {line.strip() for line in out.stdout.splitlines() if line.strip()}
-    return tag in tags
+    if out.returncode == 0:
+        return True
+    diagnostic = f"{out.stdout}\n{out.stderr}".lower()
+    if (
+        "manifest unknown" in diagnostic
+        or "no such manifest" in diagnostic
+        or f"{reference.lower()}: not found" in diagnostic
+    ):
+        return False
+    return None
 
 
 def _gh_release_present(tag: str, repo: str = "knaisoma/data-olympus") -> bool | None:

--- a/tests/test_operations_release.py
+++ b/tests/test_operations_release.py
@@ -257,6 +257,68 @@ def test_prepare_blocks_when_the_release_pr_was_merged_before_review() -> None:
     assert "must remain unmerged" in result["reason"]
 
 
+def _prepared_unpublished_input() -> dict[str, object]:
+    return {
+        "candidate": {"version": "0.6.1", "source_revision": SOURCE_SHA},
+        "preparation_mode": "prepared_unpublished",
+        "extra_context": DEFAULT_EXTRA_CONTEXT,
+        "prepared_main": {
+            "source_revision": SOURCE_SHA,
+            "tree_revision": BRANCH_SHA,
+            "version": "0.6.1",
+            "changelog_hash": "1" * 64,
+            "release_note_hash": "2" * 64,
+            "release_date": "2026-08-02",
+        },
+        "changelog": {
+            "source_revision": SOURCE_SHA,
+            "content_hash": "1" * 64,
+            "document_mode": "prepared_unpublished",
+        },
+        "security": {"exit_code": 0, "report_hash": "3" * 64},
+        "tests": {
+            "source_revision": SOURCE_SHA,
+            "passed": True,
+            "evidence_hash": "4" * 64,
+        },
+        "rollback_point": {
+            "image": f"ghcr.io/knaisoma/data-olympus@{PREVIOUS_DIGEST}",
+            "digest": PREVIOUS_DIGEST,
+            "keel_policy": "never",
+        },
+    }
+
+
+def test_prepare_accepts_only_exact_prepared_unpublished_main_without_a_pr() -> None:
+    result = evaluate_stage("prepare", _prepared_unpublished_input())
+
+    assert result["status"] == "pass"
+    assert result["evidence"]["preparation_mode"] == "prepared_unpublished"
+    assert result["evidence"]["prepared_tree_revision"] == BRANCH_SHA
+    assert result["outputs"] == {
+        "preparation_reference": f"origin/main@{SOURCE_SHA}"
+    }
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        lambda value: value.__setitem__("release_pr", {"number": 178}),
+        lambda value: value["prepared_main"].__setitem__(
+            "source_revision", CANDIDATE_SHA
+        ),
+        lambda value: value["changelog"].__setitem__("document_mode", "normal"),
+    ],
+)
+def test_prepare_rejects_ambiguous_prepared_unpublished_evidence(mutate) -> None:
+    input_document = _prepared_unpublished_input()
+    mutate(input_document)
+
+    result = evaluate_stage("prepare", input_document)
+
+    assert result["status"] == "blocked"
+
+
 def test_validate_requires_unchanged_candidate_and_all_exact_gates() -> None:
     result = evaluate_stage(
         "validate",
@@ -458,6 +520,68 @@ def test_deliver_accepts_only_existing_workflows_bound_to_candidate() -> None:
 
     assert result["status"] == "pass"
     assert result["outputs"]["published_version"] == "0.6.1"
+
+
+def test_deliver_accepts_reviewed_prepared_unpublished_source_without_merge() -> None:
+    input_document = {
+        "candidate": _candidate(),
+        "current_source_revision": SOURCE_SHA,
+        "delivery_proof": {
+            "preparation_mode": "prepared_unpublished",
+            "admitted_revision": SOURCE_SHA,
+            "approved_candidate_revision": SOURCE_SHA,
+            "delivery_revision": SOURCE_SHA,
+            "delivery_tree_revision": BRANCH_SHA,
+            "merge_confirmed": False,
+            "merge_skipped": True,
+            "reviewed_tree_revision": BRANCH_SHA,
+        },
+        "workflows": [
+            {
+                "name": "rc-publish.yml",
+                "conclusion": "success",
+                "source_revision": SOURCE_SHA,
+                "candidate_tag": "0.6.1-rc.1",
+            },
+            {
+                "name": "tag-release.yml",
+                "conclusion": "success",
+                "source_revision": SOURCE_SHA,
+                "candidate_tag": "0.6.1-rc.1",
+            },
+            {
+                "name": "set-channel.yml",
+                "conclusion": "success",
+                "source_revision": SOURCE_SHA,
+                "source_tag": "v0.6.1",
+            },
+        ],
+        "canary": {
+            "candidate_tag": "0.6.1-rc.1",
+            "source_revision": SOURCE_SHA,
+            "digest": IMAGE_DIGEST,
+            "keel_policy": "never",
+            "rollout_complete": True,
+            "healthy": True,
+            "ready": True,
+            "mcp_search": True,
+            "enforcement": True,
+        },
+        "deployment": {
+            "keel_policy": "never",
+            "image_digest": IMAGE_DIGEST,
+            "source_revision": SOURCE_SHA,
+            "rollout_complete": True,
+        },
+    }
+
+    result = evaluate_stage("deliver", input_document)
+
+    assert result["status"] == "pass"
+    assert result["evidence"]["preparation_mode"] == "prepared_unpublished"
+
+    input_document["delivery_proof"]["merge_confirmed"] = True
+    assert evaluate_stage("deliver", input_document)["status"] == "failed"
 
 
 def test_deliver_fails_stable_promotion_without_verified_canary() -> None:
@@ -1023,6 +1147,128 @@ def test_one_release_command_emits_the_exact_runner_protocol() -> None:
         "candidate_revision": CANDIDATE_SHA,
         "review_model_use_id": 71,
     }
+
+
+def test_release_command_reviews_and_delivers_prepared_unpublished_main() -> None:
+    dependencies = _release_dependencies()
+    captured: dict[str, object] = {}
+    artifact_candidate = _candidate()
+    prepared = _prepared_unpublished_input()
+
+    dependencies.update(
+        {
+            "candidate_revision": lambda: SOURCE_SHA,
+            "prepare": lambda _run, _admitted: prepared,
+            "validate": lambda _run, _admitted, _prepared: {
+                "candidate": prepared["candidate"],
+                "current_source_revision": SOURCE_SHA,
+                "ci": {
+                    "source_revision": SOURCE_SHA,
+                    "all_success": True,
+                    "missing_required": [],
+                },
+                "security": {"exit_code": 0},
+                "version_free": {"version": "0.6.1", "free": True},
+                "tests": {"source_revision": SOURCE_SHA, "passed": True},
+            },
+            "invoke_model": lambda request: (
+                captured.__setitem__("packet", request["packet"])
+                or _approved_review(request)
+            ),
+            "collect_candidate_approval": lambda run, _candidate, review: {
+                "approval_id_hash": "6" * 64,
+                "authority": "standing-delegation",
+                "candidate_revision": SOURCE_SHA,
+                "contract_digest": run["contract_revision"],
+                "review_model_use_id": review["model_use_id"],
+                "run_id": run["run_id"],
+            },
+            "deliver": lambda _run, _admitted, _prepared, _review: {
+                "candidate": artifact_candidate,
+                "current_source_revision": SOURCE_SHA,
+                "delivery_proof": {
+                    "preparation_mode": "prepared_unpublished",
+                    "admitted_revision": SOURCE_SHA,
+                    "approved_candidate_revision": SOURCE_SHA,
+                    "delivery_revision": SOURCE_SHA,
+                    "delivery_tree_revision": BRANCH_SHA,
+                    "merge_confirmed": False,
+                    "merge_skipped": True,
+                    "reviewed_tree_revision": BRANCH_SHA,
+                },
+                "workflows": [
+                    {
+                        "name": "rc-publish.yml",
+                        "conclusion": "success",
+                        "source_revision": SOURCE_SHA,
+                        "candidate_tag": "0.6.1-rc.1",
+                    },
+                    {
+                        "name": "tag-release.yml",
+                        "conclusion": "success",
+                        "source_revision": SOURCE_SHA,
+                        "candidate_tag": "0.6.1-rc.1",
+                    },
+                    {
+                        "name": "set-channel.yml",
+                        "conclusion": "success",
+                        "source_revision": SOURCE_SHA,
+                        "source_tag": "v0.6.1",
+                    },
+                ],
+                "canary": {
+                    "candidate_tag": "0.6.1-rc.1",
+                    "source_revision": SOURCE_SHA,
+                    "digest": IMAGE_DIGEST,
+                    "keel_policy": "never",
+                    "rollout_complete": True,
+                    "healthy": True,
+                    "ready": True,
+                    "mcp_search": True,
+                    "enforcement": True,
+                },
+                "deployment": {
+                    "keel_policy": "never",
+                    "image_digest": IMAGE_DIGEST,
+                    "source_revision": SOURCE_SHA,
+                    "rollout_complete": True,
+                },
+            },
+            "verify": lambda _run, _admitted, _delivery: {
+                "candidate": artifact_candidate,
+                "github_release": {
+                    "tag": "v0.6.1",
+                    "source_revision": SOURCE_SHA,
+                },
+                "pypi": {
+                    "version": "0.6.1",
+                    "provenance_source_revision": SOURCE_SHA,
+                },
+                "image": {"tag": "v0.6.1", "digest": IMAGE_DIGEST},
+                "deployment": {
+                    "source_revision": SOURCE_SHA,
+                    "digest": IMAGE_DIGEST,
+                    "healthy": True,
+                    "ready": True,
+                    "mcp_search": True,
+                    "enforcement": True,
+                    "documentation": True,
+                },
+            },
+        }
+    )
+
+    events = execute_release_run(json.dumps(RUN_INPUT), dependencies)
+
+    assert events[-1]["status"] == "delivered", events[-1]
+    assert events[-1]["candidate_revision"] == SOURCE_SHA
+    assert events[-1]["evidence"]["preparation_reference"] == (
+        f"origin/main@{SOURCE_SHA}"
+    )
+    assert "release_pr_number" not in events[-1]["evidence"]
+    packet = captured["packet"]
+    assert isinstance(packet, dict)
+    assert packet["preparation_controls"] == prepared["prepared_main"]
 
 
 def test_review_evidence_hash_binds_the_packet_and_claude_response() -> None:

--- a/tests/test_operations_release_runtime.py
+++ b/tests/test_operations_release_runtime.py
@@ -23,6 +23,7 @@ from scripts.operations.release_runtime import (
     governed_release_controls,
     render_release_documents,
     stable_release_evidence,
+    validate_prepared_release_documents,
 )
 
 if TYPE_CHECKING:
@@ -1090,6 +1091,91 @@ def test_render_release_documents_rejects_roll_forward_replay_atomically(
     assert {path: path.read_bytes() for path in paths} == before
 
 
+def _write_resumable_release_documents(root: Path) -> None:
+    _write_prepared_release_documents(root)
+    changelog_path = root / "CHANGELOG.md"
+    changelog_path.write_text(
+        changelog_path.read_text(encoding="utf-8").replace(
+            "## [Unreleased]\n\n"
+            "### Fixed\n\n"
+            "* Retry one transient bound tag inventory response.\n\n",
+            "## [Unreleased]\n\n",
+            1,
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_validate_prepared_release_documents_accepts_exact_unpublished_state(
+    tmp_path: Path,
+) -> None:
+    _write_resumable_release_documents(tmp_path)
+
+    evidence = validate_prepared_release_documents(
+        tmp_path,
+        "0.7.0",
+        {
+            "breaking": [],
+            "features": ["feat(automation): make releases outcome based"],
+            "fixes": ["fix(mcp): preserve exact source evidence"],
+        },
+    )
+
+    assert evidence["document_mode"] == "prepared_unpublished"
+    assert evidence["release_date"] == "2026-08-01"
+    assert len(evidence["changelog_hash"]) == 64
+    assert len(evidence["release_note_hash"]) == 64
+
+
+@pytest.mark.parametrize(
+    ("target", "replacement", "reason"),
+    [
+        (
+            "## [Unreleased]\n\n",
+            "## [Unreleased]\n\n### Fixed\n\n* late change\n\n",
+            "Unreleased",
+        ),
+        (
+            "* fix(mcp): preserve exact source evidence\n",
+            "* fix(mcp): altered release note\n",
+            "release note",
+        ),
+        (
+            "* fix(mcp): preserve exact source evidence\n\n\n### Fixed",
+            "* fix(mcp): altered canonical prefix\n\n\n### Fixed",
+            "canonical prefix",
+        ),
+    ],
+)
+def test_validate_prepared_release_documents_rejects_any_state_drift(
+    tmp_path: Path,
+    target: str,
+    replacement: str,
+    reason: str,
+) -> None:
+    _write_resumable_release_documents(tmp_path)
+    path = (
+        tmp_path / "docs" / "releases" / "v0.7.0.md"
+        if "release note" in reason
+        else tmp_path / "CHANGELOG.md"
+    )
+    path.write_text(
+        path.read_text(encoding="utf-8").replace(target, replacement, 1),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match=reason):
+        validate_prepared_release_documents(
+            tmp_path,
+            "0.7.0",
+            {
+                "breaking": [],
+                "features": ["feat(automation): make releases outcome based"],
+                "fixes": ["fix(mcp): preserve exact source evidence"],
+            },
+        )
+
+
 def test_completed_check_evidence_requires_every_expected_check_and_no_failures() -> None:
     payload = {
         "check_runs": [
@@ -1694,6 +1780,148 @@ def test_prepare_stops_at_the_unmerged_review_candidate(
     ]
 
 
+def test_prepare_recognizes_exact_prepared_unpublished_main_without_mutation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _write_resumable_release_documents(tmp_path)
+    commands: list[list[str]] = []
+    gateway = StubGateway()
+
+    def command_output(command: list[str], _cwd: Path, _timeout: int) -> str:
+        commands.append(command)
+        return ""
+
+    runtime = ReleaseRuntime(
+        tmp_path,
+        gateway=gateway,
+        command_output=command_output,
+        authority_consult=lambda _arguments: {
+            "consulted_at": 1.0,
+            "ttl_seconds": 300,
+        },
+        authority_gate_check=lambda arguments: {
+            "verdict": "allow",
+            "session_id": arguments["session_id"],
+            "workspace": "data-olympus",
+        },
+        clock=lambda: 1.0,
+    )
+    monkeypatch.setattr(runtime, "source_revision", lambda: SOURCE_SHA)
+    monkeypatch.setattr(runtime, "remote_main_revision", lambda: SOURCE_SHA)
+    monkeypatch.setattr(runtime, "_tree_revision", lambda _revision: CANDIDATE_TREE)
+    monkeypatch.setattr(
+        runtime,
+        "_final_local_gates",
+        lambda source, version: {
+            "ci": {"all_success": True, "missing_required": []},
+            "security": {"exit_code": 0, "report_hash": "5" * 64},
+            "tests": {
+                "source_revision": source,
+                "passed": True,
+                "evidence_hash": "6" * 64,
+            },
+            "version_free": {"version": version, "free": True},
+        },
+    )
+    monkeypatch.setattr(
+        "scripts.operations.release_runtime.deployment_state",
+        lambda _statefulset: {
+            "digest": DIGEST,
+            "keel_policy": "never",
+            "rollout_complete": True,
+        },
+    )
+    monkeypatch.setattr(runtime, "live_statefulset", lambda: {})
+
+    result = runtime.prepare(
+        {
+            "extra_context": "No extra context for this run",
+            "run_id": "11111111-2222-4333-8444-555555555555",
+            "source_revision": SOURCE_SHA,
+        },
+        {
+            "evidence": {
+                "computed_release": {
+                    "changes": {
+                        "breaking": [],
+                        "features": [
+                            "feat(automation): make releases outcome based"
+                        ],
+                        "fixes": ["fix(mcp): preserve exact source evidence"],
+                    }
+                }
+            },
+            "outputs": {"candidate": {"version": "0.7.0"}},
+        },
+    )
+
+    assert result["preparation_mode"] == "prepared_unpublished"
+    assert result["candidate"] == {
+        "source_revision": SOURCE_SHA,
+        "version": "0.7.0",
+    }
+    assert result["prepared_main"] == {
+        "changelog_hash": result["changelog"]["content_hash"],
+        "release_date": "2026-08-01",
+        "release_note_hash": result["prepared_main"]["release_note_hash"],
+        "source_revision": SOURCE_SHA,
+        "tree_revision": CANDIDATE_TREE,
+        "version": "0.7.0",
+    }
+    assert "release_pr" not in result
+    assert "release_controls" not in result
+    assert gateway.calls == []
+    assert not any(
+        command[:2] in {
+            ("git", "switch"),
+            ("git", "add"),
+            ("git", "commit"),
+            ("git", "push"),
+        }
+        for command in map(tuple, commands)
+    )
+
+
+def test_strict_version_free_requires_all_candidate_channels_absent(
+    tmp_path: Path,
+) -> None:
+    commands: list[list[str]] = []
+
+    def command_output(command: list[str], _cwd: Path, _timeout: int) -> str:
+        commands.append(command)
+        return json.dumps(
+            {
+                "free": True,
+                "ghcr_taken": False,
+                "github_release_taken": False,
+                "pypi_taken": False,
+                "unreachable": [],
+            }
+        )
+
+    runtime = ReleaseRuntime(
+        tmp_path,
+        gateway=StubGateway(),
+        command_output=command_output,
+    )
+
+    result = runtime._strict_version_free("0.7.0-rc.1")
+
+    assert result["free"] is True
+    assert commands == [[
+        "uv",
+        "run",
+        "--python",
+        "3.13",
+        "python",
+        "scripts/version_free.py",
+        "--version",
+        "0.7.0-rc.1",
+        "--json",
+    ]]
+
+
 def test_deliver_merges_only_after_review_and_proves_exact_tree_transfer(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -1793,6 +2021,20 @@ def test_deliver_merges_only_after_review_and_proves_exact_tree_transfer(
     )
     monkeypatch.setattr(
         runtime,
+        "_strict_version_free",
+        lambda version: (
+            order.append(f"candidate-free:{version}")
+            or {
+                "free": True,
+                "ghcr_taken": False,
+                "github_release_taken": False,
+                "pypi_taken": False,
+                "unreachable": [],
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        runtime,
         "_candidate_publication",
         lambda revision, _version, tag: {
             "candidate_tag": tag,
@@ -1830,7 +2072,17 @@ def test_deliver_merges_only_after_review_and_proves_exact_tree_transfer(
 
     result = runtime.deliver(
         {},
-        {},
+        {
+            "evidence": {
+                "computed_release": {
+                    "changes": {
+                        "breaking": [],
+                        "features": [],
+                        "fixes": ["fix(release): resume prepared release"],
+                    }
+                }
+            }
+        },
         {},
         {
             "status": "pass",
@@ -1855,6 +2107,170 @@ def test_deliver_merges_only_after_review_and_proves_exact_tree_transfer(
     assert order.index("merge") < order.index(f"tree:{DELIVERY_SHA}")
     assert order.index(f"tree:{DELIVERY_SHA}") < order.index("final-gates")
     assert order.index("final-gates") < order.index("workflow:rc-publish.yml")
+
+
+def test_deliver_resumes_exact_prepared_main_and_never_attempts_merge(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    previous = "sha256:" + "e" * 64
+    order: list[str] = []
+    documents = {
+        "changelog_hash": "1" * 64,
+        "content_hash": "2" * 64,
+        "document_mode": "prepared_unpublished",
+        "release_date": "2026-08-02",
+        "release_note_hash": "2" * 64,
+    }
+    runtime = ReleaseRuntime(
+        tmp_path,
+        gateway=StubGateway({"list_tags": []}),
+        command_output=lambda _command, _cwd, _timeout: "",
+    )
+    runtime._prepared = {
+        "raw": {
+            "candidate": {"source_revision": SOURCE_SHA, "version": "0.7.0"},
+            "preparation_mode": "prepared_unpublished",
+            "prepared_main": {
+                "source_revision": SOURCE_SHA,
+                "tree_revision": CANDIDATE_TREE,
+                "version": "0.7.0",
+                "changelog_hash": "1" * 64,
+                "release_note_hash": "2" * 64,
+                "release_date": "2026-08-02",
+            },
+            "rollback_point": {"digest": previous},
+        },
+        "document_evidence": documents,
+    }
+    monkeypatch.setattr(runtime, "remote_main_revision", lambda: SOURCE_SHA)
+    monkeypatch.setattr(runtime, "source_revision", lambda: SOURCE_SHA)
+    monkeypatch.setattr(runtime, "_tree_revision", lambda _revision: CANDIDATE_TREE)
+    monkeypatch.setattr(
+        "scripts.operations.release_runtime.validate_prepared_release_documents",
+        lambda *_arguments: documents,
+    )
+    monkeypatch.setattr(
+        runtime,
+        "_merge_and_prove_delivery",
+        lambda **_arguments: (_ for _ in ()).throw(
+            AssertionError("prepared unpublished delivery must not merge")
+        ),
+    )
+    monkeypatch.setattr(
+        runtime,
+        "_final_local_gates",
+        lambda revision, version: (
+            order.append("final-gates")
+            or {
+                "ci": {"all_success": True, "missing_required": []},
+                "security": {"exit_code": 0},
+                "tests": {"source_revision": revision, "passed": True},
+                "version_free": {"version": version, "free": True},
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        runtime,
+        "_strict_version_free",
+        lambda version: (
+            order.append(f"candidate-free:{version}")
+            or {
+                "free": True,
+                "ghcr_taken": False,
+                "github_release_taken": False,
+                "pypi_taken": False,
+                "unreachable": [],
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        runtime,
+        "_workflow_run",
+        lambda name, revision, _inputs, **_kwargs: (
+            order.append(f"workflow:{name}")
+            or {
+                "conclusion": "success",
+                "run_id": len(order),
+                "source_revision": revision,
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        runtime,
+        "_candidate_publication",
+        lambda revision, _version, tag: {
+            "candidate_tag": tag,
+            "image_digest": DIGEST,
+            "source_revision": revision,
+        },
+    )
+    monkeypatch.setattr(
+        runtime,
+        "_stable_publication",
+        lambda revision, version: {
+            "pypi_version": version,
+            "source_revision": revision,
+        },
+    )
+    monkeypatch.setattr(runtime, "_registry_digest", lambda _tag: DIGEST)
+    monkeypatch.setattr(
+        runtime,
+        "_apply_digest",
+        lambda _digest, **_kwargs: {
+            "keel_policy": "never",
+            "rollout_complete": True,
+        },
+    )
+    monkeypatch.setattr(
+        runtime,
+        "_service_acceptance",
+        lambda: {
+            "enforcement": True,
+            "healthy": True,
+            "mcp_search": True,
+            "ready": True,
+        },
+    )
+
+    result = runtime.deliver(
+        {},
+        {
+            "evidence": {
+                "computed_release": {
+                    "changes": {
+                        "breaking": [],
+                        "features": [],
+                        "fixes": ["fix(release): resume prepared release"],
+                    }
+                }
+            }
+        },
+        {},
+        {
+            "status": "pass",
+            "evidence": {
+                "reviewer_family": "claude",
+                "source_revision": SOURCE_SHA,
+            },
+        },
+    )
+
+    assert result["candidate"]["source_revision"] == SOURCE_SHA
+    assert result["delivery_proof"] == {
+        "preparation_mode": "prepared_unpublished",
+        "admitted_revision": SOURCE_SHA,
+        "approved_candidate_revision": SOURCE_SHA,
+        "delivery_revision": SOURCE_SHA,
+        "delivery_tree_revision": CANDIDATE_TREE,
+        "merge_confirmed": False,
+        "merge_skipped": True,
+        "reviewed_tree_revision": CANDIDATE_TREE,
+    }
+    assert order.index("final-gates") < order.index("candidate-free:0.7.0-rc.1")
+    assert order.index("candidate-free:0.7.0-rc.1") < order.index(
+        "workflow:rc-publish.yml"
+    )
 
 
 def test_delivery_blocks_ruleset_drift_without_attempting_merge(
@@ -2024,6 +2440,17 @@ def _prime_approved_delivery(
         "_final_local_gates",
         lambda _revision, _version: {},
     )
+    monkeypatch.setattr(
+        runtime,
+        "_strict_version_free",
+        lambda _version: {
+            "free": True,
+            "ghcr_taken": False,
+            "github_release_taken": False,
+            "pypi_taken": False,
+            "unreachable": [],
+        },
+    )
     return {
         "status": "pass",
         "evidence": {
@@ -2061,6 +2488,33 @@ def test_postmerge_tag_inventory_failure_preserves_delivery_proof(
         "rollback_completed": False,
         "sole_parent_revision": SOURCE_SHA,
     }
+
+
+def test_postmerge_candidate_collision_failure_preserves_delivery_proof(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime = ReleaseRuntime(tmp_path, gateway=StubGateway({"list_tags": []}))
+    reviewed = _prime_approved_delivery(
+        runtime,
+        monkeypatch,
+        "sha256:" + "e" * 64,
+    )
+    monkeypatch.setattr(
+        runtime,
+        "_strict_version_free",
+        lambda _version: (_ for _ in ()).throw(
+            ValueError("candidate version is taken")
+        ),
+    )
+
+    with pytest.raises(ReleaseDeliveryError, match="candidate version is taken") as raised:
+        runtime.deliver({}, {}, {}, reviewed)
+
+    assert raised.value.evidence["delivery_revision"] == DELIVERY_SHA
+    assert raised.value.evidence["merge_confirmed"] is True
+    assert raised.value.evidence["release_pr_number"] == 182
+    assert raised.value.evidence["rollback_completed"] is False
 
 
 @pytest.mark.parametrize("dispatch_started", [False, True])

--- a/tests/test_version_free.py
+++ b/tests/test_version_free.py
@@ -1,11 +1,8 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+import pytest
 
-from scripts.version_free import evaluate, main, registry_versions
-
-if TYPE_CHECKING:
-    import pytest
+from scripts.version_free import _ghcr_present, evaluate, main, registry_versions
 
 
 def test_evaluate_all_absent_is_free() -> None:
@@ -104,3 +101,66 @@ def test_main_queries_candidate_registry_spellings(
         "ghcr": "0.6.0-rc.3",
         "github": "0.6.0-rc.3",
     }
+
+
+def test_ghcr_present_uses_public_manifest_inspection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import scripts.version_free as module
+
+    seen: list[list[str]] = []
+
+    def run(command: list[str], **_kwargs) -> object:
+        seen.append(command)
+        return module.subprocess.CompletedProcess(command, 0, "manifest", "")
+
+    monkeypatch.setattr(module.subprocess, "run", run)
+
+    assert _ghcr_present("0.7.0-rc.1") is True
+    assert seen == [[
+        "docker",
+        "buildx",
+        "imagetools",
+        "inspect",
+        "ghcr.io/knaisoma/data-olympus:0.7.0-rc.1",
+    ]]
+
+
+def test_ghcr_present_accepts_only_explicit_missing_manifest(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import scripts.version_free as module
+
+    monkeypatch.setattr(
+        module.subprocess,
+        "run",
+        lambda *_args, **_kwargs: module.subprocess.CompletedProcess(
+            [], 1, "", "manifest unknown"
+        ),
+    )
+
+    assert _ghcr_present("0.7.0-rc.1") is False
+
+
+@pytest.mark.parametrize(
+    "failure",
+    [
+        "unauthorized",
+        "connection refused",
+    ],
+)
+def test_ghcr_present_fails_closed_on_client_or_registry_error(
+    monkeypatch: pytest.MonkeyPatch,
+    failure: str,
+) -> None:
+    import scripts.version_free as module
+
+    monkeypatch.setattr(
+        module.subprocess,
+        "run",
+        lambda *_args, **_kwargs: module.subprocess.CompletedProcess(
+            [], 1, "", failure
+        ),
+    )
+
+    assert _ghcr_present("0.7.0-rc.1") is None


### PR DESCRIPTION
## Outcome

Add one fail closed recovery for an exact Data Olympus release preparation that is already on origin/main while all selected public release surfaces remain absent.

## Safety

The recovery creates no branch, commit, pull request, merge, or invented parent. It requires fresh independent review, unchanged source and tree, exact canonical documents, complete local gates, a ready rollback point, and strict public candidate absence before workflow dispatch. The ordinary pull request release path remains unchanged.

## Verification

* Complete Python suite passed with the two documented optional dependency skips.
* Ruff passed.
* mypy passed across 73 source files.
* All 74 Bats tests passed.
* Benchmark documentation, bundle lint, and documentation consistency passed.
* Wheel and sdist build and isolated artifact smokes passed.
* Security alerts and stable version availability passed.
* Real v0.7.0 documents validated against the current deterministic computation.
* Real 0.7.0-rc.1 public checks reported PyPI, GHCR, and GitHub releases absent.

## Companion review (Claude Opus 5)

APPROVE on exact staged diff SHA256 239fa820863c13813ea8c570c4441f8993aeb97adc1bced30fd81f504cfa655f and candidate commit 44f56cd506bfa963549f1a9abe43ef552caf3c32.