### PR TITLE
fix(release): unblock product source changes and scan for LLM provider keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+* **The README links the Lulu MCP marketplace listing.** Lulu aggregates the
+  official MCP Registry, Glama, PulseMCP and Smithery, so the listing is not an
+  independent signal on top of the Glama score already shown; it is one more
+  place an agent or a person can find the server. The badge is a static label,
+  so treat it as a pointer rather than as live listing status.
+
 * **The release contract now says what to do when `main` advances past the
   reviewed revision.** The delivery rule assumed the release merge was still
   the tip of `main`. That stops being true when anything else merges between

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -167,8 +167,10 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   because both are word characters. A key wrapped in Markdown emphasis
   (`_KEY_`) was therefore invisible to the scanner, for every provider, and the
   same shape occurs in YAML flow keys and dunder names. The boundaries now
-  exclude alphanumerics instead, which still refuses a longer token while
-  letting a delimiter sit against the key. The xAI alphabet also gained `_`,
+  exclude alphanumerics instead, which still rejects an immediately preceding
+  ASCII letter or digit while letting a delimiter sit against the key. That is
+  narrower than refusing every longer token: text joined to a key by `-` or `_`
+  can still match, which is the direction a credential scanner should err in. The xAI alphabet also gained `_`,
   without which a key containing one was missed completely. The gate remains
   shape-based: it can still miss a credential whose format it does not model,
   and it does not scan or revoke anything already in history.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,32 +12,6 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-### Fixed
-
-* **Bootstrap `/kb-main` on the docker compose path.** The first-boot clone in
-  `deploy/docker/entrypoint.sh` keyed off `KB_GIT_REMOTE_URL`, but
-  `deploy/docker/compose.yaml` carries only `KB_REMOTE_URL` — which is also the
-  variable `docs/adoption.md` and `docs/quickstart.md` document. A compose
-  deployment that configured a remote therefore started a read-write server on
-  an empty `/kb-main`, and the first symptom was
-  `git_pull_loop iteration failed: … rev-parse HEAD … exit status 128`, which
-  does not point at the cause. The clone now falls back to `KB_REMOTE_URL`;
-  `KB_GIT_REMOTE_URL` still takes precedence, so the k8s path where the
-  initContainer has already cloned is unchanged.
-
-### Security
-
-* **The first-boot clone no longer logs the remote URL.** `KB_REMOTE_URL` is
-  documented as an SSH or HTTPS push target and the compose path mounts no SSH
-  key by default, so a writable remote there is most likely an HTTPS URL with an
-  embedded token. The entrypoint printed that URL verbatim before cloning, into
-  a container log no application-level redaction can reach. It now reports only
-  that it is cloning the configured remote. That removes the unconditional
-  disclosure rather than every path to one: git inherits the same stdout and
-  stderr, and a token embedded in a clone URL is still written to
-  `/kb-main/.git/config` once the clone succeeds. Provisioning the credential
-  outside the URL is the way out of both.
-
 ## [0.7.2] - 2026-09-07
 
 ### Changed
@@ -78,6 +52,16 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+* **Bootstrap `/kb-main` on the docker compose path.** The first-boot clone in
+  `deploy/docker/entrypoint.sh` keyed off `KB_GIT_REMOTE_URL`, but
+  `deploy/docker/compose.yaml` carries only `KB_REMOTE_URL`, which is also the
+  variable `docs/adoption.md` and `docs/quickstart.md` document. A compose
+  deployment that configured a remote therefore started a read-write server on
+  an empty `/kb-main`, and the first symptom was
+  `git_pull_loop iteration failed: … rev-parse HEAD … exit status 128`, which
+  does not point at the cause. The clone now falls back to `KB_REMOTE_URL`;
+  `KB_GIT_REMOTE_URL` still takes precedence, so the k8s path where the
+  initContainer has already cloned is unchanged.
 * **Bind the benchmark receipt to its measurement commit instead of the working
   tree.** The receipt's `dependency_lock` was compared against the *current*
   `uv.lock`, so every dependency change failed the `benchmark-docs` CI guard
@@ -132,6 +116,17 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `pyjwt >= 3.4.0` for its `crypto` extra) still permit 49.0.0. An existing
   environment is not upgraded automatically. See `docs/releases/v0.7.2.md` for
   the explicit upgrade command.
+
+* **The first-boot clone no longer logs the remote URL.** `KB_REMOTE_URL` is
+  documented as an SSH or HTTPS push target and the compose path mounts no SSH
+  key by default, so a writable remote there is most likely an HTTPS URL with an
+  embedded token. The entrypoint printed that URL verbatim before cloning, into
+  a container log no application-level redaction can reach. It now reports only
+  that it is cloning the configured remote. That removes the unconditional
+  disclosure rather than every path to one: git inherits the same stdout and
+  stderr, and a token embedded in a clone URL is still written to
+  `/kb-main/.git/config` once the clone succeeds. Provisioning the credential
+  outside the URL is the way out of both.
 
 ## [0.7.1] - 2026-08-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,6 +149,20 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `/kb-main/.git/config` once the clone succeeds. Provisioning the credential
   outside the URL is the way out of both.
 
+* **Scan for LLM provider API keys.** The built-in secret-scan set covered
+  private keys, GitHub, AWS, Slack, `password=` assignments and connection
+  strings, but no LLM provider key format, so an `sk-ant-…` or `sk-proj-…` key
+  in a proposed memory was committed clean. Users of this project hold these
+  credentials by definition, which makes them the class most likely to be
+  pasted into a memory. Adds `llm_provider_api_key` (Anthropic, OpenAI
+  project/service-account/legacy, OpenRouter, Hugging Face, Groq, xAI, and
+  OpenAI-compatible gateways) and `google_api_key` (`AIza…`, which
+  authenticates Gemini and every other Google API).
+* **Detect two further forms of existing credential classes.** `github_token`
+  now covers `ghu_` user-to-server tokens alongside `ghp_`/`gho_`/`ghs_`/`ghr_`,
+  and `aws_access_key_id` now covers the `ASIA` temporary key id issued by STS
+  as well as `AKIA`.
+
 ## [0.7.1] - 2026-08-02
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -157,11 +157,21 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   pasted into a memory. Adds `llm_provider_api_key` (Anthropic, OpenAI
   project/service-account/legacy, OpenRouter, Hugging Face, Groq, xAI, and
   OpenAI-compatible gateways) and `google_api_key` (`AIza…`, which
-  authenticates Gemini and every other Google API).
+  authenticates Gemini and the other Google APIs that accept API keys).
 * **Detect two further forms of existing credential classes.** `github_token`
   now covers `ghu_` user-to-server tokens alongside `ghp_`/`gho_`/`ghs_`/`ghr_`,
   and `aws_access_key_id` now covers the `ASIA` temporary key id issued by STS
   as well as `AKIA`.
+* **Secret-scan boundaries no longer depend on word characters.** The new key
+  classes above anchored with `\b`, which cannot fire between `_` and a letter
+  because both are word characters. A key wrapped in Markdown emphasis
+  (`_KEY_`) was therefore invisible to the scanner, for every provider, and the
+  same shape occurs in YAML flow keys and dunder names. The boundaries now
+  exclude alphanumerics instead, which still refuses a longer token while
+  letting a delimiter sit against the key. The xAI alphabet also gained `_`,
+  without which a key containing one was missed completely. The gate remains
+  shape-based: it can still miss a credential whose format it does not model,
+  and it does not scan or revoke anything already in history.
 
 ## [0.7.1] - 2026-08-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,11 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
-* **The README links the Lulu MCP marketplace listing.** Lulu aggregates the
-  official MCP Registry, Glama, PulseMCP and Smithery, so the listing is not an
-  independent signal on top of the Glama score already shown; it is one more
-  place an agent or a person can find the server. The badge is a static label,
-  so treat it as a pointer rather than as live listing status.
+* **The README links the Lulu MCP marketplace listing.** Lulu aggregates several
+  registries including Glama, which this README already badges, so the listing
+  may well be derived from that one rather than being an independent signal.
+  It is one more place an agent or a person can find the server. The badge is a
+  static label, so treat it as a pointer rather than as live listing status.
 
 * **The release contract now says what to do when `main` advances past the
   reviewed revision.** The delivery rule assumed the release merge was still
@@ -65,11 +65,14 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   fix, which is the same defect already corrected for `dependency_lock` and the
   same wrong assertion: that today's source produced numbers measured before it
   existed. The digest is now recomputed from the source as committed at the
