### PR TITLE
fix(release): complete protected workflow delivery

### DIFF
--- a/.rules/release-routine.md
+++ b/.rules/release-routine.md
@@ -48,11 +48,13 @@ The fixed milestones are:
 The project command owns Git, release artifact, workflow, registry, and kn dev
 evidence. Supported external mutations and reads go through FastMCP. Current
 gateway capability gaps are CodeQL analysis and alert enumeration, Code
-Quality setup, ruleset details, GraphQL review threads, container package
-digest lookup, and a pull request merge with an expected head SHA precondition.
-They reuse governed repository commands and record the direct GitHub fallback
-because the gateway exposes none of those exact operations. These gaps remain
-tracked platform work and do not weaken the release gates.
+Quality setup, ruleset details, GraphQL review threads, environment deployment
+review, and a pull request merge with an expected head SHA precondition. They
+reuse governed repository commands and record the direct GitHub fallback
+because the gateway exposes none of those exact operations.
+Public image digest verification uses the registry directly and requires no
+GitHub Packages API scope. These gaps remain tracked platform work and do not
+weaken the release gates.
 An unconditional gateway merge is not an acceptable substitute for the
 expected head precondition.
 After the conditional merge mutation begins, an unknown merge outcome or any
@@ -194,6 +196,13 @@ The release host requires:
     workflow dispatch request, even though the workflow declares a numeric
     input. GitHub rejects a JSON number for this endpoint. Do not reproduce
     version computation or publication logic in the runner.
+    If GitHub places `rc-publish.yml` or `tag-release.yml` in `waiting`, require
+    the exact run readback to match `M`, require exactly one pending environment
+    named `pypi`, require the authenticated operator to be an allowed reviewer,
+    require a zero wait timer, and approve only that environment. Verify the
+    approval response still names `M`. Any different workflow, environment,
+    source, reviewer shape, or response fails closed. The SHA bound standing
+    approval must already exist before delivery reaches this operation.
 14. Verify the complete candidate transaction:
 
     * GitHub prerelease.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+* Resolve release image digests from the exact public GHCR tag without
+  requiring GitHub Packages API scope.
+* Advance only the exact reviewed release workflow through its single pending
+  `pypi` environment approval, preserving the protected environment gate while
+  removing a manual scheduled-run follow-up.
+
 ## [0.7.0] - 2026-08-02
 
 ### New features

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -600,6 +600,19 @@ PyPI publication happen before the stable Git tag is created. The workflow then
 retags the candidate image digest as the version, `stable`, and `latest`; it does
 not build another image.
 
+The operations runner advances a protected candidate or stable workflow only
+after its independent review and exact SHA bound standing approval pass. When
+GitHub reports a waiting deployment, the runner verifies the exact workflow run
+and source SHA, accepts exactly one pending environment named `pypi` with an
+operator reviewer and zero wait timer, approves only that environment, and
+verifies the returned deployment SHA. FastMCP currently has no environment
+deployment review operation, so this bounded step uses the GitHub CLI fallback.
+Any other pending deployment shape fails closed.
+
+Release image digest verification uses `docker buildx imagetools inspect` on
+the exact public GHCR tag. It does not require `read:packages` or enumerate the
+GitHub Packages API.
+
 Rerun a partial candidate with the same `ref` and `number`. An existing image is
 accepted only when its embedded revision matches the requested source. PyPI
 publishing uses `skip-existing`, followed by exact SHA256 verification. Never

--- a/docs/releases/pypi-trusted-publishing.md
+++ b/docs/releases/pypi-trusted-publishing.md
@@ -42,6 +42,13 @@ Create an environment named `pypi` in the repository settings.
    another exact source SHA.
 4. Do not add a PyPI password or API token secret.
 
