### PR TITLE
fix(automation): preserve recovery result binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+* Keep the operations runner candidate revision null when resuming a release
+  that is already prepared on `main`, while retaining the exact admitted source
+  revision throughout review, approval, delivery, and verification evidence.
+
 ## [0.7.0] - 2026-08-02
 
 ### New features

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -603,6 +603,15 @@ accepted only when its embedded revision matches the requested source. PyPI
 publishing uses `skip-existing`, followed by exact SHA256 verification. Never
 overwrite an immutable candidate or stable version.
 
+When the operations runner resumes a release that is already prepared and
+unpublished on `main`, it reviews and delivers the admitted source SHA directly.
+The final project result keeps `candidate_revision` null because no derived
+candidate commit exists. The exact source SHA remains mandatory in the review,
+approval, delivery, and verification evidence. Pull request preparation still
+reports its distinct derived candidate revision. This separation prevents the
+central runner from mistaking a prepared source recovery for a newly created
+candidate while preserving end to end source identity.
+
 Yank an unsuitable PyPI candidate and publish a higher candidate number. Roll a
 moving GHCR channel back by applying the channel tag to a previously verified
 digest with `docker buildx imagetools create`. Keep the immutable version tag for

--- a/scripts/operations/release.py
+++ b/scripts/operations/release.py
@@ -1434,6 +1434,7 @@ def execute_release_run(
     run_input: dict[str, Any] | None = None
     events: list[dict[str, Any]] = []
     candidate_revision: str | None = None
+    project_candidate_revision: str | None = None
 
     def record(event: dict[str, Any]) -> dict[str, Any]:
         event["sequence"] = len(events) + 1
@@ -1507,6 +1508,8 @@ def execute_release_run(
             candidate.get("source_revision"),
             "candidate.source_revision",
         )
+        if prepared_input.get("preparation_mode") != "prepared_unpublished":
+            project_candidate_revision = candidate_revision
         record(
             _milestone(2, "prepare", prepared["reason"], prepared["evidence"])
         )
@@ -1644,7 +1647,7 @@ def execute_release_run(
                     ],
                     **preparation_reference,
                 },
-                candidate_revision=candidate_revision,
+                candidate_revision=project_candidate_revision,
                 review_model_use_id=review["model_use_id"],
             )
         )
@@ -1672,7 +1675,7 @@ def execute_release_run(
                 str(error),
                 run_input,
                 failure_evidence,
-                candidate_revision=candidate_revision,
+                candidate_revision=project_candidate_revision,
             )
         )
         return events

--- a/tests/test_operations_release.py
+++ b/tests/test_operations_release.py
@@ -1261,14 +1261,64 @@ def test_release_command_reviews_and_delivers_prepared_unpublished_main() -> Non
     events = execute_release_run(json.dumps(RUN_INPUT), dependencies)
 
     assert events[-1]["status"] == "delivered", events[-1]
-    assert events[-1]["candidate_revision"] == SOURCE_SHA
+    assert events[-1]["candidate_revision"] is None
     assert events[-1]["evidence"]["preparation_reference"] == (
         f"origin/main@{SOURCE_SHA}"
     )
+    assert events[-1]["evidence"]["approved_candidate_revision"] == SOURCE_SHA
+    assert events[-1]["evidence"]["delivery_revision"] == SOURCE_SHA
     assert "release_pr_number" not in events[-1]["evidence"]
     packet = captured["packet"]
     assert isinstance(packet, dict)
+    assert packet["source_revision"] == SOURCE_SHA
+    assert packet["candidate"]["source_revision"] == SOURCE_SHA
     assert packet["preparation_controls"] == prepared["prepared_main"]
+
+
+def test_prepared_unpublished_review_failure_keeps_central_candidate_null() -> None:
+    dependencies = _release_dependencies()
+    captured: dict[str, object] = {}
+    prepared = _prepared_unpublished_input()
+
+    def fail_review(request: dict[str, object]) -> dict[str, object]:
+        captured["packet"] = request["packet"]
+        raise ValueError("review model invocation failed")
+
+    dependencies.update(
+        {
+            "candidate_revision": lambda: SOURCE_SHA,
+            "prepare": lambda _run, _admitted: prepared,
+            "validate": lambda _run, _admitted, _prepared: {
+                "candidate": prepared["candidate"],
+                "current_source_revision": SOURCE_SHA,
+                "ci": {
+                    "source_revision": SOURCE_SHA,
+                    "all_success": True,
+                    "missing_required": [],
+                },
+                "security": {"exit_code": 0},
+                "version_free": {"version": "0.6.1", "free": True},
+                "tests": {"source_revision": SOURCE_SHA, "passed": True},
+            },
+            "invoke_model": fail_review,
+        }
+    )
+
+    events = execute_release_run(json.dumps(RUN_INPUT), dependencies)
+
+    assert [event.get("name") for event in events[:-1]] == [
+        "admission",
+        "prepare",
+        "validate",
+    ]
+    assert events[-1]["status"] == "blocked"
+    assert events[-1]["reason"] == "review model invocation failed"
+    assert events[-1]["source_revision"] == SOURCE_SHA
+    assert events[-1]["candidate_revision"] is None
+    packet = captured["packet"]
+    assert isinstance(packet, dict)
+    assert packet["source_revision"] == SOURCE_SHA
+    assert packet["candidate"]["source_revision"] == SOURCE_SHA
 
 
 def test_review_evidence_hash_binds_the_packet_and_claude_response() -> None:


### PR DESCRIPTION
## Summary

* Keep the central candidate revision null when resuming an already prepared unpublished release on main.
* Preserve the exact admitted source SHA in review, approval, delivery, and verification evidence.
* Add success and pre delivery failure regression coverage, plus operations documentation and changelog updates.

## Verification

* 1,951 Python tests passed, with two documented optional dependency skips.
* 74 Bats CLI contracts passed.
* Ruff, strict mypy, benchmark documentation, document consistency, example bundle lint, changelog guard, and diff checks passed.
* Claude Sonnet 5 independently reviewed exact diff `4be684f8451986c5b7e378040a382f77ace635f6bbb18282517c8861459b9070` and returned `APPROVE`.