### PR TITLE
fix(write-gate): scan for LLM provider API keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,20 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `/kb-main/.git/config` once the clone succeeds. Provisioning the credential
   outside the URL is the way out of both.
 
+* **Scan for LLM provider API keys.** The built-in secret-scan set covered
+  private keys, GitHub, AWS, Slack, `password=` assignments and connection
+  strings, but no LLM provider key format, so an `sk-ant-…` or `sk-proj-…` key
+  in a proposed memory was committed clean. Users of this project hold these
+  credentials by definition, which makes them the class most likely to be
+  pasted into a memory. Adds `llm_provider_api_key` (Anthropic, OpenAI
+  project/service-account/legacy, OpenRouter, Hugging Face, Groq, xAI, and
+  OpenAI-compatible gateways) and `google_api_key` (`AIza…`, which
+  authenticates Gemini and every other Google API).
+* **Detect two further forms of existing credential classes.** `github_token`
+  now covers `ghu_` user-to-server tokens alongside `ghp_`/`gho_`/`ghs_`/`ghr_`,
+  and `aws_access_key_id` now covers the `ASIA` temporary key id issued by STS
+  as well as `AKIA`.
+
 ## [0.7.2] - 2026-09-07
 
 ### Changed

--- a/docs/serving.md
+++ b/docs/serving.md
@@ -235,8 +235,14 @@ section so concurrent writes cannot corrupt each other:
   `rejected_secret_detected` path, never via `rejected_invalid_document`
   (which echoes the offending value verbatim in its message). The gate
   checks a built-in pattern set (PEM private-key blocks; GitHub `ghp_`/`gho_`/
-  `ghs_`/`ghr_`/`github_pat_` tokens; AWS `AKIA...` access key ids; Slack
-  `xox[bpars]-` tokens; generic `password=`/`passwd=`/`secret=` assignments,
+  `ghs_`/`ghr_`/`ghu_`/`github_pat_` tokens; AWS `AKIA...`/`ASIA...` access key
+  ids, the second being the temporary form issued by STS; Slack `xox[bpars]-`
+  tokens; LLM provider API keys as one `llm_provider_api_key` class (Anthropic
+  `sk-ant-`, OpenAI `sk-proj-`/`sk-svcacct-`/legacy `sk-`, OpenRouter
+  `sk-or-v1-`, Hugging Face `hf_`, Groq `gsk_`, xAI `xai-`, and
+  OpenAI-compatible gateways minting the same shape); Google `AIza...` API
+  keys, which authenticate Gemini and every other Google API and so are their
+  own class; generic `password=`/`passwd=`/`secret=` assignments,
   including env-style prefixed keys like `DB_PASSWORD=`, with a
   non-placeholder value; and `scheme://user:pass@host` connection strings)
   plus any operator-supplied `KB_SECRET_SCAN_EXTRA_PATTERNS`. A match on an

--- a/src/data_olympus/write_gate.py
+++ b/src/data_olympus/write_gate.py
@@ -492,6 +492,14 @@ _GITHUB_TOKEN_RE = re.compile(
 )
 # AKIA is a long-lived access key id; ASIA is the temporary/session form issued
 # by STS. Both are access key ids and leak the same way, so they share a class.
+#
+# Known limit, inherited from the key shape rather than introduced here: a
+# 20-character all-caps word beginning with one of the prefixes is
+# indistinguishable from a key id (``ASIAPACIFICREGIONXYZ`` matches). Requiring
+# a digit among the 16 would exclude it, but a key id is drawn from uppercase
+# letters and digits, and a digit-free one is on the order of a percent of all
+# ids -- far too common to reject. Missing a real credential is the worse
+# failure, so the shape stays as AWS documents it.
 _AWS_ACCESS_KEY_RE = re.compile(r"\b(?:AKIA|ASIA)[0-9A-Z]{16}\b")
 # LLM provider API keys. Users of this project hold these by definition -- an
 # agent-facing knowledge base is configured with at least one of them -- so they
