### PR TITLE
fix(release): retry unbound gateway reads

### DIFF
--- a/scripts/operations/release_runtime.py
+++ b/scripts/operations/release_runtime.py
@@ -1138,6 +1138,22 @@ class ReleaseRuntime:
         self.heartbeat()
         return _object(result, f"{name} response")
 
+    def gateway_read_object(
+        self,
+        name: str,
+        arguments: dict[str, object],
+    ) -> dict[str, Any]:
+        for attempt in range(2):
+            try:
+                return self.gateway_object(name, arguments)
+            except UnboundGatewayResultError:
+                self.heartbeat()
+                if attempt != 0:
+                    raise
+                self.sleep(1.0)
+                continue
+        raise AssertionError("gateway read retry loop exhausted")
+
     def live_statefulset(self) -> dict[str, Any]:
         self.heartbeat()
         result = self.gateway.execute(
@@ -1423,7 +1439,7 @@ class ReleaseRuntime:
     ) -> dict[str, Any]:
         last_error = "pull request checks did not appear"
         for _attempt in range(120):
-            checks = self.gateway_object(
+            checks = self.gateway_read_object(
                 "pull_request_read",
                 {
                     "method": "get_check_runs",
@@ -1449,7 +1465,7 @@ class ReleaseRuntime:
                 self.sleep(10)
                 self.heartbeat()
                 continue
-            pull = self.gateway_object(
+            pull = self.gateway_read_object(
                 "pull_request_read",
                 {
                     "method": "get",
@@ -2046,7 +2062,7 @@ class ReleaseRuntime:
         *,
         on_dispatch: Callable[[], None] | None = None,
     ) -> dict[str, Any]:
-        listed = self.gateway_object(
+        listed = self.gateway_read_object(
             "actions_list",
             {
                 "method": "list_workflow_runs",
@@ -2081,7 +2097,7 @@ class ReleaseRuntime:
         )
         self.heartbeat()
         for _attempt in range(180):
-            listed = self.gateway_object(
+            listed = self.gateway_read_object(
                 "actions_list",
                 {
                     "method": "list_workflow_runs",
@@ -2111,7 +2127,7 @@ class ReleaseRuntime:
                     run_id = run.get("id")
                     if type(run_id) is not int:
                         raise ValueError(f"{workflow_id} run identifier is invalid")
-                    exact = self.gateway_object(
+                    exact = self.gateway_read_object(
                         "actions_get",
                         {
                             "method": "get_workflow_run",
@@ -2136,7 +2152,7 @@ class ReleaseRuntime:
         raise ValueError(f"{workflow_id} did not complete before timeout")
 
     def _release(self, tag: str) -> dict[str, Any]:
-        return self.gateway_object(
+        return self.gateway_read_object(
             "get_release_by_tag",
             {"owner": GITHUB_OWNER, "repo": GITHUB_REPOSITORY, "tag": tag},
         )
@@ -2354,7 +2370,7 @@ class ReleaseRuntime:
         head_revision: str,
         base_revision: str,
     ) -> str | None:
-        pull = self.gateway_object(
+        pull = self.gateway_read_object(
             "pull_request_read",
             {
                 "method": "get",

--- a/tests/test_operations_release_runtime.py
+++ b/tests/test_operations_release_runtime.py
@@ -514,6 +514,34 @@ def test_fastmcp_gateway_rejects_a_different_tool_result() -> None:
         )
 
 
+def test_gateway_object_never_retries_an_unbound_mutation_response(
+    tmp_path: Path,
+) -> None:
+    class UnboundMutationGateway:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def execute(self, _name: str, _arguments: dict[str, object]) -> object:
+            self.calls += 1
+            raise UnboundGatewayResultError(
+                "FastMCP text content omitted gateway result"
+            )
+
+    sleeps: list[float] = []
+    gateway = UnboundMutationGateway()
+    runtime = ReleaseRuntime(
+        tmp_path,
+        gateway=gateway,
+        sleep=sleeps.append,
+    )
+
+    with pytest.raises(UnboundGatewayResultError, match="omitted gateway result"):
+        runtime.gateway_object("create_pull_request", {})
+
+    assert gateway.calls == 1
+    assert sleeps == []
+
+
 def test_list_tags_retries_one_unbound_fastmcp_text_response(
     tmp_path: Path,
 ) -> None:
@@ -1561,6 +1589,138 @@ def test_workflow_receipt_is_new_completed_and_bound_to_exact_source(
             "workflow_id": "rc-publish.yml",
         },
     )
+
+
+def test_workflow_retries_one_unbound_read_without_replaying_dispatch(
+    tmp_path: Path,
+) -> None:
+    class FlakyReadGateway:
+        def __init__(self) -> None:
+            self.calls: list[tuple[str, dict[str, object]]] = []
+            self.list_calls = 0
+
+        def execute(self, name: str, arguments: dict[str, object]) -> object:
+            self.calls.append((name, arguments))
+            if name == "actions_list":
+                self.list_calls += 1
+                if self.list_calls == 1:
+                    raise UnboundGatewayResultError(
+                        "FastMCP text content omitted gateway result"
+                    )
+                if self.list_calls == 2:
+                    return {"workflow_runs": [{"id": 4, "head_sha": SOURCE_SHA}]}
+                return {
+                    "workflow_runs": [
+                        {
+                            "id": 5,
+                            "head_sha": SOURCE_SHA,
+                            "event": "workflow_dispatch",
+                            "status": "completed",
+                            "conclusion": "success",
+                        }
+                    ]
+                }
+            if name == "actions_run_trigger":
+                return {}
+            if name == "actions_get":
+                return {
+                    "id": 5,
+                    "head_sha": SOURCE_SHA,
+                    "conclusion": "success",
+                }
+            raise AssertionError(f"unexpected gateway tool: {name}")
+
+    sleeps: list[float] = []
+    gateway = FlakyReadGateway()
+    runtime = ReleaseRuntime(
+        tmp_path,
+        gateway=gateway,
+        sleep=sleeps.append,
+    )
+
+    receipt = runtime._workflow_run(
+        "rc-publish.yml",
+        SOURCE_SHA,
+        {"number": 1, "ref": SOURCE_SHA},
+    )
+
+    assert receipt == {
+        "conclusion": "success",
+        "run_id": 5,
+        "source_revision": SOURCE_SHA,
+    }
+    assert [name for name, _arguments in gateway.calls] == [
+        "actions_list",
+        "actions_list",
+        "actions_run_trigger",
+        "actions_list",
+        "actions_get",
+    ]
+    assert sleeps == [1.0]
+
+
+def test_workflow_stops_after_one_unbound_read_retry_before_dispatch(
+    tmp_path: Path,
+) -> None:
+    class UnboundReadGateway:
+        def __init__(self) -> None:
+            self.calls: list[str] = []
+
+        def execute(self, name: str, _arguments: dict[str, object]) -> object:
+            self.calls.append(name)
+            raise UnboundGatewayResultError(
+                "FastMCP text content omitted gateway result"
+            )
+
+    sleeps: list[float] = []
+    gateway = UnboundReadGateway()
+    runtime = ReleaseRuntime(
+        tmp_path,
+        gateway=gateway,
+        sleep=sleeps.append,
+    )
+
+    with pytest.raises(UnboundGatewayResultError, match="omitted gateway result"):
+        runtime._workflow_run(
+            "rc-publish.yml",
+            SOURCE_SHA,
+            {"number": 1, "ref": SOURCE_SHA},
+        )
+
+    assert gateway.calls == ["actions_list", "actions_list"]
+    assert sleeps == [1.0]
+
+
+def test_workflow_never_retries_an_unbound_dispatch_response(tmp_path: Path) -> None:
+    class UnboundDispatchGateway:
+        def __init__(self) -> None:
+            self.calls: list[str] = []
+
+        def execute(self, name: str, _arguments: dict[str, object]) -> object:
+            self.calls.append(name)
+            if name == "actions_list":
+                return {"workflow_runs": []}
+            raise UnboundGatewayResultError(
+                "FastMCP text content omitted gateway result"
+            )
+
+    sleeps: list[float] = []
+    gateway = UnboundDispatchGateway()
+    runtime = ReleaseRuntime(
+        tmp_path,
+        gateway=gateway,
+        sleep=sleeps.append,
+    )
+
+    with pytest.raises(UnboundGatewayResultError, match="omitted gateway result"):
+        runtime._workflow_run(
+            "rc-publish.yml",
+            SOURCE_SHA,
+            {"number": 1, "ref": SOURCE_SHA},
+        )
+
+    assert gateway.calls == ["actions_list", "actions_run_trigger"]
+    assert sleeps == []
 
 
 def test_merge_uses_github_expected_head_precondition(tmp_path: Path) -> None:


### PR DESCRIPTION
## Outcome

Recover once from the intermittent unbound FastMCP text envelope only on idempotent object shaped reads. Pull request creation, workflow dispatch, Kubernetes apply, and all other mutations remain single attempt.

## Incident evidence

* Release run `b311ab20-f878-46fa-82a2-07551f1878fb` merged reviewed PR 216 to exact main `598106d4b911609e86839689bb6a7874b418b2fb`, then failed before workflow dispatch with `FastMCP text content omitted gateway result`.
* `0.7.0` and `0.7.0-rc.1` remain absent from PyPI, GHCR, and GitHub releases.
* No release workflow was dispatched.
* kn-dev remains on rollback digest `sha256:d2388b3c5a96b2cda6f968db0b7403aae225d4a9cc3417c04fee4c59b6e3d77f`.

## Verification

* Ruff and strict mypy pass.
* Benchmark documentation, full pytest with two optional skips, 74 Bats contracts, example bundle lint, documentation consistency, and diff checks pass.
* Tests prove one read retry, fail closed after that retry, single attempt pull request creation, and single attempt workflow dispatch.
* Claude Opus 5 explicitly approved exact commit `b2dd417326da7c33205764c8510659233605906c`, tree `c8defb158a0965a383eaa2ab8837ba8e2cde6494`; Fable was not used.

This behavior correction restarts baseline certification from authority item one.