### PR TITLE
fix(release): stop logging the k8s git remote and fix silent path configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.7.3] - 2026-09-07
+
 ### Fixed
 
 * **A blank `KB_MAIN_PATH` no longer makes the server index its own working
@@ -2009,7 +2011,8 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `docs/adoption.md`: bring-your-own-KB guide (author, lint, index, serve, wire an agent).
 - `docs/comparison.md`: how data-olympus relates to OKF, enterprise catalogs, markdown KB tools, agent-context conventions, RAG, and ADR tooling.
 
-[Unreleased]: https://github.com/knaisoma/data-olympus/compare/v0.6.0...HEAD
+[Unreleased]: https://github.com/knaisoma/data-olympus/compare/v0.7.3...HEAD
+[0.7.3]: https://github.com/knaisoma/data-olympus/compare/v0.7.2...v0.7.3
 [0.6.0]: https://github.com/knaisoma/data-olympus/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/knaisoma/data-olympus/compare/v0.4.2...v0.5.0
 [0.4.1]: https://github.com/knaisoma/data-olympus/compare/v0.4.0...v0.4.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,8 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   compose, Helm or CI variable produces -- reached `Path("")`, which is
   `Path(".")`, so the server silently indexed whatever happened to be in its
   working directory. A blank or whitespace-only value now means unset and the
-  documented default applies; surrounding whitespace is stripped. And when the
+  documented default applies, while a non-blank value is used verbatim. And
+  when the
   corpus path does not resolve to a directory, startup now fails with a message
   naming the setting, the path it resolved to, and whether that path came from
   the environment or the built-in default, instead of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,21 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+* **A blank `KB_MAIN_PATH` no longer makes the server index its own working