@@ -518,7 +526,14 @@ _LLM_PROVIDER_KEY_RE = re.compile(
 # Google API key. Not LLM-specific -- the same shape authenticates Gemini, Maps
 # and every other Google API -- so it gets its own class rather than being
 # folded into the one above.
-_GOOGLE_API_KEY_RE = re.compile(r"\bAIza[A-Za-z0-9_-]{35}\b")
+#
+# The tail is a negative lookahead rather than ``\b``. The body is a fixed
+# ``{35}`` with nothing to backtrack into, so a trailing ``\b`` would demand a
+# word character in the 35th position: a key whose last character is ``-``
+# (roughly one in 64, since the alphabet includes it) would fail to match at
+# all. The lookahead asserts the key is not a prefix of a longer token without
+# constraining its final character.
+_GOOGLE_API_KEY_RE = re.compile(r"\bAIza[A-Za-z0-9_-]{35}(?![A-Za-z0-9_-])")
 _SLACK_TOKEN_RE = re.compile(r"\bxox[bpars]-[A-Za-z0-9-]{10,200}\b")
 # Generic key=value / key: value credential assignment. Matches both a bare
 # key (``password=``) and a prefixed key (``DB_PASSWORD=``, ``API_SECRET:``) --

--- a/src/data_olympus/write_gate.py
+++ b/src/data_olympus/write_gate.py
@@ -483,14 +483,42 @@ class SecretScanResult:
 _PRIVATE_KEY_RE = re.compile(
     r"-----BEGIN (?:(?:RSA|EC|OPENSSH|DSA|PGP) )?PRIVATE KEY-----"
 )
-# gh[oprs]_ covers ghp_/gho_/ghs_/ghr_ in one alternation; github_pat_ is a
-# distinct, longer-lived token format introduced later. Both are grouped under
+# gh[oprsu]_ covers ghp_/gho_/ghs_/ghr_/ghu_ in one alternation; github_pat_ is
+# a distinct, longer-lived token format introduced later. Both are grouped under
 # one pattern name since the issue treats them as a single "GitHub tokens"
 # class.
 _GITHUB_TOKEN_RE = re.compile(
-    r"\b(?:gh[oprs]_[A-Za-z0-9]{20,255}|github_pat_[A-Za-z0-9_]{20,255})\b"
+    r"\b(?:gh[oprsu]_[A-Za-z0-9]{20,255}|github_pat_[A-Za-z0-9_]{20,255})\b"
 )
-_AWS_ACCESS_KEY_RE = re.compile(r"\bAKIA[0-9A-Z]{16}\b")
+# AKIA is a long-lived access key id; ASIA is the temporary/session form issued
+# by STS. Both are access key ids and leak the same way, so they share a class.
+_AWS_ACCESS_KEY_RE = re.compile(r"\b(?:AKIA|ASIA)[0-9A-Z]{16}\b")
+# LLM provider API keys. Users of this project hold these by definition -- an
+# agent-facing knowledge base is configured with at least one of them -- so they
+# are the credential class most likely to end up pasted into a memory. Grouped
+# into one class because they leak identically and a caller only needs to know
+# "an LLM provider key is in this postimage".
+#
+# The bare ``sk-`` alternative last also covers OpenAI-compatible gateways that
+# mint keys in the same shape (LiteLLM, vLLM, LocalAI). It cannot swallow the
+# prefixed forms above it: ``[A-Za-z0-9]`` excludes the hyphen, so ``sk-ant-``
+# stops after three characters, far short of the 32 required.
+_LLM_PROVIDER_KEY_RE = re.compile(
+    r"\b(?:"
+    r"sk-ant-[A-Za-z0-9_-]{24,255}"        # Anthropic
+    r"|sk-proj-[A-Za-z0-9_-]{24,255}"      # OpenAI, project-scoped
+    r"|sk-svcacct-[A-Za-z0-9_-]{24,255}"   # OpenAI, service account
+    r"|sk-or-v1-[A-Za-z0-9]{32,255}"       # OpenRouter
+    r"|hf_[A-Za-z0-9]{32,255}"             # Hugging Face
+    r"|gsk_[A-Za-z0-9]{20,255}"            # Groq
+    r"|xai-[A-Za-z0-9]{32,255}"            # xAI
+    r"|sk-[A-Za-z0-9]{32,255}"             # OpenAI legacy / compatible gateways
+    r")\b"
+)
+# Google API key. Not LLM-specific -- the same shape authenticates Gemini, Maps
+# and every other Google API -- so it gets its own class rather than being
+# folded into the one above.
+_GOOGLE_API_KEY_RE = re.compile(r"\bAIza[A-Za-z0-9_-]{35}\b")
 _SLACK_TOKEN_RE = re.compile(r"\bxox[bpars]-[A-Za-z0-9-]{10,200}\b")
 # Generic key=value / key: value credential assignment. Matches both a bare
 # key (``password=``) and a prefixed key (``DB_PASSWORD=``, ``API_SECRET:``) --
@@ -518,6 +546,8 @@ _BUILTIN_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
     ("github_token", _GITHUB_TOKEN_RE),
     ("aws_access_key_id", _AWS_ACCESS_KEY_RE),
     ("slack_token", _SLACK_TOKEN_RE),
+    ("llm_provider_api_key", _LLM_PROVIDER_KEY_RE),
+    ("google_api_key", _GOOGLE_API_KEY_RE),
     ("generic_credential_assignment", _GENERIC_CRED_RE),
     ("connection_string_password", _CONN_STRING_RE),
 )

