### PR TITLE
feat(registry): declare server.json and the mcp-name marker for the official MCP registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 [![knaisoma/data-olympus MCP server](https://glama.ai/mcp/servers/knaisoma/data-olympus/badges/score.svg)](https://glama.ai/mcp/servers/knaisoma/data-olympus)
 [![MCP Marketplace](https://img.shields.io/badge/MCP%20Marketplace-Indexed-blueviolet)](https://getlulu.dev/mcps)
 
+<!-- mcp-name: io.github.knaisoma/data-olympus -->
+
 **New here? Start with [WHY.md](WHY.md).** It is the story behind the project: the
 problem we kept hitting with coding agents, what data-olympus does differently, how
 it relates to Google's Open Knowledge Format, and where our benchmarks say it is
@@ -65,6 +67,7 @@ See `docs/adoption.md` for the full bundle authoring guide.
 - [`docs/comparison.md`](docs/comparison.md): how data-olympus relates to OKF, enterprise catalogs, markdown KB tools, agent-context conventions, RAG, and ADR tooling.
 - [`docs/okf-profile.md`](docs/okf-profile.md): field-by-field OKF profile — which governance extensions are stable, which are runtime-only serving fields, and which are experimental candidates.
 - [`docs/glama.md`](docs/glama.md): Glama registry claim, release, and score-maintenance notes.
+- [`docs/mcp-registry.md`](docs/mcp-registry.md): official MCP Registry notes, what `server.json` declares, and the checklist for publishing.
 - [`docs/enforcement.md`](docs/enforcement.md): turning the KB into a mandatory consultation gate (hooks, `kb enforce`).
 - [`benchmarks/README.md`](benchmarks/README.md): retrieval benchmark methodology and how to reproduce the numbers in `docs/comparison.md`.
 - [`SECURITY.md`](SECURITY.md): supported versions and how to report a vulnerability.

--- a/docs/mcp-registry.md
+++ b/docs/mcp-registry.md
@@ -11,8 +11,7 @@ research task. It is the registry equivalent of [`glama.md`](./glama.md).
 
 `modelcontextprotocol/servers` no longer accepts new server implementations. Its
 CONTRIBUTING directs authors to the registry, and its README tells readers looking for
-a list of servers to browse the registry rather than that repository. Several catalogues
-treat a registry entry as a credential.
+a list of servers to browse the registry rather than that repository.
 
 ## What is in this repository
 
@@ -34,9 +33,25 @@ badges. That string is how the registry verifies package ownership: it looks for
 
 ## What is not done, and why
 
-**The marker is not on PyPI yet.** The published description for 0.7.3 contains no
-`mcp-name` line, because the marker landed after that release. Publication therefore has
-to follow a release that ships this README.
+**The marker is not on PyPI yet.** This change adds the marker to `README.md`; the
+published description for 0.7.3 lacks it. Publication therefore has to follow a release
+that ships this README.
+
+**The package and the MCP executable have different names.** The package is
+`data-olympus`, and the console script that starts the MCP server is `data-olympus-mcp`,
+alongside the `data-olympus` CLI. A consumer running `uvx data-olympus` would get the
+CLI, so the explicit form is:
+
+```bash
+uvx --from 'data-olympus==<release>' data-olympus-mcp
+```
+
+`server.json` deliberately declares no runtime launch metadata. The transport block
+describes where the server listens once somebody starts it, which matches how this
+project is deployed: the operator runs it against their own knowledge bundle. If
+automated launch is wanted later, that is a deliberate addition of `runtimeHint` and
+runtime arguments, and it should be tested against a real client rather than assumed
+from a schema that validates.
 
 **Publication authenticates as a person or as CI.** The `mcp-publisher` flow signs in
 with GitHub OAuth for an `io.github.*` namespace, or uses GitHub OIDC when it runs from
@@ -46,14 +61,20 @@ workflow, not something a docs PR completes.
 ## Checklist for whoever publishes
 
 1. Cut a release whose PyPI description contains the `mcp-name` marker.
-2. Set `version` in `server.json` to that released version.
-3. Authenticate: `mcp-publisher login github`, or publish from Actions with OIDC.
-4. Publish, then confirm the entry resolves by searching the registry API for
+2. Set **both** version fields in `server.json` to that release: the top-level `version`
+   and `packages[0].version`. Leaving the package pinned to an older version points the
+   entry at a description that does not carry the marker. Then re-validate the file
+   against the published schema.
+3. Confirm that exact PyPI version's description contains the marker, for example
+   `curl -s https://pypi.org/pypi/data-olympus/json | grep -c mcp-name`.
+4. Authenticate: `mcp-publisher login github`, or publish from Actions with OIDC.
+5. Publish, then confirm the entry resolves by searching the registry API for
    `data-olympus`.
-5. Record the resulting registry name here.
+6. Record the resulting registry name here.
 
 ## Status of the registry itself
 
-The registry reports an API freeze for v0.1 while development continues on v0, and warns
-that the preview may bring breaking changes or data resets. Treat an entry as something
-to re-verify after upstream changes rather than as permanent.
+The registry's [development status](https://github.com/modelcontextprotocol/registry#development-status)
+reports an API freeze for v0.1 dated 2025-10-24, while development continues on v0, and a
+preview launch dated 2025-09-08 that warns of possible breaking changes or data resets.
+Treat an entry as something to re-verify after upstream changes rather than as permanent.

--- a/docs/mcp-registry.md
+++ b/docs/mcp-registry.md
@@ -1,0 +1,59 @@
+# Official MCP Registry notes
+
+Data Olympus is not published in the official registry at
+<https://registry.modelcontextprotocol.io> yet. Two searches of its v0 API,
+`?search=data-olympus` and `?search=knaisoma`, returned zero servers on 2026-09-12.
+
+This file records what publication needs, so the work is a checklist rather than a
+research task. It is the registry equivalent of [`glama.md`](./glama.md).
+
+## Why it matters
+
+`modelcontextprotocol/servers` no longer accepts new server implementations. Its
+CONTRIBUTING directs authors to the registry, and its README tells readers looking for
+a list of servers to browse the registry rather than that repository. Several catalogues
+treat a registry entry as a credential.
+
+## What is in this repository
+
+[`server.json`](../server.json) at the repository root declares the server:
+
+- `name` is `io.github.knaisoma/data-olympus`. The `io.github.*` namespace authenticates
+  through GitHub, so no DNS verification is needed.
+- The package entry is `registryType: pypi`, identifier `data-olympus`, against
+  `https://pypi.org`, which is on the registry's list of accepted package sources.
+- The transport is `streamable-http` at `http://localhost:8080/mcp`, which is what
+  `data-olympus-mcp` actually serves and what [`adoption.md`](./adoption.md) documents.
+  This server is not stdio.
+- `version` tracks the released version the entry describes, so it moves with a release
+  rather than with every commit.
+
+`README.md` carries `<!-- mcp-name: io.github.knaisoma/data-olympus -->` below the
+badges. That string is how the registry verifies package ownership: it looks for
+`mcp-name: $SERVER_NAME` in the README that PyPI serves as the package description.
+
+## What is not done, and why
+
+**The marker is not on PyPI yet.** The published description for 0.7.3 contains no
+`mcp-name` line, because the marker landed after that release. Publication therefore has
+to follow a release that ships this README.
+
+**Publication authenticates as a person or as CI.** The `mcp-publisher` flow signs in
+with GitHub OAuth for an `io.github.*` namespace, or uses GitHub OIDC when it runs from
+Actions. Neither path is a file change, so it is a deliberate step by a maintainer or a
+workflow, not something a docs PR completes.
+
+## Checklist for whoever publishes
+
+1. Cut a release whose PyPI description contains the `mcp-name` marker.
+2. Set `version` in `server.json` to that released version.
+3. Authenticate: `mcp-publisher login github`, or publish from Actions with OIDC.
+4. Publish, then confirm the entry resolves by searching the registry API for
+   `data-olympus`.
+5. Record the resulting registry name here.
+
+## Status of the registry itself
+
+The registry reports an API freeze for v0.1 while development continues on v0, and warns
+that the preview may bring breaking changes or data resets. Treat an entry as something
+to re-verify after upstream changes rather than as permanent.

--- a/docs/mcp-registry.md
+++ b/docs/mcp-registry.md
@@ -65,8 +65,22 @@ workflow, not something a docs PR completes.
    and `packages[0].version`. Leaving the package pinned to an older version points the
    entry at a description that does not carry the marker. Then re-validate the file
    against the published schema.
-3. Confirm that exact PyPI version's description contains the marker, for example
-   `curl -s https://pypi.org/pypi/data-olympus/json | grep -c mcp-name`.
+3. Confirm that the pinned release's own description carries the exact marker. Run from
+   the repository root:
+
+   ```bash
+   set -euo pipefail
+   release=$(jq -er '.packages[0].version' server.json)
+   server_name=$(jq -er '.name' server.json)
+   curl -fsS "https://pypi.org/pypi/data-olympus/${release}/json" |
+     jq -e --arg marker "<!-- mcp-name: ${server_name} -->" \
+       '(.info.description // "") | contains($marker)'
+   ```
+
+   It reads the version-specific endpoint rather than `/pypi/data-olympus/json`, which
+   returns the latest release, and it matches the complete comment rather than the
+   fragment `mcp-name` anywhere in the response. Today it prints `false` and exits 1,
+   because 0.7.3 predates the marker.
 4. Authenticate: `mcp-publisher login github`, or publish from Actions with OIDC.
 5. Publish, then confirm the entry resolves by searching the registry API for
    `data-olympus`.

--- a/server.json
+++ b/server.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.knaisoma/data-olympus",
+  "title": "Data Olympus",
+  "description": "Governance-grade knowledge-base format (OKF-compatible) plus CLI and single-writer MCP server",
+  "version": "0.7.3",
+  "websiteUrl": "https://github.com/knaisoma/data-olympus",
+  "repository": {
+    "url": "https://github.com/knaisoma/data-olympus",
+    "source": "github"
+  },
+  "packages": [
+    {
+      "registryType": "pypi",
+      "registryBaseUrl": "https://pypi.org",
+      "identifier": "data-olympus",
+      "version": "0.7.3",
+      "transport": {
+        "type": "streamable-http",
+        "url": "http://localhost:8080/mcp"
+      },
+      "environmentVariables": [
+        {
+          "name": "KB_MAIN_PATH",
+          "description": "Path to the git-backed knowledge bundle this server indexes and serves."
+        },
+        {
+          "name": "KB_INDEX_PATH",
+          "description": "Path to the generated SQLite index. Rebuilt atomically and swapped in."
+        },
+        {
+          "name": "KB_HTTP_PORT",
+          "description": "Port the streamable HTTP MCP server listens on. Defaults to 8080."
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Why

The official MCP registry is where `modelcontextprotocol/servers` now sends new server implementations: its CONTRIBUTING refuses them outright, and its README tells readers looking for a list of servers to browse the registry instead. data-olympus is not published there. Two searches of the registry's v0 API, `?search=data-olympus` and `?search=knaisoma`, returned zero servers on 2026-09-12.

Context and the research that led here: #111.

## What this adds

**`server.json`** at the repository root, validated against the published schema with `jsonschema`:
- `name` is `io.github.knaisoma/data-olympus`. The `io.github.*` namespace authenticates through GitHub, so no DNS verification is needed.
- The package entry is `registryType: pypi` against `https://pypi.org`, which is on the registry's accepted-source list.
- The transport is `streamable-http` at `http://localhost:8080/mcp`, which is what `data-olympus-mcp` actually serves and what `docs/adoption.md` documents. **Not stdio.**

**The ownership marker** in `README.md`: `<!-- mcp-name: io.github.knaisoma/data-olympus -->`. The registry verifies PyPI package ownership by finding `mcp-name: $SERVER_NAME` in the README that PyPI serves as the package description.

**`docs/mcp-registry.md`**, following the `docs/glama.md` precedent: what the file declares, what publication still needs, and a checklist.

## What this deliberately does not do

- **It does not publish.** Publication authenticates as a maintainer through `mcp-publisher login github`, or from Actions through OIDC. That is a deliberate step, not a file change.
- **The marker is not on PyPI yet.** The published 0.7.3 description lacks it; the marker takes effect with the next release. The checklist covers updating **both** version fields and confirming the marker on that exact release.
- **No runtime launch metadata.** The package is `data-olympus` but the MCP console script is `data-olympus-mcp`, so `uvx data-olympus` would start the CLI. The explicit form is documented. Whether to declare automated launch is a separate decision that should be tested against a real client rather than inferred from a schema that validates.

## Verification

- `uv run pytest`: green, with two skips for optional dependencies (`sentence_transformers`, `tiktoken`). Note this needs CONTRIBUTING's documented setup (`uv pip install -e '.[dev]'`); a plain `uv run pytest` in a fresh worktree syncs a non-editable build and imports a stale `data_olympus` 0.5.0, which fails three tests on unmodified `main` too.
- `uv run ruff check .`: all checks passed.
- `uv run data-olympus lint example-bundle`: `0 errors across 0 files (14 linted)`.
- `server.json` validated against `https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json`.
- The repository's own pre-commit enforcement gate passed on each commit.
- No path touched triggers the changelog guard (`src/`, `bin/`, `deploy/`, `SPEC.md`), and no OKF schema change is involved, so no Spec Proposal applies.

## Companion review (Codex)

Three rounds. Round 1 rejected an unsupported claim that several catalogues treat a registry entry as a credential, and a checklist that updated only one of the two version fields. It also caught the `data-olympus` versus `data-olympus-mcp` executable gap. Round 2 rejected the verification command: it read the latest-release endpoint rather than the pinned one and counted the fragment `mcp-name` anywhere in the response, so a newer marked release could have masked an unmarked pinned one. The corrected command was run as written and returns `false` for 0.7.3, as it should. Round 3 approved.
