### PR TITLE
fix(deploy): bootstrap /kb-main when only KB_REMOTE_URL is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,19 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+* **Bootstrap `/kb-main` on the docker compose path.** The first-boot clone in
+  `deploy/docker/entrypoint.sh` keyed off `KB_GIT_REMOTE_URL`, but
+  `deploy/docker/compose.yaml` carries only `KB_REMOTE_URL` — which is also the
+  variable `docs/adoption.md` and `docs/quickstart.md` document. A compose
+  deployment that configured a remote therefore started a read-write server on
+  an empty `/kb-main`, and the first symptom was
+  `git_pull_loop iteration failed: … rev-parse HEAD … exit status 128`, which
+  does not point at the cause. The clone now falls back to `KB_REMOTE_URL`;
+  `KB_GIT_REMOTE_URL` still takes precedence, so the k8s path where the
+  initContainer has already cloned is unchanged.
+
 ## [0.7.2] - 2026-09-07
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,19 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `KB_GIT_REMOTE_URL` still takes precedence, so the k8s path where the
   initContainer has already cloned is unchanged.
 
+### Security
+
+* **The first-boot clone no longer logs the remote URL.** `KB_REMOTE_URL` is
+  documented as an SSH or HTTPS push target and the compose path mounts no SSH
+  key by default, so a writable remote there is most likely an HTTPS URL with an
+  embedded token. The entrypoint printed that URL verbatim before cloning, into
+  a container log no application-level redaction can reach. It now reports only
+  that it is cloning the configured remote. That removes the unconditional
+  disclosure rather than every path to one: git inherits the same stdout and
+  stderr, and a token embedded in a clone URL is still written to
+  `/kb-main/.git/config` once the clone succeeds. Provisioning the credential
+  outside the URL is the way out of both.
+
 ## [0.7.2] - 2026-09-07
 
 ### Changed
@@ -48,6 +61,7 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   and fresh zero-alert clearance after the merge before anything is published.
   Previously the rule read as an unqualified zero-alert gate, which no branch
   fixing a default-branch alert could ever satisfy before merging.
+
 
 ### Fixed
 

--- a/deploy/docker/compose.yaml
+++ b/deploy/docker/compose.yaml
@@ -16,6 +16,10 @@ services:
       KB_HTTP_PORT: "8080"
       KB_SYNC_INTERVAL_SEC: "60"
       KB_STALENESS_DEGRADED_SEC: "600"
+      # Set this to a git remote to enable the write pipeline; left empty the
+      # server runs read-only. The entrypoint also uses it to clone /kb-main on
+      # first boot when KB_GIT_REMOTE_URL is not set separately, so on this
+      # path one variable is enough.
       KB_REMOTE_URL: ""
     volumes:
       - kb-main:/kb-main

--- a/deploy/docker/entrypoint.sh
+++ b/deploy/docker/entrypoint.sh
@@ -67,14 +67,28 @@ fi
 # --- Bootstrap /kb-main on first boot (docker compose path only) -------------
 # In k8s the initContainer already cloned /kb-main. For a bare docker run there is
 # no initContainer, so do it here. Idempotent: skipped when /kb-main is non-empty.
-# Safe: only clones when KB_GIT_REMOTE_URL is set. On clone failure the volume
-# stays empty and the MCP reports degraded so the operator notices.
-if [ -n "${KB_GIT_REMOTE_URL:-}" ] && [ -d /kb-main ]; then
+# On clone failure the volume stays empty and the MCP reports degraded so the
+# operator notices.
+#
+# Two variables name a remote: KB_GIT_REMOTE_URL is the clone source read here
+# and by the k8s initContainer, KB_REMOTE_URL is the push target read by the
+# server. The k8s manifests set both from one secret key, but compose.yaml
+# carries only KB_REMOTE_URL -- which is also the one docs/adoption.md and
+# docs/quickstart.md document. A compose deployment that set the documented
+# variable therefore got a read-write server on an unbootstrapped /kb-main, and
+# the first symptom was `git_pull_loop iteration failed: ... rev-parse HEAD ...
+# exit status 128`, which does not point at the cause.
+#
+# Falling back keeps k8s behaviour identical -- KB_GIT_REMOTE_URL still wins
+# when set -- while making the compose path bootstrap as this block's own
+# comment already claims it does.
+clone_url="${KB_GIT_REMOTE_URL:-${KB_REMOTE_URL:-}}"
+if [ -n "$clone_url" ] && [ -d /kb-main ]; then
     found_real_files=$(find /kb-main -mindepth 1 -maxdepth 1 \
         ! -name 'lost+found' -print -quit 2>/dev/null || true)
     if [ -z "$found_real_files" ]; then