--- a/tests/test_secret_scan.py
+++ b/tests/test_secret_scan.py
@@ -61,16 +61,36 @@ PRIVATE_KEY = (
 )
 GITHUB_TOKEN = "ghp_" + "1234567890abcdefghijklmnopqrstuvwxyz"
 GITHUB_PAT = "github_pat_" + "11ABCDEFG0123456789_abcdefghijklmnopqrstuvwxyz01234567890"
+GITHUB_USER_TO_SERVER = "ghu_" + "1234567890abcdefghijklmnopqrstuvwxyz"
 AWS_ACCESS_KEY = "AKIA" + "ABCDEFGHIJKLMNOP"
+AWS_SESSION_KEY = "ASIA" + "ABCDEFGHIJKLMNOP"
 SLACK_TOKEN = "xoxb-" + "1234567890-abcdefghijklmnopqrst"
+ANTHROPIC_KEY = "sk-ant-" + "api03-" + "abcdefghij0123456789ABCDEFGHIJ" + "-AAAAAA"
+# Exactly 35 characters after the AIza prefix: a Google API key is 39 total.
+GOOGLE_API_KEY = "AIza" + "SyABCDEFGHIJ0123456789abcdefghij012"
 GENERIC_CRED = "password" + "=" + "Sup3rSecretValue!"
 CONN_STRING = "postgres://dbuser:" + "Sup3rSecretValue!" + "@db.example.com:5432/kb"
+
+# Every LLM provider form the llm_provider_api_key class covers. Same fragment
+# convention as above: never a contiguous literal in tracked source.
+LLM_PROVIDER_KEYS = {
+    "anthropic": ANTHROPIC_KEY,
+    "openai_project": "sk-proj-" + "abcdefghij0123456789ABCDEFGHIJKLMN",
+    "openai_service_account": "sk-svcacct-" + "abcdefghij0123456789ABCDEFGHIJ",
+    "openai_legacy": "sk-" + "abcdefghij0123456789ABCDEFGHIJKLMN",
+    "openrouter": "sk-or-v1-" + "abcdefghij0123456789abcdefghij0123456789",
+    "huggingface": "hf_" + "abcdefghij0123456789ABCDEFGHIJKLMN",
+    "groq": "gsk_" + "abcdefghij0123456789ABCDEF",
+    "xai": "xai-" + "abcdefghij0123456789ABCDEFGHIJKLMN",
+}
 
 ALL_BUILTIN_SECRETS = {
     "private_key_block": PRIVATE_KEY,
     "github_token": GITHUB_TOKEN,
     "aws_access_key_id": AWS_ACCESS_KEY,
     "slack_token": SLACK_TOKEN,
+    "llm_provider_api_key": ANTHROPIC_KEY,
+    "google_api_key": GOOGLE_API_KEY,
     "generic_credential_assignment": GENERIC_CRED,
     "connection_string_password": CONN_STRING,
 }
@@ -131,6 +151,62 @@ def test_scan_detects_github_fine_grained_pat() -> None:
     result = scan_postimage_for_secrets(postimage=f"token: {GITHUB_PAT}\n")
     assert not result.ok
     assert result.match.pattern_name == "github_token"
