### PR TITLE
fix(operations): make the release no_action deterministic

### DIFF
--- a/scripts/operations/release.py
+++ b/scripts/operations/release.py
@@ -1545,24 +1545,11 @@ def execute_release_run(
             _milestone(1, "admission", admission["reason"], admission["evidence"])
         )
         if admission["status"] == "no_action":
-            ticket = _request_review_ticket(
-                run_input,
-                dependencies,
-                run_input["source_revision"],
-            )
-            review = _invoke_review(
-                run_input,
-                dependencies,
-                ticket,
-                {
-                    "admission": admission,
-                    "instruction": (
-                        "Approve only when exact current remote main evidence proves "
-                        "that no Data Olympus release is due."
-                    ),
-                    "source_revision": run_input["source_revision"],
-                },
-            )
+            # Deterministic, and reviewed once when the lane revision is
+            # promoted rather than on every run. The runner fails a no_action
+            # result that carries a review_model_use_id or that produced any
+            # model use, so requesting a review here killed every no_action
+            # run with "no_action cannot issue or consume a model ticket".
             record(
                 _project_result(
                     2,
@@ -1570,7 +1557,6 @@ def execute_release_run(
                     admission["reason"],
                     run_input,
                     admission["evidence"],
-                    review_model_use_id=review["model_use_id"],
                 )
             )
             return events

--- a/tests/test_operations_release.py
+++ b/tests/test_operations_release.py
@@ -1649,18 +1649,32 @@ def test_runtime_heartbeats_keep_one_contiguous_protocol_sequence() -> None:
     ]
 
 
-def test_no_action_is_reviewed_and_has_no_candidate_revision() -> None:
+def test_no_action_is_deterministic_and_consumes_no_model_ticket() -> None:
+    # The runner fails a no_action result that carries a review_model_use_id
+    # or that produced any model use at all: a deterministic no_action is
+    # reviewed once when the lane revision is promoted, not per run. This
+    # lane requested and invoked a review on every no_action, so every run
+    # died with "no_action cannot issue or consume a model ticket".
+    requested: list[dict[str, object]] = []
     dependencies = _release_dependencies()
     dependencies["collect_admission"] = lambda _run: _admission_input(
         releasable=False
     )
+    dependencies["request_model_ticket"] = lambda request: requested.append(
+        request
+    ) or _fail("no_action must not request a model ticket")
 
     events = execute_release_run(json.dumps(RUN_INPUT), dependencies)
 
     assert [event["type"] for event in events] == ["milestone", "result"]
     assert events[-1]["status"] == "no_action"
     assert events[-1]["candidate_revision"] is None
-    assert events[-1]["review_model_use_id"] == 71
+    assert events[-1]["review_model_use_id"] is None
+    assert requested == []
+
+
+def _fail(message: str):
+    raise AssertionError(message)
 
 
 def test_release_blocks_when_ledger_approval_is_not_bound_to_candidate() -> None:


### PR DESCRIPTION
## The defect

The ai-operations runner fails any run whose result is `no_action` **and** that carries a `review_model_use_id` or produced any model use:

```
no_action cannot issue or consume a model ticket
```

The documented rationale: a deterministic `no_action` is independently reviewed **once when the lane revision is promoted**, not per run.

This lane requested and invoked a review on every `no_action`, so **every** `no_action` run failed. That is the normal outcome for a daily release check, so the lane was effectively dead.

## Fix

Remove the per-run review. Reviewer feedback made the case sharper: per-run model review could not have repaired non-determinism anyway, and the runner contract prohibits it. If uncertainty remains, admission should raise rather than return `no_action`.

Verified it does: `no_action` is only returned when the computation reports not-releasable, and `ReleaseInputError` is raised when that is internally inconsistent with the bump or next version. A lookup failure cannot silently become a false negative.

## Test

`test_no_action_is_reviewed_and_has_no_candidate_revision` asserted `review_model_use_id == 71`, encoding the behaviour the runner rejects. It now asserts no ticket is requested and no review id is reported.

## Verification

Release tests pass. Full suite **11 failed, 1963 passed**, byte-identical to clean `main` (pre-existing server-CLI and packaging failures).