### PR TITLE
docs(release): define the release source when main has advanced past the reviewed revision

### DIFF
--- a/.rules/release-routine.md
+++ b/.rules/release-routine.md
@@ -86,10 +86,61 @@ sole parent `B`, preserving linear history. Other merge methods are not supporte
 Changed base or content requires new review. Candidate fields remain `H`;
 provenance names `M`. Rerun checks and security clearance on `M`.
 
+### When main has advanced past the reviewed revision
+
+The rule above assumes the release merge is still the tip of `main`. It is not
+always: another pull request can merge between review and publication. Unless
+that pull request itself carried a qualifying release review and human merge,
+no revision then satisfies the rule as written, because the reviewed revision
+is no longer `main` and `main`'s tree has not been reviewed as a unit. That is
+a real gap, not a technicality to argue past, and it must be closed
+deliberately rather than by publishing anyway.
+
+The preferred resolution is to make the reviewed revision the tip again, by
+preparing the next reviewed change on top and publishing from that. Coordinate
+a short pause on other merges around final validation and dispatch, because
+each new merge restarts this. If merges keep landing, the release is delayed;
+that is the correct outcome. Never weaken an identity check to guarantee
+progress.
+
+Publication from a revision that is not `main` is a fallback. It relaxes only
+the requirement to publish from the tip: the squash-parent and reviewed-tree
+proofs, and every other requirement in this contract, still apply in full. It
+is permitted only when every one of the following holds and is recorded:
+
+* The chosen source `S` is the exact revision whose tree was reviewed and
+  approved as a unit, and its digest is stated in the release record.
+* `S` is an ancestor of `main`.
+* Every commit between `S` and `main` was independently reviewed and merged by
+  a human through the normal pull-request path. An unreviewed commit in that
+  range blocks publication outright.
+* Those commits change no input to a published artifact, directly or
+  transitively. Absence from the wheel and sdist manifests and from the image
+  build is necessary but never sufficient on its own. Inputs include, and are
+  not limited to: packaged files, and note that `CHANGELOG.md` is in the sdist
+  manifest; build helpers and anything they read; generated metadata and
+  provenance; release notes, which the publication workflows consume; and the
+  publication and release workflows themselves, which control how artifacts
+  are produced and therefore always block this fallback. A change that alters
+  release authorization or validation blocks it too, even when no artifact
+  byte would differ.
+* The release record names `S` explicitly and notes that `main` is ahead of it,
+  listing the intervening commits. Provenance and the OCI
+  `org.opencontainers.image.revision` label name `S`, so the published image
+  identity is `S` and not `main`. Never describe the release as built from
+  `main` when it was not.
+* Gates and security clearance are rerun on `S`, not inherited from `main` or
+  from the pre-merge candidate.
+
+If any condition fails, prepare a fresh reviewed pull request and obtain a
+human merge instead. Automation never resolves this by relabelling a failed
+identity check as passing.
+
 Delivery is a direct continuation after human merge. Workflows use explicit
 `workflow_dispatch`, not push-triggered tagging:
 
-1. Dispatch `rc-publish.yml` with exact source SHA `M` and a positive candidate
+1. Dispatch `rc-publish.yml` with the exact chosen source SHA, which is `M`
+   normally and `S` under the fallback above, and a positive candidate
    number. Publish wheel, sdist, OCI image, `release-provenance.json`, PyPI
    version, and GitHub prerelease.
 2. Verify hashes, provenance, and digest. Record a rollback digest, deploy the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,19 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+* **The release contract now says what to do when `main` advances past the
+  reviewed revision.** The delivery rule assumed the release merge was still
+  the tip of `main`. That stops being true when anything else merges between
+  review and publication without itself carrying a qualifying release review
+  and human merge: the reviewed revision is no longer `main`, `main`'s tree has
+  not been reviewed as a unit, and no revision satisfies the rule as written. The contract now names the preferred resolution (make the
+  reviewed revision the tip again) and defines a narrow fallback with explicit
+  conditions, including that every intervening commit was independently
+  reviewed and human-merged, that none of them changes an input to a published
+  artifact, that a change to a publication workflow always blocks the fallback,
+  and that provenance and the OCI `org.opencontainers.image.revision` label
+  name the exact source rather than `main`.
+
 * **Python 3.14 now has test coverage.** `requires-python` has always been
   `>= 3.13`, so 3.14 was inside the supported range and users could install
   there, but nothing verified it. CI now runs `mypy` and the pytest suite on