+
+
+@pytest.mark.parametrize("provider,secret", sorted(LLM_PROVIDER_KEYS.items()))
+def test_scan_detects_every_llm_provider_key_form(provider, secret) -> None:
+    """Anthropic, OpenAI (project / service-account / legacy), OpenRouter,
+    Hugging Face, Groq and xAI all share the llm_provider_api_key class: they
+    leak identically and a caller only needs to know that an LLM provider key
+    is present."""
+    result = scan_postimage_for_secrets(postimage=f"the key is {secret}\n")
+    assert not result.ok, f"{provider} key was not detected"
+    assert result.match is not None
+    assert result.match.pattern_name == "llm_provider_api_key"
+
+
+def test_scan_bare_sk_alternative_does_not_swallow_prefixed_forms() -> None:
+    """The trailing bare ``sk-`` alternative exists for OpenAI-compatible
+    gateways, and must not be what matches a prefixed key: ``[A-Za-z0-9]``
+    excludes the hyphen, so ``sk-ant-`` stops after three characters."""
+    for secret in (LLM_PROVIDER_KEYS["anthropic"],
+                   LLM_PROVIDER_KEYS["openai_project"]):
+        result = scan_postimage_for_secrets(postimage=secret)
+        assert not result.ok
+        assert result.match.pattern_name == "llm_provider_api_key"
+
+
+def test_scan_detects_github_user_to_server_token() -> None:
+    """ghu_ is the user-to-server token form; it belongs to the same class as
+    the other gh*_ prefixes."""
+    result = scan_postimage_for_secrets(postimage=f"token: {GITHUB_USER_TO_SERVER}\n")
+    assert not result.ok
+    assert result.match.pattern_name == "github_token"
+
+
+def test_scan_detects_aws_session_access_key() -> None:
+    """ASIA is the temporary access key id issued by STS. It is still an access
+    key id and leaks the same way as AKIA."""
+    result = scan_postimage_for_secrets(postimage=f"aws key {AWS_SESSION_KEY}\n")
+    assert not result.ok
+    assert result.match.pattern_name == "aws_access_key_id"
+
+
+def test_scan_llm_key_patterns_do_not_flag_ordinary_prose() -> None:
+    """False-positive guard for the new classes. A knowledge base holds commit
+    SHAs, digests, ids and model names; none of them may be refused as a
+    secret, because the write is rejected and the caller has no way to tell the
+    rejection was wrong."""
+    for content in (
+        "Fixed in commit 2145d6251d30054e65cc5ea95b4913a3ab62edf8 on main.",
+        "sha256:ffb752e139c0a19692a43af8d8523b274222dd68eebad5d583b45c2201c6e30a",
+        "The model is claude-opus-5 and the local one is granite4.1:8b.",
+        "Document id 370a4766-588f-4ec5-97de-ce05905f5a67 was superseded.",
+        "Ask the sk- prefixed provider for a new key.",
+        "The task list is in the ADR; see ADR-002 for the serving model.",
+    ):
+        result = scan_postimage_for_secrets(postimage=content)
+        assert result.ok, f"{content!r} should not be flagged"
 
 
 def test_scan_generic_credential_placeholder_is_not_flagged() -> None:

--- a/tests/test_secret_scan.py
+++ b/tests/test_secret_scan.py
@@ -19,6 +19,7 @@ Covers:
 from __future__ import annotations
 
 import os
+import re
 import subprocess
 from unittest.mock import MagicMock
 
@@ -66,8 +67,15 @@ AWS_ACCESS_KEY = "AKIA" + "ABCDEFGHIJKLMNOP"
 AWS_SESSION_KEY = "ASIA" + "ABCDEFGHIJKLMNOP"
 SLACK_TOKEN = "xoxb-" + "1234567890-abcdefghijklmnopqrst"
 ANTHROPIC_KEY = "sk-ant-" + "api03-" + "abcdefghij0123456789ABCDEFGHIJ" + "-AAAAAA"
+# A prefixed key with no run of 32 alphanumerics anywhere in it, so the bare
+# ``sk-`` alternative provably cannot be what matches it. See
+# test_prefixed_key_is_detected_without_help_from_the_bare_sk_alternative.
+ANTHROPIC_KEY_NO_ALNUM_RUN = "sk-ant-" + "api03-" + "abc_def-ghi_jkl-mno_pqr-stu"
 # Exactly 35 characters after the AIza prefix: a Google API key is 39 total.
 GOOGLE_API_KEY = "AIza" + "SyABCDEFGHIJ0123456789abcdefghij012"
+# Same length, last character a hyphen. The key alphabet includes it, and a
+# fixed-length body followed by \b would refuse to match this one at all.
+GOOGLE_API_KEY_TRAILING_HYPHEN = "AIza" + "SyABCDEFGHIJ0123456789abcdefghij01-"
 GENERIC_CRED = "password" + "=" + "Sup3rSecretValue!"
 CONN_STRING = "postgres://dbuser:" + "Sup3rSecretValue!" + "@db.example.com:5432/kb"
 