+For an operations-runner release, the operator's exact SHA bound standing
+approval is recorded before delivery. If the protected workflow then waits,
+the runner verifies that workflow and source, requires exactly this single
+`pypi` environment with an allowed operator reviewer and zero wait timer, and
+submits only that deployment approval. Interactive releases still require the
+operator reviewer directly. Do not remove the environment protection.
+
 The candidate and stable jobs scope `id-token: write` to this environment. Other
 jobs use read only repository permissions unless they must publish a Git tag,
 GitHub release, or GHCR tag.

--- a/scripts/deployed_digest.py
+++ b/scripts/deployed_digest.py
@@ -4,9 +4,9 @@ to a named release channel (e.g. "stable", "latest"), fail-closed.
 
 Used as an evidence adapter feeding release_readiness.py's rc_digest_deployed
 condition: the evaluator compares this digest against the expected_rc_digest
-recorded in the release manifest. A channel with no matching tag, more than
-one matching tag (ambiguous), or an unreachable registry does NOT resolve a
-digest (fail-closed), never silently skipped.
+recorded in the release manifest. The exact public tag must return one top
+level OCI index digest. A missing tag, ambiguous output, unavailable client,
+or unreachable registry does not resolve a digest and fails closed.
 
 CLI: `python3 scripts/deployed_digest.py --target <channel>
       [--package data-olympus] [--org knaisoma] [--json]`
@@ -61,30 +61,33 @@ def evaluate(versions: list[dict[str, Any]], target: str) -> dict[str, Any]:
     }
 
 
-def _fetch_versions(package: str, org: str) -> list[dict[str, Any]]:
-    """Fetch every package version (one JSON object per line) via gh api.
-
-    This is the digest source: the single seam release_readiness callers
-    (and tests) mock to avoid a real network/registry dependency. Every
-    failure mode (missing gh binary, subprocess failure, malformed JSON) is
-    normalized to RuntimeError so callers have one exception type to expect;
-    main() still fails closed on any other exception type as a backstop.
-    """
-    path = f"/orgs/{org}/packages/container/{package}/versions"
+def _inspect_digest(target: str, package: str, org: str) -> str:
+    """Resolve one public tag without requiring GitHub Packages API scope."""
+    reference = f"ghcr.io/{org}/{package}:{target}"
     try:
         out = subprocess.run(
-            ["gh", "api", "--paginate", path, "--jq", ".[]"],
-            capture_output=True, text=True,
+            ["docker", "buildx", "imagetools", "inspect", reference],
+            capture_output=True,
+            stdin=subprocess.DEVNULL,
+            text=True,
+            timeout=30,
         )
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError(f"ghcr inspection timed out for {reference}") from exc
     except OSError as exc:
-        # e.g. the "gh" binary is not installed or not on PATH.
-        raise RuntimeError(f"gh api {path} could not be started: {exc}") from exc
+        raise RuntimeError(f"ghcr inspection could not start for {reference}") from exc
     if out.returncode != 0:
-        raise RuntimeError(f"gh api {path} failed:\n{out.stderr}")
-    try:
-        return [json.loads(line) for line in out.stdout.splitlines() if line.strip()]
-    except json.JSONDecodeError as exc:
-        raise RuntimeError(f"gh api {path} returned malformed JSON: {exc}") from exc
+        raise RuntimeError(f"ghcr inspection failed for {reference}")
+    digests = re.findall(
+        r"^Digest:\s*(sha256:[0-9a-f]{64})\s*$",
+        out.stdout,
+        re.MULTILINE,
+    )
+    if len(digests) != 1:
+        raise RuntimeError(
+            f"ghcr inspection returned an ambiguous digest for {reference}"
+        )
+    return digests[0]
 
 
 def _unresolved(target: str, matched_versions: int = 0) -> dict[str, Any]:
@@ -105,10 +108,15 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     try:
-        versions = _fetch_versions(args.package, args.org)
-        if not isinstance(versions, list):
-            raise TypeError(f"expected a list of package versions, got {type(versions).__name__}")
-        result = evaluate(versions, args.target)
+        digest = _inspect_digest(args.target, args.package, args.org)
+        if type(digest) is not str or _DIGEST_RE.fullmatch(digest) is None:
+            raise RuntimeError("ghcr inspection returned an invalid digest")
+        result = {
+            "target": args.target,
+            "digest": digest,
+            "source": f"ghcr:{args.target}",
+            "matched_versions": 1,
+        }
     except Exception as exc:
         # Fail-closed backstop: any failure resolving or evaluating the
         # digest lookup (subprocess/gh missing, malformed JSON, an

--- a/scripts/operations/release_runtime.py
+++ b/scripts/operations/release_runtime.py
@@ -2096,6 +2096,7 @@ class ReleaseRuntime:
             },
         )
         self.heartbeat()
+        environment_approval: dict[str, Any] | None = None
         for _attempt in range(180):
             listed = self.gateway_read_object(
                 "actions_list",
@@ -2121,12 +2122,18 @@ class ReleaseRuntime:
             ]
             if matches:
                 run = max(matches, key=lambda item: int(item.get("id", 0)))
+                run_id = run.get("id")
+                if type(run_id) is not int:
+                    raise ValueError(f"{workflow_id} run identifier is invalid")
+                if run.get("status") == "waiting" and environment_approval is None:
+                    environment_approval = self._approve_pypi_environment(
+                        workflow_id,
+                        run_id,
+                        source_revision,
+                    )
                 if run.get("status") == "completed":
                     if run.get("conclusion") != "success":
                         raise ValueError(f"{workflow_id} did not succeed")
