### PR TITLE
fix(release): ground autonomous review packets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+* Give the autonomous release reviewer the exact bounded, hash bound candidate
+  diff, changelog section, and release note, and preserve its bounded reason
+  when it blocks a release instead of reducing the diagnosis to a generic
+  verdict.
 * Keep the operations runner candidate revision null when resuming a release
   that is already prepared on `main`, while retaining the exact admitted source
   revision throughout review, approval, delivery, and verification evidence.

--- a/scripts/operations/release.py
+++ b/scripts/operations/release.py
@@ -1068,10 +1068,22 @@ _ISSUED_TICKET_FIELDS = {
 }
 _MODEL_RESPONSE_FIELDS = {
     "model_use_id",
+    "reason",
     "route_id",
     "status",
     "verdict",
 }
+_REVIEW_MATERIAL_FIELDS = {
+    "candidate_diff",
+    "candidate_diff_sha256",
+    "changelog_section",
+    "changelog_section_sha256",
+    "mode",
+    "release_note",
+    "release_note_sha256",
+    "source_revision",
+}
+_MAX_REVIEW_MATERIAL_BYTES = 128 * 1024
 _CANDIDATE_APPROVAL_FIELDS = {
     "approval_id_hash",
     "authority",
@@ -1093,6 +1105,48 @@ def _exact_fields(value: dict[str, Any], fields: set[str], name: str) -> None:
         raise ReleaseInputError(f"unknown {name} field: {unknown[0]}")
     if missing:
         raise ReleaseInputError(f"missing {name} field: {missing[0]}")
+
+
+def _review_material(value: Any, candidate_revision: str) -> dict[str, Any]:
+    material = _object(value, "review material")
+    _exact_fields(material, _REVIEW_MATERIAL_FIELDS, "review material")
+    _same_source(
+        candidate_revision,
+        material.get("source_revision"),
+        "review material source_revision",
+    )
+    mode = material.get("mode")
+    if mode not in {"pull_request_diff", "prepared_main_documents"}:
+        raise ReleaseInputError("review material mode is invalid")
+    content_fields = (
+        ("candidate_diff", mode == "prepared_main_documents"),
+        ("changelog_section", False),
+        ("release_note", False),
+    )
+    total_bytes = 0
+    for field, allow_empty in content_fields:
+        content = material.get(field)
+        if type(content) is not str or (not allow_empty and not content.strip()):
+            raise ReleaseInputError(
+                f"review material {field} must be a bounded string"
+            )
+        encoded = content.encode("utf-8")
+        total_bytes += len(encoded)
+        expected_hash = _hash(
+            material.get(f"{field}_sha256"),
+            f"review material {field}_sha256",
+        )
+        if sha256(encoded).hexdigest() != expected_hash:
+            raise ReleaseInputError(
+                f"review material {field} hash does not match"
+            )
+    if mode == "prepared_main_documents" and material["candidate_diff"] != "":
+        raise ReleaseInputError(
+            "prepared main review material must not invent a candidate diff"
+        )
+    if total_bytes > _MAX_REVIEW_MATERIAL_BYTES:
+        raise ReleaseInputError("review material exceeds the bounded packet limit")
+    return material
 
 
 def parse_release_run_input(raw_input: str) -> dict[str, Any]:
@@ -1176,8 +1230,9 @@ def _approved_model_response(value: Any, ticket: dict[str, Any]) -> dict[str, An
         raise ReleaseInputError("review response model use does not match its ticket")
     if response["route_id"] != ticket["route_id"]:
         raise ReleaseInputError("review response route does not match its ticket")
+    reason = _string(response["reason"], "review response reason")
     if response["status"] != "approved" or response["verdict"] != "APPROVE":
-        raise ReleaseInputError("independent review blocked the release")
+        raise ReleaseInputError(f"independent review blocked the release: {reason}")
     return response
 
 
@@ -1528,9 +1583,15 @@ def execute_release_run(
         if revision_reader() != candidate_revision:
             raise ReleaseInputError("candidate revision changed during validation")
 
+        candidate_material = _review_material(
+            prepared_input.get("review_material"),
+            candidate_revision,
+        )
+
         ticket = _request_review_ticket(run_input, dependencies, candidate_revision)
         packet = {
             "candidate": candidate,
+            "candidate_material": candidate_material,
             "instruction": (
                 "Independently review the exact deterministic Data Olympus release "
                 "candidate. Approve only when source identity, tests, security, "

--- a/scripts/operations/release.py
+++ b/scripts/operations/release.py
@@ -1078,6 +1078,7 @@ _REVIEW_MATERIAL_FIELDS = {
     "candidate_diff_sha256",
     "changelog_section",
     "changelog_section_sha256",
+    "changelog_sha256",
     "mode",
     "release_note",
     "release_note_sha256",
@@ -1107,7 +1108,13 @@ def _exact_fields(value: dict[str, Any], fields: set[str], name: str) -> None:
         raise ReleaseInputError(f"missing {name} field: {missing[0]}")
 
 
-def _review_material(value: Any, candidate_revision: str) -> dict[str, Any]:
+def _review_material(
+    value: Any,
+    candidate_revision: str,
+    expected_mode: str,
+    expected_changelog_hash: str,
+    expected_release_note_hash: str,
+) -> dict[str, Any]:
     material = _object(value, "review material")
     _exact_fields(material, _REVIEW_MATERIAL_FIELDS, "review material")
     _same_source(
@@ -1118,8 +1125,12 @@ def _review_material(value: Any, candidate_revision: str) -> dict[str, Any]:
     mode = material.get("mode")
     if mode not in {"pull_request_diff", "prepared_main_documents"}:
         raise ReleaseInputError("review material mode is invalid")
+    if mode != expected_mode:
+        raise ReleaseInputError(
+            "review material mode does not match the release preparation"
+        )
     content_fields = (
-        ("candidate_diff", mode == "prepared_main_documents"),
+        ("candidate_diff", expected_mode == "prepared_main_documents"),
         ("changelog_section", False),
         ("release_note", False),
     )
@@ -1132,6 +1143,8 @@ def _review_material(value: Any, candidate_revision: str) -> dict[str, Any]:
             )
         encoded = content.encode("utf-8")
         total_bytes += len(encoded)
+        if total_bytes > _MAX_REVIEW_MATERIAL_BYTES:
+            raise ReleaseInputError("review material exceeds the bounded packet limit")
         expected_hash = _hash(
             material.get(f"{field}_sha256"),
             f"review material {field}_sha256",
@@ -1140,12 +1153,17 @@ def _review_material(value: Any, candidate_revision: str) -> dict[str, Any]:
             raise ReleaseInputError(
                 f"review material {field} hash does not match"
             )
-    if mode == "prepared_main_documents" and material["candidate_diff"] != "":
+    if (
+        _hash(material.get("changelog_sha256"), "review material changelog_sha256")
+        != expected_changelog_hash
+    ):
+        raise ReleaseInputError("review material changelog document hash changed")
+    if material["release_note_sha256"] != expected_release_note_hash:
+        raise ReleaseInputError("review material release note document hash changed")
+    if expected_mode == "prepared_main_documents" and material["candidate_diff"] != "":
         raise ReleaseInputError(
             "prepared main review material must not invent a candidate diff"
         )
-    if total_bytes > _MAX_REVIEW_MATERIAL_BYTES:
-        raise ReleaseInputError("review material exceeds the bounded packet limit")
     return material
 
 
@@ -1230,7 +1248,9 @@ def _approved_model_response(value: Any, ticket: dict[str, Any]) -> dict[str, An
         raise ReleaseInputError("review response model use does not match its ticket")
     if response["route_id"] != ticket["route_id"]:
         raise ReleaseInputError("review response route does not match its ticket")
-    reason = _string(response["reason"], "review response reason")
+    reason = " ".join(_string(response["reason"], "review response reason").split())
+    if len(reason) > 1024:
+        reason = reason[:1021] + "..."
     if response["status"] != "approved" or response["verdict"] != "APPROVE":
         raise ReleaseInputError(f"independent review blocked the release: {reason}")
     return response
@@ -1583,9 +1603,34 @@ def execute_release_run(
         if revision_reader() != candidate_revision:
             raise ReleaseInputError("candidate revision changed during validation")
 
+        changelog_input = _object(prepared_input.get("changelog"), "changelog")
+        expected_changelog_hash = _hash(
+            changelog_input.get("content_hash"),
+            "changelog.content_hash",
+        )
+        expected_release_note_hash = _hash(
+            changelog_input.get("release_note_hash"),
+            "changelog.release_note_hash",
+        )
+        if prepared_input.get("preparation_mode") == "prepared_unpublished":
+            expected_review_mode = "prepared_main_documents"
+            prepared_main = _object(
+                prepared_input.get("prepared_main"),
+                "prepared_main",
+            )
+            if prepared_main.get("release_note_hash") != expected_release_note_hash:
+                raise ReleaseInputError(
+                    "prepared main release note hash changed before review"
+                )
+        else:
+            expected_review_mode = "pull_request_diff"
+            _object(prepared_input.get("release_pr"), "release_pr")
         candidate_material = _review_material(
             prepared_input.get("review_material"),
             candidate_revision,
+            expected_review_mode,
+            expected_changelog_hash,
+            expected_release_note_hash,
         )
 
         ticket = _request_review_ticket(run_input, dependencies, candidate_revision)

--- a/scripts/operations/release_runtime.py
+++ b/scripts/operations/release_runtime.py
@@ -71,6 +71,7 @@ AuthorityGateCheck = Callable[[dict[str, object]], dict[str, Any]]
 
 MAX_AUTHORITY_CONSULT_AGE_SECONDS = 300.0
 MAX_AUTHORITY_CLOCK_SKEW_SECONDS = 5.0
+MAX_REVIEW_MATERIAL_BYTES = 128 * 1024
 
 
 class ReleaseDeliveryError(ValueError):
@@ -1203,9 +1204,10 @@ class ReleaseRuntime:
             or _SHA40.fullmatch(base_revision) is None
         ):
             raise ValueError("review material source revision is invalid")
-        changelog = (self.repository_root / "CHANGELOG.md").read_text(
-            encoding="utf-8"
-        )
+        changelog = self.command(
+            ["git", "show", f"{source_revision}:CHANGELOG.md"],
+            timeout=120,
+        ) + "\n"
         heading = re.compile(
             rf"^## \[{re.escape(version)}\] - \d{{4}}-\d{{2}}-\d{{2}}\n",
             re.MULTILINE,
@@ -1220,8 +1222,14 @@ class ReleaseRuntime:
         )
         end = following.start() if following is not None else len(changelog)
         changelog_section = changelog[start:end].rstrip() + "\n"
-        release_note_path = self.repository_root / "docs" / "releases" / f"v{version}.md"
-        release_note = release_note_path.read_text(encoding="utf-8")
+        release_note = self.command(
+            [
+                "git",
+                "show",
+                f"{source_revision}:docs/releases/v{version}.md",
+            ],
+            timeout=120,
+        ) + "\n"
         if not release_note.strip():
             raise ValueError("review material release note is empty")
         if source_revision == base_revision:
@@ -1242,6 +1250,11 @@ class ReleaseRuntime:
             )
             if not candidate_diff:
                 raise ValueError("release candidate review diff is empty")
+        if sum(
+            len(content.encode("utf-8"))
+            for content in (candidate_diff, changelog_section, release_note)
+        ) > MAX_REVIEW_MATERIAL_BYTES:
+            raise ValueError("review material exceeds the bounded packet limit")
         return {
             "mode": mode,
             "source_revision": source_revision,
@@ -1251,6 +1264,7 @@ class ReleaseRuntime:
             "changelog_section_sha256": sha256(
                 changelog_section.encode()
             ).hexdigest(),
+            "changelog_sha256": sha256(changelog.encode()).hexdigest(),
             "release_note": release_note,
             "release_note_sha256": sha256(release_note.encode()).hexdigest(),
         }
@@ -1821,6 +1835,7 @@ class ReleaseRuntime:
                     "source_revision": admitted,
                     "content_hash": document_evidence["changelog_hash"],
                     "document_mode": "prepared_unpublished",
+                    "release_note_hash": document_evidence["release_note_hash"],
                 },
                 "security": gates["security"],
                 "tests": gates["tests"],
@@ -1923,6 +1938,7 @@ class ReleaseRuntime:
                 "source_revision": head_revision,
                 "content_hash": document_evidence["changelog_hash"],
                 "document_mode": document_evidence["document_mode"],
+                "release_note_hash": document_evidence["release_note_hash"],
             },
             "security": gates["security"],
             "tests": gates["tests"],

--- a/scripts/operations/release_runtime.py
+++ b/scripts/operations/release_runtime.py
@@ -1192,6 +1192,69 @@ class ReleaseRuntime:
             raise ValueError("git parent evidence is invalid")
         return parts[1:]
 
+    def _review_material(
+        self,
+        version: str,
+        source_revision: str,
+        base_revision: str,
+    ) -> dict[str, str]:
+        if (
+            _SHA40.fullmatch(source_revision) is None
+            or _SHA40.fullmatch(base_revision) is None
+        ):
+            raise ValueError("review material source revision is invalid")
+        changelog = (self.repository_root / "CHANGELOG.md").read_text(
+            encoding="utf-8"
+        )
+        heading = re.compile(
+            rf"^## \[{re.escape(version)}\] - \d{{4}}-\d{{2}}-\d{{2}}\n",
+            re.MULTILINE,
+        )
+        matches = list(heading.finditer(changelog))
+        if len(matches) != 1:
+            raise ValueError("review material release changelog section is ambiguous")
+        start = matches[0].start()
+        following = re.compile(r"^## \[", re.MULTILINE).search(
+            changelog,
+            matches[0].end(),
+        )
+        end = following.start() if following is not None else len(changelog)
+        changelog_section = changelog[start:end].rstrip() + "\n"
+        release_note_path = self.repository_root / "docs" / "releases" / f"v{version}.md"
+        release_note = release_note_path.read_text(encoding="utf-8")
+        if not release_note.strip():
+            raise ValueError("review material release note is empty")
+        if source_revision == base_revision:
+            mode = "prepared_main_documents"
+            candidate_diff = ""
+        else:
+            mode = "pull_request_diff"
+            candidate_diff = self.command(
+                [
+                    "git",
+                    "diff",
+                    "--no-ext-diff",
+                    "--unified=3",
+                    f"{base_revision}..{source_revision}",
+                    "--",
+                ],
+                timeout=120,
+            )
+            if not candidate_diff:
+                raise ValueError("release candidate review diff is empty")
+        return {
+            "mode": mode,
+            "source_revision": source_revision,
+            "candidate_diff": candidate_diff,
+            "candidate_diff_sha256": sha256(candidate_diff.encode()).hexdigest(),
+            "changelog_section": changelog_section,
+            "changelog_section_sha256": sha256(
+                changelog_section.encode()
+            ).hexdigest(),
+            "release_note": release_note,
+            "release_note_sha256": sha256(release_note.encode()).hexdigest(),
+        }
+
     def collect_admission(self, run_input: dict[str, Any]) -> dict[str, Any]:
         admitted = run_input.get("source_revision")
         if type(admitted) is not str or _SHA40.fullmatch(admitted) is None:
@@ -1740,6 +1803,11 @@ class ReleaseRuntime:
                     "source_revision": admitted,
                 },
                 "preparation_mode": "prepared_unpublished",
+                "review_material": self._review_material(
+                    version,
+                    admitted,
+                    admitted,
+                ),
                 "extra_context": run_input["extra_context"],
                 "prepared_main": {
                     "source_revision": admitted,
@@ -1844,6 +1912,11 @@ class ReleaseRuntime:
         }
         raw = {
             "candidate": review_candidate,
+            "review_material": self._review_material(
+                version,
+                head_revision,
+                admitted,
+            ),
             "extra_context": run_input["extra_context"],
             "release_controls": ready["controls"],
             "changelog": {

--- a/tests/test_operations_release.py
+++ b/tests/test_operations_release.py
@@ -23,6 +23,35 @@ AUTHORITY_SHA = "b" * 40
 CONTRACT_SHA = "c" * 64
 IMAGE_DIGEST = "sha256:" + "d" * 64
 PREVIOUS_DIGEST = "sha256:" + "e" * 64
+RELEASE_NOTE = "# data-olympus 0.6.1\n\n## Fixed\n\n* Exact release evidence.\n"
+CHANGELOG_SECTION = (
+    "## [0.6.1] - 2026-08-02\n\n### Fixed\n\n"
+    "* Exact release evidence.\n"
+)
+CANDIDATE_DIFF = (
+    "diff --git a/CHANGELOG.md b/CHANGELOG.md\n"
+    "+## [0.6.1] - 2026-08-02\n"
+)
+
+
+def _review_material(
+    *,
+    mode: str = "pull_request_diff",
+    source_revision: str = CANDIDATE_SHA,
+) -> dict[str, object]:
+    candidate_diff = CANDIDATE_DIFF if mode == "pull_request_diff" else ""
+    return {
+        "mode": mode,
+        "source_revision": source_revision,
+        "candidate_diff": candidate_diff,
+        "candidate_diff_sha256": sha256(candidate_diff.encode()).hexdigest(),
+        "changelog_section": CHANGELOG_SECTION,
+        "changelog_section_sha256": sha256(
+            CHANGELOG_SECTION.encode()
+        ).hexdigest(),
+        "release_note": RELEASE_NOTE,
+        "release_note_sha256": sha256(RELEASE_NOTE.encode()).hexdigest(),
+    }
 
 
 def _candidate() -> dict[str, object]:
@@ -261,6 +290,10 @@ def _prepared_unpublished_input() -> dict[str, object]:
     return {
         "candidate": {"version": "0.6.1", "source_revision": SOURCE_SHA},
         "preparation_mode": "prepared_unpublished",
+        "review_material": _review_material(
+            mode="prepared_main_documents",
+            source_revision=SOURCE_SHA,
+        ),
         "extra_context": DEFAULT_EXTRA_CONTEXT,
         "prepared_main": {
             "source_revision": SOURCE_SHA,
@@ -940,6 +973,7 @@ def _approved_review(request: dict[str, object]) -> dict[str, object]:
     assert isinstance(ticket, dict)
     return {
         "model_use_id": ticket["model_use_id"],
+        "reason": "candidate approved",
         "route_id": ticket["route_id"],
         "status": "approved",
         "verdict": "APPROVE",
@@ -963,6 +997,7 @@ def _release_dependencies(*, source_revision: str = SOURCE_SHA) -> dict[str, obj
         state["head"] = CANDIDATE_SHA
         return {
             "candidate": prepared_candidate,
+            "review_material": _review_material(),
             "release_controls": _release_controls(CANDIDATE_SHA),
             "extra_context": run["extra_context"],
             "changelog": {
@@ -1372,7 +1407,33 @@ def test_release_review_packet_omits_the_validated_prereview_state() -> None:
     release_controls = packet["release_controls"]
     assert isinstance(release_controls, dict)
     assert "review_decision" not in release_controls
+    assert packet["candidate_material"] == _review_material()
     assert events[-1]["status"] == "delivered"
+
+
+def test_release_blocks_before_model_when_review_material_hash_changes() -> None:
+    dependencies = _release_dependencies()
+    original_prepare = dependencies["prepare"]
+    invoked = False
+
+    def prepare(run, admitted):
+        prepared = original_prepare(run, admitted)
+        prepared["review_material"]["release_note_sha256"] = "0" * 64
+        return prepared
+
+    def invoke_model(_request):
+        nonlocal invoked
+        invoked = True
+        raise AssertionError("invalid review material must not reach a model")
+
+    dependencies["prepare"] = prepare
+    dependencies["invoke_model"] = invoke_model
+
+    events = execute_release_run(json.dumps(RUN_INPUT), dependencies)
+
+    assert events[-1]["status"] == "blocked"
+    assert "release_note hash does not match" in events[-1]["reason"]
+    assert invoked is False
 
 
 def test_failed_model_process_is_not_misreported_as_invalid_json(
@@ -1415,6 +1476,7 @@ def test_nonzero_model_block_remains_an_independent_review_block(
 ) -> None:
     response = {
         "model_use_id": 71,
+        "reason": "release note content was absent from the review packet",
         "route_id": "claude-code",
         "status": "blocked",
         "verdict": "BLOCK",
@@ -1439,7 +1501,10 @@ def test_nonzero_model_block_remains_an_independent_review_block(
 
     with pytest.raises(
         ValueError,
-        match="^independent review blocked the release$",
+        match=(
+            "^independent review blocked the release: release note content "
+            "was absent from the review packet$"
+        ),
     ):
         release_module._invoke_ticketed_model_from_runner(
             RUN_INPUT,
@@ -1455,6 +1520,7 @@ def test_nonzero_model_approval_is_still_an_invocation_failure(
 ) -> None:
     response = {
         "model_use_id": 71,
+        "reason": "candidate approved",
         "route_id": "claude-code",
         "status": "approved",
         "verdict": "APPROVE",

--- a/tests/test_operations_release.py
+++ b/tests/test_operations_release.py
@@ -1466,6 +1466,32 @@ def test_pull_request_review_rejects_prepared_main_material_mode() -> None:
     assert invoked is False
 
 
+def test_pull_request_review_rejects_an_empty_candidate_diff() -> None:
+    dependencies = _release_dependencies()
+    original_prepare = dependencies["prepare"]
+    invoked = False
+
+    def prepare(run, admitted):
+        prepared = original_prepare(run, admitted)
+        prepared["review_material"]["candidate_diff"] = ""
+        prepared["review_material"]["candidate_diff_sha256"] = sha256(b"").hexdigest()
+        return prepared
+
+    def invoke_model(_request):
+        nonlocal invoked
+        invoked = True
+        raise AssertionError("empty candidate diff must not reach a model")
+
+    dependencies["prepare"] = prepare
+    dependencies["invoke_model"] = invoke_model
+
+    events = execute_release_run(json.dumps(RUN_INPUT), dependencies)
+
+    assert events[-1]["status"] == "blocked"
+    assert "candidate_diff must be a bounded string" in events[-1]["reason"]
+    assert invoked is False
+
+
 def test_failed_model_process_is_not_misreported_as_invalid_json(
     monkeypatch,
     tmp_path,

--- a/tests/test_operations_release.py
+++ b/tests/test_operations_release.py
@@ -45,6 +45,7 @@ def _review_material(
         "source_revision": source_revision,
         "candidate_diff": candidate_diff,
         "candidate_diff_sha256": sha256(candidate_diff.encode()).hexdigest(),
+        "changelog_sha256": "1" * 64,
         "changelog_section": CHANGELOG_SECTION,
         "changelog_section_sha256": sha256(
             CHANGELOG_SECTION.encode()
@@ -300,13 +301,14 @@ def _prepared_unpublished_input() -> dict[str, object]:
             "tree_revision": BRANCH_SHA,
             "version": "0.6.1",
             "changelog_hash": "1" * 64,
-            "release_note_hash": "2" * 64,
+            "release_note_hash": sha256(RELEASE_NOTE.encode()).hexdigest(),
             "release_date": "2026-08-02",
         },
         "changelog": {
             "source_revision": SOURCE_SHA,
             "content_hash": "1" * 64,
             "document_mode": "prepared_unpublished",
+            "release_note_hash": sha256(RELEASE_NOTE.encode()).hexdigest(),
         },
         "security": {"exit_code": 0, "report_hash": "3" * 64},
         "tests": {
@@ -1003,6 +1005,7 @@ def _release_dependencies(*, source_revision: str = SOURCE_SHA) -> dict[str, obj
             "changelog": {
                 "source_revision": CANDIDATE_SHA,
                 "content_hash": "1" * 64,
+                "release_note_hash": sha256(RELEASE_NOTE.encode()).hexdigest(),
             },
             "security": {"exit_code": 0, "report_hash": "2" * 64},
             "tests": {
@@ -1433,6 +1436,33 @@ def test_release_blocks_before_model_when_review_material_hash_changes() -> None
 
     assert events[-1]["status"] == "blocked"
     assert "release_note hash does not match" in events[-1]["reason"]
+    assert invoked is False
+
+
+def test_pull_request_review_rejects_prepared_main_material_mode() -> None:
+    dependencies = _release_dependencies()
+    original_prepare = dependencies["prepare"]
+    invoked = False
+
+    def prepare(run, admitted):
+        prepared = original_prepare(run, admitted)
+        prepared["review_material"] = _review_material(
+            mode="prepared_main_documents"
+        )
+        return prepared
+
+    def invoke_model(_request):
+        nonlocal invoked
+        invoked = True
+        raise AssertionError("mismatched review mode must not reach a model")
+
+    dependencies["prepare"] = prepare
+    dependencies["invoke_model"] = invoke_model
+
+    events = execute_release_run(json.dumps(RUN_INPUT), dependencies)
+
+    assert events[-1]["status"] == "blocked"
+    assert "mode does not match the release preparation" in events[-1]["reason"]
     assert invoked is False
 
 

--- a/tests/test_operations_release_runtime.py
+++ b/tests/test_operations_release_runtime.py
@@ -1761,6 +1761,7 @@ def test_prepare_rolls_forward_new_changes_to_unmerged_review_candidate(
     assert result["changelog"] == {
         "content_hash": "1" * 64,
         "document_mode": "roll_forward",
+        "release_note_hash": "2" * 64,
         "source_revision": CANDIDATE_SHA,
     }
     assert result["review_material"] == {
@@ -1794,6 +1795,93 @@ def test_prepare_rolls_forward_new_changes_to_unmerged_review_candidate(
     ]
 
 
+def test_review_material_reads_documents_from_the_bound_revision(
+    tmp_path: Path,
+) -> None:
+    committed_changelog = (
+        "# Changelog\n\n## [Unreleased]\n\n"
+        "## [0.7.0] - 2026-08-02\n\n### Fixed\n\n"
+        "* Committed release evidence.\n\n"
+        "## [0.6.0] - 2026-07-18\n\n* Prior release.\n"
+    )
+    committed_note = (
+        "# data-olympus 0.7.0\n\n## Fixed\n\n"
+        "* Committed release evidence.\n"
+    )
+    candidate_diff = "diff --git a/CHANGELOG.md b/CHANGELOG.md\n+committed"
+    (tmp_path / "docs" / "releases").mkdir(parents=True)
+    (tmp_path / "CHANGELOG.md").write_text(
+        committed_changelog.replace("Committed", "Working tree drift"),
+        encoding="utf-8",
+    )
+    (tmp_path / "docs" / "releases" / "v0.7.0.md").write_text(
+        committed_note.replace("Committed", "Working tree drift"),
+        encoding="utf-8",
+    )
+
+    def command_output(command: list[str], _cwd: Path, _timeout: int) -> str:
+        if command == ["git", "show", f"{CANDIDATE_SHA}:CHANGELOG.md"]:
+            return committed_changelog
+        if command == [
+            "git",
+            "show",
+            f"{CANDIDATE_SHA}:docs/releases/v0.7.0.md",
+        ]:
+            return committed_note
+        if command[:2] == ["git", "diff"]:
+            return candidate_diff
+        raise AssertionError(command)
+
+    runtime = ReleaseRuntime(
+        tmp_path,
+        gateway=StubGateway(),
+        command_output=command_output,
+    )
+
+    material = runtime._review_material(
+        "0.7.0",
+        CANDIDATE_SHA,
+        SOURCE_SHA,
+    )
+
+    assert material["release_note"] == committed_note
+    assert "Committed release evidence" in material["changelog_section"]
+    assert "Working tree drift" not in json.dumps(material)
+    assert material["candidate_diff"] == candidate_diff
+
+
+def test_review_material_rejects_an_oversize_candidate_diff(
+    tmp_path: Path,
+) -> None:
+    changelog = (
+        "# Changelog\n\n## [Unreleased]\n\n"
+        "## [0.7.0] - 2026-08-02\n\n### Fixed\n\n* Evidence.\n"
+    )
+    note = "# data-olympus 0.7.0\n\n## Fixed\n\n* Evidence.\n"
+
+    def command_output(command: list[str], _cwd: Path, _timeout: int) -> str:
+        if command == ["git", "show", f"{CANDIDATE_SHA}:CHANGELOG.md"]:
+            return changelog
+        if command == [
+            "git",
+            "show",
+            f"{CANDIDATE_SHA}:docs/releases/v0.7.0.md",
+        ]:
+            return note
+        if command[:2] == ["git", "diff"]:
+            return "x" * (128 * 1024)
+        raise AssertionError(command)
+
+    runtime = ReleaseRuntime(
+        tmp_path,
+        gateway=StubGateway(),
+        command_output=command_output,
+    )
+
+    with pytest.raises(ValueError, match="bounded packet limit"):
+        runtime._review_material("0.7.0", CANDIDATE_SHA, SOURCE_SHA)
+
+
 def test_prepare_recognizes_exact_prepared_unpublished_main_without_mutation(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -1804,6 +1892,16 @@ def test_prepare_recognizes_exact_prepared_unpublished_main_without_mutation(
 
     def command_output(command: list[str], _cwd: Path, _timeout: int) -> str:
         commands.append(command)
+        if command == ["git", "show", f"{SOURCE_SHA}:CHANGELOG.md"]:
+            return (tmp_path / "CHANGELOG.md").read_text(encoding="utf-8")
+        if command == [
+            "git",
+            "show",
+            f"{SOURCE_SHA}:docs/releases/v0.7.0.md",
+        ]:
+            return (
+                tmp_path / "docs" / "releases" / "v0.7.0.md"
+            ).read_text(encoding="utf-8")
         return ""
 
     runtime = ReleaseRuntime(

--- a/tests/test_operations_release_runtime.py
+++ b/tests/test_operations_release_runtime.py
@@ -1882,6 +1882,38 @@ def test_review_material_rejects_an_oversize_candidate_diff(
         runtime._review_material("0.7.0", CANDIDATE_SHA, SOURCE_SHA)
 
 
+def test_review_material_rejects_an_empty_pull_request_diff(
+    tmp_path: Path,
+) -> None:
+    changelog = (
+        "# Changelog\n\n## [Unreleased]\n\n"
+        "## [0.7.0] - 2026-08-02\n\n### Fixed\n\n* Evidence.\n"
+    )
+    note = "# data-olympus 0.7.0\n\n## Fixed\n\n* Evidence.\n"
+
+    def command_output(command: list[str], _cwd: Path, _timeout: int) -> str:
+        if command == ["git", "show", f"{CANDIDATE_SHA}:CHANGELOG.md"]:
+            return changelog
+        if command == [
+            "git",
+            "show",
+            f"{CANDIDATE_SHA}:docs/releases/v0.7.0.md",
+        ]:
+            return note
+        if command[:2] == ["git", "diff"]:
+            return ""
+        raise AssertionError(command)
+
+    runtime = ReleaseRuntime(
+        tmp_path,
+        gateway=StubGateway(),
+        command_output=command_output,
+    )
+
+    with pytest.raises(ValueError, match="release candidate review diff is empty"):
+        runtime._review_material("0.7.0", CANDIDATE_SHA, SOURCE_SHA)
+
+
 def test_prepare_recognizes_exact_prepared_unpublished_main_without_mutation(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_operations_release_runtime.py
+++ b/tests/test_operations_release_runtime.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 from datetime import date
+from hashlib import sha256
 from typing import TYPE_CHECKING
 
 import pytest
@@ -1675,6 +1676,14 @@ def test_prepare_rolls_forward_new_changes_to_unmerged_review_candidate(
     monkeypatch.setattr(runtime, "_parent_revisions", lambda _revision: [SOURCE_SHA])
     monkeypatch.setattr(
         runtime,
+        "_review_material",
+        lambda _version, source, _base: {
+            "mode": "pull_request_diff",
+            "source_revision": source,
+        },
+    )
+    monkeypatch.setattr(
+        runtime,
         "_wait_pull_request",
         lambda _number, _head, _base: {
             "checks": completed_check_evidence(
@@ -1752,6 +1761,10 @@ def test_prepare_rolls_forward_new_changes_to_unmerged_review_candidate(
     assert result["changelog"] == {
         "content_hash": "1" * 64,
         "document_mode": "roll_forward",
+        "source_revision": CANDIDATE_SHA,
+    }
+    assert result["review_material"] == {
+        "mode": "pull_request_diff",
         "source_revision": CANDIDATE_SHA,
     }
     assert runtime.candidate_revision() == CANDIDATE_SHA
@@ -1872,6 +1885,16 @@ def test_prepare_recognizes_exact_prepared_unpublished_main_without_mutation(
     }
     assert "release_pr" not in result
     assert "release_controls" not in result
+    material = result["review_material"]
+    assert material["mode"] == "prepared_main_documents"
+    assert material["source_revision"] == SOURCE_SHA
+    assert material["candidate_diff"] == ""
+    assert material["release_note_sha256"] == sha256(
+        material["release_note"].encode()
+    ).hexdigest()
+    assert material["changelog_section_sha256"] == sha256(
+        material["changelog_section"].encode()
+    ).hexdigest()
     assert gateway.calls == []
     assert not any(
         command[:2] in {


### PR DESCRIPTION
## Outcome

Give the autonomous release reviewer exact bounded candidate material sourced from the bound Git revision, cross bind the material mode and hashes to preparation evidence, and preserve a bounded single line block reason.

## Verification

* 1,954 pytest tests pass with two documented optional skips.
* Ruff and strict mypy pass.
* Benchmark documentation, 74 Bats tests, example bundle lint, and documentation consistency pass.
* Claude Opus 5 findings were addressed test first.
* Claude Sonnet 5 approved exact revision `4db3e0a65ef6ac0454637ff2e314d7fdbd905e01` and tree `5f96c90672f969346513130e39015f60abbbdd16`.

Depends on the AI Operations bounded review reason PR.