### PR TITLE
chore(release): prepare v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * feat(automation): make weekly releases outcome based
 ### Fixed
 
+* fix(release): retry unbound gateway reads (#217)
 * fix(release): ground autonomous review packets (#215)
 * fix(release): preserve prepared roll forward (#213)
 * fix(automation): preserve recovery result binding (#212)

--- a/docs/releases/v0.7.0.md
+++ b/docs/releases/v0.7.0.md
@@ -7,6 +7,7 @@
 
 ## Fixed
 
+* fix(release): retry unbound gateway reads (#217)
 * fix(release): ground autonomous review packets (#215)
 * fix(release): preserve prepared roll forward (#213)
 * fix(automation): preserve recovery result binding (#212)


### PR DESCRIPTION
## Outcome

Prepare immutable Data Olympus release v0.7.0 from exact source `14a6cd5a38dcc654061e7b937cec081edfbbc9fd`.

## Verification

All repository checks must pass before the deterministic release commit is merged. Publication remains blocked until the resulting exact main SHA receives independent review and SHA bound standing approval.