-                    run_id = run.get("id")
-                    if type(run_id) is not int:
-                        raise ValueError(f"{workflow_id} run identifier is invalid")
                     exact = self.gateway_read_object(
                         "actions_get",
                         {
@@ -2142,14 +2149,101 @@ class ReleaseRuntime:
                         or exact.get("conclusion") != "success"
                     ):
                         raise ValueError(f"{workflow_id} exact receipt changed")
-                    return {
+                    receipt = {
                         "conclusion": "success",
                         "run_id": run_id,
                         "source_revision": source_revision,
                     }
+                    if environment_approval is not None:
+                        receipt["environment_approval"] = environment_approval
+                    return receipt
             self.sleep(10)
             self.heartbeat()
         raise ValueError(f"{workflow_id} did not complete before timeout")
+
+    def _approve_pypi_environment(
+        self,
+        workflow_id: str,
+        run_id: int,
+        source_revision: str,
+    ) -> dict[str, Any]:
+        if workflow_id not in {"rc-publish.yml", "tag-release.yml"}:
+            raise ValueError("pending deployment is not an approved release workflow")
+        exact = self.gateway_read_object(
+            "actions_get",
+            {
+                "method": "get_workflow_run",
+                "owner": GITHUB_OWNER,
+                "repo": GITHUB_REPOSITORY,
+                "resource_id": str(run_id),
+            },
+        )
+        if (
+            exact.get("id") != run_id
+            or exact.get("head_sha") != source_revision
+            or exact.get("status") != "waiting"
+        ):
+            raise ValueError("pending deployment workflow identity changed")
+        path = (
+            f"repos/{GITHUB_OWNER}/{GITHUB_REPOSITORY}/actions/runs/"
+            f"{run_id}/pending_deployments"
+        )
+        raw_pending = self.command(["gh", "api", path], timeout=60)
+        try:
+            pending = json.loads(raw_pending)
+        except json.JSONDecodeError as error:
+            raise ValueError("pending deployment response is invalid") from error
+        if type(pending) is not list or len(pending) != 1:
+            raise ValueError("pending deployment is not exact pypi")
+        deployment = _object(pending[0], "pending deployment")
+        environment = _object(
+            deployment.get("environment"),
+            "pending deployment environment",
+        )
+        environment_id = environment.get("id")
+        reviewers = deployment.get("reviewers")
+        if (
+            environment.get("name") != "pypi"
+            or type(environment_id) is not int
+            or deployment.get("current_user_can_approve") is not True
+            or deployment.get("wait_timer") != 0
+            or type(reviewers) is not list
+            or not any(
+                type(reviewer) is dict and reviewer.get("type") == "User"
+                for reviewer in reviewers
+            )
+        ):
+            raise ValueError("pending deployment is not exact pypi")
+        comment = f"Approved exact reviewed release source {source_revision}."
+        raw_approved = self.command(
+            [
+                "gh",
+                "api",
+                "--method",
+                "POST",
+                path,
+                "-F",
+                f"environment_ids[]={environment_id}",
+                "-f",
+                "state=approved",
+                "-f",
+                f"comment={comment}",
+            ],
+            timeout=60,
+        )
+        try:
+            approved = json.loads(raw_approved)
+        except json.JSONDecodeError as error:
+            raise ValueError("deployment approval response is invalid") from error
+        if (
+            type(approved) is not list
+            or len(approved) != 1
+            or type(approved[0]) is not dict
+            or approved[0].get("environment") != "pypi"
+            or approved[0].get("sha") != source_revision
+        ):
+            raise ValueError("deployment approval identity changed")
+        return {"environment": "pypi", "environment_id": environment_id}
 
     def _release(self, tag: str) -> dict[str, Any]:
         return self.gateway_read_object(

--- a/scripts/rc_tag.py
+++ b/scripts/rc_tag.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python3
 """Print the next release-candidate channel tag `X.Y.Z-rc.N`.
 
-CI usage: pipe the existing ghcr tags (one per line) on stdin and pass the
-target base version. N is one past the highest existing `<base>-rc.N`.
-
-    gh api "/orgs/knaisoma/packages/container/data-olympus/versions" \
-      --jq '.[].metadata.container.tags[]' | python3 scripts/rc_tag.py --base 0.5.0
+Usage: pipe known candidate tags, one per line, on stdin and pass the target
+base version. N is one past the highest existing `<base>-rc.N`. Tag discovery
+belongs to the caller so this helper does not require a registry credential or
+API scope.
 """
 from __future__ import annotations
 

--- a/tests/test_deployed_digest.py
+++ b/tests/test_deployed_digest.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from subprocess import CompletedProcess
 from typing import TYPE_CHECKING, Any
 
 from scripts.deployed_digest import evaluate, main
@@ -60,19 +61,19 @@ def test_evaluate_malformed_metadata_ignored() -> None:
     assert result["matched_versions"] == 0
 
 
-def _patch_fetch(monkeypatch: pytest.MonkeyPatch, *, versions: object) -> None:
+def _patch_inspect(monkeypatch: pytest.MonkeyPatch, *, result: object) -> None:
     import scripts.deployed_digest as mod
 
-    def _raise_or_return(_package: str, _org: str) -> list[dict]:
-        if isinstance(versions, Exception):
-            raise versions
-        return versions  # type: ignore[return-value]
+    def _raise_or_return(_target: str, _package: str, _org: str) -> object:
+        if isinstance(result, Exception):
+            raise result
+        return result
 
-    monkeypatch.setattr(mod, "_fetch_versions", _raise_or_return)
+    monkeypatch.setattr(mod, "_inspect_digest", _raise_or_return)
 
 
 def test_main_success_path_exits_zero(monkeypatch: pytest.MonkeyPatch, capsys) -> None:
-    _patch_fetch(monkeypatch, versions=[_version(_DIGEST_C, ["stable"])])
+    _patch_inspect(monkeypatch, result=_DIGEST_C)
     code = main(["--target", "stable", "--json"])
     assert code == 0
     out = capsys.readouterr().out
@@ -80,8 +81,56 @@ def test_main_success_path_exits_zero(monkeypatch: pytest.MonkeyPatch, capsys) -
     assert '"digest": null' not in out
 
 
+def test_main_resolves_public_registry_digest_without_packages_api(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys,
+) -> None:
+    import scripts.deployed_digest as mod
+
+    commands: list[list[str]] = []
+
+    def inspect(
+        command: list[str],
+        **_kwargs: object,
+    ) -> CompletedProcess[str]:
+        commands.append(command)
+        return CompletedProcess(
+            command,
+            0,
+            stdout=(
+                "Name: ghcr.io/knaisoma/data-olympus:0.7.0-rc.1\n"
+                f"Digest: {_DIGEST_C}\n"
+                "Manifests:\n"
+                f"  Name: image@{_DIGEST_B}\n"
+            ),
+            stderr="",
+        )
+
+    monkeypatch.setattr(mod.subprocess, "run", inspect)
+
+    code = main(["--target", "0.7.0-rc.1", "--json"])
+
+    assert code == 0
+    assert commands == [
+        [
+            "docker",
+            "buildx",
+            "imagetools",
+            "inspect",
+            "ghcr.io/knaisoma/data-olympus:0.7.0-rc.1",
+        ]
+    ]
+    result = __import__("json").loads(capsys.readouterr().out)
+    assert result == {
+        "target": "0.7.0-rc.1",
+        "digest": _DIGEST_C,
+        "source": "ghcr:0.7.0-rc.1",
+        "matched_versions": 1,
+    }
+
+
 def test_main_fail_closed_on_lookup_error(monkeypatch: pytest.MonkeyPatch, capsys) -> None:
-    _patch_fetch(monkeypatch, versions=RuntimeError("gh api unreachable"))
+    _patch_inspect(monkeypatch, result=RuntimeError("ghcr unreachable"))
     code = main(["--target", "stable", "--json"])
     assert code != 0
     out = capsys.readouterr().out
@@ -89,7 +138,7 @@ def test_main_fail_closed_on_lookup_error(monkeypatch: pytest.MonkeyPatch, capsy
 
 
 def test_main_fail_closed_on_no_match(monkeypatch: pytest.MonkeyPatch) -> None:
-    _patch_fetch(monkeypatch, versions=[_version("sha256:aaaa", ["edge"])])
+    _patch_inspect(monkeypatch, result=RuntimeError("tag not found"))
     code = main(["--target", "stable", "--json"])
     assert code != 0
 
@@ -103,7 +152,7 @@ def test_evaluate_non_sha256_digest_fails_closed() -> None:
 
 
 def test_main_fail_closed_on_non_sha256_digest(monkeypatch: pytest.MonkeyPatch, capsys) -> None:
-    _patch_fetch(monkeypatch, versions=[_version("not-a-digest", ["stable"])])
+    _patch_inspect(monkeypatch, result="not-a-digest")
     code = main(["--target", "stable", "--json"])
     assert code != 0
     out = capsys.readouterr().out
@@ -111,11 +160,7 @@ def test_main_fail_closed_on_non_sha256_digest(monkeypatch: pytest.MonkeyPatch, 
 
 
 def test_main_fail_closed_on_malformed_json(monkeypatch: pytest.MonkeyPatch, capsys) -> None:
-    import json as json_mod
-
-    _patch_fetch(
-        monkeypatch, versions=json_mod.JSONDecodeError("bad json", "{not valid", 0)
-    )
+    _patch_inspect(monkeypatch, result=RuntimeError("malformed inspection output"))
     code = main(["--target", "stable", "--json"])
     assert code != 0
     out = capsys.readouterr().out
@@ -126,10 +171,8 @@ def test_main_fail_closed_on_malformed_json(monkeypatch: pytest.MonkeyPatch, cap
 def test_main_fail_closed_on_non_dict_payload_shape(
     monkeypatch: pytest.MonkeyPatch, capsys
 ) -> None:
-    # _fetch_versions returning something that isn't a list of version dicts
-    # (e.g. a single dict instead of a list) must not crash main(); it must
-    # fail closed the same as any other lookup failure.
-    _patch_fetch(monkeypatch, versions={"unexpected": "shape"})
+    # An unexpected inspection result must fail closed without a traceback.
+    _patch_inspect(monkeypatch, result={"unexpected": "shape"})
     code = main(["--target", "stable", "--json"])
     assert code != 0
     out = capsys.readouterr().out

--- a/tests/test_operations_release_runtime.py
+++ b/tests/test_operations_release_runtime.py
@@ -1591,6 +1591,373 @@ def test_workflow_receipt_is_new_completed_and_bound_to_exact_source(
     )
 
 
+def test_workflow_approves_only_exact_pending_pypi_environment(
+    tmp_path: Path,
+) -> None:
+    environment_id = 17641982902
+    gateway = StubGateway(
+        {
+            "actions_list": (
+                {"workflow_runs": []},
+                {
+                    "workflow_runs": [
+                        {
+                            "id": 5,
+                            "head_sha": SOURCE_SHA,
+                            "event": "workflow_dispatch",
+                            "status": "waiting",
+                            "conclusion": None,
+                        }
+                    ]
+                },
+                {
+                    "workflow_runs": [
+                        {
+                            "id": 5,
+                            "head_sha": SOURCE_SHA,
+                            "event": "workflow_dispatch",
+                            "status": "completed",
+                            "conclusion": "success",
+                        }
+                    ]
+                },
+            ),
+            "actions_run_trigger": {},
+            "actions_get": (
+                {
+                    "id": 5,
+                    "head_sha": SOURCE_SHA,
+                    "status": "waiting",
+                },
+                {
+                    "id": 5,
+                    "head_sha": SOURCE_SHA,
+                    "conclusion": "success",
+                },
+            ),
+        }
+    )
+    commands: list[list[str]] = []
+
+    def command_output(command: list[str], _cwd: Path, _timeout: int) -> str:
+        commands.append(command)
+        if "--method" not in command:
+            return json.dumps(
+                [
+                    {
+                        "current_user_can_approve": True,
+                        "environment": {
+                            "id": environment_id,
+                            "name": "pypi",
+                        },
+                        "reviewers": [{"type": "User"}],
+                        "wait_timer": 0,
+                    }
+                ]
+            )
+        return json.dumps(
+            [
+                {
+                    "environment": "pypi",
+                    "id": 19,
+                    "sha": SOURCE_SHA,
+                }
+            ]
+        )
+
+    runtime = ReleaseRuntime(
+        tmp_path,
+        gateway=gateway,
+        command_output=command_output,
+        sleep=lambda _seconds: None,
+    )
+
+    receipt = runtime._workflow_run(
+        "tag-release.yml",
+        SOURCE_SHA,
+        {"candidate_tag": "0.7.0-rc.2"},
+    )
+
+    assert receipt == {
+        "conclusion": "success",
+        "environment_approval": {
+            "environment": "pypi",
+            "environment_id": environment_id,
+        },
+        "run_id": 5,
+        "source_revision": SOURCE_SHA,
+    }
+    assert commands == [
+        [
+            "gh",
+            "api",
+            "repos/knaisoma/data-olympus/actions/runs/5/pending_deployments",
+        ],
+        [
+            "gh",
+            "api",
+            "--method",
+            "POST",
+            "repos/knaisoma/data-olympus/actions/runs/5/pending_deployments",
+            "-F",
+            f"environment_ids[]={environment_id}",
+            "-f",
+            "state=approved",
+            "-f",
+            f"comment=Approved exact reviewed release source {SOURCE_SHA}.",
+        ],
+    ]
+
+
+def test_workflow_rejects_unexpected_pending_environment(
+    tmp_path: Path,
+) -> None:
+    gateway = StubGateway(
+        {
+            "actions_list": (
+                {"workflow_runs": []},
+                {
+                    "workflow_runs": [
+                        {
+                            "id": 5,
+                            "head_sha": SOURCE_SHA,
+                            "event": "workflow_dispatch",
+                            "status": "waiting",
+                            "conclusion": None,
+                        }
+                    ]
+                },
+            ),
+            "actions_run_trigger": {},
+            "actions_get": {
+                "id": 5,
+                "head_sha": SOURCE_SHA,
+                "status": "waiting",
+            },
+        }
+    )
+
+    def command_output(_command: list[str], _cwd: Path, _timeout: int) -> str:
+        return json.dumps(
+            [
+                {
+                    "current_user_can_approve": True,
+                    "environment": {"id": 9, "name": "production"},
+                    "reviewers": [{"type": "User"}],
+                    "wait_timer": 0,
+                }
+            ]
+        )
+
+    runtime = ReleaseRuntime(
+        tmp_path,
+        gateway=gateway,
+        command_output=command_output,
+        sleep=lambda _seconds: None,
+    )
+
+    with pytest.raises(ValueError, match="pending deployment is not exact pypi"):
+        runtime._workflow_run(
+            "tag-release.yml",
+            SOURCE_SHA,
+            {"candidate_tag": "0.7.0-rc.2"},
+        )
+
+
+def _waiting_workflow_gateway(
+    *,
+    exact_run: dict[str, object] | None = None,
+) -> StubGateway:
+    return StubGateway(
+        {
+            "actions_list": (
+                {"workflow_runs": []},
+                {
+                    "workflow_runs": [
+                        {
+                            "id": 5,
+                            "head_sha": SOURCE_SHA,
+                            "event": "workflow_dispatch",
+                            "status": "waiting",
+                            "conclusion": None,
+                        }
+                    ]
+                },
+            ),
+            "actions_run_trigger": {},
+            "actions_get": exact_run
+            or {
+                "id": 5,
+                "head_sha": SOURCE_SHA,
+                "status": "waiting",
+            },
+        }
+    )
+
+
+def _pending_pypi_environment(
+    *,
+    environment_id: int = 9,
+    can_approve: bool = True,
+    wait_timer: int = 0,
+    reviewer_type: str = "User",
+) -> dict[str, object]:
+    return {
+        "current_user_can_approve": can_approve,
+        "environment": {"id": environment_id, "name": "pypi"},
+        "reviewers": [{"type": reviewer_type}],
+        "wait_timer": wait_timer,
+    }
+
+
+@pytest.mark.parametrize(
+    "exact_run",
+    [
+        {"id": 6, "head_sha": SOURCE_SHA, "status": "waiting"},
+        {"id": 5, "head_sha": "f" * 40, "status": "waiting"},
+        {"id": 5, "head_sha": SOURCE_SHA, "status": "in_progress"},
+    ],
+    ids=("run-id-changed", "source-changed", "status-changed"),
+)
+def test_workflow_rejects_waiting_run_identity_change_before_direct_fallback(
+    tmp_path: Path,
+    exact_run: dict[str, object],
+) -> None:
+    commands: list[list[str]] = []
+
+    def command_output(command: list[str], _cwd: Path, _timeout: int) -> str:
+        commands.append(command)
+        return "[]"
+
+    runtime = ReleaseRuntime(
+        tmp_path,
+        gateway=_waiting_workflow_gateway(exact_run=exact_run),
+        command_output=command_output,
+        sleep=lambda _seconds: None,
+    )
+
+    with pytest.raises(ValueError, match="workflow identity changed"):
+        runtime._workflow_run(
+            "tag-release.yml",
+            SOURCE_SHA,
+            {"candidate_tag": "0.7.0-rc.2"},
+        )
+
+    assert commands == []
+
+
+@pytest.mark.parametrize(
+    "pending",
+    [
+        [],
+        [
+            _pending_pypi_environment(environment_id=9),
+            _pending_pypi_environment(environment_id=10),
+        ],
+        [_pending_pypi_environment(can_approve=False)],
+        [_pending_pypi_environment(wait_timer=1)],
+        [_pending_pypi_environment(reviewer_type="Team")],
+    ],
+    ids=(
+        "missing",
+        "multiple",
+        "cannot-approve",
+        "wait-timer",
+        "no-user-reviewer",
+    ),
+)
+def test_workflow_rejects_non_exact_pending_pypi_shape_without_approval_post(
+    tmp_path: Path,
+    pending: list[dict[str, object]],
+) -> None:
+    commands: list[list[str]] = []
+
+    def command_output(command: list[str], _cwd: Path, _timeout: int) -> str:
+        commands.append(command)
+        return json.dumps(pending)
+
+    runtime = ReleaseRuntime(
+        tmp_path,
+        gateway=_waiting_workflow_gateway(),
+        command_output=command_output,
+        sleep=lambda _seconds: None,
+    )
+
+    with pytest.raises(ValueError, match="pending deployment is not exact pypi"):
+        runtime._workflow_run(
+            "tag-release.yml",
+            SOURCE_SHA,
+            {"candidate_tag": "0.7.0-rc.2"},
+        )
+
+    assert commands == [
+        [
+            "gh",
+            "api",
+            "repos/knaisoma/data-olympus/actions/runs/5/pending_deployments",
+        ]
+    ]
+
+
+def test_workflow_rejects_approval_response_bound_to_different_source(
+    tmp_path: Path,
+) -> None:
+    commands: list[list[str]] = []
+
+    def command_output(command: list[str], _cwd: Path, _timeout: int) -> str:
+        commands.append(command)
+        if "--method" not in command:
+            return json.dumps([_pending_pypi_environment()])
+        return json.dumps(
+            [
+                {
+                    "environment": "pypi",
+                    "id": 19,
+                    "sha": "f" * 40,
+                }
+            ]
+        )
+
+    runtime = ReleaseRuntime(
+        tmp_path,
+        gateway=_waiting_workflow_gateway(),
+        command_output=command_output,
+        sleep=lambda _seconds: None,
+    )
+
+    with pytest.raises(ValueError, match="deployment approval identity changed"):
+        runtime._workflow_run(
+            "tag-release.yml",
+            SOURCE_SHA,
+            {"candidate_tag": "0.7.0-rc.2"},
+        )
+
+    assert len(commands) == 2
+    assert commands[0][-1].endswith("/5/pending_deployments")
+    assert "--method" in commands[1]
+
+
+def test_workflow_rejects_pending_environment_for_unapproved_workflow(
+    tmp_path: Path,
+) -> None:
+    commands: list[list[str]] = []
+    runtime = ReleaseRuntime(
+        tmp_path,
+        gateway=_waiting_workflow_gateway(),
+        command_output=lambda command, _cwd, _timeout: commands.append(command) or "[]",
+        sleep=lambda _seconds: None,
+    )
+
+    with pytest.raises(ValueError, match="not an approved release workflow"):
+        runtime._workflow_run(
+            "set-channel.yml",
+            SOURCE_SHA,
+            {"source": "0.7.0-rc.2", "channel": "rc"},
+        )
+
+    assert commands == []
+
+
 def test_workflow_retries_one_unbound_read_without_replaying_dispatch(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary

* resolve exact public GHCR tag digests without GitHub Packages API scope
* advance only exact reviewed RC and stable workflows through one protected pypi environment
* prove every workflow, source, environment, reviewer, timer, cardinality, and response mismatch fails closed

## Verification

* Ruff
* strict mypy across 73 source files
* full Python suite with two documented optional skips
* 74 Bats contracts
* benchmark and documentation guards
* example bundle lint
* Claude Opus review BLOCK addressed by negative coverage
* Claude Sonnet 5 rereview APPROVE for exact commit 4a3161a5804afaa9a8bbfc935e301368b13b794c