+  directory.** `KB_MAIN_PATH=` and `KB_INDEX_PATH=` -- what an unsubstituted
+  compose, Helm or CI variable produces -- reached `Path("")`, which is
+  `Path(".")`, so the server silently indexed whatever happened to be in its
+  working directory. A blank or whitespace-only value now means unset and the
+  documented default applies; surrounding whitespace is stripped. And when the
+  corpus path does not resolve to a directory, startup now fails with a message
+  naming the setting, the path it resolved to, and whether that path came from
+  the environment or the built-in default, instead of
+  `KB root not a directory: /kb-main` -- a path the operator never configured
+  and no setting name to search for. An existing but empty corpus keeps
+  starting normally, as before. A deployment that relied on blank-means-cwd
+  changes behaviour; that reliance was on the silent defect being fixed here.
+  ([#244](https://github.com/knaisoma/data-olympus/issues/244))
+
 * **The Kubernetes first-boot log no longer prints the configured git remote.**
   The StatefulSet initContainer echoed the remote URL immediately before
   cloning it. The remote is documented as "SSH or HTTPS", and an HTTPS remote

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+* **The Kubernetes first-boot log no longer prints the configured git remote.**
+  The StatefulSet initContainer echoed the remote URL immediately before
+  cloning it. The remote is documented as "SSH or HTTPS", and an HTTPS remote
+  carries its credential inside the URL, so an adopter using one wrote that
+  credential into the pod log on every first boot, where no application-level
+  redaction reaches it. The message now names no URL, matching the Docker
+  entrypoint. Nothing else about the clone changes.
+  ([#248](https://github.com/knaisoma/data-olympus/issues/248))
+
 ## [0.7.2] - 2026-09-07
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * **The Kubernetes first-boot log no longer prints the configured git remote.**
   The StatefulSet initContainer echoed the remote URL immediately before
   cloning it. The remote is documented as "SSH or HTTPS", and an HTTPS remote
-  carries its credential inside the URL, so an adopter using one wrote that
+  may carry a credential inside the URL, so an adopter using one wrote that
   credential into the pod log on every first boot, where no application-level
   redaction reaches it. The message now names no URL, matching the Docker
   entrypoint. Nothing else about the clone changes.

--- a/deploy/k8s/statefulset.yaml
+++ b/deploy/k8s/statefulset.yaml
@@ -71,7 +71,7 @@ spec:
                 if [ -z "$real" ]; then
                   # The URL is deliberately absent from this message, matching
                   # deploy/docker/entrypoint.sh. docs/adoption.md documents the
-                  # remote as "SSH or HTTPS", and an HTTPS remote carries its
+                  # remote as "SSH or HTTPS", and an HTTPS remote may carry a
                   # credential in the URL, so expanding it here would write that
                   # token to the pod log on every first boot -- before the clone
                   # runs, and where no application-level redaction reaches it.

--- a/deploy/k8s/statefulset.yaml
+++ b/deploy/k8s/statefulset.yaml
@@ -69,7 +69,14 @@ spec:
               if [ -n "${KB_GIT_REMOTE_URL:-}" ] && [ -d /kb-main ]; then
                 real=$(find /kb-main -mindepth 1 -maxdepth 1 ! -name 'lost+found' -print -quit 2>/dev/null || true)
                 if [ -z "$real" ]; then
-                  echo "[init] /kb-main empty; cloning $KB_GIT_REMOTE_URL"
+                  # The URL is deliberately absent from this message, matching
+                  # deploy/docker/entrypoint.sh. docs/adoption.md documents the
+                  # remote as "SSH or HTTPS", and an HTTPS remote carries its
+                  # credential in the URL, so expanding it here would write that
+                  # token to the pod log on every first boot -- before the clone
+                  # runs, and where no application-level redaction reaches it.
+                  # The operator already has the value in the Secret.
+                  echo "[init] /kb-main is empty; cloning configured remote"
                   GIT_SSH_COMMAND="ssh -i /state/git-key -o UserKnownHostsFile=/state/known_hosts -o StrictHostKeyChecking=yes" \
                     git clone "$KB_GIT_REMOTE_URL" /kb-main \
                     && echo "[init] bootstrap complete" \

--- a/docs/releases/v0.7.3.md
+++ b/docs/releases/v0.7.3.md
@@ -22,7 +22,9 @@ corrects two claims 0.7.2 made about its own Google API key detection.
 
   This is the Kubernetes half of the disclosure whose Docker half was fixed in
   0.7.2. That release said its own fix removed "the unconditional disclosure,
-  not every path to one" and named this line as still open; it is now closed.
+  not every path to one", and named this specific line as still open. That one
+  line is what closes here. The broader statement still holds: this removes an
+  unconditional disclosure, not every path to one.
   `deploy/k8s/read-replica/deployment.yaml` was checked and has no equivalent
   line. A sweep of `deploy/` for log lines expanding a variable now leaves only
   the `ssh-keyscan` host, which is a build argument and ConfigMap value, not a
@@ -44,7 +46,9 @@ corrects two claims 0.7.2 made about its own Google API key detection.
   It silently indexed whatever happened to be in the server's working directory,
   which is a confidentiality question as much as a correctness one. A blank or
   whitespace-only `KB_MAIN_PATH` or `KB_INDEX_PATH` now means unset, so the
-  documented default applies, and surrounding whitespace is stripped.
+  documented default applies. A value that is not blank is used exactly as
+  given and is never rewritten, since a path may legitimately carry leading or
+  trailing whitespace.
 
 * **A corpus path that does not resolve now names the setting that produced
   it.** The failure was `NotADirectoryError: KB root not a directory: /kb-main`,

--- a/docs/releases/v0.7.3.md
+++ b/docs/releases/v0.7.3.md
@@ -3,18 +3,19 @@
 Scheduled availability 2026-09-07. Until this version is published, that date is
 a plan, not a record.
 
-A Kubernetes deployment no longer writes its git remote URL, and any credential
-embedded in it, to the pod log on first boot. A blank path setting no longer
-makes the server silently index its own working directory, and a corpus path
-that does not resolve now says which setting produced it. This release also
-corrects two claims 0.7.2 made about its own Google API key detection.
+The Kubernetes first-boot bootstrap message no longer prints the configured git
+remote URL, and so no longer prints a credential embedded in it. A blank path
+setting no longer makes the server silently index its own working directory, and
+a corpus path that does not resolve now says which setting produced it. This
+release also corrects two claims 0.7.2 made about its own Google API key
+detection.
 
 ## Security
 
 * **The Kubernetes initContainer no longer prints the configured git remote.**
   `deploy/k8s/statefulset.yaml` interpolated `$KB_GIT_REMOTE_URL` into a log
   line immediately before `git clone`. `docs/adoption.md` documents that remote
-  as SSH or HTTPS, and an HTTPS remote carries its credential inside the URL, so
+  as SSH or HTTPS, and an HTTPS remote may carry a credential inside the URL, so
   an adopter using one wrote that credential into the pod log on every first
   boot, before the clone ran and where no application-level redaction reaches
   it. The line now names no URL and matches the message the Docker entrypoint

--- a/docs/releases/v0.7.3.md
+++ b/docs/releases/v0.7.3.md
@@ -1,0 +1,101 @@
+# data-olympus 0.7.3
+
+Scheduled availability 2026-09-07. Until this version is published, that date is
+a plan, not a record.
+
+A Kubernetes deployment no longer writes its git remote URL, and any credential
+embedded in it, to the pod log on first boot. A blank path setting no longer
+makes the server silently index its own working directory, and a corpus path
+that does not resolve now says which setting produced it. This release also
+corrects two claims 0.7.2 made about its own Google API key detection.
+
+## Security
+
+* **The Kubernetes initContainer no longer prints the configured git remote.**
+  `deploy/k8s/statefulset.yaml` interpolated `$KB_GIT_REMOTE_URL` into a log
+  line immediately before `git clone`. `docs/adoption.md` documents that remote
+  as SSH or HTTPS, and an HTTPS remote carries its credential inside the URL, so
+  an adopter using one wrote that credential into the pod log on every first
+  boot, before the clone ran and where no application-level redaction reaches
+  it. The line now names no URL and matches the message the Docker entrypoint
+  already used.
+
+  This is the Kubernetes half of the disclosure whose Docker half was fixed in
+  0.7.2. That release said its own fix removed "the unconditional disclosure,
+  not every path to one" and named this line as still open; it is now closed.
+  `deploy/k8s/read-replica/deployment.yaml` was checked and has no equivalent
+  line. A sweep of `deploy/` for log lines expanding a variable now leaves only
+  the `ssh-keyscan` host, which is a build argument and ConfigMap value, not a
+  secret.
+
+  Two limits carry over unchanged from 0.7.2, and both follow from putting a
+  credential in a URL at all. Git inherits the same stdout and stderr, and a
+  token embedded in a clone URL is still written to `/kb-main/.git/config` once
+  the clone succeeds. If a token has already reached a pod log or a committed
+  git config, rotate it; nothing in this release does that for you.
+
+## Fixed
+
+* **A blank `KB_MAIN_PATH` no longer makes the server index its own working
+  directory.** `os.environ.get(name, default)` falls back only when a variable
+  is absent. A variable that is set but empty, which is exactly what an
+  unsubstituted compose, Helm or CI variable produces, returned `""`, and
+  `Path("")` is `Path(".")`. So `KB_MAIN_PATH=` did not fail and did not warn.
+  It silently indexed whatever happened to be in the server's working directory,
+  which is a confidentiality question as much as a correctness one. A blank or
+  whitespace-only `KB_MAIN_PATH` or `KB_INDEX_PATH` now means unset, so the
+  documented default applies, and surrounding whitespace is stripped.
+
+* **A corpus path that does not resolve now names the setting that produced
+  it.** The failure was `NotADirectoryError: KB root not a directory: /kb-main`,
+  which printed a path the operator had never configured and gave no setting
+  name to search for. Startup now reports the setting, the path it resolved to,
+  and whether that path came from the environment or the built-in default,
+  which is what makes the message actionable.
+
+  An existing but empty corpus is explicitly not an error and is unchanged: the
+  server starts, builds the schema, and reports `degraded` until content
+  arrives.
+
+## Changed
+
+* **Two claims 0.7.2 made about Google API key detection were too strong, and
+  are corrected here.** The detection behaviour is not changing; the regex is
+  byte-identical. Only the description was wrong, and it was wrong in the source
+  comment a maintainer reads before touching the pattern.
+
+  0.7.2 described the `AIza` shape as authenticating "Gemini and every other
+  Google API". Many Google APIs require OAuth or a service account and reject an
+  API key outright, so the class means the credential is Google-shaped, not that
+  it opens any given Google service.
+
+  0.7.2 also said the pattern's negative lookahead "refuses a longer token
+  without constraining the last character". It refuses a continuation in
+  `[A-Za-z0-9-]` only. `_` is in the Google key alphabet and is deliberately not
+  excluded, because excluding it would lose detection of a key followed by
+  `_KEY_`, which a fixed-length body cannot recover from by backtracking. A
+  maintainer who trusted the stronger claim and tightened the lookahead would
+  have destroyed that detection. The comment now states the weaker guarantee and
+  says what breaks if it is strengthened.
+
+  Nothing about what the gate detects changed in this release. The 0.7.2 notes
+  are published and are not edited retroactively; this entry is the correction.
+
+* The changelog's `[Unreleased]` comparison link, stale since 0.6.0, now points
+  at this release.
+
+## Upgrading
+
+No action is required for a deployment that sets `KB_MAIN_PATH` to a real path,
+which is every documented configuration.
+
+One behaviour change can affect you. If a deployment relied on a blank
+`KB_MAIN_PATH` resolving to the process working directory, it will now use
+`/kb-main` instead and fail loudly if nothing is mounted there. That reliance
+was on the silent defect this release fixes, so it is called out rather than
+preserved behind a compatibility shim. Set `KB_MAIN_PATH` explicitly to the
+corpus you intend to serve.
+
+A Kubernetes deployment picks up the log change by applying the updated
+`deploy/k8s/statefulset.yaml`. The change is to an initContainer log line only,
+so it takes effect on the next pod start and needs no data migration.

--- a/docs/serving.md
+++ b/docs/serving.md
@@ -53,9 +53,10 @@ trigram, auth, audit rotation):
 - `KB_MAIN_PATH`: the knowledge-base corpus to index and serve (default
   `/kb-main`). `KB_INDEX_PATH`: where the SQLite index is written (default
   `/index/kb.db`). **Both treat a blank value as unset.** A variable that is set
-  but empty -- what an unsubstituted compose/Helm/CI variable produces -- gets
-  the documented default, not the server's working directory, and surrounding
-  whitespace is stripped before the value is used. If `KB_MAIN_PATH` does not
+  but empty, or whitespace-only, -- what an unsubstituted compose/Helm/CI
+  variable produces -- gets the documented default, not the server's working
+  directory. A non-blank value is used verbatim and never rewritten. If
+  `KB_MAIN_PATH` does not
   resolve to a directory, startup fails with a message naming the setting, the
   path it resolved to, and whether that path came from the environment or the
   built-in default. An existing but empty corpus is not an error: the server

--- a/docs/serving.md
+++ b/docs/serving.md
@@ -50,6 +50,16 @@ A few server-wide settings, beyond the feature-specific env vars documented in
 their own sections below (search ranking, synonyms, embeddings, co-occurrence,
 trigram, auth, audit rotation):
 
+- `KB_MAIN_PATH`: the knowledge-base corpus to index and serve (default
+  `/kb-main`). `KB_INDEX_PATH`: where the SQLite index is written (default
+  `/index/kb.db`). **Both treat a blank value as unset.** A variable that is set
+  but empty -- what an unsubstituted compose/Helm/CI variable produces -- gets
+  the documented default, not the server's working directory, and surrounding
+  whitespace is stripped before the value is used. If `KB_MAIN_PATH` does not
+  resolve to a directory, startup fails with a message naming the setting, the
+  path it resolved to, and whether that path came from the environment or the
+  built-in default. An existing but empty corpus is not an error: the server
+  starts, builds the schema, and reports `degraded` until content arrives.
 - `KB_HTTP_PORT`: TCP port the MCP HTTP server binds (default `8080`).
 - `KB_CONFIDENCE_THRESHOLD`: the auto-commit confidence cutoff, in `[0, 1]`
   (default `0.85`). A proposal at or above it from a principal holding

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "data-olympus"
-version = "0.7.2"
+version = "0.7.3"
 description = "Governance-grade knowledge-base format (OKF-compatible) plus CLI and single-writer MCP server"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/data_olympus/config.py
+++ b/src/data_olympus/config.py
@@ -11,6 +11,12 @@ from data_olympus.tool_discovery import ToolDiscoveryMode, load_tool_discovery_m
 
 _log = logging.getLogger("data_olympus.config")
 
+# How a path setting got its value, for error messages that tell the operator
+# where to look. A path that came from the environment is the operator's to fix;
+# a path that came from the default means the setting was never supplied.
+PATH_SOURCE_ENV = "environment"
+PATH_SOURCE_DEFAULT = "default"
+
 
 @dataclass(frozen=True, slots=True)
 class Config:
@@ -90,6 +96,14 @@ class Config:
     # intentionally reverses the #114 "never guess status" stance: for the narrow
     # legacy-upgrade case, a seamless default beats conservative flagging.
     status_autofill: bool = True
+    # Where kb_main_path / kb_index_path came from: PATH_SOURCE_ENV when the
+    # operator supplied a non-blank value, PATH_SOURCE_DEFAULT when the setting
+    # was absent or blank. Used only to make a startup failure name the setting
+    # and say whether the operator ever configured it. Defaults to
+    # PATH_SOURCE_DEFAULT so a programmatic caller that passes paths directly
+    # (build_app in tests) does not have to supply provenance it does not have.
+    kb_main_path_source: str = PATH_SOURCE_DEFAULT
+    kb_index_path_source: str = PATH_SOURCE_DEFAULT
     # Streamable-http session reaping: terminate transports idle beyond this many
     # seconds to bound _server_instances (see session_metrics). 0 disables the
     # reaper (observability-only). The scan runs every session_reap_interval_sec.
@@ -200,6 +214,60 @@ def _load_status_weights(raw: str) -> dict[str, float] | None:
             f"got {type(data).__name__}"
         )
     return {str(k): float(v) for k, v in data.items()}
+def _env_path(name: str, default: str) -> tuple[Path, str]:
+    """Resolve a filesystem path setting, treating blank as unset.
+
+    ``os.environ.get(name, default)`` only falls back when the variable is
+    ABSENT. A variable that is set but empty -- which is exactly what an
+    unsubstituted compose/Helm/CI variable produces -- returns ``""``, and
+    ``Path("")`` is ``Path(".")``. So a blank ``KB_MAIN_PATH`` used to make the
+    server silently index its own working directory instead of the corpus, with
+    no error and no log line naming the setting.
+
+    Surrounding whitespace is stripped first, so a value that is only whitespace
+    is the same mistake with a space in it and is treated identically. What
+    remains, if empty, means unset and the documented default applies.
+
+    Returns the resolved path and which of :data:`PATH_SOURCE_ENV` /
+    :data:`PATH_SOURCE_DEFAULT` it came from.
+    """
+    raw = os.environ.get(name)
+    if raw is None or not raw.strip():
+        return Path(default), PATH_SOURCE_DEFAULT
+    return Path(raw.strip()), PATH_SOURCE_ENV
+
+
+def corpus_path_problem(config: Config) -> str | None:
+    """Return an actionable message when the configured corpus is unusable.
+
+    ``None`` when ``kb_main_path`` is a directory. The message names the
+    setting, the path it resolved to, and whether that path came from the
+    environment or the built-in default -- the three things the previous
+    ``NotADirectoryError: KB root not a directory: /kb-main`` left the operator
+    to guess, since it printed a path they had never configured and no setting
+    name to search for.
+    """
+    path = config.kb_main_path
+    if path.is_dir():
+        return None
+    if config.kb_main_path_source == PATH_SOURCE_ENV:
+        origin = "That path came from the KB_MAIN_PATH environment variable."
+        fix = "Point KB_MAIN_PATH at the knowledge-base checkout."
+    else:
+        origin = (
+            "KB_MAIN_PATH is unset or blank, so that path is the built-in "
+            "default."
+        )
+        fix = (
+            f"Set KB_MAIN_PATH to the knowledge-base checkout, or mount the "
+            f"corpus at {path}."
+        )
+    what = "does not exist" if not path.exists() else "is not a directory"
+    return (
+        f"KB_MAIN_PATH resolves to {path}, which {what}. {origin} {fix}"
+    )
+
+
 def _env_bool(raw: str) -> bool:
     """Parse a truthy env string. True for 1/true/yes/on (case-insensitive);
     everything else (including empty) is False."""
@@ -299,9 +367,15 @@ def load_config() -> Config:
     version_check_interval_sec = int(
         os.getenv("KB_VERSION_CHECK_INTERVAL_SEC", "86400")
     )
+    kb_main_path, kb_main_path_source = _env_path("KB_MAIN_PATH", "/kb-main")
+    kb_index_path, kb_index_path_source = _env_path(
+        "KB_INDEX_PATH", "/index/kb.db"
+    )
     return Config(
-        kb_main_path=Path(os.environ.get("KB_MAIN_PATH", "/kb-main")),
-        kb_index_path=Path(os.environ.get("KB_INDEX_PATH", "/index/kb.db")),
+        kb_main_path=kb_main_path,
+        kb_index_path=kb_index_path,
+        kb_main_path_source=kb_main_path_source,
+        kb_index_path_source=kb_index_path_source,
         kb_remote_url=os.environ.get("KB_REMOTE_URL", ""),
         sync_interval_sec=int(os.environ.get("KB_SYNC_INTERVAL_SEC", "60")),
         staleness_degraded_sec=int(os.environ.get("KB_STALENESS_DEGRADED_SEC", "600")),

--- a/src/data_olympus/config.py
+++ b/src/data_olympus/config.py
@@ -214,6 +214,8 @@ def _load_status_weights(raw: str) -> dict[str, float] | None:
             f"got {type(data).__name__}"
         )
     return {str(k): float(v) for k, v in data.items()}
+
+
 def _env_path(name: str, default: str) -> tuple[Path, str]:
     """Resolve a filesystem path setting, treating blank as unset.
 
@@ -224,9 +226,12 @@ def _env_path(name: str, default: str) -> tuple[Path, str]:
     server silently index its own working directory instead of the corpus, with
     no error and no log line naming the setting.
 
-    Surrounding whitespace is stripped first, so a value that is only whitespace
-    is the same mistake with a space in it and is treated identically. What
-    remains, if empty, means unset and the documented default applies.
+    A whitespace-only value is the same mistake with a space in it, so it is
+    treated as unset too. A value that is NOT blank is used verbatim: a path may
+    legitimately carry leading or trailing whitespace, and silently rewriting an
+    operator's path is a different bug from the one being fixed. A padded path
+    that does not exist now fails through :func:`corpus_path_problem`, which
+    names the setting and the exact resolved value.
 
     Returns the resolved path and which of :data:`PATH_SOURCE_ENV` /
     :data:`PATH_SOURCE_DEFAULT` it came from.
@@ -234,7 +239,7 @@ def _env_path(name: str, default: str) -> tuple[Path, str]:
     raw = os.environ.get(name)
     if raw is None or not raw.strip():
         return Path(default), PATH_SOURCE_DEFAULT
-    return Path(raw.strip()), PATH_SOURCE_ENV
+    return Path(raw), PATH_SOURCE_ENV
 
 
 def corpus_path_problem(config: Config) -> str | None:

--- a/src/data_olympus/server.py
+++ b/src/data_olympus/server.py
@@ -23,7 +23,12 @@ if TYPE_CHECKING:
 
 from data_olympus.audit_log import AuditLog
 from data_olympus.auth import PathBlocklist
-from data_olympus.config import Config, load_config
+from data_olympus.config import (
+    PATH_SOURCE_DEFAULT,
+    Config,
+    corpus_path_problem,
+    load_config,
+)
 from data_olympus.cooccurrence import (
     DEFAULT_MAX_TERMS,
     compose_expanders,
@@ -447,6 +452,8 @@ def build_app(
     maintenance_recently_expired_days: int = 30,
     maintenance_expiring_soon_days: int = 30,
     status_autofill: bool = True,
+    kb_main_path_source: str = PATH_SOURCE_DEFAULT,
+    kb_index_path_source: str = PATH_SOURCE_DEFAULT,
 ) -> FastMCP:
     """Construct a FastMCP app with the read tools registered.
 
@@ -500,6 +507,8 @@ def build_app(
         maintenance_recently_expired_days=maintenance_recently_expired_days,
         maintenance_expiring_soon_days=maintenance_expiring_soon_days,
         status_autofill=status_autofill,
+        kb_main_path_source=kb_main_path_source,
+        kb_index_path_source=kb_index_path_source,
     )
     if audit_log_path is not None:
         config_kwargs["audit_log_path"] = audit_log_path
@@ -1185,7 +1194,16 @@ def build_app_from_config(config: Config, *, bootstrap_now: bool = True) -> Fast
     integration tests that need env-driven config to reach the app state.
     Every Config field is threaded through to build_app, so no value is silently
     dropped or overridden by a hardcoded default.
+
+    When bootstrapping, the corpus path is checked first so the failure names
+    KB_MAIN_PATH, the path it resolved to, and whether the operator supplied it.
+    Index.build would otherwise raise ``KB root not a directory: /kb-main``,
+    naming a path the operator never configured and no setting to search for.
     """
+    if bootstrap_now:
+        problem = corpus_path_problem(config)
+        if problem is not None:
+            raise NotADirectoryError(problem)
     return build_app(
         kb_main_path=config.kb_main_path,
         kb_index_path=config.kb_index_path,
@@ -1229,6 +1247,8 @@ def build_app_from_config(config: Config, *, bootstrap_now: bool = True) -> Fast
         maintenance_recently_expired_days=config.maintenance_recently_expired_days,
         maintenance_expiring_soon_days=config.maintenance_expiring_soon_days,
         status_autofill=config.status_autofill,
+        kb_main_path_source=config.kb_main_path_source,
+        kb_index_path_source=config.kb_index_path_source,
     )
 
 

--- a/src/data_olympus/write_gate.py
+++ b/src/data_olympus/write_gate.py
@@ -536,15 +536,21 @@ _LLM_PROVIDER_KEY_RE = re.compile(
     r")(?![A-Za-z0-9])"
 )
 # Google API key. Not LLM-specific -- the same shape authenticates Gemini, Maps
-# and every other Google API -- so it gets its own class rather than being
-# folded into the one above.
+# and the other Google APIs that accept an API key -- so it gets its own class
+# rather than being folded into the one above. It is not every Google API:
+# many require OAuth or a service account and reject an API key outright, so
+# this class says the credential is Google-shaped, not that it opens any given
+# Google service.
 #
 # The tail is a negative lookahead rather than ``\b``. The body is a fixed
 # ``{35}`` with nothing to backtrack into, so a trailing ``\b`` would demand a
 # word character in the 35th position: a key whose last character is ``-``
 # (roughly one in 64, since the alphabet includes it) would fail to match at
-# all. The lookahead asserts the key is not a prefix of a longer token without
-# constraining its final character.
+# all. The lookahead refuses a continuation in ``[A-Za-z0-9-]`` without
+# constraining the key's own final character. It is deliberately weaker than
+# "not a prefix of a longer token": ``_`` is in the key alphabet and is NOT
+# excluded, for the reason the next paragraph gives. Tightening the lookahead
+# to cover ``_`` would satisfy the stronger reading and destroy that detection.
 # The trailing exclusion omits ``_`` deliberately. A key is exactly 39
 # characters, so a following ``_`` is either a delimiter or proof the token was
 # never a key; treating it as a delimiter costs a possible needless flag and

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,7 +3,27 @@ from pathlib import Path
 
 import pytest
 
-from data_olympus.config import Config, load_config
+from data_olympus.config import (
+    PATH_SOURCE_DEFAULT,
+    PATH_SOURCE_ENV,
+    Config,
+    corpus_path_problem,
+    load_config,
+)
+
+
+def _config_with_main_path(path: Path, source: str) -> Config:
+    """A minimal Config carrying just the corpus path and its provenance."""
+    return Config(
+        kb_main_path=path,
+        kb_index_path=Path("/index/kb.db"),
+        kb_remote_url="",
+        sync_interval_sec=60,
+        staleness_degraded_sec=600,
+        confidence_threshold=0.85,
+        http_port=8080,
+        kb_main_path_source=source,
+    )
 
 
 def test_load_config_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -161,3 +181,124 @@ def test_config_loads_audit_log_path(monkeypatch, tmp_path) -> None:
     from data_olympus.config import load_config
     cfg = load_config()
     assert cfg.audit_log_path == "/custom/audit.log"
+
+
+# --- Issue #244: a blank path setting must not silently index the cwd ---------
+
+
+@pytest.mark.parametrize("blank", ["", "   ", "\t", "\n  "])
+def test_blank_kb_main_path_is_unset_not_cwd(
+    monkeypatch: pytest.MonkeyPatch, blank: str
+) -> None:
+    """A set-but-blank KB_MAIN_PATH applies the documented default.
+
+    ``os.environ.get(name, default)`` only falls back when the variable is
+    ABSENT, so a blank value (what an unsubstituted compose/Helm/CI variable
+    produces) used to reach ``Path("")``, which is ``Path(".")`` -- the server
+    silently indexed its own working directory.
+    """
+    monkeypatch.setenv("KB_MAIN_PATH", blank)
+    cfg = load_config()
+    assert cfg.kb_main_path == Path("/kb-main")
+    assert cfg.kb_main_path != Path(".")
+    assert cfg.kb_main_path_source == PATH_SOURCE_DEFAULT
+
+
+@pytest.mark.parametrize("blank", ["", "   ", "\t", "\n  "])
+def test_blank_kb_index_path_is_unset_not_cwd(
+    monkeypatch: pytest.MonkeyPatch, blank: str
+) -> None:
+    """Same rule for KB_INDEX_PATH; the issue names both path settings."""
+    monkeypatch.setenv("KB_INDEX_PATH", blank)
+    cfg = load_config()
+    assert cfg.kb_index_path == Path("/index/kb.db")
+    assert cfg.kb_index_path != Path(".")
+    assert cfg.kb_index_path_source == PATH_SOURCE_DEFAULT
+
+
+def test_supplied_path_settings_are_honoured_and_marked_as_from_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A real value still wins, and is recorded as operator-supplied."""
+    monkeypatch.setenv("KB_MAIN_PATH", "/srv/kb")
+    monkeypatch.setenv("KB_INDEX_PATH", "/srv/index/kb.db")
+    cfg = load_config()
+    assert cfg.kb_main_path == Path("/srv/kb")
+    assert cfg.kb_index_path == Path("/srv/index/kb.db")
+    assert cfg.kb_main_path_source == PATH_SOURCE_ENV
+    assert cfg.kb_index_path_source == PATH_SOURCE_ENV
+
+
+def test_surrounding_whitespace_is_stripped_from_a_path_setting(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A padded value is the same input error as a blank one, minus the blank."""
+    monkeypatch.setenv("KB_MAIN_PATH", "  /srv/kb  ")
+    cfg = load_config()
+    assert cfg.kb_main_path == Path("/srv/kb")
+    assert cfg.kb_main_path_source == PATH_SOURCE_ENV
+
+
+def test_corpus_problem_is_none_for_a_real_directory(tmp_path: Path) -> None:
+    """An existing directory is not a problem -- including an EMPTY one.
+
+    The empty-corpus startup path is supported behaviour (see
+    tests/test_server_smoke.py::test_empty_corpus_startup_builds_schema_and_read_tools_degrade);
+    this fix targets missing/blank configuration, not an empty corpus.
+    """
+    empty = tmp_path / "empty-kb"
+    empty.mkdir()
+    cfg = _config_with_main_path(empty, PATH_SOURCE_ENV)
+    assert corpus_path_problem(cfg) is None
+
+
+def test_corpus_problem_names_setting_path_and_env_origin(tmp_path: Path) -> None:
+    """An operator-supplied path that is missing names all three facts."""
+    missing = tmp_path / "nope"
+    cfg = _config_with_main_path(missing, PATH_SOURCE_ENV)
+    msg = corpus_path_problem(cfg)
+    assert msg is not None
+    assert "KB_MAIN_PATH" in msg
+    assert str(missing) in msg
+    assert "environment variable" in msg
+
+
+def test_corpus_problem_says_the_path_came_from_the_default() -> None:
+    """The reported symptom: /kb-main named, but never configured by anyone.
+
+    The old message was ``KB root not a directory: /kb-main`` -- a path the
+    operator had not set and no setting name to search for.
+    """
+    cfg = _config_with_main_path(Path("/kb-main"), PATH_SOURCE_DEFAULT)
+    msg = corpus_path_problem(cfg)
+    assert msg is not None
+    assert "KB_MAIN_PATH" in msg
+    assert "/kb-main" in msg
+    assert "unset or blank" in msg
+    assert "built-in" in msg
+
+
+def test_corpus_problem_distinguishes_a_file_from_a_missing_path(
+    tmp_path: Path,
+) -> None:
+    """A path that exists but is a file is a different mistake from an absent one."""
+    a_file = tmp_path / "kb.txt"
+    a_file.write_text("not a corpus")
+    msg = corpus_path_problem(_config_with_main_path(a_file, PATH_SOURCE_ENV))
+    assert msg is not None and "is not a directory" in msg
+    gone = corpus_path_problem(
+        _config_with_main_path(tmp_path / "absent", PATH_SOURCE_ENV)
+    )
+    assert gone is not None and "does not exist" in gone
+
+
+def test_bootstrap_refuses_a_missing_corpus_with_the_actionable_message(
+    tmp_path: Path,
+) -> None:
+    """build_app_from_config is the production bootstrap path (main() uses it)."""
+    from data_olympus import server
+
+    cfg = _config_with_main_path(tmp_path / "absent", PATH_SOURCE_DEFAULT)
+    with pytest.raises(NotADirectoryError) as excinfo:
+        server.build_app_from_config(cfg, bootstrap_now=True)
+    assert "KB_MAIN_PATH" in str(excinfo.value)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -229,14 +229,21 @@ def test_supplied_path_settings_are_honoured_and_marked_as_from_env(
     assert cfg.kb_index_path_source == PATH_SOURCE_ENV
 
 
-def test_surrounding_whitespace_is_stripped_from_a_path_setting(
+def test_a_nonblank_path_setting_is_used_verbatim(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A padded value is the same input error as a blank one, minus the blank."""
+    """Only BLANK means unset. A non-blank value is never rewritten.
+
+    A path may legitimately carry leading or trailing whitespace, so silently
+    trimming it would be a different bug from the one #244 fixes. A padded path
+    that does not exist fails loudly through corpus_path_problem instead.
+    """
     monkeypatch.setenv("KB_MAIN_PATH", "  /srv/kb  ")
     cfg = load_config()
-    assert cfg.kb_main_path == Path("/srv/kb")
+    assert cfg.kb_main_path == Path("  /srv/kb  ")
     assert cfg.kb_main_path_source == PATH_SOURCE_ENV
+    msg = corpus_path_problem(cfg)
+    assert msg is not None and "  /srv/kb  " in msg
 
 
 def test_corpus_problem_is_none_for_a_real_directory(tmp_path: Path) -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -270,17 +270,24 @@ def test_corpus_problem_names_setting_path_and_env_origin(tmp_path: Path) -> Non
     assert "environment variable" in msg
 
 
-def test_corpus_problem_says_the_path_came_from_the_default() -> None:
-    """The reported symptom: /kb-main named, but never configured by anyone.
+def test_corpus_problem_says_the_path_came_from_the_default(tmp_path: Path) -> None:
+    """The reported symptom: the default named, but never configured by anyone.
 
     The old message was ``KB root not a directory: /kb-main`` -- a path the
     operator had not set and no setting name to search for.
+
+    The path is a missing directory under ``tmp_path`` rather than the literal
+    ``/kb-main``, because that default DOES exist inside the product's own
+    container image; asserting on it directly would make this test pass or fail
+    depending on where it runs. That the built-in default is ``/kb-main`` is
+    pinned separately by :func:`test_load_config_defaults`.
     """
-    cfg = _config_with_main_path(Path("/kb-main"), PATH_SOURCE_DEFAULT)
+    missing_default = tmp_path / "kb-main"
+    cfg = _config_with_main_path(missing_default, PATH_SOURCE_DEFAULT)
     msg = corpus_path_problem(cfg)
     assert msg is not None
     assert "KB_MAIN_PATH" in msg
-    assert "/kb-main" in msg
+    assert str(missing_default) in msg
     assert "unset or blank" in msg
     assert "built-in" in msg
 

--- a/uv.lock
+++ b/uv.lock
@@ -627,7 +627,7 @@ wheels = [
 
 [[package]]
 name = "data-olympus"
-version = "0.7.2"
+version = "0.7.3"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Summary

Release 0.7.3. A Kubernetes deployment no longer prints its configured git
remote URL, and so no longer prints a credential embedded in it, in the
first-boot bootstrap message. A blank path setting no longer makes the server
silently index its own working directory, and a corpus path that does not
resolve now names the setting that produced it. This also corrects two claims
0.7.2 made about its own Google API key detection.

Closes #248, closes #244, closes #250.

## Type of change

- [x] Tool / code change (CLI, MCP server, `kb` client, deploy)
- [ ] Spec / format change (requires a linked Spec Proposal issue with maintainer sign-off)
- [x] Documentation
- [ ] CI

## What changed

### The Kubernetes first-boot log no longer prints the configured git remote (#248)

`deploy/k8s/statefulset.yaml` interpolated `$KB_GIT_REMOTE_URL` into a log line
immediately before `git clone`. `docs/adoption.md` documents that remote as SSH
or HTTPS, and an HTTPS remote may carry a credential inside the URL, so an
adopter using one wrote that credential into the pod log on every first boot,
before the clone ran and where no application-level redaction reaches it.

The message now names no URL and matches the one
`deploy/docker/entrypoint.sh` already uses, which was fixed the same way in
#238. Nothing else about the clone changes.

This is the Kubernetes half of the disclosure whose Docker half shipped in
0.7.2. That release said its own fix removed "the unconditional disclosure, not
every path to one" and named this line as still open. That one line is what
closes here. The broader statement still holds: git inherits the initContainer's
stdout and stderr, so a git error can still surface a remote URL. A sweep of
`deploy/` for log lines that expand a variable now leaves only the `ssh-keyscan`
host, which is a build argument and ConfigMap value, not secret-derived.
`deploy/k8s/read-replica/deployment.yaml` was checked and has no equivalent line.

### A blank path setting is unset, not the working directory (#244)

`KB_MAIN_PATH` and `KB_INDEX_PATH` were read straight into `Path(...)`. A
variable that is set but empty, which is what an unsubstituted compose, Helm or
CI variable produces, reached `Path("")`, which is `Path(".")`. The server then
silently indexed whatever happened to be in its working directory, with no error
and no log line naming the setting.

A blank or whitespace-only value now means unset and the documented default
applies. A value that is not blank is used exactly as given and is never
rewritten, since a path may legitimately carry leading or trailing whitespace.

A corpus path that does not resolve to a directory now fails with a message
naming the setting, the path it resolved to, and whether that path came from the
environment or the built-in default, instead of
`NotADirectoryError: KB root not a directory: /kb-main`, which named a path the
operator had never configured and gave no setting to search for.

An existing but empty corpus keeps starting normally, exactly as before. That is
a supported state, not a configuration error, and its smoke test is unchanged by
this PR.

**Compatibility note.** A deployment that relied on blank-means-working-directory
changes behaviour. That reliance was on the silent defect being fixed here; set
`KB_MAIN_PATH` explicitly if you want the old path.

### Two overstated claims about the Google API key pattern (#250)

The comment above `_GOOGLE_API_KEY_RE` claimed the `AIza` shape authenticates
"every other Google API" (many require OAuth or a service account and reject an
API key), and claimed the trailing lookahead "asserts the key is not a prefix of
a longer token" when it excludes `-` but not `_`, which the very next paragraph
then explains is deliberate so that `_KEY_` style surroundings are still caught.
A maintainer trusting the stronger claim could tighten the lookahead and destroy
detection the next paragraph paid for.

Both wordings are narrowed. The regex is byte-identical: the assignment line
hashes the same before and after, only its line number moved.

## Verification

- `uv run pytest`: 1886 passed, 2 skipped (optional `sentence_transformers` and
  `tiktoken` not installed; unrelated and pre-existing).
- `uv run ruff check .`: all checks passed.
- `uv run mypy src`: no issues in 73 source files.
- `bats -r tests`: 74/74 ok.
- `uv run python scripts/okf_conformance.py verify-pin`: verified.
- `uv run python scripts/check_benchmark_docs.py`: ok.
- `uv run data-olympus lint example-bundle`: 0 errors across 14 files.
- `uv run python scripts/security_alerts.py`: 0 open Dependabot alerts, 0 open
  CodeQL alerts.
- `kubectl apply -k deploy/k8s --dry-run=server`: exit 0 over all five
  resources, since this touches a deployed manifest.
- `scripts/compute_release.py`: releasable, patch bump, 0.7.2 to 0.7.3.

The regression guard for #244 is explicit:
`tests/test_server_smoke.py` is unmodified by this PR, and
`test_empty_corpus_startup_builds_schema_and_read_tools_degrade` passes both in
the full run and on its own.

## Checklist

- [x] Tests pass (`uv run pytest`)
- [x] `ruff` reports no errors (`uv run ruff check .`)
- [x] `data-olympus lint` exits 0 on any bundle touched by this PR
- [x] Documentation updated (if the changed behaviour is documented)
- [x] `SPEC.md` and the validator are consistent (required if the schema changed)
- [x] No em-dashes in any prose added or modified by this PR
- [x] No credentials or secrets committed
