### PR TITLE
fix(release): serialize workflow number input

### DIFF
--- a/.rules/release-routine.md
+++ b/.rules/release-routine.md
@@ -190,8 +190,10 @@ The release host requires:
     Publication is a direct continuation after these freshly derived proofs,
     never a replay from stored evidence.
 13. Dispatch `rc-publish.yml` for `M` and the next unused candidate
-    number. Do not reproduce version computation or publication logic in the
-    runner.
+    number. Serialize the candidate number as a decimal string in the GitHub
+    workflow dispatch request, even though the workflow declares a numeric
+    input. GitHub rejects a JSON number for this endpoint. Do not reproduce
+    version computation or publication logic in the runner.
 14. Verify the complete candidate transaction:
 
     * GitHub prerelease.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * feat(automation): make weekly releases outcome based
 ### Fixed
 
+* fix(release): serialize workflow number input
 * fix(release): retry unbound gateway reads (#217)
 * fix(release): ground autonomous review packets (#215)
 * fix(release): preserve prepared roll forward (#213)

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -585,9 +585,11 @@ Set `KB_ENDPOINT` / `KB_AUTH_TOKEN` in the hook's environment the same way
 
 Candidate publication is a complete transaction across PyPI, GHCR, and GitHub.
 Dispatch `rc-publish.yml` from `main` with the reviewed source in `ref` and an
-explicit positive `number`. The workflow does not move `:rc` or create a public
-prerelease until the candidate wheel, source distribution, image, and provenance
-receipt have passed registry read back verification.
+explicit positive `number`. Send that number as a decimal string in the GitHub
+workflow dispatch request because GitHub rejects a JSON number even though the
+workflow input type is numeric. The workflow does not move `:rc` or create a
+public prerelease until the candidate wheel, source distribution, image, and
+provenance receipt have passed registry read back verification.
 
 Stable promotion runs only through an explicit `tag-release.yml` dispatch from
 `main`. Supply the highest complete candidate in `candidate_tag`; any lower or

--- a/docs/releases/v0.7.0.md
+++ b/docs/releases/v0.7.0.md
@@ -7,6 +7,7 @@
 
 ## Fixed
 
+* fix(release): serialize workflow number input
 * fix(release): retry unbound gateway reads (#217)
 * fix(release): ground autonomous review packets (#215)
 * fix(release): preserve prepared roll forward (#213)

--- a/scripts/operations/release_runtime.py
+++ b/scripts/operations/release_runtime.py
@@ -2640,7 +2640,7 @@ class ReleaseRuntime:
             rc_receipt = self._workflow_run(
                 "rc-publish.yml",
                 source_revision,
-                {"number": rc_number, "ref": source_revision},
+                {"number": str(rc_number), "ref": source_revision},
                 on_dispatch=mark_external_state_changed,
             )
             external_state_changed = True

--- a/tests/test_operations_release_runtime.py
+++ b/tests/test_operations_release_runtime.py
@@ -2429,6 +2429,7 @@ def test_deliver_resumes_exact_prepared_main_and_never_attempts_merge(
 ) -> None:
     previous = "sha256:" + "e" * 64
     order: list[str] = []
+    workflow_inputs: dict[str, dict[str, object]] = {}
     documents = {
         "changelog_hash": "1" * 64,
         "content_hash": "2" * 64,
@@ -2498,18 +2499,21 @@ def test_deliver_resumes_exact_prepared_main_and_never_attempts_merge(
             }
         ),
     )
-    monkeypatch.setattr(
-        runtime,
-        "_workflow_run",
-        lambda name, revision, _inputs, **_kwargs: (
-            order.append(f"workflow:{name}")
-            or {
-                "conclusion": "success",
-                "run_id": len(order),
-                "source_revision": revision,
-            }
-        ),
-    )
+    def workflow_run(
+        name: str,
+        revision: str,
+        inputs: dict[str, object],
+        **_kwargs: object,
+    ) -> dict[str, object]:
+        workflow_inputs[name] = inputs
+        order.append(f"workflow:{name}")
+        return {
+            "conclusion": "success",
+            "run_id": len(order),
+            "source_revision": revision,
+        }
+
+    monkeypatch.setattr(runtime, "_workflow_run", workflow_run)
     monkeypatch.setattr(
         runtime,
         "_candidate_publication",
@@ -2585,6 +2589,10 @@ def test_deliver_resumes_exact_prepared_main_and_never_attempts_merge(
     assert order.index("candidate-free:0.7.0-rc.1") < order.index(
         "workflow:rc-publish.yml"
     )
+    assert workflow_inputs["rc-publish.yml"] == {
+        "number": "1",
+        "ref": SOURCE_SHA,
+    }
 
 
 def test_delivery_blocks_ruleset_drift_without_attempting_merge(


### PR DESCRIPTION
## Outcome

Serialize the rc-publish candidate number as a decimal string so GitHub accepts the workflow dispatch while preserving exact source binding and the single-attempt mutation rule.

## Evidence

The live failure returned HTTP 422 Invalid value for input number and created no workflow run. Full local verification passed. Claude Sonnet independently approved exact commit 392b26dfc8af6affcf56e44ed3d02e3a066dd18a with no blockers or concerns.