### PR TITLE
fix(release): bind no action review to remote main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+* **Bound no action review to current remote main.** Release admission now
+  preserves the freshly fetched `origin/main` revision in the compact review
+  evidence, so an independent reviewer can verify that the admitted source and
+  current remote source are identical before accepting that no release is due.
+
 ## [0.7.0] - 2026-08-02
 
 ### New features

--- a/scripts/operations/release.py
+++ b/scripts/operations/release.py
@@ -299,6 +299,7 @@ def _admission(input_document: dict[str, Any]) -> StageResult:
 
     evidence = {
         "source_revision": source_revision,
+        "remote_main_revision": remote_main_revision,
         "current_version": current,
         "computed_release": {
             "releasable": releasable,

--- a/tests/test_operations_release.py
+++ b/tests/test_operations_release.py
@@ -144,6 +144,7 @@ def test_admission_returns_truthful_no_action_only_for_no_release() -> None:
 
     assert result["status"] == "no_action"
     assert result["evidence"]["source_revision"] == SOURCE_SHA
+    assert result["evidence"]["remote_main_revision"] == SOURCE_SHA
     assert result["outputs"] == {}
 
 


### PR DESCRIPTION
## Summary

Preserve the freshly fetched `origin/main` revision in release admission evidence so the independent no action review can verify the admitted source is current.

## Verification

* Regression test failed first with the missing `remote_main_revision`, then passed after the one field correction.
* Complete Python 3.13 pytest suite passed with two documented optional dependency skips.
* Ruff, `mypy src`, benchmark documentation, 74 Bats checks, bundle lint, documentation consistency, package build, wheel smoke, and source distribution smoke passed.
* Claude Sonnet 5 independently reviewed exact commit `9895853e7acdc504a7834b02ee3cf16b371ac6b4` against `5cb91083d1d7ed846ea22e936d7d766d70f9c18c` and returned `APPROVE` with no findings.