### PR TITLE
chore(release): prepare v0.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.7.2] - 2026-08-07
+
+### Fixed
+
+* fix(operations): report why a command failed, not just which one (#230)
+* fix(operations): make the release no_action deterministic (#226)
+
+
 ## [0.7.1] - 2026-08-02
 
 ### Fixed

--- a/docs/releases/v0.7.2.md
+++ b/docs/releases/v0.7.2.md
@@ -1,0 +1,6 @@
+# data-olympus 0.7.2
+
+## Fixed
+
+* fix(operations): report why a command failed, not just which one (#230)
+* fix(operations): make the release no_action deterministic (#226)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "data-olympus"
-version = "0.7.1"
+version = "0.7.2"
 description = "Governance-grade knowledge-base format (OKF-compatible) plus CLI and single-writer MCP server"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -475,7 +475,7 @@ wheels = [
 
 [[package]]
 name = "data-olympus"
-version = "0.7.1"
+version = "0.7.2"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Outcome

Prepare immutable Data Olympus release v0.7.2 from exact source `b59583444bffe65d85187b2332db0e453f7e2c35`.

## Verification

All repository checks must pass before the deterministic release commit is merged. Publication remains blocked until the resulting exact main SHA receives independent review and SHA bound standing approval.