### PR TITLE
chore(release): prepare v0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.7.1] - 2026-08-02
+
+### Fixed
+
+* fix(release): bind no action review to remote main
+
+
 ### Fixed
 
 * **Bound no action review to current remote main.** Release admission now

--- a/docs/releases/v0.7.1.md
+++ b/docs/releases/v0.7.1.md
@@ -1,0 +1,5 @@
+# data-olympus 0.7.1
+
+## Fixed
+
+* fix(release): bind no action review to remote main

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "data-olympus"
-version = "0.7.0"
+version = "0.7.1"
 description = "Governance-grade knowledge-base format (OKF-compatible) plus CLI and single-writer MCP server"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -475,7 +475,7 @@ wheels = [
 
 [[package]]
 name = "data-olympus"
-version = "0.7.0"
+version = "0.7.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Outcome

Prepare immutable Data Olympus release v0.7.1 from exact source `b2dcacb3c6e25c43574ccc8c3b023e0418cd9272`.

## Verification

All repository checks must pass before the deterministic release commit is merged. Publication remains blocked until the resulting exact main SHA receives independent review and SHA bound standing approval.