--- a/docs/releases/v0.7.2.md
+++ b/docs/releases/v0.7.2.md
@@ -70,6 +70,14 @@ before a release can be handed over.
 
 ## Changed
 
+* **The release contract covers the case where `main` moves between review and
+  publication.** Previously the delivery rule assumed the release merge was
+  still the tip of `main`; once anything else merged first without carrying its
+  own qualifying release review, no revision satisfied it. The contract now prefers making the reviewed revision the tip
+  again, and defines a narrow, fully conditioned fallback for publishing from
+  an earlier reviewed revision, including that the published image identity
+  names that exact source rather than `main`.
+
 * **Python 3.14 now has test coverage.** `requires-python` has always been
   `>= 3.13`, so 3.14 was already inside the supported range, but nothing
   verified it. CI now runs `mypy` and the pytest suite on 3.14 alongside 3.13.


### PR DESCRIPTION
## Outcome

Closes the delivery gap that stopped v0.7.2 publication, and makes this branch
the reviewed tip so the release identity proof passes exactly rather than by
exception.

## The problem, which is not hypothetical

`.rules/release-routine.md` says: *"Fetch main SHA `M`; prove its tree exactly
equals reviewed tree `T`."* That assumes the release merge is still the tip of
`main`.

It stopped being true during this cycle. #245 squash-merged as `6c244a6`, whose
tree is exactly the reviewed tree with the approved sole parent. #169 then
merged on top. From that moment **no revision satisfied the contract**:

- `6c244a6` has the reviewed tree, but is not `main`.
- `a1913ad` is `main`, but its tree was never reviewed as a unit.

Publication stopped there rather than picking whichever reading was convenient.

## What this changes

The contract now states the preferred resolution first: **make the reviewed
revision the tip again** by preparing the next reviewed change on top and
publishing from that. This pull request is itself that resolution for the
current release.

It then defines a narrow fallback for publishing from an earlier reviewed
revision, permitted only when every condition holds and is recorded:

- The source is the exact revision reviewed and approved as a unit, digest
  stated in the release record.
- It is an ancestor of `main`.
- Every commit between it and `main` was independently reviewed and
  human-merged. An unreviewed commit in that range blocks publication outright.
- None of those commits changes an input to a published artifact, **directly or
  transitively**. Absence from the wheel and sdist manifests and from the image
  build is necessary but **never sufficient on its own**. Inputs include
  packaged files (note that `CHANGELOG.md` is in the sdist manifest), build
  helpers and anything they read, generated metadata and provenance, release
  notes which the publication workflows consume, and the publication and
  release workflows themselves, which always block the fallback. A change that
  alters release authorization or validation blocks it too, even when no
  artifact byte would differ.
- The release record names the source explicitly, notes that `main` is ahead,
  and lists the intervening commits. Provenance and the OCI
  `org.opencontainers.image.revision` label name that source, so the published
  image identity is the source and not `main`.
- Gates and security clearance are rerun on that source, never inherited.

If any condition fails, a fresh reviewed pull request and human merge are
required. Automation never resolves this by relabelling a failed identity check
as passing.

The fallback relaxes **only** the requirement to publish from the tip. The
squash-parent and reviewed-tree proofs, and every other requirement in this
contract, still apply in full.

The clause also names the convergence risk: each new merge restarts this, so it
tells the reader to coordinate a short pause on other merges around final
validation and dispatch, and states that if merges keep landing the release is
delayed and that this is the correct outcome. Identity checks are never
weakened to guarantee progress.

## Why the image-label condition is there

It was nearly missed. Choosing a different source SHA changes
`org.opencontainers.image.revision`, so the published image identity differs
even when the packaged bytes do not. A release described as built from `main`
when it was built from an ancestor would be inaccurate provenance, which is
precisely the class of problem this project exists to prevent.

## Scope

Contract and release documents only: no code, no dependency, and no workflow
logic changes. Note that this is **not** the same as touching no packaged
input - `CHANGELOG.md` ships in the sdist, which is exactly why the clause now
names it. That was caught in review after I claimed otherwise, and it is why
artifact validation is re-run on the exact head rather than inferred.

The version stays 0.7.2, which `scripts/compute_release.py` still computes for
this history.

## Verification on this exact head

Local gate suite: **all ten gates pass, `complete: true`**, including
`security_alerts` with zero open Dependabot and code scanning alerts. CI: all
ten checks SUCCESS, including `test-python-3-14`. Base rechecked immediately
before handoff and unchanged.

## Merge

Squash merge only. After this merges, `main`'s tree equals this reviewed tree,
and v0.7.2 publishes from `main` with the identity proof satisfied as written.
