### PR TITLE
fix(release): preserve prepared roll forward

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * Keep the operations runner candidate revision null when resuming a release
   that is already prepared on `main`, while retaining the exact admitted source
   revision throughout review, approval, delivery, and verification evidence.
+* Select exact prepared recovery only when the current release documents match
+  the complete computed change set. A new reviewed change now reaches the
+  existing atomic roll forward pull request path instead of blocking recovery.
 
 ## [0.7.0] - 2026-08-02
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -612,6 +612,15 @@ reports its distinct derived candidate revision. This separation prevents the
 central runner from mistaking a prepared source recovery for a newly created
 candidate while preserving end to end source identity.
 
+Exact recovery applies only while the prepared documents still match the
+complete computed release change set. If another reviewed commit reaches
+`main` before publication, the next run uses the ordinary isolated branch and
+the deterministic roll forward renderer. That renderer must preserve every
+prior release item, incorporate at least one newly computed item, empty the
+Unreleased section, and pass the full pull request gates before delivery. An
+incomplete, corrupt, replayed, or ambiguous prepared state still fails before
+any commit, push, merge, publication, or deployment.
+
 Yank an unsuitable PyPI candidate and publish a higher candidate number. Roll a
 moving GHCR channel back by applying the channel tag to a previously verified
 digest with `docker buildx imagetools create`. Keep the immutable version tag for

--- a/scripts/operations/release_runtime.py
+++ b/scripts/operations/release_runtime.py
@@ -12,6 +12,7 @@ import time
 import urllib.error
 import urllib.request
 from collections.abc import Callable
+from contextlib import suppress
 from copy import deepcopy
 from hashlib import sha256
 from pathlib import Path
@@ -1653,10 +1654,19 @@ class ReleaseRuntime:
         if self.command(["git", "status", "--porcelain"]):
             raise ValueError("managed release worktree is not clean")
         run_id = str(run_input["run_id"])
-        prepared_unpublished = _has_prepared_release_indicators(
-            self.repository_root,
-            version,
-        )
+        prepared_document_evidence: dict[str, str] | None = None
+        if _has_prepared_release_indicators(self.repository_root, version):
+            # A valid post-preparation change belongs to the existing atomic
+            # roll-forward path. That renderer still rejects every incomplete,
+            # corrupt, or ambiguous prepared state before it changes a
+            # governed file.
+            with suppress(ValueError):
+                prepared_document_evidence = validate_prepared_release_documents(
+                    self.repository_root,
+                    version,
+                    changes,
+                )
+        prepared_unpublished = prepared_document_evidence is not None
         authority_intent = (
             f"Resume governed prepared unpublished Data Olympus release v{version} "
             f"from exact source {admitted}."
@@ -1709,11 +1719,9 @@ class ReleaseRuntime:
         ):
             raise ValueError("authority gate receipt is invalid")
         if prepared_unpublished:
-            document_evidence = validate_prepared_release_documents(
-                self.repository_root,
-                version,
-                changes,
-            )
+            document_evidence = prepared_document_evidence
+            if document_evidence is None:
+                raise ValueError("prepared unpublished evidence is unavailable")
             self.command(["git", "fetch", "origin", "main"], timeout=120)
             if (
                 self.source_revision() != admitted

--- a/tests/test_operations_release_runtime.py
+++ b/tests/test_operations_release_runtime.py
@@ -1627,10 +1627,11 @@ def test_merge_response_distinguishes_no_merge_from_confirmed_missing_identity(
     }
 
 
-def test_prepare_stops_at_the_unmerged_review_candidate(
+def test_prepare_rolls_forward_new_changes_to_unmerged_review_candidate(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    _write_prepared_release_documents(tmp_path)
     consultations: list[dict[str, object]] = []
     gate_checks: list[dict[str, object]] = []
     gateway = StubGateway(
@@ -1664,7 +1665,7 @@ def test_prepare_stops_at_the_unmerged_review_candidate(
         lambda *_arguments: {
             "changelog_hash": "1" * 64,
             "content_hash": "2" * 64,
-            "document_mode": "normal",
+            "document_mode": "roll_forward",
             "release_note_hash": "2" * 64,
         },
     )
@@ -1727,7 +1728,7 @@ def test_prepare_stops_at_the_unmerged_review_candidate(
         {
             "evidence": {
                 "computed_release": {
-                    "changes": {"breaking": [], "features": [], "fixes": []}
+                    "changes": _roll_forward_changes()
                 }
             },
             "outputs": {"candidate": {"version": "0.7.0"}},
@@ -1750,7 +1751,7 @@ def test_prepare_stops_at_the_unmerged_review_candidate(
     }
     assert result["changelog"] == {
         "content_hash": "1" * 64,
-        "document_mode": "normal",
+        "document_mode": "roll_forward",
         "source_revision": CANDIDATE_SHA,
     }
     assert runtime.candidate_revision() == CANDIDATE_SHA


### PR DESCRIPTION
## Summary

* Select exact prepared recovery only when current documents match the full computed release change set.
* Send a legitimate post preparation change through the existing atomic roll forward pull request path.
* Preserve strict rejection of incomplete, corrupt, replayed, or ambiguous prepared state before merge or publication.

## Verification

* 1,951 Python tests passed, with two documented optional dependency skips.
* 74 Bats CLI contracts passed.
* Ruff, strict mypy, benchmark documentation, document consistency, example bundle lint, changelog guard, and diff checks passed.
* Claude Sonnet 5 independently reviewed exact diff `477f351a63de1fc385cbec23c0165a1e148645a30cc6761c4c71167c287b5a50` and returned `APPROVE`.