-        echo "[entrypoint] /kb-main is empty; cloning ${KB_GIT_REMOTE_URL}"
-        if git clone "$KB_GIT_REMOTE_URL" /kb-main; then
+        echo "[entrypoint] /kb-main is empty; cloning ${clone_url}"
+        if git clone "$clone_url" /kb-main; then
             echo "[entrypoint] bootstrap complete"
         else
             echo "[entrypoint] WARNING: clone failed; pod will start degraded"

--- a/deploy/docker/entrypoint.sh
+++ b/deploy/docker/entrypoint.sh
@@ -87,7 +87,13 @@ if [ -n "$clone_url" ] && [ -d /kb-main ]; then
     found_real_files=$(find /kb-main -mindepth 1 -maxdepth 1 \
         ! -name 'lost+found' -print -quit 2>/dev/null || true)
     if [ -z "$found_real_files" ]; then
-        echo "[entrypoint] /kb-main is empty; cloning ${clone_url}"
+        # The URL is deliberately absent from this message. KB_REMOTE_URL is
+        # documented as an "SSH or HTTPS" push target and this path mounts no SSH
+        # key by default, so the realistic way to reach a writable remote here is
+        # an HTTPS URL with an embedded token. Echoing it would put that token in
+        # the container log before the clone even runs, where nothing downstream
+        # can redact it. The operator already has the value in the environment.
+        echo "[entrypoint] /kb-main is empty; cloning configured remote"
         if git clone "$clone_url" /kb-main; then
             echo "[entrypoint] bootstrap complete"
         else

--- a/tests/test_deploy_manifests.py
+++ b/tests/test_deploy_manifests.py
@@ -165,3 +165,24 @@ def test_entrypoint_has_no_gosu_or_chown() -> None:
 def test_compose_binds_loopback() -> None:
     text = (DOCKER_DIR / "compose.yaml").read_text()
     assert "127.0.0.1:8080:8080" in text
+
+
+def test_entrypoint_bootstrap_falls_back_to_kb_remote_url() -> None:
+    """The compose path sets only KB_REMOTE_URL -- it is the documented one and
+    the only remote variable compose.yaml carries -- so the first-boot clone
+    must fall back to it. Without the fallback a compose deployment that
+    configured a remote started a read-write server on an unbootstrapped
+    /kb-main. KB_GIT_REMOTE_URL must still take precedence so the k8s path,
+    where the initContainer has already cloned, is unchanged.
+    """
+    text = (DOCKER_DIR / "entrypoint.sh").read_text()
+    assert '${KB_GIT_REMOTE_URL:-${KB_REMOTE_URL:-}}' in text, (
+        "first-boot clone must fall back from KB_GIT_REMOTE_URL to KB_REMOTE_URL"
+    )
+
+
+def test_compose_documents_that_kb_remote_url_also_bootstraps() -> None:
+    """A reader of compose.yaml should not have to discover the fallback by
+    watching the pull loop fail."""
+    text = (DOCKER_DIR / "compose.yaml").read_text()
+    assert "KB_GIT_REMOTE_URL" in text

--- a/tests/test_deploy_manifests.py
+++ b/tests/test_deploy_manifests.py
@@ -257,16 +257,25 @@ def test_bootstrap_is_a_no_op_with_no_remote_configured(tmp_path: Path) -> None:
 
 
 @requires_sh
