### PR TITLE
fix(operations): report why a command failed, not just which one

### DIFF
--- a/scripts/operations/release_runtime.py
+++ b/scripts/operations/release_runtime.py
@@ -88,6 +88,23 @@ class UnboundGatewayResultError(ValueError):
     """A text fallback omitted the gateway's requested tool binding."""
 
 
+MAX_COMMAND_FAILURE_STDERR = 400
+
+
+def _command_failure(name: str, returncode: int, stderr: str | None) -> str:
+    """Name the exit code and why, not just which command.
+
+    Both call sites captured stderr and discarded it, so a failure reported
+    only "command failed: uv" while the same command succeeded when run by
+    hand. The detail is bounded because it reaches the run ledger.
+    """
+    detail = (stderr or "").strip().replace("\n", " ")
+    if len(detail) > MAX_COMMAND_FAILURE_STDERR:
+        detail = detail[:MAX_COMMAND_FAILURE_STDERR] + "..."
+    suffix = f": {detail}" if detail else ""
+    return f"command failed: {name} exited {returncode}{suffix}"
+
+
 def _default_command_output(command: list[str], cwd: Path, timeout: int) -> str:
     process = subprocess.run(
         command,
@@ -98,7 +115,9 @@ def _default_command_output(command: list[str], cwd: Path, timeout: int) -> str:
         check=False,
     )
     if process.returncode != 0:
-        raise ValueError(f"command failed: {command[0]}")
+        raise ValueError(
+            _command_failure(command[0], process.returncode, process.stderr)
+        )
     return process.stdout.strip()
 
 
@@ -1123,13 +1142,15 @@ class ReleaseRuntime:
                 process.communicate()
                 raise subprocess.TimeoutExpired(arguments, timeout)
             try:
-                stdout, _stderr = process.communicate(timeout=min(20.0, remaining))
+                stdout, stderr = process.communicate(timeout=min(20.0, remaining))
                 break
             except subprocess.TimeoutExpired:
                 self.heartbeat()
         self.heartbeat()
         if process.returncode != 0:
-            raise ValueError(f"command failed: {arguments[0]}")
+            raise ValueError(
+                _command_failure(arguments[0], process.returncode, stderr)
+            )
         return stdout.strip()
 
     def gateway_object(self, name: str, arguments: dict[str, object]) -> dict[str, Any]:

--- a/tests/test_operations_release_runtime.py
+++ b/tests/test_operations_release_runtime.py
@@ -3364,3 +3364,26 @@ def test_rollback_failure_evidence_tracks_the_digest_apply_boundary(
     )
     assert raised.value.evidence["rollback_completed"] is False
     assert raised.value.evidence["rollback_digest"] == rollback_digest
+
+
+def test_command_failure_reports_the_exit_code_and_stderr(tmp_path) -> None:
+    # Both command paths captured stderr and threw it away, reporting only
+    # "command failed: uv". The release lane failed with exactly that while
+    # the same command succeeded by hand, with no way to see why.
+    import sys
+
+    from scripts.operations.release_runtime import _default_command_output
+
+    script = tmp_path / "boom.py"
+    script.write_text(
+        "import sys\n"
+        "sys.stderr.write('the actual reason\\n')\n"
+        "sys.exit(7)\n"
+    )
+
+    with pytest.raises(ValueError) as caught:
+        _default_command_output([sys.executable, str(script)], tmp_path, 30)
+
+    message = str(caught.value)
+    assert "7" in message
+    assert "the actual reason" in message


### PR DESCRIPTION
Both command paths in `release_runtime` captured stderr and threw it away, raising only `command failed: uv`. The release lane failed with exactly that while the identical command succeeded when run by hand, leaving no way to see the cause.

The message now names the exit code and a bounded stderr excerpt, capped because it reaches the run ledger.

**Fifth instance of this pattern found today.** The others: the runner's inactivity guard masking a batched-event bug, the enigma zero-revision placeholder masking every input error, the gateway's null spawn status discarding ENOENT, and a spawn buffer set equal to the limit it was supposed to report.