@@ -165,15 +173,35 @@ def test_scan_detects_every_llm_provider_key_form(provider, secret) -> None:
     assert result.match.pattern_name == "llm_provider_api_key"
 
 
-def test_scan_bare_sk_alternative_does_not_swallow_prefixed_forms() -> None:
-    """The trailing bare ``sk-`` alternative exists for OpenAI-compatible
-    gateways, and must not be what matches a prefixed key: ``[A-Za-z0-9]``
-    excludes the hyphen, so ``sk-ant-`` stops after three characters."""
-    for secret in (LLM_PROVIDER_KEYS["anthropic"],
-                   LLM_PROVIDER_KEYS["openai_project"]):
-        result = scan_postimage_for_secrets(postimage=secret)
-        assert not result.ok
-        assert result.match.pattern_name == "llm_provider_api_key"
+def test_prefixed_key_is_detected_without_help_from_the_bare_sk_alternative() -> None:
+    """The prefixed alternatives must do their own work.
+
+    A SecretMatch carries only a pattern name and a line number, by design, so
+    no assertion can observe which alternative of the class fired. This uses a
+    fixture the bare ``sk-`` alternative cannot possibly match instead: that
+    alternative is ``[A-Za-z0-9]{32,255}``, which excludes both ``-`` and ``_``,
+    and ANTHROPIC_KEY_NO_ALNUM_RUN contains no run of 32 alphanumerics anywhere.
+    A detection therefore proves ``sk-ant-`` matched it.
+    """
+    assert not re.search(r"[A-Za-z0-9]{32}", ANTHROPIC_KEY_NO_ALNUM_RUN), (
+        "fixture must not contain a 32-character alphanumeric run, or the bare "
+        "sk- alternative could match it and this test proves nothing"
+    )
+    result = scan_postimage_for_secrets(postimage=f"the key is {ANTHROPIC_KEY_NO_ALNUM_RUN}\n")
+    assert not result.ok
+    assert result.match.pattern_name == "llm_provider_api_key"
+
+
+def test_scan_detects_google_api_key_ending_in_a_hyphen() -> None:
+    """A Google key's alphabet includes ``-``, so roughly one key in 64 ends
+    with one. The pattern body is a fixed ``{35}`` with nothing to backtrack
+    into, so closing it with ``\\b`` would demand a word character in the final
+    position and silently refuse to match those keys."""
+    result = scan_postimage_for_secrets(
+        postimage=f"key: {GOOGLE_API_KEY_TRAILING_HYPHEN}\n"
+    )
+    assert not result.ok
+    assert result.match.pattern_name == "google_api_key"
 
 
 def test_scan_detects_github_user_to_server_token() -> None:
@@ -207,6 +235,34 @@ def test_scan_llm_key_patterns_do_not_flag_ordinary_prose() -> None:
     ):
         result = scan_postimage_for_secrets(postimage=content)
         assert result.ok, f"{content!r} should not be flagged"
+
+
+def test_scan_asia_prefix_does_not_flag_ordinary_capitalised_prose() -> None:
+    """False-positive guard for widening the AWS class to ASIA. A knowledge
+    base writes about regions, and the word starts the same way as a session
+    key id."""
+    for content in (
+        "Rollout order is ASIA, then EMEA, then AMER.",
+        "The ASIAPACIFIC bucket is replicated nightly.",
+        "Tagged ASIA-PACIFIC-SOUTHEAST for the regional index.",
+        "ASIA and the other three regions share one control plane.",
+    ):
+        result = scan_postimage_for_secrets(postimage=content)
+        assert result.ok, f"{content!r} should not be flagged"
+
+
+def test_scan_asia_prefix_cannot_separate_a_long_all_caps_word_from_a_key_id() -> None:
+    """The known limit of the shape above, asserted rather than left implicit.
+
+    An access key id is a prefix plus 16 characters of uppercase letters and
+    digits, so a 20-character all-caps word starting with ASIA is the same
+    string as far as any regex is concerned. Requiring a digit would resolve it
+    and would also miss the real ids that contain none, which is the worse
+    failure for a gate whose job is to refuse credentials.
+    """
+    result = scan_postimage_for_secrets(postimage="region ASIAPACIFICREGIONXYZ note")
+    assert not result.ok
+    assert result.match.pattern_name == "aws_access_key_id"
 
 
 def test_scan_generic_credential_placeholder_is_not_flagged() -> None:


### PR DESCRIPTION
## The gap

The built-in secret-scan set covers private keys, GitHub, AWS, Slack, `password=` assignments and connection strings, but no LLM provider key format. An `sk-ant-…` key in a proposed memory is committed clean:

```python
>>> scan_postimage_for_secrets(postimage="the key is sk-ant-api03-…")
SecretScanResult(ok=True, match=None)
```

Confirmed end to end against a running server: a memory whose body was an Anthropic key, submitted at confidence 0.99, returned `{"status": "committed"}`.

Users of this project hold these credentials by definition, since an agent-facing knowledge base is configured with at least one of them, which makes them the credential class most likely to be pasted into a memory.

## What this adds

Two classes:

| class | covers |
|---|---|
| `llm_provider_api_key` | Anthropic, OpenAI (`sk-proj-` / `sk-svcacct-` / legacy `sk-`), OpenRouter, Hugging Face, Groq, xAI, and OpenAI-compatible gateways that mint keys in the same shape |
| `google_api_key` | `AIza…`, not LLM-specific (it authenticates Gemini and every other Google API), so it gets its own class rather than being folded in |

Grouping the providers into one class follows the precedent set by `github_token`, which already covers several prefixes: they leak identically, and a caller only needs to know that an LLM provider key is present.

And two forms missing from classes that already exist:

- `github_token` now covers `ghu_` user-to-server tokens alongside `ghp_`/`gho_`/`ghs_`/`ghr_`, a one-character change to the existing alternation.
- `aws_access_key_id` now covers `ASIA`, the temporary key id issued by STS, as well as `AKIA`.

`docs/serving.md` enumerates the built-in set, so it is updated to match; without that it would understate coverage on four counts.

## Notes for review

**Ordering.** The bare `sk-` alternative is last and cannot swallow the prefixed forms above it: `[A-Za-z0-9]` excludes the hyphen, so `sk-ant-` stops after three characters, far short of the 32 required. The test for this uses a fixture with no 32-character alphanumeric run anywhere in it, which the bare alternative provably cannot match, because a `SecretMatch` carries only a pattern name and a line number and so cannot report which alternative fired.

**Terminators.** `google_api_key` closes with a negative lookahead rather than `\b`. Its body is a fixed `{35}` with nothing to backtrack into, so `\b` would demand a word character in the final position, and a key ending in `-` (about one in 64, since the alphabet includes it) would never match at all. The `{24,255}` LLM patterns can shrink, so they keep `\b`.

**Linearity.** All patterns are stdlib `re` with bounded repetition and no nested quantifiers, matching the hand-audited linear-time property of the existing built-ins.

**False positives.** A wrongly rejected write is reported to the caller as a detected secret, with no way to tell the rejection was wrong, so this adds a guard asserting that commit SHAs, `sha256:` digests, UUIDs, model names like `granite4.1:8b`, prose containing the words `sk-`, and capitalised region prose such as `ASIA, then EMEA` are all still accepted. One limit is asserted rather than left implicit: a 20-character all-caps word beginning with `ASIA` is the same string as a session key id, and requiring a digit among the 16 would exclude it at the cost of missing the real ids that contain none. Deliberately **not** added: bare fixed-length tokens with no prefix. Cloudflare's API token shape is `[A-Za-z0-9_-]{40}`, which also matches every git SHA.

**Test fixtures** follow the existing fragment-concatenation convention in `test_secret_scan.py`, so no contiguous credential literal enters tracked source.

## Verification

`uv run ruff check .` clean, `uv run mypy src` clean, `uv run pytest` exit 0 (4 environment skips: `sentence_transformers`, `bun` x2, `tiktoken`) on a fresh clone at `86eecdd`, installed with `uv pip install -e '.[dev]'` as CI does.

Every fix is mutation-checked against a reverted `write_gate.py`:

| mutation | result |
|---|---|
| Google tail back to `\b` | caught |
| `sk-ant-` alternative neutered | caught, including the no-alphanumeric-run test |
| `gh[oprsu]_` back to `gh[oprs]_` | caught |
| `AKIA\|ASIA` back to `AKIA` | caught |

Rebased onto `4d8336b`; the new entries sit alongside the existing `### Security` block under `[Unreleased]`.

Happy to extend the set further if wanted. Telegram bot tokens, `npm_`, `glpat-`, `dckr_pat_` and JWTs were all left out to keep this reviewable, but they are one line each.