-def test_bootstrap_log_does_not_leak_a_credential(tmp_path: Path) -> None:
+@pytest.mark.parametrize("variable", ["KB_REMOTE_URL", "KB_GIT_REMOTE_URL"])
+def test_bootstrap_log_does_not_leak_a_credential(tmp_path: Path, variable: str) -> None:
     """KB_REMOTE_URL is documented as an "SSH or HTTPS" push target and the
     compose path mounts no SSH key, so a writable remote there is most likely an
     HTTPS URL carrying a token. The pre-clone log line must not put it in the
-    container log, where no application-level redaction can reach it."""
-    url = "https://kb-bot:s3cr3t-token@example.test/kb.git"
-    out, argv = _run_bootstrap(tmp_path, {"KB_REMOTE_URL": url})
+    container log, where no application-level redaction can reach it.
+
+    Both variables carry the case. Either can hold the token, and a log line
+    naming whichever one this case leaves unset would still leak: with only the
+    compose variable covered, an `echo ... ${KB_GIT_REMOTE_URL}` regression
+    expands to nothing here and passes.
+    """
+    url = f"https://kb-bot:s3cr3t-token@{variable.lower()}.example.test/kb.git"
+    out, argv = _run_bootstrap(tmp_path, {variable: url})
     assert url in argv, "sanity: the clone still uses the configured remote"
     assert "s3cr3t-token" not in out
     assert "example.test" not in out
+    # Catches URL shapes these cases do not spell out, credential-bearing or not.
+    assert "://" not in out
 
 
 def test_compose_documents_that_kb_remote_url_also_bootstraps() -> None:

--- a/tests/test_deploy_manifests.py
+++ b/tests/test_deploy_manifests.py
@@ -8,10 +8,12 @@ default apply, and the readiness probe pointed at /readyz.
 """
 from __future__ import annotations
 
+import os
 import shutil
 import subprocess
 from pathlib import Path
 
+import pytest
 import yaml
 
 K8S_DIR = Path(__file__).resolve().parents[1] / "deploy" / "k8s"
@@ -167,18 +169,104 @@ def test_compose_binds_loopback() -> None:
     assert "127.0.0.1:8080:8080" in text
 
 