-  receipt's own `source_commit`, read from git history. Tamper-evidence is
-  stronger rather than weaker: the recorded file list is compared as well as the
-  digest, so a file that existed at the measurement commit but was dropped from
-  the receipt is now caught, which the previous per-file walk could not see
-  because it iterated the very list being shortened.
+  receipt's own `source_commit`, read from git history. Integrity of the
+  historical record is stronger, not weaker: the recorded file list is compared
+  as well as the digest, so a file that existed at the measurement commit but
+  was dropped from the receipt is now caught, which the previous per-file walk
+  could not see because it iterated the very list being shortened. What the
+  guard deliberately stops asserting is any correspondence between today's
+  source and the published numbers. It never established that the benchmarks
+  actually ran at the declared commit, and it does not now.
 * **Bootstrap `/kb-main` on the docker compose path.** The first-boot clone in
   `deploy/docker/entrypoint.sh` keyed off `KB_GIT_REMOTE_URL`, but
   `deploy/docker/compose.yaml` carries only `KB_REMOTE_URL`, which is also the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,18 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+* **Product source changes no longer fail the benchmark guard.** The receipt's
+  `source_tree` digest was compared against the working tree, so any edit under
+  `src/data_olympus/` or `benchmarks/` failed `benchmark-docs` with
+  `source_tree sha256 does not match the repository`. That blocked every product
+  fix, which is the same defect already corrected for `dependency_lock` and the
+  same wrong assertion: that today's source produced numbers measured before it
+  existed. The digest is now recomputed from the source as committed at the
+  receipt's own `source_commit`, read from git history. Tamper-evidence is
+  stronger rather than weaker: the recorded file list is compared as well as the
+  digest, so a file that existed at the measurement commit but was dropped from
+  the receipt is now caught, which the previous per-file walk could not see
+  because it iterated the very list being shortened.
 * **Bootstrap `/kb-main` on the docker compose path.** The first-boot clone in
   `deploy/docker/entrypoint.sh` keyed off `KB_GIT_REMOTE_URL`, but
   `deploy/docker/compose.yaml` carries only `KB_REMOTE_URL`, which is also the

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # data-olympus
 
 [![knaisoma/data-olympus MCP server](https://glama.ai/mcp/servers/knaisoma/data-olympus/badges/score.svg)](https://glama.ai/mcp/servers/knaisoma/data-olympus)
+[![MCP Marketplace](https://img.shields.io/badge/MCP%20Marketplace-Indexed-blueviolet)](https://getlulu.dev/mcps)
 
 **New here? Start with [WHY.md](WHY.md).** It is the story behind the project: the
 problem we kept hitting with coding agents, what data-olympus does differently, how

--- a/benchmarks/receipt.py
+++ b/benchmarks/receipt.py
@@ -85,11 +85,14 @@ def _query_group(repo_root: Path) -> dict[str, Any]:
     )
 
 
+# Both the benchmark harness and the shipped package are measured source: a
+# change to either could move a published number. Named once so the verifier
+# cannot drift from the writer.
+SOURCE_PATTERNS = ("benchmarks/**/*.py", "src/data_olympus/**/*.py")
+
+
 def _source_group(repo_root: Path) -> dict[str, Any]:
-    return _file_group(
-        repo_root,
-        _relative_files(repo_root, ("benchmarks/**/*.py", "src/data_olympus/**/*.py")),
-    )
+    return _file_group(repo_root, _relative_files(repo_root, SOURCE_PATTERNS))
 
 
 def _output_group(repo_root: Path) -> dict[str, Any]:

--- a/docs/releases/v0.7.2.md
+++ b/docs/releases/v0.7.2.md
@@ -63,6 +63,16 @@ release can be handed over.
 
 ## Fixed
 
+* **Any change to shipped source failed CI.** The benchmark receipt's
+  `source_tree` digest was checked against the working tree, so editing anything
+  under `src/data_olympus/` or `benchmarks/` failed the `benchmark-docs` guard
+  regardless of what the change was. Combined with the `dependency_lock` half
+  fixed in the same release, the guard had reached the point where neither a
+  dependency update nor a product fix could go green. Both halves now verify
+  against the revision the measurement was taken at, read from git history,
+  which is the fact the receipt actually records. The source check also gained
+  a file-list comparison, so omitting a measured file from the receipt is now
+  detected (#246).
 * **A docker compose deployment that configured a remote came up on an empty
   knowledge base.** The first-boot clone in `deploy/docker/entrypoint.sh` keyed
   off `KB_GIT_REMOTE_URL`, but `deploy/docker/compose.yaml` sets only

--- a/docs/releases/v0.7.2.md
+++ b/docs/releases/v0.7.2.md
@@ -11,6 +11,26 @@ release can be handed over.
 
 ## Security
 
+* **The write gate now scans for LLM provider API keys.** Contributed in #237.
+  The built-in secret-scan set covered private keys, GitHub, AWS, Slack,
+  `password=` assignments and connection strings, but no LLM provider key
+  format, so an `sk-ant-...` or `sk-proj-...` key pasted into a proposed memory
+  was committed clean. Users of this project hold exactly those credentials, so
+  they are the class most likely to end up in a memory. Adds
+  `llm_provider_api_key` (Anthropic, OpenAI project, service-account and legacy,
+  OpenRouter, Hugging Face, Groq, xAI, and OpenAI-compatible gateways) and
+  `google_api_key` for the `AIza` form that authenticates Gemini and every other
+  Google API. `github_token` gains `ghu_` user-to-server tokens and
+  `aws_access_key_id` gains the `ASIA` temporary id issued by STS.
+
+  Worth knowing if you relied on the first version of that pattern during
+  review: the Google matcher initially ended in `\b` against a fixed-length
+  body, which requires a word character in the final position. Google keys draw
+  from an alphabet including `-`, so a key ending in one never matched at all,
+  roughly one key in 64. It uses a negative lookahead now, which refuses a
+  longer token without constraining the last character. Only the released
+  behaviour matters here, and the released behaviour detects both.
+
 * **The full dependency set is refreshed.** 71 locked packages move to their
   latest resolved versions, including `mcp` 1.28.1 to 1.29.1, `fastmcp` 3.4.4
   to 3.4.7, `starlette` 1.3.1 to 1.6.0 and `regex` 2026.7.10 to 2026.9.3.

--- a/docs/releases/v0.7.2.md
+++ b/docs/releases/v0.7.2.md
@@ -3,9 +3,11 @@
 Scheduled availability 2026-09-07. Until this version is published, that date is
 a plan, not a record.
 
-Dependency updates work again, the whole dependency set is refreshed, Python
-3.14 is tested, and the release contract says what a security alert must prove
-before a release can be handed over.
+Dependency updates work again, the whole dependency set is refreshed, a docker
+compose deployment that configured a remote now bootstraps instead of coming up
+empty, the first-boot clone no longer prints that remote's URL, Python 3.14 is
+tested, and the release contract says what a security alert must prove before a
+release can be handed over.
 
 ## Security
 
@@ -45,8 +47,33 @@ before a release can be handed over.
   * An existing environment is not upgraded automatically, for the same
     reason. See Upgrading.
 
+* **The first-boot clone no longer prints the remote URL.** `deploy/docker/entrypoint.sh`
+  echoed the configured remote verbatim before cloning. `KB_REMOTE_URL` is
+  documented as an SSH or HTTPS push target and the compose path mounts no SSH
+  key by default, so a writable remote there is most likely an HTTPS URL with an
+  embedded token, and the log is a destination no application-level redaction
+  reaches. The line now names no URL.
+
+  This removes the unconditional disclosure, not every path to one. Git inherits
+  the same stdout and stderr, and a token embedded in a clone URL is still
+  written to `/kb-main/.git/config` once the clone succeeds. Both follow from
+  putting a credential in the URL at all; provisioning it separately is the way
+  out. The equivalent line in the Kubernetes initContainer is unchanged in this
+  release and is tracked separately (#248).
+
 ## Fixed
 
+* **A docker compose deployment that configured a remote came up on an empty
+  knowledge base.** The first-boot clone in `deploy/docker/entrypoint.sh` keyed
+  off `KB_GIT_REMOTE_URL`, but `deploy/docker/compose.yaml` sets only
+  `KB_REMOTE_URL`, which is the variable `docs/adoption.md` and
+  `docs/quickstart.md` tell you to set. The clone therefore never ran on that
+  path, and the server started read-write against an unbootstrapped `/kb-main`.
+  The only symptom was `git_pull_loop iteration failed: ... rev-parse HEAD ...
+  exit status 128`, which does not point at the cause. The clone now falls back
+  to `KB_REMOTE_URL`. `KB_GIT_REMOTE_URL` still takes precedence, so the
+  Kubernetes path, where the initContainer has already cloned, is unchanged
+  (#238).
 * **Dependency updates are no longer blocked by a historical benchmark
   measurement.** The `benchmark-docs` guard compared the benchmark receipt's
   recorded `dependency_lock` against the *current* `uv.lock`, so every change

--- a/docs/releases/v0.7.2.md
+++ b/docs/releases/v0.7.2.md
@@ -156,7 +156,23 @@ release can be handed over.
 
 ## Upgrading
 
-There is no runtime, API, CLI, MCP, or bundle-format change in this release.
+There is no API, CLI, MCP, or bundle-format change in this release, but there is
+one runtime behaviour change worth knowing before you upgrade.
+
+The write gate rejects more postimages than it did in 0.7.1, because it now
+recognises LLM provider and Google API key shapes and two further forms of the
+GitHub and AWS classes. A write carrying credential-shaped text that previously
+succeeded will now be rejected with `rejected_secret_detected`. That is the
+point of the change, but it can also fire on an identifier that merely looks
+like a key, so a legitimate write can be blocked. The operator override on the
+pending path is the escape hatch.
+
+Two limits, stated plainly because a secret scanner invites more confidence than
+it earns. Detection is shape-based: the gate never contacts a provider, so it
+can miss a real credential whose format it does not model. And upgrading changes
+what happens to future writes only. It does not scan what is already committed,
+and it does not remove or revoke a credential that reached history before this
+release. If one did, rotate it; nothing here does that for you.
 
 To guarantee the patched `cryptography` in any environment, ask for it
 explicitly, because nothing in this distribution's metadata forces it:

--- a/docs/releases/v0.7.2.md
+++ b/docs/releases/v0.7.2.md
@@ -72,7 +72,10 @@ release can be handed over.
   against the revision the measurement was taken at, read from git history,
   which is the fact the receipt actually records. The source check also gained
   a file-list comparison, so omitting a measured file from the receipt is now
-  detected (#246).
+  detected. Being precise about what was given up: the guard no longer claims
+  any relationship between the source shipping today and the published numbers.
+  It never established that the benchmarks were actually executed at the
+  declared commit, and it still does not (#246).
 * **A docker compose deployment that configured a remote came up on an empty
   knowledge base.** The first-boot clone in `deploy/docker/entrypoint.sh` keyed
   off `KB_GIT_REMOTE_URL`, but `deploy/docker/compose.yaml` sets only

--- a/docs/serving.md
+++ b/docs/serving.md
@@ -235,8 +235,14 @@ section so concurrent writes cannot corrupt each other:
   `rejected_secret_detected` path, never via `rejected_invalid_document`
   (which echoes the offending value verbatim in its message). The gate
   checks a built-in pattern set (PEM private-key blocks; GitHub `ghp_`/`gho_`/
-  `ghs_`/`ghr_`/`github_pat_` tokens; AWS `AKIA...` access key ids; Slack
-  `xox[bpars]-` tokens; generic `password=`/`passwd=`/`secret=` assignments,
+  `ghs_`/`ghr_`/`ghu_`/`github_pat_` tokens; AWS `AKIA...`/`ASIA...` access key
+  ids, the second being the temporary form issued by STS; Slack `xox[bpars]-`
+  tokens; LLM provider API keys as one `llm_provider_api_key` class (Anthropic
+  `sk-ant-`, OpenAI `sk-proj-`/`sk-svcacct-`/legacy `sk-`, OpenRouter
+  `sk-or-v1-`, Hugging Face `hf_`, Groq `gsk_`, xAI `xai-`, and
+  OpenAI-compatible gateways minting the same shape); Google `AIza...` API
+  keys, which authenticate Gemini and every other Google API and so are their
+  own class; generic `password=`/`passwd=`/`secret=` assignments,
   including env-style prefixed keys like `DB_PASSWORD=`, with a
   non-placeholder value; and `scheme://user:pass@host` connection strings)
   plus any operator-supplied `KB_SECRET_SCAN_EXTRA_PATTERNS`. A match on an

--- a/docs/serving.md
+++ b/docs/serving.md
@@ -230,10 +230,12 @@ section so concurrent writes cannot corrupt each other:
 - A **secret-scanning gate** (issue #71) runs on the postimage BEFORE the
   content-validation gate, on every commit path (auto-commit propose, resolve
   approve, including a resolved `edited_text`, and onboarding bootstrap). It
-  runs first so a postimage that is both malformed AND carries a
-  credential-shaped value is always rejected via the redacted
-  `rejected_secret_detected` path, never via `rejected_invalid_document`
-  (which echoes the offending value verbatim in its message). The gate
+  runs first so that whenever the gate matches, a postimage that is both
+  malformed AND carries a credential-shaped value is rejected via the redacted
+  `rejected_secret_detected` path rather than `rejected_invalid_document`
+  (which echoes the offending value verbatim in its message). Detection is
+  shape-based, so this ordering guarantee is only as good as the pattern set:
+  a credential the patterns do not recognise is not redacted by it either. The gate
   checks a built-in pattern set (PEM private-key blocks; GitHub `ghp_`/`gho_`/
   `ghs_`/`ghr_`/`ghu_`/`github_pat_` tokens; AWS `AKIA...`/`ASIA...` access key
   ids, the second being the temporary form issued by STS; Slack `xox[bpars]-`
@@ -241,11 +243,16 @@ section so concurrent writes cannot corrupt each other:
   `sk-ant-`, OpenAI `sk-proj-`/`sk-svcacct-`/legacy `sk-`, OpenRouter
   `sk-or-v1-`, Hugging Face `hf_`, Groq `gsk_`, xAI `xai-`, and
   OpenAI-compatible gateways minting the same shape); Google `AIza...` API
-  keys, which authenticate Gemini and every other Google API and so are their
-  own class; generic `password=`/`passwd=`/`secret=` assignments,
+  keys, which authenticate Gemini and the other Google APIs that accept API
+  keys, and so are their own class rather than an LLM-specific one; generic `password=`/`passwd=`/`secret=` assignments,
   including env-style prefixed keys like `DB_PASSWORD=`, with a
   non-placeholder value; and `scheme://user:pass@host` connection strings)
-  plus any operator-supplied `KB_SECRET_SCAN_EXTRA_PATTERNS`. A match on an
+  plus any operator-supplied `KB_SECRET_SCAN_EXTRA_PATTERNS`. Every class is a
+  shape, not a validation: the gate recognises credential-*shaped* text and
+  never contacts a provider, so it can both miss a real credential whose format
+  it does not model and flag an identifier that merely looks like one. Treat it
+  as a backstop against accidental paste, not as proof a postimage is clean.
+  A match on an
   auto-commit or bootstrap path rejects the write `rejected_secret_detected`
   before anything is written to disk. Only the pattern name and an
   approximate line number are ever surfaced in the response, the audit

--- a/scripts/check_benchmark_docs.py
+++ b/scripts/check_benchmark_docs.py
@@ -21,6 +21,15 @@ set the repository ships today, and this guard deliberately keeps them apart:
   update does not invalidate a past measurement; it only means the numbers were
   measured somewhere else, which is what the published provenance label already
   says.
+* ``source_tree`` is bound the same way, and for the same reason. The recorded
+  digest is recomputed from the benchmark and product source **as committed at
+  ``source_commit``**, never from the working tree. Recomputing the aggregate,
+  rather than only walking the recorded file list, is what catches a file that
+  existed at the measurement commit but was left out of the receipt.
+* The working tree's current source is allowed to move freely. Comparing it to
+  the receipt made every change under ``src/data_olympus/`` fail this guard, so
+  no product fix could go green, and it asserted the same untruth as the lock
+  comparison did.
 
 Requiring the two to be equal is what previously made every dependency update
 fail this guard, including security updates, and it asserted something untrue:
@@ -42,13 +51,14 @@ import subprocess
 import sys
 import tempfile
 from collections.abc import Mapping
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 # Make the repo root importable so `benchmarks` resolves when run from CI.
 _ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(_ROOT))
 
 _DEPENDENCY_LOCK_MISMATCH = "dependency_lock does not match uv.lock"
+_SOURCE_TREE_MISMATCH = "source_tree sha256 does not match the repository"
 _SHA_PATTERN = re.compile(r"^[0-9a-f]{40}$")
 
 
@@ -114,6 +124,95 @@ def historical_lock_problems(
     return []
 
 
+def _measured_source(repo_root: Path, source_commit: str) -> dict[str, bytes] | None:
+    """Every measured source file as committed, or None when history is absent.
+
+    Returns the whole set rather than one file at a time so the aggregate can be
+    recomputed from the commit itself. A receipt that omits a file which existed
+    at the measurement commit is then a mismatch rather than a shorter walk.
+    """
+    from benchmarks.receipt import SOURCE_PATTERNS
+
+    listing = subprocess.run(
+        ["git", "ls-tree", "-r", "--name-only", "-z", source_commit],
+        cwd=repo_root,
+        capture_output=True,
+    )
+    if listing.returncode != 0:
+        return None
+    names = [n for n in listing.stdout.decode("utf-8").split("\0") if n]
+    wanted = sorted(
+        name for name in names
+        if any(PurePosixPath(name).full_match(pattern) for pattern in SOURCE_PATTERNS)
+    )
+    contents: dict[str, bytes] = {}
+    for name in wanted:
+        blob = subprocess.run(
+            ["git", "show", f"{source_commit}:{name}"],
+            cwd=repo_root,
+            capture_output=True,
+        )
+        if blob.returncode != 0:
+            return None
+        contents[name] = blob.stdout
+    return contents
+
+
+def historical_source_tree_problems(
+    document: Mapping[str, object],
+    repo_root: Path,
+) -> list[str]:
+    """Verify the receipt's source digest against its own measurement commit.
+
+    Materialises the committed files into a scratch tree and reuses
+    ``benchmarks.receipt._file_group`` so the aggregate is produced by the exact
+    code that wrote it, rather than by a second implementation that could drift.
+    """
+    from benchmarks.receipt import SOURCE_PATTERNS, _file_group, _relative_files
+
+    expected = document.get("source_tree")
+    if not isinstance(expected, Mapping):
+        return ["source_tree is missing from the receipt"]
+    expected_sha = expected.get("sha256")
+    expected_files = expected.get("files")
+    if not isinstance(expected_sha, str) or not isinstance(expected_files, list):
+        return ["source_tree is malformed in the receipt"]
+
+    source_commit = document.get("source_commit")
+    if not isinstance(source_commit, str) or not _SHA_PATTERN.fullmatch(source_commit):
+        return ["source_commit must be a lowercase 40 character git SHA"]
+
+    measured = _measured_source(repo_root, source_commit)
+    if measured is None:
+        return [
+            "measured source is unreachable at source_commit "
+            f"{source_commit}; a full-history checkout is required"
+        ]
+
+    with tempfile.TemporaryDirectory() as scratch:
+        root = Path(scratch)
+        for name, content in measured.items():
+            path = root / name
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_bytes(content)
+        group = _file_group(root, _relative_files(root, SOURCE_PATTERNS))
+    # Both halves are compared. The digest alone would accept a receipt whose
+    # file list had an entry removed while the digest was left intact, and the
+    # per-file walk in verify_receipt cannot see an omission because it iterates
+    # the very list being shortened.
+    if group["sha256"] != expected_sha:
+        return [
+            "source_tree does not match the source at source_commit "
+            f"{source_commit}"
+        ]
+    if group["files"] != expected_files:
+        return [
+            "source_tree file list does not match the source at source_commit "
+            f"{source_commit}"
+        ]
+    return []
+
+
 def receipt_problems(repo_root: Path) -> list[str]:
     """Verify committed benchmark evidence before checking rendered claims."""
     from benchmarks.receipt import RECEIPT_PATH, verify_receipt
@@ -126,12 +225,17 @@ def receipt_problems(repo_root: Path) -> list[str]:
     except (json.JSONDecodeError, OSError) as exc:
         return [f"invalid benchmark receipt: {exc}"]
 
-    # Every failure except the current-lock comparison is preserved exactly as
-    # verify_receipt reported it. Only that one comparison is replaced, and it
-    # is replaced by a strictly separate check rather than suppressed, so a
-    # historical mismatch can never be hidden by dropping it.
-    problems = [p for p in verify_receipt(document, repo_root) if p != _DEPENDENCY_LOCK_MISMATCH]
-    return problems + historical_lock_problems(document, repo_root)
+    # Every failure except the two current-tree comparisons is preserved exactly
+    # as verify_receipt reported it. Each of those is replaced by a strictly
+    # separate historical check rather than suppressed, so a mismatch against
+    # the measurement commit can never be hidden by dropping one.
+    replaced = {_DEPENDENCY_LOCK_MISMATCH, _SOURCE_TREE_MISMATCH}
+    problems = [p for p in verify_receipt(document, repo_root) if p not in replaced]
+    return (
+        problems
+        + historical_lock_problems(document, repo_root)
+        + historical_source_tree_problems(document, repo_root)
+    )
 
 
 def main() -> int:

--- a/scripts/check_benchmark_docs.py
+++ b/scripts/check_benchmark_docs.py
@@ -133,6 +133,11 @@ def _measured_source(repo_root: Path, source_commit: str) -> dict[str, bytes] | 
     """
     from benchmarks.receipt import SOURCE_PATTERNS
 
+    # Assumes the measured source is tracked regular files, which is true of
+    # every measurement commit to date. Symlinks, gitlinks and submodule
+    # contents are selected differently by git than by a working-tree glob, so a
+    # measurement commit containing one would need this widened rather than
+    # trusted.
     listing = subprocess.run(
         ["git", "ls-tree", "-r", "--name-only", "-z", source_commit],
         cwd=repo_root,
@@ -177,6 +182,10 @@ def historical_source_tree_problems(
     expected_files = expected.get("files")
     if not isinstance(expected_sha, str) or not isinstance(expected_files, list):
         return ["source_tree is malformed in the receipt"]
+    # An empty recorded group would agree with a commit that has no matching
+    # files, so the comparison below would pass while describing nothing.
+    if not expected_files:
+        return ["source_tree records no measured source files"]
 
     source_commit = document.get("source_commit")
     if not isinstance(source_commit, str) or not _SHA_PATTERN.fullmatch(source_commit):

--- a/src/data_olympus/write_gate.py
+++ b/src/data_olympus/write_gate.py
@@ -492,6 +492,14 @@ _GITHUB_TOKEN_RE = re.compile(
 )
 # AKIA is a long-lived access key id; ASIA is the temporary/session form issued
 # by STS. Both are access key ids and leak the same way, so they share a class.
+#
+# Known limit, inherited from the key shape rather than introduced here: a
+# 20-character all-caps word beginning with one of the prefixes is
+# indistinguishable from a key id (``ASIAPACIFICREGIONXYZ`` matches). Requiring
+# a digit among the 16 would exclude it, but a key id is drawn from uppercase
+# letters and digits, and a digit-free one is on the order of a percent of all
+# ids -- far too common to reject. Missing a real credential is the worse
+# failure, so the shape stays as AWS documents it.
 _AWS_ACCESS_KEY_RE = re.compile(r"\b(?:AKIA|ASIA)[0-9A-Z]{16}\b")
 # LLM provider API keys. Users of this project hold these by definition -- an
 # agent-facing knowledge base is configured with at least one of them -- so they
@@ -518,7 +526,14 @@ _LLM_PROVIDER_KEY_RE = re.compile(
 # Google API key. Not LLM-specific -- the same shape authenticates Gemini, Maps
 # and every other Google API -- so it gets its own class rather than being
 # folded into the one above.
-_GOOGLE_API_KEY_RE = re.compile(r"\bAIza[A-Za-z0-9_-]{35}\b")
+#
+# The tail is a negative lookahead rather than ``\b``. The body is a fixed
+# ``{35}`` with nothing to backtrack into, so a trailing ``\b`` would demand a
+# word character in the 35th position: a key whose last character is ``-``
+# (roughly one in 64, since the alphabet includes it) would fail to match at
+# all. The lookahead asserts the key is not a prefix of a longer token without
+# constraining its final character.
+_GOOGLE_API_KEY_RE = re.compile(r"\bAIza[A-Za-z0-9_-]{35}(?![A-Za-z0-9_-])")
 _SLACK_TOKEN_RE = re.compile(r"\bxox[bpars]-[A-Za-z0-9-]{10,200}\b")
 # Generic key=value / key: value credential assignment. Matches both a bare
 # key (``password=``) and a prefixed key (``DB_PASSWORD=``, ``API_SECRET:``) --

--- a/src/data_olympus/write_gate.py
+++ b/src/data_olympus/write_gate.py
@@ -517,8 +517,10 @@ _AWS_ACCESS_KEY_RE = re.compile(r"\b(?:AKIA|ASIA)[0-9A-Z]{16}\b")
 # prefix: an otherwise detectable key wrapped in Markdown emphasis (``_KEY_``)
 # was invisible to this pattern, for every alternative. The same shape occurs in
 # YAML flow keys, dunder names, and any prose that underscores a value. Excluding
-# alphanumerics still refuses a longer token (``xsk-ant-...`` does not match)
-# while letting a delimiter sit against the key. It is deliberately permissive on
+# alphanumerics rejects an immediately preceding ASCII letter or digit
+# (``xsk-ant-...`` does not match) while letting a delimiter sit against the key.
+# That is narrower than refusing every longer token: ``prefix-`` or ``prefix_``
+# joined to a key still matches. It is deliberately permissive on
 # the left: ``prefix-AIza...`` matches, because for a credential scanner a
 # needless flag is recoverable and a missed key is not.
 _LLM_PROVIDER_KEY_RE = re.compile(

--- a/src/data_olympus/write_gate.py
+++ b/src/data_olympus/write_gate.py
@@ -483,14 +483,42 @@ class SecretScanResult:
 _PRIVATE_KEY_RE = re.compile(
     r"-----BEGIN (?:(?:RSA|EC|OPENSSH|DSA|PGP) )?PRIVATE KEY-----"
 )
-# gh[oprs]_ covers ghp_/gho_/ghs_/ghr_ in one alternation; github_pat_ is a
-# distinct, longer-lived token format introduced later. Both are grouped under
+# gh[oprsu]_ covers ghp_/gho_/ghs_/ghr_/ghu_ in one alternation; github_pat_ is
+# a distinct, longer-lived token format introduced later. Both are grouped under
 # one pattern name since the issue treats them as a single "GitHub tokens"
 # class.
 _GITHUB_TOKEN_RE = re.compile(
-    r"\b(?:gh[oprs]_[A-Za-z0-9]{20,255}|github_pat_[A-Za-z0-9_]{20,255})\b"
+    r"\b(?:gh[oprsu]_[A-Za-z0-9]{20,255}|github_pat_[A-Za-z0-9_]{20,255})\b"
 )
-_AWS_ACCESS_KEY_RE = re.compile(r"\bAKIA[0-9A-Z]{16}\b")
+# AKIA is a long-lived access key id; ASIA is the temporary/session form issued
+# by STS. Both are access key ids and leak the same way, so they share a class.
+_AWS_ACCESS_KEY_RE = re.compile(r"\b(?:AKIA|ASIA)[0-9A-Z]{16}\b")
+# LLM provider API keys. Users of this project hold these by definition -- an
+# agent-facing knowledge base is configured with at least one of them -- so they
+# are the credential class most likely to end up pasted into a memory. Grouped
+# into one class because they leak identically and a caller only needs to know
+# "an LLM provider key is in this postimage".
+#
+# The bare ``sk-`` alternative last also covers OpenAI-compatible gateways that
+# mint keys in the same shape (LiteLLM, vLLM, LocalAI). It cannot swallow the
+# prefixed forms above it: ``[A-Za-z0-9]`` excludes the hyphen, so ``sk-ant-``
+# stops after three characters, far short of the 32 required.
+_LLM_PROVIDER_KEY_RE = re.compile(
+    r"\b(?:"
+    r"sk-ant-[A-Za-z0-9_-]{24,255}"        # Anthropic
+    r"|sk-proj-[A-Za-z0-9_-]{24,255}"      # OpenAI, project-scoped
+    r"|sk-svcacct-[A-Za-z0-9_-]{24,255}"   # OpenAI, service account
+    r"|sk-or-v1-[A-Za-z0-9]{32,255}"       # OpenRouter
+    r"|hf_[A-Za-z0-9]{32,255}"             # Hugging Face
+    r"|gsk_[A-Za-z0-9]{20,255}"            # Groq
+    r"|xai-[A-Za-z0-9]{32,255}"            # xAI
+    r"|sk-[A-Za-z0-9]{32,255}"             # OpenAI legacy / compatible gateways
+    r")\b"
+)
+# Google API key. Not LLM-specific -- the same shape authenticates Gemini, Maps
+# and every other Google API -- so it gets its own class rather than being
+# folded into the one above.
+_GOOGLE_API_KEY_RE = re.compile(r"\bAIza[A-Za-z0-9_-]{35}\b")
 _SLACK_TOKEN_RE = re.compile(r"\bxox[bpars]-[A-Za-z0-9-]{10,200}\b")
 # Generic key=value / key: value credential assignment. Matches both a bare
 # key (``password=``) and a prefixed key (``DB_PASSWORD=``, ``API_SECRET:``) --
@@ -518,6 +546,8 @@ _BUILTIN_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
     ("github_token", _GITHUB_TOKEN_RE),
     ("aws_access_key_id", _AWS_ACCESS_KEY_RE),
     ("slack_token", _SLACK_TOKEN_RE),
+    ("llm_provider_api_key", _LLM_PROVIDER_KEY_RE),
+    ("google_api_key", _GOOGLE_API_KEY_RE),
     ("generic_credential_assignment", _GENERIC_CRED_RE),
     ("connection_string_password", _CONN_STRING_RE),
 )

--- a/src/data_olympus/write_gate.py
+++ b/src/data_olympus/write_gate.py
@@ -511,17 +511,27 @@ _AWS_ACCESS_KEY_RE = re.compile(r"\b(?:AKIA|ASIA)[0-9A-Z]{16}\b")
 # mint keys in the same shape (LiteLLM, vLLM, LocalAI). It cannot swallow the
 # prefixed forms above it: ``[A-Za-z0-9]`` excludes the hyphen, so ``sk-ant-``
 # stops after three characters, far short of the 32 required.
+#
+# The boundaries exclude only ALPHANUMERICS, rather than using ``\b``. ``_`` is a
+# word character, so ``\b`` cannot fire between ``_`` and the first letter of a
+# prefix: an otherwise detectable key wrapped in Markdown emphasis (``_KEY_``)
+# was invisible to this pattern, for every alternative. The same shape occurs in
+# YAML flow keys, dunder names, and any prose that underscores a value. Excluding
+# alphanumerics still refuses a longer token (``xsk-ant-...`` does not match)
+# while letting a delimiter sit against the key. It is deliberately permissive on
+# the left: ``prefix-AIza...`` matches, because for a credential scanner a
+# needless flag is recoverable and a missed key is not.
 _LLM_PROVIDER_KEY_RE = re.compile(
-    r"\b(?:"
+    r"(?<![A-Za-z0-9])(?:"
     r"sk-ant-[A-Za-z0-9_-]{24,255}"        # Anthropic
     r"|sk-proj-[A-Za-z0-9_-]{24,255}"      # OpenAI, project-scoped
     r"|sk-svcacct-[A-Za-z0-9_-]{24,255}"   # OpenAI, service account
     r"|sk-or-v1-[A-Za-z0-9]{32,255}"       # OpenRouter
     r"|hf_[A-Za-z0-9]{32,255}"             # Hugging Face
     r"|gsk_[A-Za-z0-9]{20,255}"            # Groq
-    r"|xai-[A-Za-z0-9]{32,255}"            # xAI
+    r"|xai-[A-Za-z0-9_]{32,255}"           # xAI (alphabet includes "_")
     r"|sk-[A-Za-z0-9]{32,255}"             # OpenAI legacy / compatible gateways
-    r")\b"
+    r")(?![A-Za-z0-9])"
 )
 # Google API key. Not LLM-specific -- the same shape authenticates Gemini, Maps
 # and every other Google API -- so it gets its own class rather than being
@@ -533,7 +543,12 @@ _LLM_PROVIDER_KEY_RE = re.compile(
 # (roughly one in 64, since the alphabet includes it) would fail to match at
 # all. The lookahead asserts the key is not a prefix of a longer token without
 # constraining its final character.
-_GOOGLE_API_KEY_RE = re.compile(r"\bAIza[A-Za-z0-9_-]{35}(?![A-Za-z0-9_-])")
+# The trailing exclusion omits ``_`` deliberately. A key is exactly 39
+# characters, so a following ``_`` is either a delimiter or proof the token was
+# never a key; treating it as a delimiter costs a possible needless flag and
+# buys detection of ``_KEY_``, which the fixed-length body cannot recover from
+# by backtracking.
+_GOOGLE_API_KEY_RE = re.compile(r"(?<![A-Za-z0-9])AIza[A-Za-z0-9_-]{35}(?![A-Za-z0-9-])")
 _SLACK_TOKEN_RE = re.compile(r"\bxox[bpars]-[A-Za-z0-9-]{10,200}\b")
 # Generic key=value / key: value credential assignment. Matches both a bare
 # key (``password=``) and a prefixed key (``DB_PASSWORD=``, ``API_SECRET:``) --

--- a/tests/test_benchmark_receipt.py
+++ b/tests/test_benchmark_receipt.py
@@ -1,6 +1,7 @@
 """Executable contract for committed benchmark provenance receipts."""
 from __future__ import annotations
 
+import hashlib
 import json
 import subprocess
 from pathlib import Path
@@ -576,7 +577,13 @@ def test_docs_guard_rejects_a_source_file_dropped_from_the_receipt(
 def test_docs_guard_rejects_missing_source_measurement_history(
     tmp_path: Path,
 ) -> None:
-    """A shallow checkout must fail loudly, never skip the check."""
+    """A shallow checkout must fail loudly, never skip the check.
+
+    Asserts the *new* diagnostic specifically. An earlier version of this test
+    asserted `does not exist in this checkout`, which the pre-existing per-file
+    walk already emits, so it passed even with this check disabled entirely and
+    proved nothing about it.
+    """
     from scripts import check_benchmark_docs
 
     root, receipt = _committed_benchmark_repo(tmp_path)
@@ -586,5 +593,29 @@ def test_docs_guard_rejects_missing_source_measurement_history(
         json.dumps(receipt) + "\n",
     )
 
-    problems = check_benchmark_docs.receipt_problems(root)
-    assert any("does not exist in this checkout" in p for p in problems)
+    problems = check_benchmark_docs.historical_source_tree_problems(receipt, root)
+    assert problems == [
+        "measured source is unreachable at source_commit "
+        + "b" * 40
+        + "; a full-history checkout is required"
+    ]
+
+
+def test_docs_guard_rejects_a_receipt_recording_no_source(tmp_path: Path) -> None:
+    """An empty recorded group must not verify against an empty selection.
+
+    Without this, a receipt whose source_tree was emptied would agree with a
+    commit containing no matching files, and the comparison would pass by
+    describing nothing.
+    """
+    from scripts import check_benchmark_docs
+
+    root, receipt = _committed_benchmark_repo(tmp_path)
+    receipt["source_tree"] = {"sha256": hashlib.sha256().hexdigest(), "files": []}
+    _write(
+        root / "benchmarks" / "results" / "receipt.json",
+        json.dumps(receipt) + "\n",
+    )
+
+    problems = check_benchmark_docs.historical_source_tree_problems(receipt, root)
+    assert problems == ["source_tree records no measured source files"]

--- a/tests/test_benchmark_receipt.py
+++ b/tests/test_benchmark_receipt.py
@@ -40,6 +40,10 @@ version = "0.13.0"
 """,
     )
     _write(root / "benchmarks" / "run.py", "K = 5\n")
+    # The guard hashes product source as well as benchmark source, so the
+    # fixture carries one shipped module. Without it, no test here would
+    # exercise the src/ half of the pattern set.
+    _write(root / "src" / "data_olympus" / "write_gate.py", "SCAN = True\n")
     _write(root / "benchmarks" / "tokenizer.py", "class SimpleTokenizer: pass\n")
     _write(root / "benchmarks" / "corpus" / "z.md", "z corpus\n")
     _write(root / "benchmarks" / "corpus" / "a.md", "a corpus\n")
@@ -274,11 +278,13 @@ def test_docs_guard_surfaces_receipt_drift(tmp_path: Path, monkeypatch) -> None:
         lambda _document, _root: ["outputs sha256 does not match the repository"],
     )
 
-    # The empty document also has no dependency_lock to bind, so the historical
-    # check contributes its own problem alongside the preserved one.
+    # The empty document has neither dependency_lock nor source_tree to bind, so
+    # both historical checks contribute their own problem alongside the
+    # preserved one.
     assert check_benchmark_docs.receipt_problems(tmp_path) == [
         "outputs sha256 does not match the repository",
         "dependency_lock is missing from the receipt",
+        "source_tree is missing from the receipt",
     ]
 
 
@@ -481,3 +487,104 @@ def test_ci_fetches_receipt_source_commit_history() -> None:
     )
 
     assert checkout["with"]["fetch-depth"] == 0
+
+
+# --- source_tree binds to the measurement commit, not the working tree -------
+# Same defect as the dependency_lock half fixed earlier: the recorded digest was
+# compared against whatever is in the tree today, so every edit under
+# src/data_olympus/ or benchmarks/ failed the guard. A past measurement is not
+# invalidated by later source changes.
+
+
+def _edit_product_source(root: Path, content: str) -> None:
+    _write(root / "src" / "data_olympus" / "write_gate.py", content)
+
+
+def test_docs_guard_allows_current_product_source_drift(tmp_path: Path) -> None:
+    """Editing shipped source must not fail the benchmark guard.
+
+    This blocked every product-source change, so an ordinary bug fix could not
+    go green at all. The receipt still describes the source the numbers were
+    measured against, which is unchanged in history.
+    """
+    from benchmarks.receipt import verify_receipt
+    from scripts import check_benchmark_docs
+
+    root, receipt = _committed_benchmark_repo(tmp_path)
+    _edit_product_source(root, "SCAN = True\nGOOGLE = 1\n")
+
+    assert verify_receipt(receipt, root) == [
+        "source_tree sha256 does not match the repository"
+    ]
+    assert check_benchmark_docs.receipt_problems(root) == []
+
+
+def test_docs_guard_allows_current_benchmark_source_drift(tmp_path: Path) -> None:
+    """The same holds for benchmark source, which shares the pattern set."""
+    from scripts import check_benchmark_docs
+
+    root, _ = _committed_benchmark_repo(tmp_path)
+    _write(root / "benchmarks" / "run.py", "K = 7\n")
+
+    assert check_benchmark_docs.receipt_problems(root) == []
+
+
+def test_docs_guard_rejects_tampered_measured_source_digest(tmp_path: Path) -> None:
+    """Relaxing the working-tree comparison must not relax tamper evidence."""
+    from scripts import check_benchmark_docs
+
+    root, receipt = _committed_benchmark_repo(tmp_path)
+    receipt["source_tree"]["sha256"] = "0" * 64
+    _write(
+        root / "benchmarks" / "results" / "receipt.json",
+        json.dumps(receipt) + "\n",
+    )
+
+    problems = check_benchmark_docs.receipt_problems(root)
+    assert any("source_tree does not match the source at source_commit" in p for p in problems)
+
+
+def test_docs_guard_rejects_a_source_file_dropped_from_the_receipt(
+    tmp_path: Path,
+) -> None:
+    """The per-file check walks the recorded list, so it cannot see an omission.
+
+    Only an aggregate recomputed from the measurement commit catches a file that
+    existed when the benchmark ran but was left out of the receipt. Without this,
+    dropping an inconvenient module from the record would verify clean.
+    """
+    from scripts import check_benchmark_docs
+
+    root, receipt = _committed_benchmark_repo(tmp_path)
+    receipt["source_tree"]["files"] = [
+        entry
+        for entry in receipt["source_tree"]["files"]
+        if not entry["path"].startswith("src/data_olympus/")
+    ]
+    _write(
+        root / "benchmarks" / "results" / "receipt.json",
+        json.dumps(receipt) + "\n",
+    )
+
+    problems = check_benchmark_docs.receipt_problems(root)
+    assert any(
+        "source_tree file list does not match the source at source_commit" in p
+        for p in problems
+    )
+
+
+def test_docs_guard_rejects_missing_source_measurement_history(
+    tmp_path: Path,
+) -> None:
+    """A shallow checkout must fail loudly, never skip the check."""
+    from scripts import check_benchmark_docs
+
+    root, receipt = _committed_benchmark_repo(tmp_path)
+    receipt["source_commit"] = "b" * 40
+    _write(
+        root / "benchmarks" / "results" / "receipt.json",
+        json.dumps(receipt) + "\n",
+    )
+
+    problems = check_benchmark_docs.receipt_problems(root)
+    assert any("does not exist in this checkout" in p for p in problems)

--- a/tests/test_secret_scan.py
+++ b/tests/test_secret_scan.py
@@ -61,16 +61,36 @@ PRIVATE_KEY = (
 )
 GITHUB_TOKEN = "ghp_" + "1234567890abcdefghijklmnopqrstuvwxyz"
 GITHUB_PAT = "github_pat_" + "11ABCDEFG0123456789_abcdefghijklmnopqrstuvwxyz01234567890"
+GITHUB_USER_TO_SERVER = "ghu_" + "1234567890abcdefghijklmnopqrstuvwxyz"
 AWS_ACCESS_KEY = "AKIA" + "ABCDEFGHIJKLMNOP"
+AWS_SESSION_KEY = "ASIA" + "ABCDEFGHIJKLMNOP"
 SLACK_TOKEN = "xoxb-" + "1234567890-abcdefghijklmnopqrst"
+ANTHROPIC_KEY = "sk-ant-" + "api03-" + "abcdefghij0123456789ABCDEFGHIJ" + "-AAAAAA"
+# Exactly 35 characters after the AIza prefix: a Google API key is 39 total.
+GOOGLE_API_KEY = "AIza" + "SyABCDEFGHIJ0123456789abcdefghij012"
 GENERIC_CRED = "password" + "=" + "Sup3rSecretValue!"
 CONN_STRING = "postgres://dbuser:" + "Sup3rSecretValue!" + "@db.example.com:5432/kb"
+
+# Every LLM provider form the llm_provider_api_key class covers. Same fragment
+# convention as above: never a contiguous literal in tracked source.
+LLM_PROVIDER_KEYS = {
+    "anthropic": ANTHROPIC_KEY,
+    "openai_project": "sk-proj-" + "abcdefghij0123456789ABCDEFGHIJKLMN",
+    "openai_service_account": "sk-svcacct-" + "abcdefghij0123456789ABCDEFGHIJ",
+    "openai_legacy": "sk-" + "abcdefghij0123456789ABCDEFGHIJKLMN",
+    "openrouter": "sk-or-v1-" + "abcdefghij0123456789abcdefghij0123456789",
+    "huggingface": "hf_" + "abcdefghij0123456789ABCDEFGHIJKLMN",
+    "groq": "gsk_" + "abcdefghij0123456789ABCDEF",
+    "xai": "xai-" + "abcdefghij0123456789ABCDEFGHIJKLMN",
+}
 
 ALL_BUILTIN_SECRETS = {
     "private_key_block": PRIVATE_KEY,
     "github_token": GITHUB_TOKEN,
     "aws_access_key_id": AWS_ACCESS_KEY,
     "slack_token": SLACK_TOKEN,
+    "llm_provider_api_key": ANTHROPIC_KEY,
+    "google_api_key": GOOGLE_API_KEY,
     "generic_credential_assignment": GENERIC_CRED,
     "connection_string_password": CONN_STRING,
 }
@@ -131,6 +151,62 @@ def test_scan_detects_github_fine_grained_pat() -> None:
     result = scan_postimage_for_secrets(postimage=f"token: {GITHUB_PAT}\n")
     assert not result.ok
     assert result.match.pattern_name == "github_token"
+
+
+@pytest.mark.parametrize("provider,secret", sorted(LLM_PROVIDER_KEYS.items()))
+def test_scan_detects_every_llm_provider_key_form(provider, secret) -> None:
+    """Anthropic, OpenAI (project / service-account / legacy), OpenRouter,
+    Hugging Face, Groq and xAI all share the llm_provider_api_key class: they
+    leak identically and a caller only needs to know that an LLM provider key
+    is present."""
+    result = scan_postimage_for_secrets(postimage=f"the key is {secret}\n")
+    assert not result.ok, f"{provider} key was not detected"
+    assert result.match is not None
+    assert result.match.pattern_name == "llm_provider_api_key"
+
+
+def test_scan_bare_sk_alternative_does_not_swallow_prefixed_forms() -> None:
+    """The trailing bare ``sk-`` alternative exists for OpenAI-compatible
+    gateways, and must not be what matches a prefixed key: ``[A-Za-z0-9]``
+    excludes the hyphen, so ``sk-ant-`` stops after three characters."""
+    for secret in (LLM_PROVIDER_KEYS["anthropic"],
+                   LLM_PROVIDER_KEYS["openai_project"]):
+        result = scan_postimage_for_secrets(postimage=secret)
+        assert not result.ok
+        assert result.match.pattern_name == "llm_provider_api_key"
+
+
+def test_scan_detects_github_user_to_server_token() -> None:
+    """ghu_ is the user-to-server token form; it belongs to the same class as
+    the other gh*_ prefixes."""
+    result = scan_postimage_for_secrets(postimage=f"token: {GITHUB_USER_TO_SERVER}\n")
+    assert not result.ok
+    assert result.match.pattern_name == "github_token"
+
+
+def test_scan_detects_aws_session_access_key() -> None:
+    """ASIA is the temporary access key id issued by STS. It is still an access
+    key id and leaks the same way as AKIA."""
+    result = scan_postimage_for_secrets(postimage=f"aws key {AWS_SESSION_KEY}\n")
+    assert not result.ok
+    assert result.match.pattern_name == "aws_access_key_id"
+
+
+def test_scan_llm_key_patterns_do_not_flag_ordinary_prose() -> None:
+    """False-positive guard for the new classes. A knowledge base holds commit
+    SHAs, digests, ids and model names; none of them may be refused as a
+    secret, because the write is rejected and the caller has no way to tell the
+    rejection was wrong."""
+    for content in (
+        "Fixed in commit 2145d6251d30054e65cc5ea95b4913a3ab62edf8 on main.",
+        "sha256:ffb752e139c0a19692a43af8d8523b274222dd68eebad5d583b45c2201c6e30a",
+        "The model is claude-opus-5 and the local one is granite4.1:8b.",
+        "Document id 370a4766-588f-4ec5-97de-ce05905f5a67 was superseded.",
+        "Ask the sk- prefixed provider for a new key.",
+        "The task list is in the ADR; see ADR-002 for the serving model.",
+    ):
+        result = scan_postimage_for_secrets(postimage=content)
+        assert result.ok, f"{content!r} should not be flagged"
 
 
 def test_scan_generic_credential_placeholder_is_not_flagged() -> None:

--- a/tests/test_secret_scan.py
+++ b/tests/test_secret_scan.py
@@ -19,6 +19,7 @@ Covers:
 from __future__ import annotations
 
 import os
+import re
 import subprocess
 from unittest.mock import MagicMock
 
@@ -66,8 +67,15 @@ AWS_ACCESS_KEY = "AKIA" + "ABCDEFGHIJKLMNOP"
 AWS_SESSION_KEY = "ASIA" + "ABCDEFGHIJKLMNOP"
 SLACK_TOKEN = "xoxb-" + "1234567890-abcdefghijklmnopqrst"
 ANTHROPIC_KEY = "sk-ant-" + "api03-" + "abcdefghij0123456789ABCDEFGHIJ" + "-AAAAAA"
+# A prefixed key with no run of 32 alphanumerics anywhere in it, so the bare
+# ``sk-`` alternative provably cannot be what matches it. See
+# test_prefixed_key_is_detected_without_help_from_the_bare_sk_alternative.
+ANTHROPIC_KEY_NO_ALNUM_RUN = "sk-ant-" + "api03-" + "abc_def-ghi_jkl-mno_pqr-stu"
 # Exactly 35 characters after the AIza prefix: a Google API key is 39 total.
 GOOGLE_API_KEY = "AIza" + "SyABCDEFGHIJ0123456789abcdefghij012"
+# Same length, last character a hyphen. The key alphabet includes it, and a
+# fixed-length body followed by \b would refuse to match this one at all.
+GOOGLE_API_KEY_TRAILING_HYPHEN = "AIza" + "SyABCDEFGHIJ0123456789abcdefghij01-"
 GENERIC_CRED = "password" + "=" + "Sup3rSecretValue!"
 CONN_STRING = "postgres://dbuser:" + "Sup3rSecretValue!" + "@db.example.com:5432/kb"
 
@@ -165,15 +173,35 @@ def test_scan_detects_every_llm_provider_key_form(provider, secret) -> None:
     assert result.match.pattern_name == "llm_provider_api_key"
 
 
-def test_scan_bare_sk_alternative_does_not_swallow_prefixed_forms() -> None:
-    """The trailing bare ``sk-`` alternative exists for OpenAI-compatible
-    gateways, and must not be what matches a prefixed key: ``[A-Za-z0-9]``
-    excludes the hyphen, so ``sk-ant-`` stops after three characters."""
-    for secret in (LLM_PROVIDER_KEYS["anthropic"],
-                   LLM_PROVIDER_KEYS["openai_project"]):
-        result = scan_postimage_for_secrets(postimage=secret)
-        assert not result.ok
-        assert result.match.pattern_name == "llm_provider_api_key"
+def test_prefixed_key_is_detected_without_help_from_the_bare_sk_alternative() -> None:
+    """The prefixed alternatives must do their own work.
+
+    A SecretMatch carries only a pattern name and a line number, by design, so
+    no assertion can observe which alternative of the class fired. This uses a
+    fixture the bare ``sk-`` alternative cannot possibly match instead: that
+    alternative is ``[A-Za-z0-9]{32,255}``, which excludes both ``-`` and ``_``,
+    and ANTHROPIC_KEY_NO_ALNUM_RUN contains no run of 32 alphanumerics anywhere.
+    A detection therefore proves ``sk-ant-`` matched it.
+    """
+    assert not re.search(r"[A-Za-z0-9]{32}", ANTHROPIC_KEY_NO_ALNUM_RUN), (
+        "fixture must not contain a 32-character alphanumeric run, or the bare "
+        "sk- alternative could match it and this test proves nothing"
+    )
+    result = scan_postimage_for_secrets(postimage=f"the key is {ANTHROPIC_KEY_NO_ALNUM_RUN}\n")
+    assert not result.ok
+    assert result.match.pattern_name == "llm_provider_api_key"
+
+
+def test_scan_detects_google_api_key_ending_in_a_hyphen() -> None:
+    """A Google key's alphabet includes ``-``, so roughly one key in 64 ends
+    with one. The pattern body is a fixed ``{35}`` with nothing to backtrack
+    into, so closing it with ``\\b`` would demand a word character in the final
+    position and silently refuse to match those keys."""
+    result = scan_postimage_for_secrets(
+        postimage=f"key: {GOOGLE_API_KEY_TRAILING_HYPHEN}\n"
+    )
+    assert not result.ok
+    assert result.match.pattern_name == "google_api_key"
 
 
 def test_scan_detects_github_user_to_server_token() -> None:
@@ -207,6 +235,34 @@ def test_scan_llm_key_patterns_do_not_flag_ordinary_prose() -> None:
     ):
         result = scan_postimage_for_secrets(postimage=content)
         assert result.ok, f"{content!r} should not be flagged"
+
+
+def test_scan_asia_prefix_does_not_flag_ordinary_capitalised_prose() -> None:
+    """False-positive guard for widening the AWS class to ASIA. A knowledge
+    base writes about regions, and the word starts the same way as a session
+    key id."""
+    for content in (
+        "Rollout order is ASIA, then EMEA, then AMER.",
+        "The ASIAPACIFIC bucket is replicated nightly.",
+        "Tagged ASIA-PACIFIC-SOUTHEAST for the regional index.",
+        "ASIA and the other three regions share one control plane.",
+    ):
+        result = scan_postimage_for_secrets(postimage=content)
+        assert result.ok, f"{content!r} should not be flagged"
+
+
+def test_scan_asia_prefix_cannot_separate_a_long_all_caps_word_from_a_key_id() -> None:
+    """The known limit of the shape above, asserted rather than left implicit.
+
+    An access key id is a prefix plus 16 characters of uppercase letters and
+    digits, so a 20-character all-caps word starting with ASIA is the same
+    string as far as any regex is concerned. Requiring a digit would resolve it
+    and would also miss the real ids that contain none, which is the worse
+    failure for a gate whose job is to refuse credentials.
+    """
+    result = scan_postimage_for_secrets(postimage="region ASIAPACIFICREGIONXYZ note")
+    assert not result.ok
+    assert result.match.pattern_name == "aws_access_key_id"
 
 
 def test_scan_generic_credential_placeholder_is_not_flagged() -> None:

--- a/tests/test_secret_scan.py
+++ b/tests/test_secret_scan.py
@@ -1000,3 +1000,57 @@ def test_resolve_of_legacy_pending_entry_with_secret_path_rejected(
     assert len(events) >= 1
     for ev in events:
         assert AWS_ACCESS_KEY not in str(ev), "audit event must not carry the raw path"
+
+
+# --- Delimiters that are word characters --------------------------------------
+# A leading \b cannot fire between "_" and a letter, because both are word
+# characters. Markdown emphasis around a key therefore hid it from the scanner
+# entirely. The same shape appears in YAML flow keys, __dunder__ names, and any
+# prose that underscores a value for emphasis.
+
+
+def _scan(text: str):
+    from data_olympus.write_gate import scan_postimage_for_secrets
+
+    return scan_postimage_for_secrets(postimage=text).match is not None
+
+
+def test_llm_key_is_detected_inside_markdown_emphasis() -> None:
+    key = "sk-ant-api03-" + "A" * 40
+    assert _scan(f"_{key}_"), "underscore-delimited key must not hide from the scanner"
+
+
+def test_google_key_is_detected_inside_markdown_emphasis() -> None:
+    key = "AIza" + "B" * 35
+    assert _scan(f"_{key}_")
+
+
+def test_underscore_delimited_key_is_found_for_every_llm_provider() -> None:
+    """Every alternative, not just the one that happened to be tested."""
+    keys = [
+        "sk-ant-api03-" + "A" * 40,
+        "sk-proj-" + "A" * 40,
+        "sk-svcacct-" + "A" * 40,
+        "sk-or-v1-" + "a1" * 32,
+        "hf_" + "a1" * 17,
+        "gsk_" + "a1" * 26,
+        "xai-" + "a1" * 40,
+        "sk-" + "a1" * 24,
+    ]
+    missed = [k for k in keys if not _scan(f"_{k}_")]
+    assert missed == [], f"hidden by underscore delimiters: {missed}"
+
+
+def test_llm_key_is_not_matched_mid_token() -> None:
+    """Excluding only alphanumerics on the left must still refuse a longer token."""
+    key = "sk-ant-api03-" + "A" * 40
+    assert not _scan(f"x{key}")
+
+
+def test_xai_key_body_may_contain_underscores() -> None:
+    """xAI keys draw from an alphabet that includes "_".
+
+    Excluding it missed such a key completely: the trailing boundary cannot fire
+    before "_", so even a long alphanumeric run ahead of it did not match.
+    """
+    assert _scan("xai-" + "a" * 20 + "_" + "b" * 20)


### PR DESCRIPTION
Completes v0.7.2. `main` moved twice after the original release preparation was
reviewed, so this makes the reviewed revision the tip again rather than
publishing from an earlier one.

## Why this exists rather than publishing what was already reviewed

The release contract permits publishing from an earlier reviewed revision only
when every commit between it and `main` changes no input to a published
artifact. #238 changes `CHANGELOG.md`, which `pyproject.toml` includes in the
sdist, and `deploy/docker/entrypoint.sh`, which the Dockerfile copies into the
image. Either one alone closes that door, so the fallback does not apply and
this branch is the reviewed tree.

## What is in it

**Fixed: product source changes no longer fail CI (#246).** The benchmark
receipt's `source_tree` digest was compared against the working tree, so any
edit under `src/data_olympus/` or `benchmarks/` failed the `benchmark-docs`
guard. Together with the `dependency_lock` half fixed earlier in this release,
neither a dependency update nor a product fix could go green. Both halves now
verify against the revision the measurement was taken at, read from git history.

Integrity of the historical record improves rather than degrades: the recorded
file list is compared alongside the digest, so a file that existed at the
measurement commit but was dropped from the receipt is now caught, which the
previous per-file walk could not see because it iterated the list being
shortened. What the guard deliberately stops asserting is any relationship
between today's source and the published numbers. It never established that the
benchmarks actually ran at the declared commit, and it still does not.

**Security: the write gate scans for LLM provider API keys (#237).** Contributed
by @yuzi-co, whose commits are carried here with authorship intact. Adds
`llm_provider_api_key` and `google_api_key` classes, and extends `github_token`
with `ghu_` and `aws_access_key_id` with the STS `ASIA` form.

Review of that work found a false negative worth naming: the patterns anchored
with `\b`, which cannot fire between `_` and a letter because both are word
characters, so a key wrapped in Markdown emphasis was invisible to the scanner
for every provider. Fixed here, along with the xAI alphabet, which excluded `_`
and therefore missed any key containing one. Both were reproduced before being
fixed and are covered by regression tests.

**Fixed: docker compose bootstrap (#238), already merged**, folded into the
0.7.2 record. Its entries had been left under `[Unreleased]` and the release
notes did not mention it.

**Docs: the README links the Lulu MCP marketplace listing (#236).**

## Known limits, stated rather than discovered later

The secret scanner is a shape detector. It never contacts a provider, so it can
miss a credential whose format it does not model, and it can flag an identifier
that merely looks like one. The length ranges are deliberately generous:
`hf_requiredCharacteristicTypesForDisplayMetadata` matches and would block a
legitimate write. Tightening them trades a recoverable false positive for an
unrecoverable false negative, which is the tradeoff this module already
documents for `AKIA`/`ASIA`. Upgrading also changes future writes only: it does
not scan history and does not revoke anything already exposed.

This is a runtime behaviour change. Writes that previously succeeded can now be
rejected. The Upgrading section of the release notes says so.

## Verification

All ten gates pass on this exact tree, `complete: true`, every return code zero:
environment, dependencies, ruff, mypy, pytest, bats, conformance,
benchmark_docs, bundle_lint, security_alerts. Zero open Dependabot alerts and
zero open code scanning alerts.

Independently reviewed across four rounds. Round 2 returned CHANGES REQUESTED on
a blocking scanner false negative and a false claim of "no runtime change"; both
are fixed above. Two findings were accepted as non-blocking and are documented
rather than silently carried: the length ranges, and that the boundaries reject
a preceding letter or digit rather than every longer token.

Version stays `0.7.2`; this is patch content.