-def test_entrypoint_bootstrap_falls_back_to_kb_remote_url() -> None:
-    """The compose path sets only KB_REMOTE_URL -- it is the documented one and
-    the only remote variable compose.yaml carries -- so the first-boot clone
-    must fall back to it. Without the fallback a compose deployment that
-    configured a remote started a read-write server on an unbootstrapped
-    /kb-main. KB_GIT_REMOTE_URL must still take precedence so the k8s path,
-    where the initContainer has already cloned, is unchanged.
+# --- First-boot clone: run the real block, do not grep it --------------------
+# The bootstrap block decides which of two variables names the remote and logs a
+# line before cloning. Both are behaviours, so they are exercised rather than
+# matched as strings: the block is lifted out of entrypoint.sh unmodified and run
+# with a stub `git` that records its argv.
+
+BOOTSTRAP_MARKER = "# --- Bootstrap /kb-main on first boot"
+
+# The container mount point cannot exist on the test host, so it is redirected
+# into the tmp dir. Nothing else about the block is rewritten.
+KB_MAIN_MOUNT = "/kb-main"
+
+
+def _bootstrap_block() -> str:
+    """The first-boot clone block, taken verbatim from entrypoint.sh.
+
+    The surrounding script writes to fixed absolute paths (/tmp/known_hosts) and
+    ends in ``exec "$@"``, so running it whole on a test host is not an option.
     """
     text = (DOCKER_DIR / "entrypoint.sh").read_text()
-    assert '${KB_GIT_REMOTE_URL:-${KB_REMOTE_URL:-}}' in text, (
-        "first-boot clone must fall back from KB_GIT_REMOTE_URL to KB_REMOTE_URL"
+    start = text.index(BOOTSTRAP_MARKER)
+    end = text.index('exec "$@"', start)
+    return text[start:end]
+
+
+def _run_bootstrap(tmp_path: Path, env: dict[str, str]) -> tuple[str, list[str]]:
+    """Run the block with a stub git; return its output and git's argv.
+
+    The stub prints nothing, so everything captured is the block's own output.
+    """
+    kb_main = tmp_path / "kb-main"
+    kb_main.mkdir()
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    argv_file = tmp_path / "git-argv"
+    git_stub = bin_dir / "git"
+    git_stub.write_text(f'#!/bin/sh\nprintf "%s\\n" "$@" >> "{argv_file}"\n')
+    git_stub.chmod(0o755)
+
+    script = tmp_path / "bootstrap.sh"
+    script.write_text("set -e\n" + _bootstrap_block().replace(KB_MAIN_MOUNT, str(kb_main)))
+
+    proc = subprocess.run(
+        ["sh", str(script)],
+        capture_output=True, text=True, timeout=30,
+        env={"PATH": f"{bin_dir}:{os.environ.get('PATH', '')}", **env},
     )
+    assert proc.returncode == 0, proc.stderr
+    argv = argv_file.read_text().splitlines() if argv_file.exists() else []
+    return proc.stdout + proc.stderr, argv
+
+
+requires_sh = pytest.mark.skipif(os.name != "posix", reason="POSIX shell required")
+
+
+@requires_sh
+def test_bootstrap_clones_when_only_kb_remote_url_is_set(tmp_path: Path) -> None:
+    """The compose path carries only KB_REMOTE_URL -- it is the documented one,
+    and the only remote variable compose.yaml sets. Without the fallback the
+    clone never ran there and the server came up read-write on an unbootstrapped
+    /kb-main, whose first symptom was the pull loop failing `rev-parse HEAD`."""
+    _, argv = _run_bootstrap(tmp_path, {"KB_REMOTE_URL": "ssh://git@example.test/kb.git"})
+    assert "clone" in argv
+    assert "ssh://git@example.test/kb.git" in argv
+
+
+@requires_sh
+def test_bootstrap_prefers_kb_git_remote_url(tmp_path: Path) -> None:
+    """k8s sets both from one secret key and its initContainer has already
+    cloned, so the clone source must not change there."""
+    _, argv = _run_bootstrap(tmp_path, {
+        "KB_GIT_REMOTE_URL": "ssh://git@example.test/clone-source.git",
+        "KB_REMOTE_URL": "ssh://git@example.test/push-target.git",
+    })
+    assert "ssh://git@example.test/clone-source.git" in argv
+    assert "ssh://git@example.test/push-target.git" not in argv
+
+
+@requires_sh
+def test_bootstrap_is_a_no_op_with_no_remote_configured(tmp_path: Path) -> None:
+    """compose.yaml ships KB_REMOTE_URL empty; the server then runs read-only and
+    there is nothing to clone."""
+    out, argv = _run_bootstrap(tmp_path, {"KB_REMOTE_URL": ""})
+    assert argv == []
+    assert out.strip() == ""
+
+
+@requires_sh
+def test_bootstrap_log_does_not_leak_a_credential(tmp_path: Path) -> None:
+    """KB_REMOTE_URL is documented as an "SSH or HTTPS" push target and the
+    compose path mounts no SSH key, so a writable remote there is most likely an
+    HTTPS URL carrying a token. The pre-clone log line must not put it in the
+    container log, where no application-level redaction can reach it."""
+    url = "https://kb-bot:s3cr3t-token@example.test/kb.git"
+    out, argv = _run_bootstrap(tmp_path, {"KB_REMOTE_URL": url})
+    assert url in argv, "sanity: the clone still uses the configured remote"
+    assert "s3cr3t-token" not in out
+    assert "example.test" not in out
 
 
 def test_compose_documents_that_kb_remote_url_also_bootstraps() -> None:


### PR DESCRIPTION
## The problem

`deploy/docker/entrypoint.sh` keys its first-boot clone off `KB_GIT_REMOTE_URL`:

```sh
if [ -n "${KB_GIT_REMOTE_URL:-}" ] && [ -d /kb-main ]; then
```

But `deploy/docker/compose.yaml` carries only `KB_REMOTE_URL`, which is also the variable documented in `docs/adoption.md` and `docs/quickstart.md`, and the one the server reads for its push target.

So on the compose path the block is a no-op, and a deployment that configured a remote gets a **read-write server on an unbootstrapped `/kb-main`** — even though the block's own comment says it handles the clone "for a plain `docker compose` run (no initContainer)".

## Why it is hard to diagnose

Nothing says "not cloned". The MCP write tools return

```json
{"status": "write_pipeline_disabled"}
```

as a *successful* call rather than an error, and the visible symptom is

```
git_pull_loop iteration failed: Command '['git', '-C', '/kb-main',
'rev-parse', 'HEAD']' returned non-zero exit status 128
```

which names neither the missing clone nor the variable responsible.

## The fix

The two names look like a mistake but are a deliberate split: `KB_GIT_REMOTE_URL` is the clone source read by the entrypoint and the k8s initContainer, `KB_REMOTE_URL` is the push target read by the server, and `deploy/k8s/statefulset.yaml` wires **both** from a single secret key. So this renames nothing. It falls back:

```sh
clone_url="${KB_GIT_REMOTE_URL:-${KB_REMOTE_URL:-}}"
```

`KB_GIT_REMOTE_URL` still wins when set, leaving the k8s path byte-identical, while the compose path bootstraps as documented.

The pre-clone log line no longer prints the URL (review follow-up in `3ce063a`). `KB_REMOTE_URL` is documented as an SSH or HTTPS push target and the compose path mounts no SSH key by default, so the realistic way to get a writable remote there is an HTTPS URL with an embedded token. Routing that variable into the clone would have put the token in the container log, before the clone runs and regardless of whether it succeeds, where no application-level redaction can reach it. The message now reads:

```sh
echo "[entrypoint] /kb-main is empty; cloning configured remote"
```

That closes the unconditional disclosure, not every path to one. `git` inherits the same stdout and stderr, and a token embedded in a clone URL is written to `/kb-main/.git/config` once the clone succeeds. Both follow from putting a credential in the URL at all, and provisioning it separately is the way out; neither is in scope here.

What stays unchanged on the k8s path is remote selection: `deploy/k8s/statefulset.yaml` and `deploy/k8s/read-replica/deployment.yaml` bind both variables to the same secret key, so the `:-` fallthrough cannot pick a different remote there. The line that path would log if it ever did bootstrap does change.

## Verification

Ran the isolated bootstrap block against a local bare repo in all three cases:

| environment | result |
|---|---|
| only `KB_REMOTE_URL` set | clones — this is the case that was broken |
| both set | uses `KB_GIT_REMOTE_URL`, k8s behaviour unchanged |
| neither set | no clone, exits 0 |

Those three cases plus the log-redaction rule are now regression tests in `tests/test_deploy_manifests.py`. They run the real block rather than grepping it: the block is lifted out of `entrypoint.sh` between its marker comment and `exec "$@"`, with only the `/kb-main` mount point redirected into a tmp dir, and executed with a stub `git` on `PATH` that records its argv and prints nothing. So the assertions cover which URL git was actually invoked with, and the captured output is entirely the entrypoint's own.

Every test was checked against a mutated `entrypoint.sh`, since a test that has never failed proves nothing:

| mutation | result |
|---|---|
| `cloning ${clone_url}` | caught (2 tests) |
| `cloning ${KB_GIT_REMOTE_URL}` | caught (1) |
| `cloning ${KB_REMOTE_URL}` | caught (1) |
| fallback removed | caught (2) |
| precedence inverted | caught (1) |

`sh -n` clean, `uv run ruff check .` clean, `uv run mypy src` clean, `uv run pytest` exit 0 (4 environment skips: `sentence_transformers`, `bun` x2, `tiktoken`) on a fresh clone of this branch at `2469aef`, installed with `uv pip install -e '.[dev]'` as CI does.

Rebased onto `a1913ad`. The only conflict was `CHANGELOG.md`; both entries now sit under the current empty `[Unreleased]` block, above `## [0.7.2] - 2026-09-07`.

Found while deploying v0.7.1 via `docker compose` against a self-hosted remote.
